### PR TITLE
Make the controller use Kubernetes' CA bundle.

### DIFF
--- a/chart/keda/templates/deployment.yaml
+++ b/chart/keda/templates/deployment.yaml
@@ -33,5 +33,8 @@ spec:
           name: https
         - containerPort: 8080
           name: http
+        env:
+        - name: SSL_CERT_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       imagePullSecrets:
       - name: {{ template "keda.fullname" . }}-docker-auth

--- a/deploy/KedaScaleController.yaml
+++ b/deploy/KedaScaleController.yaml
@@ -93,6 +93,9 @@ spec:
           name: https
         - containerPort: 8080
           name: http
+        env:
+        - name: SSL_CERT_FILE
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         volumeMounts:
         - mountPath: /tmp
           name: temp-vol


### PR DESCRIPTION
In environments where the certificates are actually verified, the spawned server should use Kubernetes' common CA bundle. This failed, for instance, while installing on OCP4.