### PR TITLE
Event Hub scalar expansion to work with Java and C# applications

### DIFF
--- a/pkg/scalers/azure_eventhub.go
+++ b/pkg/scalers/azure_eventhub.go
@@ -86,14 +86,15 @@ func GetCheckpointFromBlobStorage(ctx context.Context, partitionID string, event
 	}
 
 	// TODO: add more ways to read from different types of storage and read checkpoints/leases written in different JSON formats
+	var u *url.URL
 	// Checking blob store for C# and Java applications
 	if eventHubMetadata.blobContainer != "" {
 		// URL format - <endpointProtocol>://<storageAccountName>.blob.<endpointSuffix>/<blobContainer>/<eventHubConsumerGroup>/<partitionID>
-		u, _ := url.Parse(fmt.Sprintf("%s://%s.blob.%s/%s/%s/%s", endpointProtocol, storageAccountName, endpointSuffix, eventHubMetadata.blobContainer, eventHubMetadata.eventHubConsumerGroup, partitionID))
+		u, _ = url.Parse(fmt.Sprintf("%s://%s.blob.%s/%s/%s/%s", endpointProtocol, storageAccountName, endpointSuffix, eventHubMetadata.blobContainer, eventHubMetadata.eventHubConsumerGroup, partitionID))
 	} else {
 		// Checking blob store for Azure functions
 		// URL format - <endpointProtocol>://<storageAccountName>.blob.<endpointSuffix>/azure-webjobs-eventhub/<eventHubNamespace>/<eventHubName>/<eventHubConsumerGroup>/<partitionID>
-		u, _ := url.Parse(fmt.Sprintf("%s://%s.blob.%s/azure-webjobs-eventhub/%s/%s/%s/%s", endpointProtocol, storageAccountName, endpointSuffix, eventHubNamespace, eventHubName, eventHubMetadata.eventHubConsumerGroup, partitionID))
+		u, _ = url.Parse(fmt.Sprintf("%s://%s.blob.%s/azure-webjobs-eventhub/%s/%s/%s/%s", endpointProtocol, storageAccountName, endpointSuffix, eventHubNamespace, eventHubName, eventHubMetadata.eventHubConsumerGroup, partitionID))
 	}
 
 	_, cred, err := GetStorageCredentials(eventHubMetadata.storageConnection)

--- a/pkg/scalers/azure_eventhub.go
+++ b/pkg/scalers/azure_eventhub.go
@@ -29,7 +29,7 @@ type baseCheckpoint struct {
 
 // Checkpoint is the object eventhub processor stores in storage
 // for checkpointing event processors. This matches the object
-// stored by the eventhub C# sdk
+// stored by the eventhub C# sdk and Java sdk
 type Checkpoint struct {
 	baseCheckpoint
 	PartitionID    string `json:"PartitionId"`
@@ -86,7 +86,15 @@ func GetCheckpointFromBlobStorage(ctx context.Context, partitionID string, event
 	}
 
 	// TODO: add more ways to read from different types of storage and read checkpoints/leases written in different JSON formats
-	u, _ := url.Parse(fmt.Sprintf("%s://%s.blob.%s/azure-webjobs-eventhub/%s/%s/%s/%s", endpointProtocol, storageAccountName, endpointSuffix, eventHubNamespace, eventHubName, eventHubMetadata.eventHubConsumerGroup, partitionID))
+	// Checking blob store for C# and Java applications
+	if eventHubMetadata.blobContainer != "" {
+		// URL format - <endpointProtocol>://<storageAccountName>.blob.<endpointSuffix>/<blobContainer>/<eventHubConsumerGroup>/<partitionID>
+		u, _ := url.Parse(fmt.Sprintf("%s://%s.blob.%s/%s/%s/%s", endpointProtocol, storageAccountName, endpointSuffix, eventHubMetadata.blobContainer, eventHubMetadata.eventHubConsumerGroup, partitionID))
+	} else {
+		// Checking blob store for Azure functions
+		// URL format - <endpointProtocol>://<storageAccountName>.blob.<endpointSuffix>/azure-webjobs-eventhub/<eventHubNamespace>/<eventHubName>/<eventHubConsumerGroup>/<partitionID>
+		u, _ := url.Parse(fmt.Sprintf("%s://%s.blob.%s/azure-webjobs-eventhub/%s/%s/%s/%s", endpointProtocol, storageAccountName, endpointSuffix, eventHubNamespace, eventHubName, eventHubMetadata.eventHubConsumerGroup, partitionID))
+	}
 
 	_, cred, err := GetStorageCredentials(eventHubMetadata.storageConnection)
 	if err != nil {

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -23,6 +23,7 @@ const (
 	defaultEventHubConsumerGroup     = "$Default"
 	defaultEventHubConnectionSetting = "EventHub"
 	defaultStorageConnectionSetting  = "AzureWebJobsStorage"
+	defaultBlobContainer             = ""
 )
 
 var eventhubLog = logf.Log.WithName("azure_eventhub_scaler")
@@ -38,6 +39,7 @@ type EventHubMetadata struct {
 	eventHubConsumerGroup string
 	threshold             int64
 	storageConnection     string
+	blobContainer         string
 }
 
 // NewAzureEventHubScaler creates a new scaler for eventHub
@@ -103,6 +105,11 @@ func parseAzureEventHubMetadata(metadata, resolvedEnv map[string]string) (*Event
 	meta.eventHubConsumerGroup = defaultEventHubConsumerGroup
 	if val, ok := metadata["consumerGroup"]; ok {
 		meta.eventHubConsumerGroup = val
+	}
+
+	meta.blobContainer = defaultBlobContainer
+	if val, ok := metadata["blobContainer"]; ok {
+		meta.blobContainer = val
 	}
 
 	return &meta, nil

--- a/pkg/scalers/azure_eventhub_test.go
+++ b/pkg/scalers/azure_eventhub_test.go
@@ -48,6 +48,8 @@ var parseEventHubMetadataDataset = []parseEventHubMetadataTestData{
 	{map[string]string{"storageConnection": storageConnectionSetting, "connection": eventHubConnectionSetting, "unprocessedEventThreshold": "15"}, false},
 	// missing unprocessed event threshold - should replace with default
 	{map[string]string{"storageConnection": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connection": eventHubConnectionSetting}, false},
+	// added blob container details
+	{map[string]string{"storageConnection": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connection": eventHubConnectionSetting, "blobContainer": testContainerName}, false},
 }
 
 var testEventHubScaler = AzureEventHubScaler{


### PR DESCRIPTION
Solves #516 

- Made changes to azure_eventhub.go, azure_eventhub_scaler.go, azure_eventhub_test.go
- Added compatibility for reading azure blob store uri for Java applications using EventProcessorHost SDK for Event Hubs