### PR TITLE
Total running Jobs must not exceed maxScale - Running jobs

### DIFF
--- a/pkg/handler/scale_jobs.go
+++ b/pkg/handler/scale_jobs.go
@@ -132,9 +132,5 @@ func (h *ScaleHandler) getRunningJobCount(scaledObject *kedav1alpha1.ScaledObjec
 		}
 	}
 
-	if runningJobs > maxScale {
-		runningJobs = maxScale
-	}
-
 	return runningJobs
 }

--- a/pkg/handler/scale_jobs.go
+++ b/pkg/handler/scale_jobs.go
@@ -16,6 +16,13 @@ import (
 func (h *ScaleHandler) scaleJobs(scaledObject *kedav1alpha1.ScaledObject, isActive bool, scaleTo int64, maxScale int64) {
 	runningJobCount := h.getRunningJobCount(scaledObject, maxScale)
 	h.logger.Info("Scaling Jobs", "Number of running Jobs ", runningJobCount)
+
+	var effectiveMaxScale int64
+	effectiveMaxScale = maxScale - runningJobCount
+	if effectiveMaxScale < 0 {
+		effectiveMaxScale = 0
+	}
+
 	h.logger.Info("Scaling Jobs")
 
 	if isActive {
@@ -23,7 +30,7 @@ func (h *ScaleHandler) scaleJobs(scaledObject *kedav1alpha1.ScaledObject, isActi
 		now := metav1.Now()
 		scaledObject.Status.LastActiveTime = &now
 		h.updateScaledObjectStatus(scaledObject)
-		h.createJobs(scaledObject, scaleTo, maxScale-runningJobCount)
+		h.createJobs(scaledObject, scaleTo, effectiveMaxScale)
 
 	} else {
 		h.logger.V(1).Info("No change in activity")

--- a/pkg/handler/scale_jobs.go
+++ b/pkg/handler/scale_jobs.go
@@ -7,20 +7,24 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/pkg/apis/keda/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func (h *ScaleHandler) scaleJobs(scaledObject *kedav1alpha1.ScaledObject, isActive bool, scaleTo int64, maxScale int64) {
-	// TODO: get current job count
-	h.logger.V(1).Info("Scaling Jobs")
+	runningJobCount := h.getRunningJobCount(scaledObject, maxScale)
+	h.logger.Info("Scaling Jobs", "Number of running Jobs ", runningJobCount)
+	h.logger.Info("Scaling Jobs")
 
 	if isActive {
 		h.logger.V(1).Info("At least one scaler is active")
 		now := metav1.Now()
 		scaledObject.Status.LastActiveTime = &now
 		h.updateScaledObjectStatus(scaledObject)
-		h.createJobs(scaledObject, scaleTo, maxScale)
+		h.createJobs(scaledObject, scaleTo, maxScale-runningJobCount)
+
 	} else {
 		h.logger.V(1).Info("No change in activity")
 	}
@@ -33,6 +37,8 @@ func (h *ScaleHandler) createJobs(scaledObject *kedav1alpha1.ScaledObject, scale
 		scaledObject.Spec.JobTargetRef.Template.Labels = map[string]string{}
 	}
 	scaledObject.Spec.JobTargetRef.Template.Labels["scaledobject"] = scaledObject.GetName()
+
+	h.logger.Info("Creating jobs", "Effective number of max jobs", maxScale)
 
 	if scaleTo > maxScale {
 		scaleTo = maxScale
@@ -94,4 +100,41 @@ func (h *ScaleHandler) parseJobAuthRef(triggerAuthRef *kedav1alpha1.ScaledObject
 		}
 		return env[name]
 	})
+}
+
+func (h *ScaleHandler) isJobFinished(j *batchv1.Job) bool {
+	for _, c := range j.Status.Conditions {
+		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *ScaleHandler) getRunningJobCount(scaledObject *kedav1alpha1.ScaledObject, maxScale int64) int64 {
+	var runningJobs int64
+
+	opts := []client.ListOption{
+		client.InNamespace(scaledObject.GetNamespace()),
+		client.MatchingLabels(map[string]string{"scaledobject": scaledObject.GetName()}),
+	}
+
+	jobs := &batchv1.JobList{}
+	err := h.client.List(context.TODO(), jobs, opts...)
+
+	if err != nil {
+		return 0
+	}
+
+	for _, job := range jobs.Items {
+		if !h.isJobFinished(&job) {
+			runningJobs++
+		}
+	}
+
+	if runningJobs > maxScale {
+		runningJobs = maxScale
+	}
+
+	return runningJobs
 }


### PR DESCRIPTION
This PR is to honor the `queueLength` taking into account the number of running Jobs.  
In short, total running Jobs will be `queueLength - runningJobs`.

Running jobs are those jobs which are not in `Completed` or `Failed` Status.
This should address issue https://github.com/kedacore/keda/issues/525
