### PR TITLE
Changed exiting in a warning when GOROOT is not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ GO_BUILD_VARS= GO111MODULE=on CGO_ENABLED=$(CGO) GOOS=$(TARGET_OS) GOARCH=$(ARCH
 .PHONY: checkenv
 checkenv:
 ifndef GOROOT
-	@echo "GOROOT is not defined"
-	@exit 1
+	@echo "WARNING: GOROOT is not defined"
 endif
 
 .PHONY: build


### PR DESCRIPTION
This PR fixes #604 just printing a warning when GOROOT is not defined instead of exiting.