### PR TITLE
Returning podAuth so it doesn't get overridden

### DIFF
--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -104,7 +104,7 @@ func parseAzureQueueMetadata(metadata, resolvedEnv, authParams map[string]string
 		return nil, "", fmt.Errorf("pod identity %s not supported for azure storage queues", podAuth)
 	}
 
-	return &meta, "", nil
+	return &meta, podAuth, nil
 }
 
 // GetScaleDecision is a func


### PR DESCRIPTION
parseAzureQueueMetadata was not returning the podAuth setting, which was overriding podIdentity, and then getting set as part of the azureQueueMetadata{} object.

@ahmelsayed for visibility / review