### PR TITLE
Fix sample for job ScaledObject

### DIFF
--- a/examples/azurequeue_scaledobject_jobs.yaml
+++ b/examples/azurequeue_scaledobject_jobs.yaml
@@ -11,20 +11,23 @@ spec:
   jobTargetRef:
     parallelism: 1
     completions: 1
-    activeDeadlineSeconds: 60
+    activeDeadlineSeconds: 600
     backoffLimit: 6
     template:
-      containers:
-      - name: consumer-job
-        image: sgricci/queue-consumer
-        env:
-        - name: AzureWebJobsStorage
-          valueFrom:
-            secretKeyRef:
-              name: secrets
-              key: AzureWebJobsStorage
+      spec:
+        containers:
+        - name: consumer-job
+          image: tomconte/queue-consumer
+          env:
+          - name: AzureWebJobsStorage
+            valueFrom:
+              secretKeyRef:
+                name: secrets
+                key: AzureWebJobsStorage
+          - name: QUEUE_NAME
+            value: keda-queue
   triggers:
   - type: azure-queue
     metadata:
-      queueName: queue-name
+      queueName: keda-queue
       connection: AzureWebJobsStorage


### PR DESCRIPTION
I am proposing a fix to the sample for a job ScaledObject (it was missing the template.spec element).

It also now points to a working sample container image that reads one message from the queue. 
