### PR TITLE
Metrics adapter: change location where certs are stored

### DIFF
--- a/build/Dockerfile.adapter
+++ b/build/Dockerfile.adapter
@@ -8,11 +8,9 @@ COPY build/_output/bin/keda-adapter ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN /usr/local/bin/user_setup && \
-    mkdir /adapter && \
-    chmod 777 /adapter && \
+    mkdir /apiserver.local.config && \
+    chmod 777 /apiserver.local.config && \
     chmod +x ${OPERATOR}
-
-WORKDIR /adapter
 
 ENTRYPOINT ["/usr/local/bin/entrypoint", "--secure-port=6443", "--logtostderr=true", "--v=0"]
 


### PR DESCRIPTION
This change allows us to use [generate certs function in Operator Lifecycly Manager](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#your-api-services), if operator is deployed through OLM.

This is not a breaking change for other deployment types.