### PR TITLE
Add unique name for aws-sqs-queue external metrics

### DIFF
--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -31,6 +32,7 @@ type awsSqsQueueScaler struct {
 type awsSqsQueueMetadata struct {
 	targetQueueLength int
 	queueURL          string
+	queueName         string
 	awsRegion         string
 	awsAuthorization  awsAuthorizationMetadata
 }
@@ -69,6 +71,16 @@ func parseAwsSqsQueueMetadata(metadata, resolvedEnv, authParams map[string]strin
 		return nil, fmt.Errorf("no queueURL given")
 	}
 
+	queueName := meta.queueURL
+	i := strings.LastIndex(queueName, "/")
+	if i > 0 {
+		meta.queueName = queueName[i+1:]
+	}
+
+	if len(meta.queueName) > 0 {
+		return nil, fmt.Errorf("cannot get queueName from queueURL")
+	}
+
 	if val, ok := metadata["awsRegion"]; ok && val != "" {
 		meta.awsRegion = val
 	} else {
@@ -102,7 +114,8 @@ func (s *awsSqsQueueScaler) Close() error {
 
 func (s *awsSqsQueueScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueLength), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: awsSqsQueueMetricName, TargetAverageValue: targetQueueLengthQty}
+	externalMetric := &v2beta1.ExternalMetricSource{MetricName: fmt.Sprintf("%s-%s-%s", "AWS-SQS-Queue", awsSqsQueueMetricName, s.metadata.queueName),
+		TargetAverageValue: targetQueueLengthQty}
 	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
 	return []v2beta1.MetricSpec{metricSpec}
 }


### PR DESCRIPTION
There is a bug where the external metric name was not unique. I have added some more meta data to the external metric name.