### PR TITLE
Fix custom keda deployment documentation

### DIFF
--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -2,7 +2,7 @@
 
 ## Developing a scaler
 
-In order to developer a scaler, a developer should do the following:
+In order to develop a scaler, a developer should do the following:
 1. Download KEDA's code
 2. Define the main pieces of data that you expect the user to supply so the scaler runs properly. For example, if your scaler needs to connect to an external source based on a connection string, you expect the user to supply this connection string in the configuration within the ScaledObject under `trigger`. This data will be passed to your constructing function as map[string]string.
 2. Create the new scaler struct under the `pkg/scalers` folder.
@@ -12,8 +12,10 @@ In order to developer a scaler, a developer should do the following:
 6. Run `make build` from the root of KEDA and your scaler is ready.
 
 If you want to deploy locally 
-1. Open the terminal and go to the root of the source code, then build a docker image of KEDA by running `docker build . -t [choose a unique tag for your custom image]`
-2. In the terminal, navigate to the `chart/keda` folder, and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=[tag used in step 1],image.pullPolicy=IfNotPresent`.
+1. run: `export IMAGE_TAG=yourchosenname`
+2. Open the terminal and go to the root of the source code, then run `make build`
+3. If you haven't done it yet clone the charts repository: `git  clone git@github.com:kedacore/charts.git` 
+2. In the terminal, navigate to the `chart/keda` folder (the charts downloaded in step 4), and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:[tag used in step 1],image.pullPolicy=IfNotPresent`.
 
 The last step assumes that you have `helm` already installed in the cluster. In this step we install the helm chart, and we substitute the image with the image we built in step 1. Notice that we are also overriding the image PullPolice to `IfNotPresent` since this is a local cluster.
 

--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -15,7 +15,7 @@ If you want to deploy locally
 1. run: `export IMAGE_TAG=yourchosenname`
 2. Open the terminal and go to the root of the source code, then run `make build`
 3. If you haven't done it yet clone the charts repository: `git  clone git@github.com:kedacore/charts.git` 
-2. In the terminal, navigate to the `chart/keda` folder (the charts downloaded in step 4), and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:[tag used in step 1],image.pullPolicy=IfNotPresent`.
+4. In the terminal, navigate to the `chart/keda` folder (the charts downloaded in step 3), and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:[tag used in step 1],image.pullPolicy=IfNotPresent`.
 
 The last step assumes that you have `helm` already installed in the cluster. In this step we install the helm chart, and we substitute the image with the image we built in step 1. Notice that we are also overriding the image PullPolice to `IfNotPresent` since this is a local cluster.
 

--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -13,7 +13,7 @@ In order to developer a scaler, a developer should do the following:
 
 If you want to deploy locally 
 1. Open the terminal and go to the root of the source code, then build a docker image of KEDA by running `docker build . -t [choose a unique tag for your custom image]`
-2. In the terminal, navigate to the `chart/keda` folder, and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.repository=[tag used in step 1],image.pullPolicy=IfNotPresent`.
+2. In the terminal, navigate to the `chart/keda` folder, and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=[tag used in step 1],image.pullPolicy=IfNotPresent`.
 
 The last step assumes that you have `helm` already installed in the cluster. In this step we install the helm chart, and we substitute the image with the image we built in step 1. Notice that we are also overriding the image PullPolice to `IfNotPresent` since this is a local cluster.
 

--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -12,10 +12,11 @@ In order to develop a scaler, a developer should do the following:
 6. Run `make build` from the root of KEDA and your scaler is ready.
 
 If you want to deploy locally 
-1. run: `export IMAGE_TAG=yourchosenname`
-2. Open the terminal and go to the root of the source code, then run `make build`
-3. If you haven't done it yet clone the charts repository: `git  clone git@github.com:kedacore/charts.git` 
-4. In the terminal, navigate to the `chart/keda` folder (the charts downloaded in step 3), and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:[tag used in step 1],image.pullPolicy=IfNotPresent`.
+1. Run `export IMAGE_TAG=local`
+2. Open the terminal and go to the root of the source code
+3. Run `make build`
+5. If you haven't done it yet clone the charts repository: `git  clone git@github.com:kedacore/charts.git` 
+6. In the terminal, navigate to the `chart/keda` folder (the charts downloaded in step 3), and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:[tag used in step 1],image.pullPolicy=IfNotPresent`.
 
 The last step assumes that you have `helm` already installed in the cluster. In this step we install the helm chart, and we substitute the image with the image we built in step 1. Notice that we are also overriding the image PullPolice to `IfNotPresent` since this is a local cluster.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ If you want to change KEDA's behaviour, or if you have created a new scaler (mor
 2. In terminal, create an environment variable `IMAGE_TAG` and assign it a value for your preference, this tag will be used when creating the operator image that will run KEDA.
 ***Note***: make sure it doesn't clash with the official tags of KEDA containers in DockerHub.
 3. Still in terminal, run `make build` at the root of the source code. This will also build the docker image for the KEDA operator that you can deploy to your local cluster. It will use the tag you used in step 2.
-4. Still in terminal, navigate to the `chart/keda` folder, and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:$IMAGE_TAG,image.pullPolicy=IfNotPresent`.
+4. If you haven't downloaded them before, clone the charts repository: `git clone git@github.com:kedacore/charts.git` 
+5. Still in terminal, navigate to the `chart/keda` folder (downlodaed in step 4), and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:$IMAGE_TAG,image.pullPolicy=IfNotPresent`.
 
 In the last step we are using the image we just create by running step 3. Notice that we are also overriding the image PullPolice to `IfNotPresent` since this is a local cluster, this is important to do, otherwise, Kubernetes will try to pull the image from Docker Hub from the internet and will complain about not finidng it.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you want to change KEDA's behaviour, or if you have created a new scaler (mor
 2. In terminal, create an environment variable `IMAGE_TAG` and assign it a value for your preference, this tag will be used when creating the operator image that will run KEDA.
 ***Note***: make sure it doesn't clash with the official tags of KEDA containers in DockerHub.
 3. Still in terminal, run `make build` at the root of the source code. This will also build the docker image for the KEDA operator that you can deploy to your local cluster. It will use the tag you used in step 2.
-4. Still in terminal, navigate to the `chart/keda` folder, and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.repository=[tag used in step 2],image.pullPolicy=IfNotPresent`.
+4. Still in terminal, navigate to the `chart/keda` folder, and run the following command (don't forget to replace the placeholder text in the command) `helm install . --set image.keda=kedacore/keda:$IMAGE_TAG,image.pullPolicy=IfNotPresent`.
 
 In the last step we are using the image we just create by running step 3. Notice that we are also overriding the image PullPolice to `IfNotPresent` since this is a local cluster, this is important to do, otherwise, Kubernetes will try to pull the image from Docker Hub from the internet and will complain about not finidng it.
 


### PR DESCRIPTION
As discussed in issue #531 the documentation about deployin custom keda is not actually working, this PR should contain the correct command to instruct helm on using the custom build instead of the stable one.
