### PR TITLE
Service bus scaler pod identity fix 

### DIFF
--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -196,7 +196,7 @@ func (s *azureServiceBusScaler) GetAzureServiceBusLength(ctx context.Context) (i
 			return -1, err
 		}
 	} else if s.podIdentity == "azure" {
-		namespace, err := servicebus.NewNamespace()
+		namespace, err = servicebus.NewNamespace()
 		if err != nil {
 			return -1, err
 		}

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -61,6 +61,12 @@ var getServiceBusLengthTestScalers = []azureServiceBusScaler{
 		topicName:        topicName,
 		subscriptionName: subscriptionName,
 	}},
+	{metadata: &azureServiceBusMetadata{
+		entityType:       Subscription,
+		topicName:        topicName,
+		subscriptionName: subscriptionName,
+	},
+		podIdentity: "azure"},
 }
 
 func TestParseServiceBusMetadata(t *testing.T) {


### PR DESCRIPTION
In the case of using the podIdentity settings,  namespace was redeclared in inner block, and have not changed the original value of  the namespace outside the block.
Remove short variable declaration in inner block