### PR TITLE
Update release-build.yml

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,9 +29,5 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
 
-      - name: Get the image tag
-        id: get_image_tag
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
-
       - name: Publish
-        run: make VERSION=$VERSION publish
+        run: make VERSION=${GITHUB_REF#refs/tags/v} publish


### PR DESCRIPTION
I'm not entirely sure why the `set-output` method isn't working even though it's exactly what's mentioned [here](https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/td-p/31595#). I tested this change on [my fork](https://github.com/ahmelsayed/keda/runs/428889056?check_suite_focus=true), so I know it works