### PR TITLE
Fix redis scaler address parsing from metadata

### DIFF
--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -64,15 +64,9 @@ func parseRedisMetadata(metadata, resolvedEnv, authParams map[string]string) (*r
 		return nil, fmt.Errorf("no list name given")
 	}
 
-	address := defaultRedisAddress
+	meta.address = defaultRedisAddress
 	if val, ok := metadata["address"]; ok && val != "" {
-		address = val
-	}
-
-	if val, ok := resolvedEnv[address]; ok {
 		meta.address = val
-	} else {
-		return nil, fmt.Errorf("no address given. Address should be in the format of host:port")
 	}
 
 	meta.password = defaultRedisPassword


### PR DESCRIPTION
Fixes #560 

Previously,  when an address was provided in metadata, the scaler resolved it from metadata but then attempted to look up the address value as a an env var of the container in the Deployment or Job.

This change uses the default redis address as before, and uses the address in the metadata if provided, as mentioned in the current documentation.