### PR TITLE
Update CI and test to build/test master tag

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,37 @@
+name: release build
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  build:
+    name: Push Release
+    runs-on: ubuntu-latest
+    # build-tools is built from ../../tools/build-tools.Dockerfile
+    container: kedacore/build-tools:latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Go modules cache
+        uses: actions/cache@v1
+        with:
+          path: /go/pkg
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Login to Docker Hub
+        env:
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+        run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
+
+      - name: Get the image tag
+        id: get_image_tag
+        run: echo ::set-output name=IMAGE_TAG::${GITHUB_REF#refs/tags/v}
+
+      - name: Publish
+        run: make publish IMAGE_TAG=$VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ##################################################
 # Variables                                      #
 ##################################################
-IMAGE_TAG      ?= 1.0.0
+IMAGE_TAG      ?= master
 IMAGE_REGISTRY ?= docker.io
 IMAGE_REPO     ?= kedacore
 
@@ -40,7 +40,7 @@ e2e-test:
 		--subscription $(AZURE_SUBSCRIPTION) \
 		--resource-group $(AZURE_RESOURCE_GROUP)
 	npm install --prefix tests
-	npm test --verbose --prefix tests
+	IMAGE_CONTROLLER=$(IMAGE_CONTROLLER) IMAGE_ADAPTER=$(IMAGE_ADAPTER) npm test --verbose --prefix tests
 
 ##################################################
 # PUBLISH                                        #

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -49,6 +49,32 @@ test.serial('Deploy Keda', t => {
 })
 
 test.serial('verifyKeda', t => {
+  const controllerImage = process.env.IMAGE_CONTROLLER || 'docker.io/kedacore/keda:master'
+  const adapterImage = process.env.IMAGE_ADAPTER || 'docker.io/kedacore/keda-metrics-adapter:master'
+  let result = sh.exec('kubectl scale deployment.apps/keda-operator --namespace keda --replicas=0')
+  if (result.code !== 0) {
+    t.fail(`error scaling keda to 0. ${result}`)
+  }
+
+  result = sh.exec(
+    `kubectl set image deployment.apps/keda-operator --namespace keda keda-operator=${controllerImage}`
+  )
+  if (result.code !== 0) {
+    t.fail(`error updating keda image. ${result}`)
+  }
+
+  result = sh.exec(
+    `kubectl set image deployment.apps/keda-operator --namespace keda keda-metrics-apiserver=${adapterImage}`
+  )
+  if (result.code !== 0) {
+    t.fail(`error updating keda image. ${result}`)
+  }
+
+  result = sh.exec('kubectl scale deployment.apps/keda-operator --namespace keda --replicas=1')
+  if (result.code !== 0) {
+    t.fail(`error scaling keda to 1. ${result}`)
+  }
+
   let success = false
   for (let i = 0; i < 20; i++) {
     let result = sh.exec(


### PR DESCRIPTION
Closes #489

This PR: 

- updated CI to push to `:master` instead of the current latest version
- updates e2e tests to use that image
- adds a new github workflow for version tags. When you create a `v2.0.0` tag, this workflow will create a corresponding `docker.io/kedacore/keda:2.0.0` and `docker.io/kedacore/keda-metrics-adapter:2.0.0`

note: versions in `deploy/operator.yml` and `version/version.go` still need to be updated manually when we want to have a release