### PR TITLE
Provide capability to subscribe for standup meetings via Google Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can find several samples for various event sources [here](https://github.com
 
 If interested in contributing or participating in the direction of KEDA, you can join our community meetings.
 
-* **Meeting time:** Weekly Thurs 18:00 UTC. ([Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC))*
+* **Meeting time:** Weekly Thurs 18:00 UTC. ([Subscribe to Google Agenda](https://calendar.google.com/calendar?cid=bjE0bjJtNWM0MHVmam1ob2ExcTgwdXVkOThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ) | [Convert to your timezone](https://www.thetimezoneconverter.com/?t=18:00&tz=UTC))*
 * **Zoom link:** [https://zoom.us/j/150360492 ](https://zoom.us/j/150360492 )
 * **Meeting agenda:** [https://hackmd.io/s/r127ErYiN](https://hackmd.io/s/r127ErYiN)
 


### PR DESCRIPTION
Provide capability to subscribe for standup meetings via Google Calendar.

This allows folks to just pull in the agenda in their calendar client and see if there is a meeting or not, for example when it's cancelled due to Thanksgiving.

Relates to #472