### PR TITLE
Add a checkenv target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,15 @@ publish: build
 ##################################################
 GO_BUILD_VARS= GO111MODULE=on CGO_ENABLED=$(CGO) GOOS=$(TARGET_OS) GOARCH=$(ARCH)
 
+.PHONY: checkenv
+checkenv:
+ifndef GOROOT
+	@echo "GOROOT is not defined"
+	@exit 1
+endif
+
 .PHONY: build
-build: build-adapter build-controller
+build: checkenv build-adapter build-controller
 
 .PHONY: build-controller
 build-controller: generate-api pkg/scalers/liiklus/LiiklusService.pb.go


### PR DESCRIPTION
This PR adds a new `checkenv` target that could be useful to check some env vars.
For example, related to #599, it checks that the `GOROOT` is set otherwise the error from #599 happens.