### PR TITLE
Add deploymentName label to SBQ scaled object example

### DIFF
--- a/examples/azurequeue_scaledobject.yaml
+++ b/examples/azurequeue_scaledobject.yaml
@@ -3,6 +3,8 @@ kind: ScaledObject
 metadata:
   name: azure-queue-scaledobject
   namespace: default
+  label:
+    deploymentName: azurequeue-function
 spec:
   scaleTargetRef:
     deploymentName: azurequeue-function

--- a/examples/azureservicebusqueue_scaledobject.yaml
+++ b/examples/azureservicebusqueue_scaledobject.yaml
@@ -3,6 +3,8 @@ kind: ScaledObject
 metadata:
   name: azure-servicebus-queue-scaledobject
   namespace: default
+  label:
+    deploymentName: azure-servicebus-queue-function
 spec:
   scaleTargetRef:
     deploymentName: azure-servicebus-queue-function

--- a/examples/kafka_scaledobject.yaml
+++ b/examples/kafka_scaledobject.yaml
@@ -3,6 +3,8 @@ kind: ScaledObject
 metadata:
   name: kafka-scaledobject
   namespace: default
+  label:
+    deploymentName: azure-functions-deployment
 spec:
   scaleTargetRef:
     deploymentName: azure-functions-deployment

--- a/examples/rabbitmq_scaledobject.yaml
+++ b/examples/rabbitmq_scaledobject.yaml
@@ -3,6 +3,8 @@ kind: ScaledObject
 metadata:
   name: rabbitmq-scaledobject
   namespace: default
+  label:
+    deploymentName: rabbitmq-deployment
 spec:
   scaleTargetRef:
     deploymentName: rabbitmq-deployment

--- a/examples/scaledobject.yaml
+++ b/examples/scaledobject.yaml
@@ -2,6 +2,8 @@ apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:
   name: functions-example-scaledobject
+  label:
+    deploymentName: functions-example-deployment
 spec:
   scaleTargetRef:
     deploymentName: functions-example-deployment


### PR DESCRIPTION
Updates the example yaml for the ScaledObject to include the deploymentName label.