### PR TITLE
Kafka scaler fix for SASL plaintext auth

### DIFF
--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -211,6 +211,11 @@ func getKafkaClients(metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin
 		config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512)
 	}
 
+	if metadata.authMode == kafkaAuthModeForSaslPlaintext {
+		config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+		config.Net.TLS.Enable = true
+	}
+
 	client, err := sarama.NewClient(metadata.brokers, config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating kafka client: %s", err)


### PR DESCRIPTION
For Issue #543.

Updated the Kafka scaler to add `config` parameters for Sarama client corresponding to SASL plaintext auth mode