### PR TITLE
Fix azure queue auth test scaling to one replica

### DIFF
--- a/tests/scalers/azure-queue-trigger-auth.test.ts
+++ b/tests/scalers/azure-queue-trigger-auth.test.ts
@@ -96,7 +96,7 @@ test.after.always.cb("clean up azure-queue deployment", t => {
     sh.exec(`kubectl delete ${resource} --namespace ${defaultNamespace}`);
   }
   sh.exec(`kubectl delete namespace ${defaultNamespace}`);
-  t.end()
+
   // delete test queue
   const queueSvc = azure.createQueueService(connectionString);
   queueSvc.deleteQueueIfExists(queueName, err => {

--- a/tests/scalers/azure-queue-trigger-auth.test.ts
+++ b/tests/scalers/azure-queue-trigger-auth.test.ts
@@ -4,7 +4,6 @@ import * as fs from "fs";
 import * as sh from "shelljs";
 import * as tmp from "tmp";
 import test from "ava";
-import { exec } from "child_process";
 
 const defaultNamespace = "azure-queue-auth-test";
 const queueName = "auth-queue-name";
@@ -45,18 +44,6 @@ test.serial.cb(
   t => {
     const queueSvc = azure.createQueueService(connectionString);
     queueSvc.messageEncoder = new azure.QueueMessageEncoder.TextBase64QueueMessageEncoder();
-    /*
-    queueSvc.createQueueIfNotExists(queueName, err => {
-      t.falsy(err, "unable to create queue");
-      for (let n = 0; n < 20; n++) {
-        queueSvc.createMessage(queueName, `test ${n}`, function(error) {
-          if(!error) {
-            // Message inserted
-          }
-        });
-      }
-    });
-    */
     queueSvc.createQueueIfNotExists(queueName, err => {
       t.falsy(err, "unable to create queue");
       for (let n = 0; n < 20; n++) {


### PR DESCRIPTION
Fix azure queue auth test scaling to one replica.

old tests were checking for replicas inside of the callback that would insert messages into a queue. It was not until the callback completed that the deployment would replicate. This fix will complete the insertion of queue messages, then check for replicas, which lets e2e test pass.