### PR TITLE
Fix panic when secret resolving fails

### DIFF
--- a/pkg/scalers/scale_handler.go
+++ b/pkg/scalers/scale_handler.go
@@ -49,6 +49,7 @@ func (h *ScaleHandler) HandleScale(scaledObject *kore_v1alpha1.ScaledObject) {
 	resolvedSecrets, err := h.resolveSecrets(deployment)
 	if err != nil {
 		log.Errorf("Error resolving secrets for deployment: %s", err)
+		return
 	}
 
 	var scaleDecision int32


### PR DESCRIPTION
If resolving secrets returns an error, the scale handler panics and
exits. It was missing a return after logging the resolving secrets
error.