### PR TITLE
Add Azure monitor scaler

### DIFF
--- a/pkg/handler/scale_handler.go
+++ b/pkg/handler/scale_handler.go
@@ -306,6 +306,8 @@ func (h *ScaleHandler) getScaler(name, namespace, triggerType string, resolvedEn
 		return scalers.NewPostgresScaler(resolvedEnv, triggerMetadata, authParams)
 	case "mysql":
 		return scalers.NewMySQLScaler(resolvedEnv, triggerMetadata, authParams)
+	case "azure-monitor":
+		return scalers.NewAzureMonitorScaler(resolvedEnv, triggerMetadata, authParams)
 	default:
 		return nil, fmt.Errorf("no scaler found for type: %s", triggerType)
 	}

--- a/pkg/scalers/azure_monitor.go
+++ b/pkg/scalers/azure_monitor.go
@@ -39,7 +39,7 @@ func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetada
 
 func createMetricsClient(metadata *azureMonitorMetadata) insights.MetricsClient {
 	client := insights.NewMetricsClient(metadata.subscriptionID)
-	config := auth.NewClientCredentialsConfig(metadata.clientID, metadata.clientPassword, metadata.tentantID)
+	config := auth.NewClientCredentialsConfig(metadata.clientID, metadata.clientPassword, metadata.tenantID)
 
 	authorizer, _ := config.Authorizer()
 	client.Authorizer = authorizer

--- a/pkg/scalers/azure_monitor.go
+++ b/pkg/scalers/azure_monitor.go
@@ -3,9 +3,9 @@ package scalers
 import (
 	"context"
 	"fmt"
-    "math"
-    "strconv"
-    "strings"
+	"math"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
@@ -62,7 +62,7 @@ func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetada
 	timespan, err := formatTimeSpan(metricMetadata.aggregationInterval)
 	if err != nil {
 		return -1, err
-    }
+	}
 
 	metricRequest.Timespan = timespan
 

--- a/pkg/scalers/azure_monitor.go
+++ b/pkg/scalers/azure_monitor.go
@@ -13,6 +13,9 @@ import (
 	"k8s.io/klog"
 )
 
+// Much of the code in this file is taken from the Azure Kubernetes Metrics Adapter
+// https://github.com/Azure/azure-k8s-metrics-adapter/tree/master/pkg/azure/externalmetrics
+
 type azureExternalMetricRequest struct {
 	MetricName                string
 	SubscriptionID            string
@@ -25,7 +28,7 @@ type azureExternalMetricRequest struct {
 	ResourceGroup             string
 }
 
-// GetAzureMetricValue is a func
+// GetAzureMetricValue returns the value of an Azure Monitor metric, rounded to the nearest int
 func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetadata) (int32, error) {
 	client := createMetricsClient(metricMetadata)
 
@@ -138,7 +141,6 @@ func extractValue(azMetricRequest azureExternalMetricRequest, metricResult insig
 }
 
 func (amr azureExternalMetricRequest) validate() error {
-	// Shared
 	if amr.MetricName == "" {
 		return fmt.Errorf("metricName is required")
 	}
@@ -160,8 +162,8 @@ func (amr azureExternalMetricRequest) metricResourceURI() string {
 		amr.ResourceName)
 }
 
+// formatTimeSpan defaults to a 5 minute timespan if the user does not provide one
 func formatTimeSpan(timeSpan string) (string, error) {
-	// defaults to last five minutes.
 	endtime := time.Now().UTC().Format(time.RFC3339)
 	starttime := time.Now().Add(-(5 * time.Minute)).UTC().Format(time.RFC3339)
 	if timeSpan != "" {

--- a/pkg/scalers/azure_monitor.go
+++ b/pkg/scalers/azure_monitor.go
@@ -91,7 +91,7 @@ func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetada
 
 func newMonitorClient(metadata *azureMonitorMetadata) azureExternalMetricClient {
 	client := insights.NewMetricsClient(metadata.subscriptionID)
-	config := auth.NewClientCredentialsConfig(metadata.servicePrincipalID, metadata.servicePrincipalPass, metadata.tentantID)
+	config := auth.NewClientCredentialsConfig(metadata.clientID, metadata.clientPassword, metadata.tentantID)
 
 	authorizer, err := config.Authorizer()
 	if err == nil {

--- a/pkg/scalers/azure_monitor.go
+++ b/pkg/scalers/azure_monitor.go
@@ -3,8 +3,9 @@ package scalers
 import (
 	"context"
 	"fmt"
-	"math"
-	"strings"
+    "math"
+    "strconv"
+    "strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
@@ -15,7 +16,6 @@ import (
 type azureExternalMetricRequest struct {
 	MetricName                string
 	SubscriptionID            string
-	Type                      string
 	ResourceName              string
 	ResourceProviderNamespace string
 	ResourceType              string
@@ -23,8 +23,6 @@ type azureExternalMetricRequest struct {
 	Timespan                  string
 	Filter                    string
 	ResourceGroup             string
-	Topic                     string
-	Subscription              string
 }
 
 type azureExternalMetricResponse struct {
@@ -48,33 +46,25 @@ func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetada
 	metricsClient := newMonitorClient(metricMetadata)
 
 	metricRequest := azureExternalMetricRequest{
-		Timespan:       timeSpan(),
+		MetricName:     metricMetadata.name,
 		SubscriptionID: metricMetadata.subscriptionID,
+		Aggregation:    metricMetadata.aggregationType,
+		Filter:         metricMetadata.filter,
+		ResourceGroup:  metricMetadata.resourceGroupName,
 	}
 
-	metricRequest.MetricName = metricMetadata.name
-	metricRequest.ResourceGroup = metricMetadata.resourceGroupName
 	resourceInfo := strings.Split(metricMetadata.resourceURI, "/")
-
-	if len(resourceInfo) != 3 {
-		return -1, fmt.Errorf("resourceURI is missing resource namespace, resource type, or resource name")
-	}
-
 	metricRequest.ResourceProviderNamespace = resourceInfo[0]
 	metricRequest.ResourceType = resourceInfo[1]
 	metricRequest.ResourceName = resourceInfo[2]
 
-	metricRequest.Aggregation = metricMetadata.aggregationType
+	// if no timespan is provided, defaults to 5 minutes
+	timespan, err := formatTimeSpan(metricMetadata.aggregationInterval)
+	if err != nil {
+		return -1, err
+    }
 
-	filter := metricMetadata.filter
-	if filter != "" {
-		metricRequest.Filter = filter
-	}
-
-	aggregationInterval := metricMetadata.aggregationInterval
-	if aggregationInterval != "" {
-		metricRequest.Timespan = aggregationInterval
-	}
+	metricRequest.Timespan = timespan
 
 	metricResponse, err := metricsClient.getAzureMetric(metricRequest)
 	if err != nil {
@@ -93,10 +83,8 @@ func newMonitorClient(metadata *azureMonitorMetadata) azureExternalMetricClient 
 	client := insights.NewMetricsClient(metadata.subscriptionID)
 	config := auth.NewClientCredentialsConfig(metadata.clientID, metadata.clientPassword, metadata.tentantID)
 
-	authorizer, err := config.Authorizer()
-	if err == nil {
-		client.Authorizer = authorizer
-	}
+	authorizer, _ := config.Authorizer()
+	client.Authorizer = authorizer
 
 	return &monitorClient{
 		client: client,
@@ -197,10 +185,21 @@ func (amr azureExternalMetricRequest) metricResourceURI() string {
 		amr.ResourceName)
 }
 
-func timeSpan() string {
+func formatTimeSpan(timeSpan string) (string, error) {
 	// defaults to last five minutes.
-	// TODO support configuration via config
 	endtime := time.Now().UTC().Format(time.RFC3339)
 	starttime := time.Now().Add(-(5 * time.Minute)).UTC().Format(time.RFC3339)
-	return fmt.Sprintf("%s/%s", starttime, endtime)
+	if timeSpan != "" {
+		aggregationInterval := strings.Split(timeSpan, ":")
+		hours, herr := strconv.Atoi(aggregationInterval[0])
+		minutes, merr := strconv.Atoi(aggregationInterval[1])
+		seconds, serr := strconv.Atoi(aggregationInterval[2])
+
+		if herr != nil || merr != nil || serr != nil {
+			return "", fmt.Errorf("Errors parsing metricAggregationInterval: %v, %v, %v", herr, merr, serr)
+		}
+
+		starttime = time.Now().Add(-(time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute + time.Duration(seconds)*time.Second)).UTC().Format(time.RFC3339)
+	}
+	return fmt.Sprintf("%s/%s", starttime, endtime), nil
 }

--- a/pkg/scalers/azure_monitor.go
+++ b/pkg/scalers/azure_monitor.go
@@ -1,0 +1,163 @@
+package scalers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"k8s.io/klog"
+)
+
+type azureExternalMetricRequest struct {
+	MetricName                string
+	SubscriptionID            string
+	Type                      string
+	ResourceName              string
+	ResourceProviderNamespace string
+	ResourceType              string
+	Aggregation               string
+	Timespan                  string
+	Filter                    string
+	ResourceGroup             string
+	Namespace                 string
+	Topic                     string
+	Subscription              string
+}
+
+type azureExternalMetricResponse struct {
+	Value float64
+}
+
+type azureExternalMetricClient interface {
+	getAzureMetric(azMetricRequest azureExternalMetricRequest) (azureExternalMetricResponse, error)
+}
+
+type insightsmonitorClient interface {
+	List(ctx context.Context, resourceURI string, timespan string, interval *string, metricnames string, aggregation string, top *int32, orderby string, filter string, resultType insights.ResultType, metricnamespace string) (result insights.Response, err error)
+}
+
+type monitorClient struct {
+	client insightsmonitorClient
+}
+
+// GetAzureMetricValue is a func
+func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetadata) (int32, error) {
+    metricsClient := newMonitorClient(metricMetadata)
+
+    metricResponse, err := metricsClient.getAzureMetric(metricRequest)
+    if err != nil  {
+        azureMonitorLog.Error(err, "error getting azure monitor metric")
+    }
+
+    return 2, nil
+}
+
+func newMonitorClient(metadata *azureMonitorMetadata) azureExternalMetricClient {
+    client := insights.NewMetricsClient(metadata.subscriptionID)
+    config := auth.NewClientCredentialsConfig(metadata.servicePrincipalID, metadata.servicePrincipalPass, metadata.tentantID)
+    
+	authorizer, err := config.Authorizer()
+	if err == nil {
+		client.Authorizer = authorizer
+	}
+
+	return &monitorClient{
+		client: client,
+	}
+}
+
+func (c *monitorClient) getAzureMetric(azMetricRequest azureExternalMetricRequest) (azureExternalMetricResponse, error) {
+	err := azMetricRequest.validate()
+	if err != nil {
+		return azureExternalMetricResponse{}, err
+	}
+
+	metricResourceURI := azMetricRequest.metricResourceURI()
+	klog.V(2).Infof("resource uri: %s", metricResourceURI)
+
+	metricResult, err := c.client.List(context.Background(), metricResourceURI,
+		azMetricRequest.Timespan, nil,
+		azMetricRequest.MetricName, azMetricRequest.Aggregation, nil,
+		"", azMetricRequest.Filter, "", "")
+	if err != nil {
+		return azureExternalMetricResponse{}, err
+	}
+
+	value, err := extractValue(azMetricRequest, metricResult)
+
+	return azureExternalMetricResponse{
+		Value: value,
+	}, err
+}
+
+func extractValue(azMetricRequest azureExternalMetricRequest, metricResult insights.Response) (float64, error) {
+	metricVals := *metricResult.Value
+
+	if len(metricVals) == 0 {
+		err := fmt.Errorf("Got an empty response for metric %s/%s and aggregate type %s", azMetricRequest.Namespace, azMetricRequest.MetricName, insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)))
+		return 0, err
+	}
+
+	timeseries := *metricVals[0].Timeseries
+	if timeseries == nil {
+		err := fmt.Errorf("Got metric result for %s/%s and aggregate type %s without timeseries", azMetricRequest.Namespace, azMetricRequest.MetricName, insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)))
+		return 0, err
+	}
+
+	data := *timeseries[0].Data
+	if data == nil {
+		err := fmt.Errorf("Got metric result for %s/%s and aggregate type %s without any metric values", azMetricRequest.Namespace, azMetricRequest.MetricName, insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)))
+		return 0, err
+	}
+
+	var valuePtr *float64
+	if strings.EqualFold(string(insights.Average), azMetricRequest.Aggregation) && data[len(data)-1].Average != nil {
+		valuePtr = data[len(data)-1].Average
+	} else if strings.EqualFold(string(insights.Total), azMetricRequest.Aggregation) && data[len(data)-1].Total != nil {
+		valuePtr = data[len(data)-1].Total
+	} else if strings.EqualFold(string(insights.Maximum), azMetricRequest.Aggregation) && data[len(data)-1].Maximum != nil {
+		valuePtr = data[len(data)-1].Maximum
+	} else if strings.EqualFold(string(insights.Minimum), azMetricRequest.Aggregation) && data[len(data)-1].Minimum != nil {
+		valuePtr = data[len(data)-1].Minimum
+	} else if strings.EqualFold(string(insights.Count), azMetricRequest.Aggregation) && data[len(data)-1].Count != nil {
+		fValue := float64(*data[len(data)-1].Count)
+		valuePtr = &fValue
+	} else {
+		err := fmt.Errorf("Unsupported aggregation type %s specified in metric %s/%s", insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)), azMetricRequest.Namespace, azMetricRequest.MetricName)
+		return 0, err
+	}
+
+	if valuePtr == nil {
+		err := fmt.Errorf("Unable to get value for metric %s/%s with aggregation %s. No value returned by the Azure Monitor", azMetricRequest.Namespace, azMetricRequest.MetricName, azMetricRequest.Aggregation)
+		return 0, err
+	}
+
+	klog.V(2).Infof("metric type: %s %f", azMetricRequest.Aggregation, *valuePtr)
+
+	return *valuePtr, nil
+}
+
+func (amr azureExternalMetricRequest) validate() error {
+	// Shared
+	if amr.MetricName == "" {
+		return fmt.Errorf("metricName is required")
+	}
+	if amr.ResourceGroup == "" {
+		return fmt.Errorf("resourceGroup is required")
+	}
+	if amr.SubscriptionID == "" {
+		return fmt.Errorf("subscriptionID is required. set a default or pass via label selectors")
+	}
+	return nil
+}
+
+func (amr azureExternalMetricRequest) metricResourceURI() string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s",
+		amr.SubscriptionID,
+		amr.ResourceGroup,
+		amr.ResourceProviderNamespace,
+		amr.ResourceType,
+		amr.ResourceName)
+}

--- a/pkg/scalers/azure_monitor.go
+++ b/pkg/scalers/azure_monitor.go
@@ -55,10 +55,14 @@ func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetada
 	metricRequest.MetricName = metricMetadata.name
 	metricRequest.ResourceGroup = metricMetadata.resourceGroupName
 	resourceInfo := strings.Split(metricMetadata.resourceURI, "/")
+
+	if len(resourceInfo) != 3 {
+		return -1, fmt.Errorf("resourceURI is missing resource namespace, resource type, or resource name")
+	}
+
 	metricRequest.ResourceProviderNamespace = resourceInfo[0]
 	metricRequest.ResourceType = resourceInfo[1]
 	metricRequest.ResourceName = resourceInfo[2]
-	// do empty checking
 
 	metricRequest.Aggregation = metricMetadata.aggregationType
 
@@ -75,8 +79,8 @@ func GetAzureMetricValue(ctx context.Context, metricMetadata *azureMonitorMetada
 	metricResponse, err := metricsClient.getAzureMetric(metricRequest)
 	if err != nil {
 		azureMonitorLog.Error(err, "error getting azure monitor metric")
-		return -1, fmt.Errorf("MetricName %s: , ResourceGroup: %s, Namespace: %s, ResourceType: %s, ResourceName: %s, Aggregation: %s, Timespan: %s", metricRequest.MetricName, metricRequest.ResourceGroup, metricRequest.ResourceProviderNamespace, metricRequest.ResourceType, metricRequest.ResourceName, metricRequest.Aggregation, metricRequest.Timespan)
-		//return -1, fmt.Errorf("Error getting azure monitor metric %s: %s", metricRequest.MetricName, err.Error())
+		//return -1, fmt.Errorf("MetricName %s: , ResourceGroup: %s, Namespace: %s, ResourceType: %s, ResourceName: %s, Aggregation: %s, Timespan: %s", metricRequest.MetricName, metricRequest.ResourceGroup, metricRequest.ResourceProviderNamespace, metricRequest.ResourceType, metricRequest.ResourceName, metricRequest.Aggregation, metricRequest.Timespan)
+		return -1, fmt.Errorf("Error getting azure monitor metric %s: %s", metricRequest.MetricName, err.Error())
 	}
 
 	// casting drops everything after decimal, so round first

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -93,6 +93,12 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 		return nil, fmt.Errorf("no metricName given")
 	}
 
+	if val, ok := metadata["metricAggregationType"]; ok && val != "" {
+		meta.aggregationType = val
+	} else {
+		return nil, fmt.Errorf("no metricAggregationType given")
+	}
+
 	if val, ok := metadata["metricFilter"]; ok {
 		if val != "" {
 			meta.filter = val

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -15,12 +15,8 @@ import (
 )
 
 const (
-	azureMonitorMetricName       = "metricName"
-	targetValueName              = "targetValue"
-	defaultSubscriptionIDSetting = "xxx"
-	defaultTenantIDSetting       = "yyy"
-	defaultClientIDSetting       = "zzz"
-	defaultClientPasswordSetting = "qqq"
+	azureMonitorMetricName = "metricName"
+	targetValueName        = "targetValue"
 )
 
 type azureMonitorScaler struct {
@@ -104,64 +100,40 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 
 	// Required authentication parameters below
 
-	subscriptionID := authParams["subscriptionId"]
-	if subscriptionID != "" {
-		meta.subscriptionID = subscriptionID
+	if val, ok := authParams["subscriptionId"]; ok && val != "" {
+		meta.subscriptionID = val
 	} else {
-		subscriptionIDSetting := defaultSubscriptionIDSetting
 		if val, ok := metadata["subscriptionId"]; ok && val != "" {
-			subscriptionIDSetting = val
-		}
-
-		if val, ok := resolvedEnv[subscriptionIDSetting]; ok {
 			meta.subscriptionID = val
 		} else {
 			return nil, fmt.Errorf("no subscriptionId given")
 		}
 	}
 
-	tenantID := authParams["tenantId"]
-	if tenantID != "" {
-		meta.tenantID = tenantID
+	if val, ok := authParams["tenantId"]; ok && val != "" {
+		meta.tenantID = val
 	} else {
-		tenantIDSetting := defaultTenantIDSetting
 		if val, ok := metadata["tenantId"]; ok && val != "" {
-			tenantIDSetting = val
-		}
-
-		if val, ok := resolvedEnv[tenantIDSetting]; ok {
 			meta.tenantID = val
 		} else {
 			return nil, fmt.Errorf("no tenantId given")
 		}
 	}
 
-	clientID := authParams["activeDirectoryClientId"]
-	if clientID != "" {
-		meta.clientID = clientID
+	if val, ok := authParams["activeDirectoryClientId"]; ok && val != "" {
+		meta.clientID = val
 	} else {
-		clientIDSetting := defaultClientIDSetting
 		if val, ok := metadata["activeDirectoryClientId"]; ok && val != "" {
-			clientIDSetting = val
-		}
-
-		if val, ok := resolvedEnv[clientIDSetting]; ok {
 			meta.clientID = val
 		} else {
 			return nil, fmt.Errorf("no activeDirectoryClientId given")
 		}
 	}
 
-	clientPassword := authParams["activeDirectoryClientPassword"]
-	if clientPassword != "" {
-		meta.clientPassword = clientPassword
+	if val, ok := authParams["activeDirectoryClientPassword"]; ok && val != "" {
+		meta.clientPassword = val
 	} else {
-		clientPasswordSetting := defaultClientPasswordSetting
 		if val, ok := metadata["activeDirectoryClientPassword"]; ok && val != "" {
-			clientPasswordSetting = val
-		}
-
-		if val, ok := resolvedEnv[clientPasswordSetting]; ok {
 			meta.clientPassword = val
 		} else {
 			return nil, fmt.Errorf("no activeDirectoryClientPassword given")

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -112,7 +112,6 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 			if len(aggregationInterval) != 3 {
 				return nil, fmt.Errorf("metricAggregationInterval not in the correct format. Should be hh:mm:ss")
 			}
-
 			meta.aggregationInterval = val
 		}
 	}

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -102,6 +102,7 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 		if len(aggregationInterval) != 3 {
 			return nil, fmt.Errorf("metricAggregationInterval not in the correct format. Should be hh:mm:ss")
 		}
+		meta.aggregationInterval = val
 	}
 
 	// Required authentication parameters below

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -167,7 +167,7 @@ func (s *azureMonitorScaler) GetMetrics(ctx context.Context, metricName string, 
 
 // GetAzureMetric does things
 func (s *azureMonitorScaler) GetAzureMetric() (int, error) {
-	return defaultTargetMetricValue, nil
+	return 16, nil
 }
 
 /*

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -1,0 +1,286 @@
+package scalers
+
+import (
+	"context"
+	"fmt"
+
+	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	defaultTargetMetricValue = 5
+	azureMonitorMetricName   = "metricName"
+)
+
+type azureMonitorScaler struct {
+	metadata *azureMonitorMetadata
+}
+
+type azureMonitorMetadata struct {
+	resourceURI          string
+	tentantID            string
+	subscriptionID       string
+	resourceGroupName    string
+	name                 string
+	filter               string
+	aggregationInterval  string
+	aggregationType      string
+	servicePrincipalID   string
+	servicePrincipalPass string
+	targetMetricValue    int
+}
+
+var azureMonitorLog = logf.Log.WithName("azure_monitor_scaler")
+
+// NewAzureMonitorScaler stuff
+func NewAzureMonitorScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler, error) {
+	meta, err := parseAzureMonitorMetadata(metadata, resolvedEnv, authParams)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing azure monitor metadata: %s", err)
+	}
+
+	return &azureMonitorScaler{
+		metadata: meta,
+	}, nil
+}
+
+func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]string) (*azureMonitorMetadata, error) {
+	meta := azureMonitorMetadata{}
+	meta.targetMetricValue = defaultTargetMetricValue
+
+	/*if val, ok := metadata[metricResourceURI]; ok {
+		Length, err := strconv.Atoi(val)
+		if err != nil {
+			azureMonitorLog.Error(err, "Error parsing azure queue metadata", "queueLengthMet ricName", LengthMetricName)
+			return nil, "", fmt.Errorf("Error parsing azure queue metadata %s: %s", LengthMetricName, err.Error())
+		}
+
+		meta.targetLength = Length
+	}*/
+
+	if val, ok := metadata["resourceURI"]; ok && val != "" {
+		meta.resourceURI = val
+	} else {
+		return nil, fmt.Errorf("no resourceURI given")
+	}
+
+	if val, ok := metadata["resourceTenantId"]; ok && val != "" {
+		meta.tentantID = val
+	} else {
+		return nil, fmt.Errorf("no resourceTenantId given")
+	}
+
+	if val, ok := metadata["resourceSubscriptionId"]; ok && val != "" {
+		meta.subscriptionID = val
+	} else {
+		return nil, fmt.Errorf("no resourceSubscriptionId given")
+	}
+
+	if val, ok := metadata["resourceGroupName"]; ok && val != "" {
+		meta.resourceGroupName = val
+	} else {
+		return nil, fmt.Errorf("no resourceGroupName given")
+	}
+
+	if val, ok := metadata[azureMonitorMetricName]; ok && val != "" {
+		meta.name = val
+	} else {
+		return nil, fmt.Errorf("no metricName given")
+	}
+
+	if val, ok := metadata["metricFilter"]; ok {
+		if val != "" {
+			meta.filter = val
+		}
+	}
+
+	if val, ok := metadata["metricAggregationInterval"]; ok {
+		if val != "" {
+			meta.aggregationInterval = val
+		}
+	}
+
+	if val, ok := metadata["metricAggregationType"]; ok && val != "" {
+		meta.subscriptionID = val
+	} else {
+		return nil, fmt.Errorf("no metricAggregationType given")
+	}
+
+	if val, ok := metadata["adServicePrincipleId"]; ok && val != "" {
+		meta.servicePrincipalID = val
+	} else {
+		return nil, fmt.Errorf("no adServicePrincipleId given")
+	}
+
+	if val, ok := metadata["adServicePrinciplePassword"]; ok {
+		meta.servicePrincipalPass = val
+	} else {
+		return nil, fmt.Errorf("no adServicePrinciplePassword given")
+	}
+
+	return &meta, nil
+}
+
+// needs to interact with azure monitor
+func (s *azureMonitorScaler) IsActive(ctx context.Context) (bool, error) {
+	val, err := s.GetAzureMetric()
+	if err != nil {
+		azureMonitorLog.Error(err, "error getting azure monitor metric")
+		return false, err
+	}
+
+	return val > 0, nil
+}
+
+func (s *azureMonitorScaler) Close() error {
+	return nil
+}
+
+func (s *azureMonitorScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+	targetMetricVal := resource.NewQuantity(int64(s.metadata.targetMetricValue), resource.DecimalSI)
+	externalMetric := &v2beta1.ExternalMetricSource{MetricName: azureMonitorMetricName, TargetAverageValue: targetMetricVal}
+	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2beta1.MetricSpec{metricSpec}
+}
+
+// GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
+func (s *azureMonitorScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
+	val, err := s.GetAzureMetric()
+	if err != nil {
+		azureMonitorLog.Error(err, "error getting azure monitor metric")
+		return []external_metrics.ExternalMetricValue{}, err
+	}
+
+	metric := external_metrics.ExternalMetricValue{
+		MetricName: metricName,
+		Value:      *resource.NewQuantity(int64(val), resource.DecimalSI),
+		Timestamp:  metav1.Now(),
+	}
+
+	return append([]external_metrics.ExternalMetricValue{}, metric), nil
+}
+
+// GetAzureMetric does things
+func (s *azureMonitorScaler) GetAzureMetric() (int, error) {
+	return defaultTargetMetricValue, nil
+}
+
+/*
+package externalmetrics
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"k8s.io/klog"
+)
+
+type insightsmonitorClient interface {
+	List(ctx context.Context, resourceURI string, timespan string, interval *string, metricnames string, aggregation string, top *int32, orderby string, filter string, resultType insights.ResultType, metricnamespace string) (result insights.Response, err error)
+}
+
+type monitorClient struct {
+	client                insightsmonitorClient
+	DefaultSubscriptionID string
+}
+
+func NewMonitorClient(defaultsubscriptionID string) AzureExternalMetricClient {
+	client := insights.NewMetricsClient(defaultsubscriptionID)
+	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	if err == nil {
+		client.Authorizer = authorizer
+	}
+
+	return &monitorClient{
+		client:                client,
+		DefaultSubscriptionID: defaultsubscriptionID,
+	}
+}
+
+func newMonitorClient(defaultsubscriptionID string, client insightsmonitorClient) monitorClient {
+	return monitorClient{
+		client:                client,
+		DefaultSubscriptionID: defaultsubscriptionID,
+	}
+}
+
+// GetAzureMetric calls Azure Monitor endpoint and returns a metric
+func (c *monitorClient) GetAzureMetric(azMetricRequest AzureExternalMetricRequest) (AzureExternalMetricResponse, error) {
+	err := azMetricRequest.Validate()
+	if err != nil {
+		return AzureExternalMetricResponse{}, err
+	}
+
+	metricResourceURI := azMetricRequest.MetricResourceURI()
+	klog.V(2).Infof("resource uri: %s", metricResourceURI)
+
+	metricResult, err := c.client.List(context.Background(), metricResourceURI,
+		azMetricRequest.Timespan, nil,
+		azMetricRequest.MetricName, azMetricRequest.Aggregation, nil,
+		"", azMetricRequest.Filter, "", "")
+	if err != nil {
+		return AzureExternalMetricResponse{}, err
+	}
+
+	value, err := extractValue(azMetricRequest, metricResult)
+
+	return AzureExternalMetricResponse{
+		Value: value,
+	}, err
+}
+
+func extractValue(azMetricRequest AzureExternalMetricRequest, metricResult insights.Response) (float64, error) {
+	metricVals := *metricResult.Value
+
+	if len(metricVals) == 0 {
+		err := fmt.Errorf("Got an empty response for metric %s/%s and aggregate type %s", azMetricRequest.Namespace, azMetricRequest.MetricName, insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)))
+		return 0, err
+	}
+
+	timeseries := *metricVals[0].Timeseries
+	if timeseries == nil {
+		err := fmt.Errorf("Got metric result for %s/%s and aggregate type %s without timeseries", azMetricRequest.Namespace, azMetricRequest.MetricName, insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)))
+		return 0, err
+	}
+
+	data := *timeseries[0].Data
+	if data == nil {
+		err := fmt.Errorf("Got metric result for %s/%s and aggregate type %s without any metric values", azMetricRequest.Namespace, azMetricRequest.MetricName, insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)))
+		return 0, err
+	}
+
+	var valuePtr *float64
+	if strings.EqualFold(string(insights.Average), azMetricRequest.Aggregation) && data[len(data)-1].Average != nil {
+		valuePtr = data[len(data)-1].Average
+	} else if strings.EqualFold(string(insights.Total), azMetricRequest.Aggregation) && data[len(data)-1].Total != nil {
+		valuePtr = data[len(data)-1].Total
+	} else if strings.EqualFold(string(insights.Maximum), azMetricRequest.Aggregation) && data[len(data)-1].Maximum != nil {
+		valuePtr = data[len(data)-1].Maximum
+	} else if strings.EqualFold(string(insights.Minimum), azMetricRequest.Aggregation) && data[len(data)-1].Minimum != nil {
+		valuePtr = data[len(data)-1].Minimum
+	} else if strings.EqualFold(string(insights.Count), azMetricRequest.Aggregation) && data[len(data)-1].Count != nil {
+		fValue := float64(*data[len(data)-1].Count)
+		valuePtr = &fValue
+	} else {
+		err := fmt.Errorf("Unsupported aggregation type %s specified in metric %s/%s", insights.AggregationType(strings.ToTitle(azMetricRequest.Aggregation)), azMetricRequest.Namespace, azMetricRequest.MetricName)
+		return 0, err
+	}
+
+	if valuePtr == nil {
+		err := fmt.Errorf("Unable to get value for metric %s/%s with aggregation %s. No value returned by the Azure Monitor", azMetricRequest.Namespace, azMetricRequest.MetricName, azMetricRequest.Aggregation)
+		return 0, err
+	}
+
+	klog.V(2).Infof("metric type: %s %f", azMetricRequest.Aggregation, *valuePtr)
+
+	return *valuePtr, nil
+}
+*/

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -3,7 +3,8 @@ package scalers
 import (
 	"context"
 	"fmt"
-	"strconv"
+    "strconv"
+    "strings"
 
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -107,6 +108,11 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 
 	if val, ok := metadata["metricAggregationInterval"]; ok {
 		if val != "" {
+            aggregationInterval := strings.Split(val, ":")
+            if len(aggregationInterval) != 3 {
+                return nil, fmt.Errorf("metricAggregationInterval not in the correct format. Should be hh:mm:ss")
+            }
+
 			meta.aggregationInterval = val
 		}
 	}

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -29,7 +29,7 @@ type azureMonitorScaler struct {
 
 type azureMonitorMetadata struct {
 	resourceURI         string
-	tentantID           string
+	tenantID            string
 	subscriptionID      string
 	resourceGroupName   string
 	name                string
@@ -120,9 +120,9 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 		}
 	}
 
-	tentantID := authParams["tenantId"]
-	if tentantID != "" {
-		meta.tentantID = tentantID
+	tenantID := authParams["tenantId"]
+	if tenantID != "" {
+		meta.tenantID = tenantID
 	} else {
 		tenantIDSetting := defaultTenantIDSetting
 		if val, ok := metadata["tenantId"]; ok && val != "" {
@@ -130,7 +130,7 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 		}
 
 		if val, ok := resolvedEnv[tenantIDSetting]; ok {
-			meta.tentantID = val
+			meta.tenantID = val
 		} else {
 			return nil, fmt.Errorf("no tenantId given")
 		}

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -15,8 +15,12 @@ import (
 )
 
 const (
-	azureMonitorMetricName = "metricName"
-	targetValueName        = "targetValue"
+	azureMonitorMetricName       = "metricName"
+	targetValueName              = "targetValue"
+	defaultSubscriptionIDSetting = "xxx"
+	defaultTenantIDSetting       = "yyy"
+	defaultClientIDSetting       = "zzz"
+	defaultClientPasswordSetting = "qqq"
 )
 
 type azureMonitorScaler struct {
@@ -60,7 +64,6 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 			azureMonitorLog.Error(err, "Error parsing azure monitor metadata", "targetValue", targetValueName)
 			return nil, fmt.Errorf("Error parsing azure monitor metadata %s: %s", targetValueName, err.Error())
 		}
-
 		meta.targetValue = targetValue
 	}
 
@@ -68,18 +71,6 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 		meta.resourceURI = val
 	} else {
 		return nil, fmt.Errorf("no resourceURI given")
-	}
-
-	if val, ok := metadata["tenantId"]; ok && val != "" {
-		meta.tentantID = val
-	} else {
-		return nil, fmt.Errorf("no tenantId given")
-	}
-
-	if val, ok := metadata["subscriptionId"]; ok && val != "" {
-		meta.subscriptionID = val
-	} else {
-		return nil, fmt.Errorf("no subscriptionId given")
 	}
 
 	if val, ok := metadata["resourceGroupName"]; ok && val != "" {
@@ -100,32 +91,81 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 		return nil, fmt.Errorf("no metricAggregationType given")
 	}
 
-	if val, ok := metadata["metricFilter"]; ok {
-		if val != "" {
-			meta.filter = val
+	if val, ok := metadata["metricFilter"]; ok && val != "" {
+		meta.filter = val
+	}
+
+	if val, ok := metadata["metricAggregationInterval"]; ok && val != "" {
+		aggregationInterval := strings.Split(val, ":")
+		if len(aggregationInterval) != 3 {
+			return nil, fmt.Errorf("metricAggregationInterval not in the correct format. Should be hh:mm:ss")
 		}
 	}
 
-	if val, ok := metadata["metricAggregationInterval"]; ok {
-		if val != "" {
-			aggregationInterval := strings.Split(val, ":")
-			if len(aggregationInterval) != 3 {
-				return nil, fmt.Errorf("metricAggregationInterval not in the correct format. Should be hh:mm:ss")
-			}
-			meta.aggregationInterval = val
+	// Required authentication parameters below
+
+	subscriptionID := authParams["subscriptionId"]
+	if subscriptionID != "" {
+		meta.subscriptionID = subscriptionID
+	} else {
+		subscriptionIDSetting := defaultSubscriptionIDSetting
+		if val, ok := metadata["subscriptionId"]; ok && val != "" {
+			subscriptionIDSetting = val
+		}
+
+		if val, ok := resolvedEnv[subscriptionIDSetting]; ok {
+			meta.subscriptionID = val
+		} else {
+			return nil, fmt.Errorf("no subscriptionId given")
 		}
 	}
 
-	if val, ok := metadata["activeDirectoryClientId"]; ok && val != "" {
-		meta.clientID = val
+	tentantID := authParams["tenantId"]
+	if tentantID != "" {
+		meta.tentantID = tentantID
 	} else {
-		return nil, fmt.Errorf("no activeDirectoryClientId given")
+		tenantIDSetting := defaultTenantIDSetting
+		if val, ok := metadata["tenantId"]; ok && val != "" {
+			tenantIDSetting = val
+		}
+
+		if val, ok := resolvedEnv[tenantIDSetting]; ok {
+			meta.tentantID = val
+		} else {
+			return nil, fmt.Errorf("no tenantId given")
+		}
 	}
 
-	if val, ok := metadata["activeDirectoryClientPassword"]; ok && val != "" {
-		meta.clientPassword = val
+	clientID := authParams["activeDirectoryClientId"]
+	if clientID != "" {
+		meta.clientID = clientID
 	} else {
-		return nil, fmt.Errorf("no activeDirectoryClientPassword given")
+		clientIDSetting := defaultClientIDSetting
+		if val, ok := metadata["activeDirectoryClientId"]; ok && val != "" {
+			clientIDSetting = val
+		}
+
+		if val, ok := resolvedEnv[clientIDSetting]; ok {
+			meta.clientID = val
+		} else {
+			return nil, fmt.Errorf("no activeDirectoryClientId given")
+		}
+	}
+
+	clientPassword := authParams["activeDirectoryClientPassword"]
+	if clientPassword != "" {
+		meta.clientPassword = clientPassword
+	} else {
+		clientPasswordSetting := defaultClientPasswordSetting
+		if val, ok := metadata["activeDirectoryClientPassword"]; ok && val != "" {
+			clientPasswordSetting = val
+		}
+
+		if val, ok := resolvedEnv[clientPasswordSetting]; ok {
+			meta.clientPassword = val
+		} else {
+			return nil, fmt.Errorf("no activeDirectoryClientPassword given")
+		}
 	}
 
 	return &meta, nil

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -39,7 +39,7 @@ type azureMonitorMetadata struct {
 
 var azureMonitorLog = logf.Log.WithName("azure_monitor_scaler")
 
-// NewAzureMonitorScaler stuff
+// NewAzureMonitorScaler creates a new AzureMonitorScaler
 func NewAzureMonitorScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler, error) {
 	meta, err := parseAzureMonitorMetadata(metadata, resolvedEnv, authParams)
 	if err != nil {
@@ -150,7 +150,7 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 	return &meta, nil
 }
 
-// needs to interact with azure monitor
+// Returns true if the Azure Monitor metric value is greater than zero
 func (s *azureMonitorScaler) IsActive(ctx context.Context) (bool, error) {
 	val, err := GetAzureMetricValue(ctx, s.metadata)
 	if err != nil {

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -61,6 +61,8 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 			return nil, fmt.Errorf("Error parsing azure monitor metadata %s: %s", targetValueName, err.Error())
 		}
 		meta.targetValue = targetValue
+	} else {
+		return nil, fmt.Errorf("no targetValue given")
 	}
 
 	if val, ok := metadata["resourceURI"]; ok && val != "" {

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -3,8 +3,8 @@ package scalers
 import (
 	"context"
 	"fmt"
-    "strconv"
-    "strings"
+	"strconv"
+	"strings"
 
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -24,17 +24,17 @@ type azureMonitorScaler struct {
 }
 
 type azureMonitorMetadata struct {
-	resourceURI          string
-	tentantID            string
-	subscriptionID       string
-	resourceGroupName    string
-	name                 string
-	filter               string
-	aggregationInterval  string
-	aggregationType      string
-	servicePrincipalID   string
-	servicePrincipalPass string
-	targetValue          int
+	resourceURI         string
+	tentantID           string
+	subscriptionID      string
+	resourceGroupName   string
+	name                string
+	filter              string
+	aggregationInterval string
+	aggregationType     string
+	clientID            string
+	clientPassword      string
+	targetValue         int
 }
 
 var azureMonitorLog = logf.Log.WithName("azure_monitor_scaler")
@@ -108,25 +108,25 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 
 	if val, ok := metadata["metricAggregationInterval"]; ok {
 		if val != "" {
-            aggregationInterval := strings.Split(val, ":")
-            if len(aggregationInterval) != 3 {
-                return nil, fmt.Errorf("metricAggregationInterval not in the correct format. Should be hh:mm:ss")
-            }
+			aggregationInterval := strings.Split(val, ":")
+			if len(aggregationInterval) != 3 {
+				return nil, fmt.Errorf("metricAggregationInterval not in the correct format. Should be hh:mm:ss")
+			}
 
 			meta.aggregationInterval = val
 		}
 	}
 
-	if val, ok := metadata["adServicePrincipleId"]; ok && val != "" {
-		meta.servicePrincipalID = val
+	if val, ok := metadata["activeDirectoryClientId"]; ok && val != "" {
+		meta.clientID = val
 	} else {
-		return nil, fmt.Errorf("no adServicePrincipleId given")
+		return nil, fmt.Errorf("no activeDirectoryClientId given")
 	}
 
-	if val, ok := metadata["adServicePrinciplePassword"]; ok {
-		meta.servicePrincipalPass = val
+	if val, ok := metadata["activeDirectoryClientPassword"]; ok && val != "" {
+		meta.clientPassword = val
 	} else {
-		return nil, fmt.Errorf("no adServicePrinciplePassword given")
+		return nil, fmt.Errorf("no activeDirectoryClientPassword given")
 	}
 
 	return &meta, nil

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -107,24 +107,16 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 
 	// Required authentication parameters below
 
-	if val, ok := authParams["subscriptionId"]; ok && val != "" {
+	if val, ok := metadata["subscriptionId"]; ok && val != "" {
 		meta.subscriptionID = val
 	} else {
-		if val, ok := metadata["subscriptionId"]; ok && val != "" {
-			meta.subscriptionID = val
-		} else {
-			return nil, fmt.Errorf("no subscriptionId given")
-		}
+		return nil, fmt.Errorf("no subscriptionId given")
 	}
 
-	if val, ok := authParams["tenantId"]; ok && val != "" {
+	if val, ok := metadata["tenantId"]; ok && val != "" {
 		meta.tenantID = val
 	} else {
-		if val, ok := metadata["tenantId"]; ok && val != "" {
-			meta.tenantID = val
-		} else {
-			return nil, fmt.Errorf("no tenantId given")
-		}
+		return nil, fmt.Errorf("no tenantId given")
 	}
 
 	if val, ok := authParams["activeDirectoryClientId"]; ok && val != "" {

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -105,12 +105,6 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 		}
 	}
 
-	if val, ok := metadata["metricAggregationType"]; ok && val != "" {
-		meta.subscriptionID = val
-	} else {
-		return nil, fmt.Errorf("no metricAggregationType given")
-	}
-
 	if val, ok := metadata["adServicePrincipleId"]; ok && val != "" {
 		meta.servicePrincipalID = val
 	} else {

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	azureMonitorMetricName = "metricName"
-	targetValueName        = "targetValue"
+	azureMonitorMetricName       = "metricName"
+	targetValueName              = "targetValue"
+	defaultClientIDSetting       = ""
+	defaultClientPasswordSetting = ""
 )
 
 type azureMonitorScaler struct {
@@ -122,7 +124,12 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 	if val, ok := authParams["activeDirectoryClientId"]; ok && val != "" {
 		meta.clientID = val
 	} else {
+		clientIDSetting := defaultClientIDSetting
 		if val, ok := metadata["activeDirectoryClientId"]; ok && val != "" {
+			clientIDSetting = val
+		}
+
+		if val, ok := resolvedEnv[clientIDSetting]; ok {
 			meta.clientID = val
 		} else {
 			return nil, fmt.Errorf("no activeDirectoryClientId given")
@@ -132,7 +139,12 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 	if val, ok := authParams["activeDirectoryClientPassword"]; ok && val != "" {
 		meta.clientPassword = val
 	} else {
+		clientPasswordSetting := defaultClientPasswordSetting
 		if val, ok := metadata["activeDirectoryClientPassword"]; ok && val != "" {
+			clientPasswordSetting = val
+		}
+
+		if val, ok := resolvedEnv[clientPasswordSetting]; ok {
 			meta.clientPassword = val
 		} else {
 			return nil, fmt.Errorf("no activeDirectoryClientPassword given")

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -64,6 +64,10 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 	}
 
 	if val, ok := metadata["resourceURI"]; ok && val != "" {
+		resourceURI := strings.Split(val, "/")
+		if len(resourceURI) != 3 {
+			return nil, fmt.Errorf("resourceURI not in the correct format. Should be namespace/resource_type/resource_name")
+		}
 		meta.resourceURI = val
 	} else {
 		return nil, fmt.Errorf("no resourceURI given")

--- a/pkg/scalers/azure_monitor_test.go
+++ b/pkg/scalers/azure_monitor_test.go
@@ -1,0 +1,55 @@
+package scalers
+
+import (
+	"testing"
+)
+
+type parseAzMonitorMetadataTestData struct {
+	metadata    map[string]string
+	isError     bool
+	resolvedEnv map[string]string
+	authParams  map[string]string
+}
+
+var testParseAzMonitorMetadata = []parseAzMonitorMetadataTestData{
+	// nothing passed
+	{map[string]string{}, true, map[string]string{}, map[string]string{}},
+	// properly formed
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, false, map[string]string{}, map[string]string{}},
+	// no optional parameters
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, false, map[string]string{}, map[string]string{}},
+	// incorrectly formatted resourceURI
+	{map[string]string{"resourceURI": "bad/format", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// improperly formatted aggregationInterval
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:1", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// missing resourceURI
+	{map[string]string{"tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// missing tenantId
+	{map[string]string{"resourceURI": "test/resource/uri", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// missing subscriptionId
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// missing resourceGroupName
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// missing metricName
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// filter included
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricFilter": "namespace eq 'default'", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, false, map[string]string{}, map[string]string{}},
+	// missing activeDirectoryClientId
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// missing activeDirectoryClientPassword
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	// missing targetValue
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234"}, true, map[string]string{}, map[string]string{}},
+}
+
+func TestAzMonitorParseMetadata(t *testing.T) {
+	for _, testData := range testParseAzMonitorMetadata {
+		_, err := parseAzureMonitorMetadata(testData.metadata, testData.resolvedEnv, testData.authParams)
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Errorf("Expected error but got success. testData: %v", testData)
+		}
+	}
+}

--- a/pkg/scalers/azure_monitor_test.go
+++ b/pkg/scalers/azure_monitor_test.go
@@ -11,35 +11,44 @@ type parseAzMonitorMetadataTestData struct {
 	authParams  map[string]string
 }
 
+var testAzMonitorResolvedEnv = map[string]string{
+	"CLIENT_ID":       "xxx",
+	"CLIENT_PASSWORD": "yyy",
+}
+
 var testParseAzMonitorMetadata = []parseAzMonitorMetadataTestData{
 	// nothing passed
 	{map[string]string{}, true, map[string]string{}, map[string]string{}},
 	// properly formed
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, false, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, false, testAzMonitorResolvedEnv, map[string]string{}},
 	// no optional parameters
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, false, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, false, testAzMonitorResolvedEnv, map[string]string{}},
 	// incorrectly formatted resourceURI
-	{map[string]string{"resourceURI": "bad/format", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "bad/format", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// improperly formatted aggregationInterval
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:1", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:1", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing resourceURI
-	{map[string]string{"tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing tenantId
-	{map[string]string{"resourceURI": "test/resource/uri", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing subscriptionId
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing resourceGroupName
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing metricName
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
+	// missing metricAggregationType
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// filter included
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricFilter": "namespace eq 'default'", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, false, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricFilter": "namespace eq 'default'", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, false, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing activeDirectoryClientId
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientPassword": "1234", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientPassword": "CLIENT_PASSWORD", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing activeDirectoryClientPassword
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "targetValue": "5"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "targetValue": "5"}, true, testAzMonitorResolvedEnv, map[string]string{}},
 	// missing targetValue
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "789", "activeDirectoryClientPassword": "1234"}, true, map[string]string{}, map[string]string{}},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPassword": "CLIENT_PASSWORD"}, true, testAzMonitorResolvedEnv, map[string]string{}},
+	// connection from authParams
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, false, map[string]string{}, map[string]string{"activeDirectoryClientId": "zzz", "activeDirectoryClientPassword": "password"}},
 }
 
 func TestAzMonitorParseMetadata(t *testing.T) {


### PR DESCRIPTION
Fixes #155 

Majority of the code in `azure_monitor.go` taken from [azure-k8s-metrics-adapter](https://github.com/Azure/azure-k8s-metrics-adapter/tree/master/pkg/azure/externalmetrics).

ScaledObject I used for testing authentication from metadata (minus the credentials)

```yaml
apiVersion: keda.k8s.io/v1alpha1
kind: ScaledObject
metadata:
  name: order-processor-scaler
  labels:
    app: order-processor
    deploymentName: order-processor
spec:
  scaleTargetRef:
    deploymentName: order-processor
  minReplicaCount: 1 # Change to define how many minimum replicas you want
  maxReplicaCount: 10
  triggers:
  - type: azure-monitor
    metadata:
      resourceURI: Microsoft.ContainerService/managedClusters/melconeKeda # Required. URI to the Azure resource
      tenantId: xxxx # Required. Used for authentication
      subscriptionId: xxxx # Required. Used for determining the full resource URI
      resourceGroupName: melconeKeda # Required. Used for determining the full resource URI
      metricName: kube_pod_status_ready # Required. Officially supported metric from https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported
      metricFilter: namespace eq 'default' # Optional. Used to define more specific part of the resource. Options for filter listed under the dimensions column in https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported
      metricAggregationInterval: '00:15:00' # Optional. Interval over which the metric values should be aggregated and reported
      metricAggregationType: Average # Required. Aggregation type to use for metric based on what is supported https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported
      targetValue: '1' # Required. Target threshold for the HPA.
      activeDirectoryClientId: CLIENT_ID_ENV_VAR # Optional. Used when no trigger auth is linked
      activeDirectoryClientPassword: CLIENT_PASSWORD_ENV_VAR # Optional. Used when no trigger auth is linked
```

Here's the file I used for testing custom `metricAggregationInterval` and authentication with `authParams` and `resolvedEnv`

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: azure-monitor-secrets
data:
  activeDirectoryClientId: xxx
  activeDirectoryClientPassword: xxx
---
apiVersion: keda.k8s.io/v1alpha1
kind: TriggerAuthentication
metadata: 
  name: azure-monitor-trigger-auth
spec:
  secretTargetRef:
    - parameter: activeDirectoryClientId
      name: azure-monitor-secrets
      key: activeDirectoryClientId
    - parameter: activeDirectoryClientPassword
      name: azure-monitor-secrets
      key: activeDirectoryClientPassword
---
apiVersion: keda.k8s.io/v1alpha1
kind: ScaledObject
metadata:
  name: azure-monitor-scaler
  labels:
    app: azure-monitor-example
    deploymentName: azure-monitor-example
spec:
  scaleTargetRef:
    deploymentName: azure-monitor-example
  minReplicaCount: 1 # Change to define how many minimum replicas you want
  maxReplicaCount: 10
  triggers:
  - type: azure-monitor
    metadata:
      resourceURI: Microsoft.ContainerService/managedClusters/melconeKeda # Required. URI to the Azure resource
      resourceGroupName: melconeKeda # Required. Used for determining the full resource URI
      metricName: kube_pod_status_ready # Required. Officially supported metric from https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported
      metricFilter: namespace eq 'default' # Optional. Used to define more specific part of the resource, in this example a queue in SB namespace
      metricAggregationInterval: '1:15:10' # Optional. Interval over which the metric values should be aggregated and reported
      metricAggregationType: Average # Required. Aggregation type to use for metric based on what is supported https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported
      targetValue: '1' # Required. Target threshold for the HPA.
    authenticationRef:
      name: azure-monitor-trigger-auth
```

### TODO
- [x] Allow for `metricAggregationInterval` other than 5 minute default
- [x] Implement authentication with `resolvedEnv` or `authParams`
- [x] Add test
- [ ] Test more Azure Monitor metrics