### PR TITLE
Fix variable shadow in azure_queue.go

### DIFF
--- a/pkg/scalers/azure_queue.go
+++ b/pkg/scalers/azure_queue.go
@@ -18,7 +18,7 @@ func GetAzureQueueLength(ctx context.Context, usePodIdentity bool, connectionStr
 	if !usePodIdentity {
 
 		var accountKey string
-		_, accountName, accountKey, _, err := ParseAzureStorageConnectionString(connectionString)
+		_, accountName, accountKey, _, err = ParseAzureStorageConnectionString(connectionString)
 
 		if err != nil {
 			return -1, err


### PR DESCRIPTION
Found during nightly E2E run. https://circleci.com/gh/kedacore/keda/455

the `:=` is defining a new `accountName` var in the `if !usePodIdentity` scope. If we're not using AAD identity, `accountName` will always be an empty string and cause KEDA to log this error 


```
time="2019-07-15T18:43:08Z" level=error msg="error -> github.com/kedacore/keda/vendor/github.com/Azure/azure-pipeline-go/pipeline.newDefaultHTTPClientFactory.func1.1, /go/src/github.com/kedacore/keda/vendor/github.com/Azure/azure-pipeline-go/pipeline/core.go:234\nHTTP request failed\n\nPut https://.queue.core.windows.net/queue-name?timeout=61: dial tcp: lookup .queue.core.windows.net: no such host\n"

time="2019-07-15T18:43:46Z" level=error msg="error -> github.com/kedacore/keda/vendor/github.com/Azure/azure-pipeline-go/pipeline.newDefaultHTTPClientFactory.func1.1, /go/src/github.com/kedacore/keda/vendor/github.com/Azure/azure-pipeline-go/pipeline/core.go:234\nHTTP request failed\n\nPut https://.queue.core.windows.net/queue-name?timeout=61: dial tcp: lookup .queue.core.windows.net: no such host\n"
```