### PR TITLE
Add ability to set private registry credentials to helm chart

### DIFF
--- a/chart/kore/templates/_helpers.tpl
+++ b/chart/kore/templates/_helpers.tpl
@@ -48,3 +48,11 @@ chart: {{ template "kore.chart" . }}
 release: {{ .Release.Name }}
 date: {{ now | htmlDate }}
 {{- end -}}
+
+{{/*
+Create the image registry credentials.
+https://github.com/helm/helm/blob/master/docs/charts_tips_and_tricks.md#creating-image-pull-secrets
+*/}}
+{{- define "image-pull-secret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
+{{- end }}

--- a/chart/kore/templates/docker-secret.yaml
+++ b/chart/kore/templates/docker-secret.yaml
@@ -1,6 +1,7 @@
+# .dockerconfigjson: eyJhdXRocyI6eyJwcm9qZWN0a29yZS5henVyZWNyLmlvIjp7InVzZXJuYW1lIjoiYjUxNGI2MGMtNjhjYy00ZjEyLWIzNjEtMzg1ODg3OGIyNDc5IiwicGFzc3dvcmQiOiI0alg1dmtQVFNyVVE5NlVCYlUvQjdDUXJCb0p3VDYyV1NzNVdmWnRGYkI4PSIsImF1dGgiOiJZalV4TkdJMk1HTXROamhqWXkwMFpqRXlMV0l6TmpFdE16ZzFPRGczT0dJeU5EYzVPalJxV0RWMmExQlVVM0pWVVRrMlZVSmlWUzlDTjBOUmNrSnZTbmRVTmpKWFUzTTFWMlphZEVaaVFqZzkifX19
+
+{{- if .Values.imageCredentials.createSecret }}
 apiVersion: v1
-data:
-  .dockerconfigjson: eyJhdXRocyI6eyJwcm9qZWN0a29yZS5henVyZWNyLmlvIjp7InVzZXJuYW1lIjoiYjUxNGI2MGMtNjhjYy00ZjEyLWIzNjEtMzg1ODg3OGIyNDc5IiwicGFzc3dvcmQiOiI0alg1dmtQVFNyVVE5NlVCYlUvQjdDUXJCb0p3VDYyV1NzNVdmWnRGYkI4PSIsImF1dGgiOiJZalV4TkdJMk1HTXROamhqWXkwMFpqRXlMV0l6TmpFdE16ZzFPRGczT0dJeU5EYzVPalJxV0RWMmExQlVVM0pWVVRrMlZVSmlWUzlDTjBOUmNrSnZTbmRVTmpKWFUzTTFWMlphZEVaaVFqZzkifX19
 kind: Secret
 metadata:
   labels:
@@ -8,3 +9,6 @@ metadata:
   name: {{ template "kore.fullname" . }}-docker-auth
   namespace: {{ .Release.Namespace }}
 type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "image-pull-secret" . }}
+{{- end }}

--- a/chart/kore/values.yaml
+++ b/chart/kore/values.yaml
@@ -6,13 +6,20 @@ image:
   tag: master
   pullPolicy: Always
 
+# For private container registries, set createSecret to true & add username & password
+imageCredentials:
+  createSecret: true
+  registry: projectkore.azurecr.io
+  username: "b514b60c-68cc-4f12-b361-3858878b2479"
+  password: "4jX5vkPTSrUQ96UBbU/B7CQrBoJwT62WSs5WfZtFbB8="
+
 replicaCount: 1
 
 rbac:
   create: true
 
 serviceAccount:
-    create: true
-    name:
+  create: true
+  name:
 
 logLevel: info


### PR DESCRIPTION
Adds a helper function to create the dockerconfig secret from registry name, username, & password. Allows user to turn creation of secret on & off in values file in case they are not pulling an image that is private.