### PR TITLE
Don't fail resolving env if could'nt read a value

### DIFF
--- a/pkg/handler/scale_handler.go
+++ b/pkg/handler/scale_handler.go
@@ -408,7 +408,8 @@ func (h *ScaleHandler) resolveEnv(container *core_v1.Container, namespace string
 							namespace)
 					}
 				} else {
-					return nil, fmt.Errorf("cannot resolve env %s to a value. fieldRef and resourceFieldRef env are skipped", envVar.Name)
+					log.Warningf("cannot resolve env %s to a value. fieldRef and resourceFieldRef env are skipped", envVar.Name)
+					continue
 				}
 
 			}


### PR DESCRIPTION
This should fix issue #319.

Without this PR, resolving the environment would fail if the parser comes across a `fieldRef` and `resourceFieldRef`. Instead, we should just ignore them.

When I checked the history it seems that we already used to skip them, but for some reason the code has changed to return nil for the whole env. Check commit [495eed](https://github.com/kedacore/keda/commit/495eed4f511dda2cd7e2e6ef447caba84f332586), maybe @Aarthisk can validate this PR.