### PR TITLE
Fixing End-to-End test failure.

### DIFF
--- a/pkg/scalers/azure_queue.go
+++ b/pkg/scalers/azure_queue.go
@@ -19,8 +19,8 @@ func GetAzureQueueLength(ctx context.Context, usePodIdentity bool, connectionStr
 
 		var accountKey string
 
-		_, accountName, accountKey, _, err := ParseAzureStorageConnectionString(connectionString)
-		
+		_, accountName, accountKey, _, err = ParseAzureStorageConnectionString(connectionString)
+
 		if err != nil {
 			return -1, err
 		}


### PR DESCRIPTION
Using the walrus (:=) in this change doesn't work, since all the
variables are already declared, or are undeclarable (_).

This causes the end-to-end test to fail, since the scalar can't parse
the azure queue credentials, used in the e2e test.