### PR TITLE
Fixed ClusterRoleBinding for HPA and fixed EOL

### DIFF
--- a/chart/keda/templates/hpa-role-binding.yaml
+++ b/chart/keda/templates/hpa-role-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "keda.fullname" . }}
+  name: {{ template "keda.fullname" . }}-hpa-controller-custom-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
* if you enabled rbac for this helm chart it resulted creation of 2 ClusterRoleBinding's with the same name
* converted hpa-role-binding.yaml to Unix EOL