### PR TITLE
Added bootstrapServers to deprecate brokerList

### DIFF
--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -32,8 +32,12 @@ var validWithAuthParams = map[string]string{
 var validWithoutAuthParams = map[string]string{}
 
 var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
-	// failure, no brokerList
+	// failure, no brokerList (deprecated) or bootstrapServers
 	{map[string]string{}, true, 0, nil, "", ""},
+	// failure, both brokerList (deprecated) and bootstrapServers
+	{map[string]string{"brokerList": "foobar:9092", "bootstrapServers": "foobar:9092"}, true, 0, nil, "", ""},
+
+	// tests with brokerList (deprecated)
 	// failure, no consumer group
 	{map[string]string{"brokerList": "foobar:9092"}, true, 1, []string{"foobar:9092"}, "", ""},
 	// failure, no topic
@@ -42,6 +46,16 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 	{map[string]string{"brokerList": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic"},
 	// success, more brokers
 	{map[string]string{"brokerList": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic"},
+
+	// tests with bootstrapServers
+	// failure, no consumer group
+	{map[string]string{"bootstrapServers": "foobar:9092"}, true, 1, []string{"foobar:9092"}, "", ""},
+	// failure, no topic
+	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group"}, true, 1, []string{"foobar:9092"}, "my-group", ""},
+	// success
+	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic"},
+	// success, more brokers
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic"},
 }
 
 func TestGetBrokers(t *testing.T) {
@@ -54,11 +68,11 @@ func TestGetBrokers(t *testing.T) {
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")
 		}
-		if len(meta.brokers) != testData.numBrokers {
-			t.Errorf("Expected %d brokers but got %d\n", testData.numBrokers, len(meta.brokers))
+		if len(meta.bootstrapServers) != testData.numBrokers {
+			t.Errorf("Expected %d bootstrap servers but got %d\n", testData.numBrokers, len(meta.bootstrapServers))
 		}
-		if !reflect.DeepEqual(testData.brokers, meta.brokers) {
-			t.Errorf("Expected %v but got %v\n", testData.brokers, meta.brokers)
+		if !reflect.DeepEqual(testData.brokers, meta.bootstrapServers) {
+			t.Errorf("Expected %v but got %v\n", testData.brokers, meta.bootstrapServers)
 		}
 		if meta.group != testData.group {
 			t.Errorf("Expected group %s but got %s\n", testData.group, meta.group)
@@ -75,11 +89,11 @@ func TestGetBrokers(t *testing.T) {
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")
 		}
-		if len(meta.brokers) != testData.numBrokers {
-			t.Errorf("Expected %d brokers but got %d\n", testData.numBrokers, len(meta.brokers))
+		if len(meta.bootstrapServers) != testData.numBrokers {
+			t.Errorf("Expected %d bootstrap servers but got %d\n", testData.numBrokers, len(meta.bootstrapServers))
 		}
-		if !reflect.DeepEqual(testData.brokers, meta.brokers) {
-			t.Errorf("Expected %v but got %v\n", testData.brokers, meta.brokers)
+		if !reflect.DeepEqual(testData.brokers, meta.bootstrapServers) {
+			t.Errorf("Expected %v but got %v\n", testData.brokers, meta.bootstrapServers)
 		}
 		if meta.group != testData.group {
 			t.Errorf("Expected group %s but got %s\n", testData.group, meta.group)


### PR DESCRIPTION
This PR fixes #608 in order to add `bootstrapServers` and deprecate `brokerList` to specify the bootstrap brokers to use for connecting the Kafka client (inside the related scaler) to the Kafka cluster.

### Checklist

- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Tests have been added


Fixes #
