### PR TITLE
Use configmap/secret key names instead of env var name in function calls

### DIFF
--- a/pkg/handler/scale_handler.go
+++ b/pkg/handler/scale_handler.go
@@ -379,7 +379,7 @@ func (h *ScaleHandler) resolveEnv(deployment *apps_v1.Deployment) (map[string]st
 				// env is an EnvVarSource, that can be one of the 4 below
 				if envVar.ValueFrom.SecretKeyRef != nil {
 					// env is a secret selector
-					value, err = h.resolveSecretValue(envVar.ValueFrom.SecretKeyRef, envVar.Name, deployment.GetNamespace())
+					value, err = h.resolveSecretValue(envVar.ValueFrom.SecretKeyRef, envVar.ValueFrom.SecretKeyRef.Key, deployment.GetNamespace())
 					if err != nil {
 						log.Errorf("Error resolving secret name %s for env %s in deployment %s/%s. Skipping",
 							envVar.ValueFrom.SecretKeyRef,
@@ -390,7 +390,7 @@ func (h *ScaleHandler) resolveEnv(deployment *apps_v1.Deployment) (map[string]st
 					}
 				} else if envVar.ValueFrom.ConfigMapKeyRef != nil {
 					// env is a configMap selector
-					value, err = h.resolveConfigValue(envVar.ValueFrom.ConfigMapKeyRef, envVar.Name, deployment.GetNamespace())
+					value, err = h.resolveConfigValue(envVar.ValueFrom.ConfigMapKeyRef, envVar.ValueFrom.ConfigMapKeyRef.Key, deployment.GetNamespace())
 					if err != nil {
 						log.Errorf("Error resolving config %s for env %s in deployment %s/%s. Skippking",
 							envVar.ValueFrom.ConfigMapKeyRef,


### PR DESCRIPTION
Fixes the issue causing #146 

There's a bug in how the scale handler resolves environment variables that are set using 'valueFrom' instead of 'envFrom' - it tries to resolve using the env var name as the key instead of the specified secret/configmap key.