### PR TITLE
ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -341,3 +341,6 @@ config
 
 # VSCode specific files
 .vscode
+
+# GO Vendor
+vendor


### PR DESCRIPTION
Merge once  #412 is merged.

`vendor` directory should be ignored, if is accidentaly generated locally.