### PR TITLE
add default log level for operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,6 +22,8 @@ spec:
           image: docker.io/kedacore/keda:1.0.0
           command:
           - keda
+          args:
+          - '--zap-level=info'
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Adding default log level to deployment.yaml. So users can easily find the right place, in case they would need to change the log level.

Fixes https://github.com/kedacore/keda/issues/467