### PR TITLE
Make keda pkg output name explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build: build-adapter build-controller
 .PHONY: build-controller
 build-controller: generate-api pkg/scalers/liiklus/LiiklusService.pb.go
 	$(GO_BUILD_VARS) operator-sdk build $(IMAGE_CONTROLLER) \
-		--go-build-args "-ldflags -X=main.GitCommit=$(GIT_COMMIT) -o build/_output/bin/keda2"
+		--go-build-args "-ldflags -X=main.GitCommit=$(GIT_COMMIT) -o build/_output/bin/keda"
 
 .PHONY: build-adapter
 build-adapter: generate-api pkg/scalers/liiklus/LiiklusService.pb.go

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ build: build-adapter build-controller
 
 .PHONY: build-controller
 build-controller: generate-api pkg/scalers/liiklus/LiiklusService.pb.go
-	$(GO_BUILD_VARS) operator-sdk build $(IMAGE_CONTROLLER) --verbose \
+	$(GO_BUILD_VARS) operator-sdk build $(IMAGE_CONTROLLER) \
 		--go-build-args "-ldflags -X=main.GitCommit=$(GIT_COMMIT) -o build/_output/bin/keda2"
 
 .PHONY: build-adapter

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ build: build-adapter build-controller
 
 .PHONY: build-controller
 build-controller: generate-api pkg/scalers/liiklus/LiiklusService.pb.go
-	$(GO_BUILD_VARS) operator-sdk build $(IMAGE_CONTROLLER) \
-		--go-build-args "-ldflags -X=main.GitCommit=$(GIT_COMMIT)"
+	$(GO_BUILD_VARS) operator-sdk build $(IMAGE_CONTROLLER) --verbose \
+		--go-build-args "-ldflags -X=main.GitCommit=$(GIT_COMMIT) -o build/_output/bin/keda2"
 
 .PHONY: build-adapter
 build-adapter: generate-api pkg/scalers/liiklus/LiiklusService.pb.go


### PR DESCRIPTION
The `operator-sdk build` command defaults to building a pkg that matches the folder name. 

Normally if you fork the keda repo and clone it to your machine, the folder name would be `keda`, so when building the Controller in `Makefile`, the pkg will be `keda` and there will be no problem. 
But if you rename the folder to something else (like I did :face_palm:) then the pkg will match the folder name and it won’t be `keda`. 
This breaks the `docker build` command in the Controller's Dockerfile, because it’s expecting the pkg name to be `keda`.

This PR makes the output pkg explicitly `keda` rather than matching the folder name.

Not a huge thing as not so many people will rename the repo folder, but it's better be explicit just like we are explicit in building the `keda-adapter`