### PR TITLE
Allow disable custom metrics

### DIFF
--- a/chart/keda/templates/customAPIService.yaml
+++ b/chart/keda/templates/customAPIService.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.customMetrics.create }}
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
@@ -11,3 +12,4 @@ spec:
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100
+{{- end -}}

--- a/chart/keda/values.yaml
+++ b/chart/keda/values.yaml
@@ -22,3 +22,6 @@ logLevel: info
 
 #set to a higher verbosity for detailed apiservice logs
 glogLevel: 2
+
+customMetrics:
+  create: true


### PR DESCRIPTION
Let the user disable installing custom metrics APIService.

**config.yaml example**

```yaml
customMetrics:
  create: false
```