### PR TITLE
Helm - No longer use fixed name for HPA ClusterRoleBinding

### DIFF
--- a/chart/keda/templates/hpa-role-binding.yaml
+++ b/chart/keda/templates/hpa-role-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: hpa-controller-custom-metrics
+  name: {{ template "keda.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
No longer use fixed name for HPA ClusterRoleBinding but use `{{ template "keda.fullname" . }}` like our other objects.

An option would also be to use a fixed prefix with the name at the end such as `hpa-controller-custom-metrics-keda-{{ .Release.Name }}`

Relates to #371

:warning: This has not been tested due to #369