### PR TITLE
Helm CRD deployment/deletion

### DIFF
--- a/chart/keda/templates/cluster-role-binding.yaml
+++ b/chart/keda/templates/cluster-role-binding.yaml
@@ -14,5 +14,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "keda.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-
 {{- end -}}

--- a/chart/keda/templates/scaledobject-crd.yaml
+++ b/chart/keda/templates/scaledobject-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.customResourceDefinition.create -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -11,3 +12,4 @@ spec:
     kind: ScaledObject
     plural: scaledobjects
   scope: Namespaced
+{{- end -}}

--- a/chart/keda/values.yaml
+++ b/chart/keda/values.yaml
@@ -8,6 +8,9 @@ image:
 
 replicaCount: 1
 
+customResourceDefinition:
+  create: true
+
 rbac:
   create: true
 


### PR DESCRIPTION
Fixes #105 

- Added value to toggle whether or not the CRD is created so that helm can be deployed w/out error while CRD still exists.
- ~Added hook to delete CRD before reinstall - still not sure if this is the preferable path~ Killed this. I think we should go with the route least likely to suddenly wipe someone's setup
- Generic helm chart cleanup

Not sure which of the paths mentioned in linked issue is preferred - delete CRD w/ deployment, or delete CRD before attempting to install?