### PR TITLE
Add close method to scalers, long lived kafka clients

### DIFF
--- a/pkg/handler/scale_handler.go
+++ b/pkg/handler/scale_handler.go
@@ -463,9 +463,9 @@ func (h *ScaleHandler) getScalers(scaledObject *kore_v1alpha1.ScaledObject) ([]s
 func (h *ScaleHandler) getScaler(trigger kore_v1alpha1.ScaleTriggers, resolvedEnv map[string]string) (scalers.Scaler, error) {
 	switch trigger.Type {
 	case "azure-queue":
-		return scalers.NewAzureQueueScaler(resolvedEnv, trigger.Metadata), nil
+		return scalers.NewAzureQueueScaler(resolvedEnv, trigger.Metadata)
 	case "kafka":
-		return scalers.NewKafkaScaler(resolvedEnv, trigger.Metadata), nil
+		return scalers.NewKafkaScaler(resolvedEnv, trigger.Metadata)
 	default:
 		return nil, fmt.Errorf("no scaler found for type: %s", trigger.Type)
 	}

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -23,11 +23,11 @@ type azureQueueScaler struct {
 }
 
 // NewAzureQueueScaler creates a new azureQueueScaler
-func NewAzureQueueScaler(resolvedEnv, metadata map[string]string) Scaler {
+func NewAzureQueueScaler(resolvedEnv, metadata map[string]string) (Scaler, error) {
 	return &azureQueueScaler{
 		resolvedEnv: resolvedEnv,
 		metadata:    metadata,
-	}
+	}, nil
 }
 
 // GetScaleDecision is a func
@@ -43,6 +43,10 @@ func (s *azureQueueScaler) IsActive(ctx context.Context) (bool, error) {
 	}
 
 	return length > 0, nil
+}
+
+func (s *azureQueueScaler) Close() error {
+	return nil
 }
 
 func (s *azureQueueScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -18,4 +18,6 @@ type Scaler interface {
 	GetMetricSpecForScaling() []v2beta1.MetricSpec
 
 	IsActive(ctx context.Context) (bool, error)
+	// Close any resources that need disposing when scaler is no longer used or destroyed
+	Close() error
 }


### PR DESCRIPTION
Adds a close functionality to scalers in order to be able to dispose of resources or connections that need closing.

Made Kafka client and admin init on scaler creation.