### PR TITLE
Proposal for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Report a bug
+about: Create a report to help us improve
+labels: bug
+---
+
+A clear and concise description of what the bug is.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+
+  1.
+  2.
+  3.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Scaler(s):

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -20,6 +20,6 @@ A clear and concise description of what the bug is.
 
 ## Specifications
 
-  - Version:
-  - Platform:
-  - Scaler(s):
+  - **Version:** *Please elaborate*
+  - **Platform:** *Please elaborate*
+  - **Scaler(s):** *Please elaborate*

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: needs-discussion
+---
+
+A clear and concise description of what you want to happen.
+
+### Use-Case
+
+Tell us more what you'd like to achieve
+
+### Specification
+
+- [ ] Demand #1

--- a/.github/ISSUE_TEMPLATE/Suggest_scaler.md
+++ b/.github/ISSUE_TEMPLATE/Suggest_scaler.md
@@ -1,0 +1,11 @@
+---
+name: Suggest a new scaler
+about: Suggest a new scaler to add
+labels: scaler, needs-discussion
+---
+
+A clear and concise description of what scaler you'd like to use and how you'd want to use it:
+
+  - **Scaler Source:** *Please elaborate*
+  - **How do you want to scale:** *Please elaborate*
+  - **Authentication:** *Please elaborate*


### PR DESCRIPTION
Proposal for issue templates that would help customers request certain features or report defects.

Experience would be similar to [Promitor](https://github.com/tomkerkhove/promitor/issues/new/choose), although a bit adapted:
![image](https://user-images.githubusercontent.com/4345663/68852565-71ca3000-06d8-11ea-9c90-572a2f7a5ca5.png)

Would also suggest to install the [`triage-new-issues`](https://github.com/apps/triage-new-issues) GitHub App for the  keep the "Open a blank issue" option.

Security is left out but tracked in #455
