### PR TITLE
kafka - don't scale beyond number of partitions

### DIFF
--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -227,7 +227,11 @@ func (s *kafkaScaler) GetMetrics(ctx context.Context, merticName string, metricS
 		totalLag += lag
 	}
 
-	// We should find a way to not scale beyond the number of partitions
+	// don't scale out beyond the number of partitions
+	if (totalLag / s.metadata.lagThreshold) > int64(len(partitions)) {
+		totalLag = int64(len(partitions)) * s.metadata.lagThreshold
+	}
+
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: merticName,
 		Value:      *resource.NewQuantity(int64(totalLag), resource.DecimalSI),


### PR DESCRIPTION
We don't want to scale beyond the number of available partitions, as that would result in pods that don't actually consume events.

This PR sets the lag threshold to not allow for more pods than needed.