### PR TITLE
fix e2e tests

### DIFF
--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -43,7 +43,7 @@ test.serial('Deploy Keda', t => {
     if (sh.exec('kubectl apply -f ../deploy/').code !== 0) {
         t.fail('error deploying keda. ' + result);
     }
-    t.pass('Keda deployed successfully using KedaScaleController.yaml');
+    t.pass('Keda deployed successfully using crds and yaml');
 });
 
 test.serial('verifyKeda', t => {

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -34,7 +34,13 @@ test.serial('Deploy Keda', t => {
         }
     }
 
-    if (sh.exec('kubectl apply -f ../deploy/KedaScaleController.yaml').code !== 0) {
+    if (sh.exec('kubectl apply -f ../deploy/crds/keda.k8s.io_scaledobjects_crd.yaml').code !== 0) {
+        t.fail('error deploying keda. ' + result);
+    }
+    if (sh.exec('kubectl apply -f ../deploy/crds/keda.k8s.io_triggerauthentications_crd.yaml').code !== 0) {
+        t.fail('error deploying keda. ' + result);
+    }
+    if (sh.exec('kubectl apply -f ../deploy/').code !== 0) {
         t.fail('error deploying keda. ' + result);
     }
     t.pass('Keda deployed successfully using KedaScaleController.yaml');


### PR DESCRIPTION
When KEDA was refactored to use operator-sdk, deploying KEDA was changed from deploy/KedaScaleController.yaml to 
```
kubectl apply -f deploy/crds/keda.k8s.io_scaledobjects_crd.yaml
kubectl apply -f deploy/crds/keda.k8s.io_triggerauthentications_crd.yaml
kubectl apply -f deploy/
```

Looks like the e2e tests were missed during the refactor - I've changed them to reflect that, since they're still trying to deploy KedaScaleController.yaml, which does not exist anymore.