### PR TITLE
Azure Queue Job Scaler continues to scale up Jobs while the message is being treated

### DIFF
--- a/pkg/handler/scale_jobs.go
+++ b/pkg/handler/scale_jobs.go
@@ -194,7 +194,7 @@ func (h *ScaleHandler) getPendingJobCount(scaledObject *kedav1alpha1.ScaledObjec
 	}
 
 	for _, job := range jobs.Items {
-		if !h.isAnyPodRunningOrCompleted(&job) {
+		if !h.isAnyPodRunningOrCompleted(job) {
 			pendingJobs++
 		}
 	}

--- a/pkg/handler/scale_jobs.go
+++ b/pkg/handler/scale_jobs.go
@@ -194,7 +194,7 @@ func (h *ScaleHandler) getPendingJobCount(scaledObject *kedav1alpha1.ScaledObjec
 	}
 
 	for _, job := range jobs.Items {
-		if !h.isAnyPodRunningOrCompleted(job) {
+		if !h.isJobFinished(&job) && !h.isAnyPodRunningOrCompleted(job) {
 			pendingJobs++
 		}
 	}

--- a/pkg/handler/scale_loop.go
+++ b/pkg/handler/scale_loop.go
@@ -68,7 +68,7 @@ func (h *ScaleHandler) handleScaleJob(ctx context.Context, scaledObject *kedav1a
 
 		isTriggerActive, err := scaler.IsActive(ctx)
 		scalerLogger.Info("Active trigger", "isTriggerActive", isTriggerActive)
-		metricSpecs := scaler.GetMetricSpecForScalingJobs()
+		metricSpecs := scaler.GetMetricSpecForScalingJob()
 
 		var metricValue int64
 		for _, metric := range metricSpecs {

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -181,6 +181,10 @@ func (c *awsCloudwatchScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *awsCloudwatchScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 func (c *awsCloudwatchScaler) IsActive(ctx context.Context) (bool, error) {
 	val, err := c.GetCloudwatchMetrics()
 

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -181,8 +181,8 @@ func (c *awsCloudwatchScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
-func (s *awsCloudwatchScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
-	return s.GetMetricSpecForScaling()
+func (c *awsCloudwatchScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return c.GetMetricSpecForScaling()
 }
 
 func (c *awsCloudwatchScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -108,6 +108,10 @@ func (s *awsKinesisStreamScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec 
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *awsKinesisStreamScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *awsKinesisStreamScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	shardCount, err := s.GetAwsKinesisOpenShardCount()

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -124,6 +124,10 @@ func (s *awsSqsQueueScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *awsSqsQueueScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *awsSqsQueueScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	queuelen, err := s.GetAwsSqsQueueLength()

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -157,6 +157,10 @@ func (s *azureBlobScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *azureBlobScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *azureBlobScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	bloblen, err := GetAzureBlobListLength(

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -185,6 +185,10 @@ func (scaler *AzureEventHubScaler) GetMetricSpecForScaling() []v2beta1.MetricSpe
 	}
 }
 
+func (s *AzureEventHubScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 // GetMetrics returns metric using total number of unprocessed events in event hub
 func (scaler *AzureEventHubScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	totalUnprocessedEventCount := int64(0)

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -185,8 +185,8 @@ func (scaler *AzureEventHubScaler) GetMetricSpecForScaling() []v2beta1.MetricSpe
 	}
 }
 
-func (s *AzureEventHubScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
-	return s.GetMetricSpecForScaling()
+func (scaler *AzureEventHubScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return scaler.GetMetricSpecForScaling()
 }
 
 // GetMetrics returns metric using total number of unprocessed events in event hub

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -176,6 +176,10 @@ func (s *azureMonitorScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *azureMonitorScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *azureMonitorScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	val, err := GetAzureMetricValue(ctx, s.metadata)

--- a/pkg/scalers/azure_queue.go
+++ b/pkg/scalers/azure_queue.go
@@ -8,8 +8,8 @@ import (
 	"github.com/Azure/azure-storage-queue-go/azqueue"
 )
 
-// GetAzureQueueLength returns the length of a queue in int
-func GetAzureQueueLength(ctx context.Context, podIdentity string, connectionString, queueName string, accountName string) (int32, error) {
+// GetAzureQueueURL returns a ready endpoint to comunicate with the API
+func GetAzureQueueURL(ctx context.Context, podIdentity string, connectionString, queueName string, accountName string) (int32, error) {
 
 	var credential azqueue.Credential
 	var err error
@@ -50,10 +50,42 @@ func GetAzureQueueLength(ctx context.Context, podIdentity string, connectionStri
 		return -1, err
 	}
 
+	return queueURL, nil
+}
+
+// GetAzureQueueLength returns the length of a queue in int
+func GetAzureQueueLength(ctx context.Context, podIdentity string, connectionString, queueName string, accountName string) (int32, error) {
+
+	var err error
+
+	queueURL, err := GetAzureQueueURL(ctx, podIdentity, connectionString, queueName, accountName)
+	if err != nil {
+		return -1, err
+	}
+
 	props, err := queueURL.GetProperties(ctx)
 	if err != nil {
 		return -1, err
 	}
 
 	return props.ApproximateMessagesCount(), nil
+}
+
+// GetAzureQueueVisibleLength returns the number of visible messages in a queue in int
+func GetAzureQueueVisibleLength(ctx context.Context, podIdentity string, connectionString, queueName string, accountName string, maxCount int32) (int32, error) {
+
+	var err error
+
+	queueURL, err := GetAzureQueueURL(ctx, podIdentity, connectionString, queueName, accountName)
+	if err != nil {
+		return -1, err
+	}
+
+	pmr, err := queueURL.Peek(ctx, maxCount)
+	if err != nil {
+		return -1, err
+	}
+	count = pmr.NumMessages()
+
+	return count, nil
 }

--- a/pkg/scalers/azure_queue.go
+++ b/pkg/scalers/azure_queue.go
@@ -71,8 +71,8 @@ func GetAzureQueueLength(ctx context.Context, podIdentity string, connectionStri
 	return props.ApproximateMessagesCount(), nil
 }
 
-// GetAzureQueueVisibleLength returns the number of visible messages in a queue in int
-func GetAzureQueueVisibleLength(ctx context.Context, podIdentity string, connectionString, queueName string, accountName string, maxCount int32) (int32, error) {
+// GetAzureVisibleQueueLength returns the number of visible messages in a queue in int
+func GetAzureVisibleQueueLength(ctx context.Context, podIdentity string, connectionString, queueName string, accountName string, maxCount int32) (int32, error) {
 
 	var err error
 

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -164,6 +164,7 @@ func (s *azureQueueScaler) GetMetrics(ctx context.Context, metricName string, me
 				s.metadata.connection,
 				s.metadata.queueName,
 				s.metadata.accountName,
+				s.metadata.targetQueueLength,
 			)
 		default:
 			return []external_metrics.ExternalMetricValue{}, fmt.Errorf("no metric found with name: %s", metricName)

--- a/pkg/scalers/azure_queue_test.go
+++ b/pkg/scalers/azure_queue_test.go
@@ -75,6 +75,33 @@ func TestGetQueueLength(t *testing.T) {
 	if !strings.Contains(err.Error(), "illegal base64") {
 		t.Error("Expected error to contain base64 error message, but got", err.Error())
 	}
+
+	length, err := GetAzureVisibleQueueLength(context.TODO(), "", "", "queueName", "")
+	if length != -1 {
+		t.Error("Expected length to be -1, but got", length)
+	}
+
+	if err == nil {
+		t.Error("Expected error for empty connection string, but got nil")
+	}
+
+	if !strings.Contains(err.Error(), "parse storage connection string") {
+		t.Error("Expected error to contain parsing error message, but got", err.Error())
+	}
+
+	length, err = GetAzureVisibleQueueLength(context.TODO(), "", "DefaultEndpointsProtocol=https;AccountName=name;AccountKey=key==;EndpointSuffix=core.windows.net", "queueName", "")
+
+	if length != -1 {
+		t.Error("Expected length to be -1, but got", length)
+	}
+
+	if err == nil {
+		t.Error("Expected error for empty connection string, but got nil")
+	}
+
+	if !strings.Contains(err.Error(), "illegal base64") {
+		t.Error("Expected error to contain base64 error message, but got", err.Error())
+	}
 }
 
 var testAzQueueResolvedEnv = map[string]string{

--- a/pkg/scalers/azure_queue_test.go
+++ b/pkg/scalers/azure_queue_test.go
@@ -76,7 +76,7 @@ func TestGetQueueLength(t *testing.T) {
 		t.Error("Expected error to contain base64 error message, but got", err.Error())
 	}
 
-	length, err := GetAzureVisibleQueueLength(context.TODO(), "", "", "queueName", "")
+	length, err = GetAzureVisibleQueueLength(context.TODO(), "", "", "queueName", "", 10)
 	if length != -1 {
 		t.Error("Expected length to be -1, but got", length)
 	}
@@ -89,7 +89,7 @@ func TestGetQueueLength(t *testing.T) {
 		t.Error("Expected error to contain parsing error message, but got", err.Error())
 	}
 
-	length, err = GetAzureVisibleQueueLength(context.TODO(), "", "DefaultEndpointsProtocol=https;AccountName=name;AccountKey=key==;EndpointSuffix=core.windows.net", "queueName", "")
+	length, err = GetAzureVisibleQueueLength(context.TODO(), "", "DefaultEndpointsProtocol=https;AccountName=name;AccountKey=key==;EndpointSuffix=core.windows.net", "queueName", "", 10)
 
 	if length != -1 {
 		t.Error("Expected length to be -1, but got", length)

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -150,6 +150,10 @@ func (s *azureServiceBusScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *azureServiceBusScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 // Returns the current metrics to be served to the HPA
 func (s *azureServiceBusScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	queuelen, err := s.GetAzureServiceBusLength(ctx)

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -163,6 +163,10 @@ func (s *externalScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return result
 }
 
+func (s *externalScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 // GetMetrics connects calls the gRPC interface to get the metrics with a specific name
 func (s *externalScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 

--- a/pkg/scalers/gcp_pub_sub_scaler.go
+++ b/pkg/scalers/gcp_pub_sub_scaler.go
@@ -116,6 +116,10 @@ func (s *pubsubScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *pubsubScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 // GetMetrics connects to Stack Driver and finds the size of the pub sub subscription
 func (s *pubsubScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	size, err := s.GetSubscriptionSize(ctx)

--- a/pkg/scalers/huawei_cloudeye_scaler.go
+++ b/pkg/scalers/huawei_cloudeye_scaler.go
@@ -248,8 +248,8 @@ func (h *huaweiCloudeyeScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
-func (s *huaweiCloudeyeScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
-	return s.GetMetricSpecForScaling()
+func (h *huaweiCloudeyeScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return h.GetMetricSpecForScaling()
 }
 
 func (h *huaweiCloudeyeScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/huawei_cloudeye_scaler.go
+++ b/pkg/scalers/huawei_cloudeye_scaler.go
@@ -248,6 +248,10 @@ func (h *huaweiCloudeyeScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *huaweiCloudeyeScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 func (h *huaweiCloudeyeScaler) IsActive(ctx context.Context) (bool, error) {
 	val, err := h.GetCloudeyeMetrics()
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -334,6 +334,10 @@ func (s *kafkaScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	}
 }
 
+func (s *kafkaScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *kafkaScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	partitions, err := s.getPartitions()

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -89,6 +89,10 @@ func (s *liiklusScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	}
 }
 
+func (s *liiklusScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 func (s *liiklusScaler) Close() error {
 	err := s.connection.Close()
 	if err != nil {

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -195,6 +195,11 @@ func (s *mySQLScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *mySQLScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	mySQLLog.Error(fmt.Errorf("error getting MySQL MetricSpec for scaling a job"), "mySQLScaler does not implements this metric yet")
+	return []v2beta1.MetricSpec{}
+}
+
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *mySQLScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	num, err := s.getQueryResult()

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -182,6 +182,11 @@ func (s *postgreSQLScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *postgreSQLScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	postgreSQLLog.Error(fmt.Errorf("error getting postgreSQL MetricSpec for scaling a job"), "postgreSQLScaler does not implements this metric yet")
+	return []v2beta1.MetricSpec{}
+}
+
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *postgreSQLScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	num, err := s.getActiveNumber()

--- a/pkg/scalers/prometheus.go
+++ b/pkg/scalers/prometheus.go
@@ -121,6 +121,10 @@ func (s *prometheusScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	}
 }
 
+func (s *prometheusScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 func (s *prometheusScaler) ExecutePromQuery() (float64, error) {
 	t := time.Now().UTC().Format(time.RFC3339)
 	query_escaped := url_pkg.QueryEscape(s.metadata.query)

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -145,6 +145,11 @@ func (s *rabbitMQScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	}
 }
 
+func (s *rabbitMQScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	rabbitmqLog.Error(fmt.Errorf("error getting rabbitMQ MetricSpec for scaling a job"), "rabbitMQScaler does not implements this metric yet")
+	return []v2beta1.MetricSpec{}
+}
+
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *rabbitMQScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	messages, err := s.getQueueMessages()

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -136,6 +136,10 @@ func (s *redisScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	return []v2beta1.MetricSpec{metricSpec}
 }
 
+func (s *redisScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 // GetMetrics connects to Redis and finds the length of the list
 func (s *redisScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	listLen, err := getRedisListLength(ctx, s.metadata.address, s.metadata.password, s.metadata.listName, s.metadata.databaseIndex, s.metadata.enableTLS)

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -17,6 +17,9 @@ type Scaler interface {
 	// this scaled object. The labels used should match the selectors used in GetMetrics
 	GetMetricSpecForScaling() []v2beta1.MetricSpec
 
+	//returns the metrics based on which this scaler determines that the job scales. The labels used should match the selectors used in GetMetrics
+	GetMetricSpecForScalingJob() []v2beta1.MetricSpec
+
 	IsActive(ctx context.Context) (bool, error)
 
 	// Close any resources that need disposing when scaler is no longer used or destroyed

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -191,6 +191,10 @@ func (s *stanScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
 	}
 }
 
+func (s *stanScaler) GetMetricSpecForScalingJob() []v2beta1.MetricSpec {
+	return s.GetMetricSpecForScaling()
+}
+
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
 func (s *stanScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	resp, err := http.Get(s.getMonitoringEndpoint())

--- a/tests/scalers/azure-queue-jobs.test.ts
+++ b/tests/scalers/azure-queue-jobs.test.ts
@@ -1,0 +1,140 @@
+import * as async from 'async'
+import * as azure from 'azure-storage'
+import * as fs from 'fs'
+import * as sh from 'shelljs'
+import * as tmp from 'tmp'
+import test from 'ava'
+
+const defaultNamespace = 'azure-queue-test'
+const connectionString = process.env['TEST_STORAGE_CONNECTION_STRING']
+
+test.before(t => {
+  if (!connectionString) {
+    t.fail('TEST_STORAGE_CONNECTION_STRING environment variable is required for queue tests')
+  }
+
+  sh.config.silent = true
+  const base64ConStr = Buffer.from(connectionString).toString('base64')
+  const tmpFile = tmp.fileSync()
+  fs.writeFileSync(tmpFile.name, jobYaml.replace('{{CONNECTION_STRING_BASE64}}', base64ConStr))
+  sh.exec(`kubectl create namespace ${defaultNamespace}`)
+  t.is(
+    0,
+    sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${defaultNamespace}`).code,
+    'creating a job scaledObject should work.'
+  )
+})
+
+test.serial('Job scaledObject should have 0 job on start', t => {
+  const replicaCount = sh.exec(
+    `kubectl get jobs --namespace ${defaultNamespace} -o jsonpath="{range .items[*]}{.spec.completions}{"\n"}{end}" | wc -l`
+  ).stdout.trim()
+  t.is(replicaCount, '0', 'replica count should start out as 0')
+})
+
+test.serial.cb(
+  'Deployment should scale to 5 with 10 messages on the queue then complete the 10',
+  t => {
+    // add 5 messages
+    const queueSvc = azure.createQueueService(connectionString)
+    queueSvc.messageEncoder = new azure.QueueMessageEncoder.TextBase64QueueMessageEncoder()
+    queueSvc.createQueueIfNotExists('queue-name', err => {
+      t.falsy(err, 'unable to create queue')
+      async.mapLimit(
+        Array(10).keys(),
+        2,
+        (n, cb) => queueSvc.createMessage('queue-name', `test ${n}`, cb),
+        () => {
+          let replicaCount = '0'
+          for (let i = 0; i < 10 && replicaCount !== '5'; i++) {
+            replicaCount = sh.exec(
+              `kubectl get jobs --namespace ${defaultNamespace} -o jsonpath="{range .items[*]}{.spec.completions}{"\n"}{end}" | wc -l`
+            ).stdout.trim()
+            if (replicaCount !== '5') {
+              sh.exec('sleep 1s')
+            }
+          }
+
+          t.is('5', replicaCount, 'Job count should be 5 after 10 seconds')
+
+          for (let i = 0; i < 50 && replicaCount !== '10'; i++) {
+            replicaCount = sh.exec(
+              `kubectl get jobs --namespace ${defaultNamespace} -o jsonpath="{range .items[*]}{.spec.completions}{"\n"}{end}" | grep 1 | wc -l`
+            ).stdout
+            if (replicaCount !== '10') {
+              sh.exec('sleep 5s')
+            }
+          }
+
+          t.is('10', replicaCount, 'Job Completion count should be 10 after 3 minutes')
+          t.end()
+        }
+      )
+    })
+  }
+)
+
+test.after.always.cb('clean up azure-queue deployment', t => {
+  const resources = [
+    'secret/test-secrets',
+    'deployment.apps/test-deployment',
+    'scaledobject.keda.k8s.io/test-scaledobject',
+  ]
+
+  for (const resource of resources) {
+    sh.exec(`kubectl delete ${resource} --namespace ${defaultNamespace}`)
+  }
+  sh.exec(`kubectl delete namespace ${defaultNamespace}`)
+
+  // delete test queue
+  const queueSvc = azure.createQueueService(connectionString)
+  queueSvc.deleteQueueIfExists('queue-name', err => {
+    t.falsy(err, 'should delete test queue successfully')
+    t.end()
+  })
+})
+
+const jobYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secrets
+  labels:
+data:
+  AzureWebJobsStorage: {{CONNECTION_STRING_BASE64}}
+---
+apiVersion: keda.k8s.io/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test-scaledobject
+spec:
+  scaleType: job
+  pollingInterval: 5
+  triggers:
+  - type: azure-queue
+    metadata:
+      queueName: queue-name
+      connection: AzureWebJobsStorage
+      queueLength: '5'
+  jobTargetRef:
+    parallelism: 1
+    completions: 1
+    activeDeadlineSeconds: 3600
+    backoffLimit: 2
+    template:
+      spec:
+        containers:
+        - name: test-job
+        image: thomaslamure/job-queue-consumer:latest
+        env:
+        - name: CompletionTime
+          value: 60
+        - name: QueueReads
+          value: 1
+        - name: AzureQueueName
+          value: queue-name
+        - name: AzureWebJobsStorage
+          valueFrom:
+            secretKeyRef:
+              name: test-secrets
+              key: AzureWebJobsStorage
+`


### PR DESCRIPTION
This PR implements a way of asking a specific metric for jobs to scale, as said in the issue the job scaler should not create more jobs because there is no 'visible' messages, even if the queue overall length is not null.

The jobs should scale as requested with this PR.

### Checklist

- [x] No PR is needed to update the documentation on https://github.com/kedacore/keda-docs, as the program is not actually behaving as explained in the docs. This PR tends to correct this.
- [x] Tests have been added


Fixes #636
