### PR TITLE
Provide "Support" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Support.md
+++ b/.github/ISSUE_TEMPLATE/Support.md
@@ -1,0 +1,7 @@
+---
+name: Support / Question
+about: Ask a question or request support for using KEDA
+labels: support
+---
+
+A clear and concise description of your question of what you are trying to achieve.


### PR DESCRIPTION
Provide "Support" issue template which applies `support` label.

We have a lot of issues open with `bug` while often it's just to ask a question or need help.
