### PR TITLE
Added test for RabbitMQ

### DIFF
--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -13,13 +13,13 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	// nothing passed
 	{map[string]string{}, true},
 	// properly formed metadata
-	{map[string]string{"queueLength": "10", "queueName": "sample", "host": "redis://redis"}, false},
+	{map[string]string{"queueLength": "10", "queueName": "sample", "host": "amqp://rabbitmq"}, false},
 	// malformed queueLength
-	{map[string]string{"queueLength": "AA", "queueName": "sample", "host": "redis://redis"}, true},
+	{map[string]string{"queueLength": "AA", "queueName": "sample", "host": "amqp://rabbitmq"}, true},
 	// missing host
 	{map[string]string{"queueLength": "AA", "queueName": "sample"}, true},
 	// missing queueName
-	{map[string]string{"queueLength": "10", "host": "redis://redis"}, true},
+	{map[string]string{"queueLength": "10", "host": "amqp://rabbitmq"}, true},
 }
 
 func TestRabbitMQParseMetadata(t *testing.T) {

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -1,0 +1,35 @@
+package scalers
+
+import (
+	"testing"
+)
+
+type parseRabbitMQMetadataTestData struct {
+	metadata map[string]string
+	isError  bool
+}
+
+var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
+	// nothing passed
+	{map[string]string{}, true},
+	// properly formed metadata
+	{map[string]string{"queueLength": "10", "queueName": "sample", "host": "redis://redis"}, false},
+	// malformed queueLength
+	{map[string]string{"queueLength": "AA", "queueName": "sample", "host": "redis://redis"}, true},
+	// missing host
+	{map[string]string{"queueLength": "AA", "queueName": "sample"}, true},
+	// missing queueName
+	{map[string]string{"queueLength": "10", "host": "redis://redis"}, true},
+}
+
+func TestRabbitMQParseMetadata(t *testing.T) {
+	for _, testData := range testRabbitMQMetadata {
+		_, err := parseRabbitMQMetadata(testData.metadata)
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+	}
+}


### PR DESCRIPTION
The RabbitMQ Scaler is missing tests that check the metadata. These tests are present for all other scalers. Opened an [issue](https://github.com/kedacore/keda/issues/267)