### PR TITLE
Make glog level configurable

### DIFF
--- a/chart/keda/templates/deployment.yaml
+++ b/chart/keda/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - /adapter
         - --secure-port=6443
         - --logtostderr=true
-        - --v=10
+        - --v={{ .Values.glogLevel }}
         - --log-level={{ .Values.logLevel }}
         ports:
         - containerPort: 6443

--- a/chart/keda/values.yaml
+++ b/chart/keda/values.yaml
@@ -23,3 +23,6 @@ serviceAccount:
   name:
 
 logLevel: info
+
+#set to a higher verbosity for detailed apiservice logs
+glogLevel: 2


### PR DESCRIPTION
Avoid verbose apiserver logs by default.