### PR TITLE
Authenticate to AWS with dedicated role without AssumeRole permissions

### DIFF
--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -201,7 +201,7 @@ func (c *awsCloudwatchScaler) GetCloudwatchMetrics() (float64, error) {
 	}))
 
 	var cloudwatchClient *cloudwatch.CloudWatch
-	if c.metadata.awsAuthorization.podIdentity {
+	if c.metadata.awsAuthorization.podIdentityOwner {
 		creds := credentials.NewStaticCredentials(c.metadata.awsAuthorization.awsAccessKeyID, c.metadata.awsAuthorization.awsSecretAccessKey, "")
 
 		if c.metadata.awsAuthorization.awsRoleArn != "" {

--- a/pkg/scalers/aws_cloudwatch_test.go
+++ b/pkg/scalers/aws_cloudwatch_test.go
@@ -144,6 +144,21 @@ var testAWSCloudwatchMetadata = []parseAWSCloudwatchMetadataTestData{
 		},
 		false,
 		"with AWS Role from TriggerAuthentication"},
+	{map[string]string{
+		"namespace":            "AWS/SQS",
+		"dimensionName":        "QueueName",
+		"dimensionValue":       "keda",
+		"metricName":           "ApproximateNumberOfMessagesVisible",
+		"targetMetricValue":    "2",
+		"minMetricValue":       "0",
+		"metricCollectionTime": "300",
+		"metricStat":           "Average",
+		"metricStatPeriod":     "300",
+		"awsRegion":            "eu-west-1",
+		"podIdentity":          "false"},
+		map[string]string{},
+		false,
+		"with AWS Role assigned on KEDA operator itself"},
 }
 
 func TestCloudwatchParseMetadata(t *testing.T) {

--- a/pkg/scalers/aws_cloudwatch_test.go
+++ b/pkg/scalers/aws_cloudwatch_test.go
@@ -155,7 +155,7 @@ var testAWSCloudwatchMetadata = []parseAWSCloudwatchMetadataTestData{
 		"metricStat":           "Average",
 		"metricStatPeriod":     "300",
 		"awsRegion":            "eu-west-1",
-		"podIdentity":          "false"},
+		"identityOwner":        "operator"},
 		map[string]string{},
 		false,
 		"with AWS Role assigned on KEDA operator itself"},

--- a/pkg/scalers/aws_iam_authorization.go
+++ b/pkg/scalers/aws_iam_authorization.go
@@ -15,16 +15,16 @@ type awsAuthorizationMetadata struct {
 	awsSecretAccessKey string
 	awsSessionToken    string
 
-	podIdentity bool
+	podIdentityOwner bool
 }
 
 func getAwsAuthorization(authParams, metadata, resolvedEnv map[string]string) (awsAuthorizationMetadata, error) {
 	meta := awsAuthorizationMetadata{}
 
-	if metadata["podIdentity"] == "false" {
-		meta.podIdentity = false
-	} else {
-		meta.podIdentity = true
+	if metadata["identityOwner"] == "operator" {
+		meta.podIdentityOwner = false
+	} else if metadata["identityOwner"] == "" || metadata["identityOwner"] == "pod" {
+		meta.podIdentityOwner = true
 		if authParams["awsRoleArn"] != "" {
 			meta.awsRoleArn = authParams["awsRoleArn"]
 		} else if (authParams["awsAccessKeyID"] != "" || authParams["awsAccessKeyId"] != "") && authParams["awsSecretAccessKey"] != "" {

--- a/pkg/scalers/aws_iam_authorization.go
+++ b/pkg/scalers/aws_iam_authorization.go
@@ -14,37 +14,44 @@ type awsAuthorizationMetadata struct {
 	awsAccessKeyID     string
 	awsSecretAccessKey string
 	awsSessionToken    string
+
+	podIdentity bool
 }
 
 func getAwsAuthorization(authParams, metadata, resolvedEnv map[string]string) (awsAuthorizationMetadata, error) {
 	meta := awsAuthorizationMetadata{}
 
-	if authParams["awsRoleArn"] != "" {
-		meta.awsRoleArn = authParams["awsRoleArn"]
-	} else if (authParams["awsAccessKeyID"] != "" || authParams["awsAccessKeyId"] != "") && authParams["awsSecretAccessKey"] != "" {
-		meta.awsAccessKeyID = authParams["awsAccessKeyID"]
-		if meta.awsAccessKeyID == "" {
-			meta.awsAccessKeyID = authParams["awsAccessKeyId"]
-		}
-		meta.awsSecretAccessKey = authParams["awsSecretAccessKey"]
+	if metadata["podIdentity"] == "false" {
+		meta.podIdentity = false
 	} else {
-		var keyName string
-		if keyName = metadata["awsAccessKeyID"]; keyName == "" {
-			keyName = awsAccessKeyIDEnvVar
-		}
-		if val, ok := resolvedEnv[keyName]; ok && val != "" {
-			meta.awsAccessKeyID = val
+		meta.podIdentity = true
+		if authParams["awsRoleArn"] != "" {
+			meta.awsRoleArn = authParams["awsRoleArn"]
+		} else if (authParams["awsAccessKeyID"] != "" || authParams["awsAccessKeyId"] != "") && authParams["awsSecretAccessKey"] != "" {
+			meta.awsAccessKeyID = authParams["awsAccessKeyID"]
+			if meta.awsAccessKeyID == "" {
+				meta.awsAccessKeyID = authParams["awsAccessKeyId"]
+			}
+			meta.awsSecretAccessKey = authParams["awsSecretAccessKey"]
 		} else {
-			return meta, fmt.Errorf("'%s' doesn't exist in the deployment environment", keyName)
-		}
+			var keyName string
+			if keyName = metadata["awsAccessKeyID"]; keyName == "" {
+				keyName = awsAccessKeyIDEnvVar
+			}
+			if val, ok := resolvedEnv[keyName]; ok && val != "" {
+				meta.awsAccessKeyID = val
+			} else {
+				return meta, fmt.Errorf("'%s' doesn't exist in the deployment environment", keyName)
+			}
 
-		if keyName = metadata["awsSecretAccessKey"]; keyName == "" {
-			keyName = awsSecretAccessKeyEnvVar
-		}
-		if val, ok := resolvedEnv[keyName]; ok && val != "" {
-			meta.awsSecretAccessKey = val
-		} else {
-			return meta, fmt.Errorf("'%s' doesn't exist in the deployment environment", keyName)
+			if keyName = metadata["awsSecretAccessKey"]; keyName == "" {
+				keyName = awsSecretAccessKeyEnvVar
+			}
+			if val, ok := resolvedEnv[keyName]; ok && val != "" {
+				meta.awsSecretAccessKey = val
+			} else {
+				return meta, fmt.Errorf("'%s' doesn't exist in the deployment environment", keyName)
+			}
 		}
 	}
 

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -137,7 +137,7 @@ func (s *awsKinesisStreamScaler) GetAwsKinesisOpenShardCount() (int64, error) {
 	}))
 
 	var kinesisClinent *kinesis.Kinesis
-	if s.metadata.awsAuthorization.podIdentity {
+	if s.metadata.awsAuthorization.podIdentityOwner {
 		creds := credentials.NewStaticCredentials(s.metadata.awsAuthorization.awsAccessKeyID, s.metadata.awsAuthorization.awsSecretAccessKey, "")
 
 		if s.metadata.awsAuthorization.awsRoleArn != "" {

--- a/pkg/scalers/aws_kinesis_stream_test.go
+++ b/pkg/scalers/aws_kinesis_stream_test.go
@@ -153,10 +153,10 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 		isError: false,
 		comment: "with AWS Role from TriggerAuthentication"},
 	{metadata: map[string]string{
-		"streamName":  testAWSKinesisStreamName,
-		"shardCount":  "2",
-		"awsRegion":   testAWSRegion,
-		"podIdentity": "false"},
+		"streamName":    testAWSKinesisStreamName,
+		"shardCount":    "2",
+		"awsRegion":     testAWSRegion,
+		"identityOwner": "operator"},
 		authParams: map[string]string{},
 		expected: &awsKinesisStreamMetadata{
 			targetShardCount: 2,

--- a/pkg/scalers/aws_kinesis_stream_test.go
+++ b/pkg/scalers/aws_kinesis_stream_test.go
@@ -51,6 +51,7 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			awsAuthorization: awsAuthorizationMetadata{
 				awsAccessKeyID:     testAWSKinesisAccessKeyID,
 				awsSecretAccessKey: testAWSKinesisSecretAccessKey,
+				podIdentity:        true,
 			},
 		},
 		isError: false,
@@ -86,6 +87,7 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			awsAuthorization: awsAuthorizationMetadata{
 				awsAccessKeyID:     testAWSKinesisAccessKeyID,
 				awsSecretAccessKey: testAWSKinesisSecretAccessKey,
+				podIdentity:        true,
 			},
 		},
 		isError: false,
@@ -103,6 +105,7 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			awsAuthorization: awsAuthorizationMetadata{
 				awsAccessKeyID:     testAWSKinesisAccessKeyID,
 				awsSecretAccessKey: testAWSKinesisSecretAccessKey,
+				podIdentity:        true,
 			},
 		},
 		isError: false,
@@ -143,11 +146,28 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			streamName:       testAWSKinesisStreamName,
 			awsRegion:        testAWSRegion,
 			awsAuthorization: awsAuthorizationMetadata{
-				awsRoleArn: testAWSKinesisRoleArn,
+				awsRoleArn:  testAWSKinesisRoleArn,
+				podIdentity: true,
 			},
 		},
 		isError: false,
 		comment: "with AWS Role from TriggerAuthentication"},
+	{metadata: map[string]string{
+		"streamName":  testAWSKinesisStreamName,
+		"shardCount":  "2",
+		"awsRegion":   testAWSRegion,
+		"podIdentity": "false"},
+		authParams: map[string]string{},
+		expected: &awsKinesisStreamMetadata{
+			targetShardCount: 2,
+			streamName:       testAWSKinesisStreamName,
+			awsRegion:        testAWSRegion,
+			awsAuthorization: awsAuthorizationMetadata{
+				podIdentity: false,
+			},
+		},
+		isError: false,
+		comment: "with AWS Role assigned on KEDA operator itself"},
 }
 
 func TestKinesisParseMetadata(t *testing.T) {

--- a/pkg/scalers/aws_kinesis_stream_test.go
+++ b/pkg/scalers/aws_kinesis_stream_test.go
@@ -51,7 +51,7 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			awsAuthorization: awsAuthorizationMetadata{
 				awsAccessKeyID:     testAWSKinesisAccessKeyID,
 				awsSecretAccessKey: testAWSKinesisSecretAccessKey,
-				podIdentity:        true,
+				podIdentityOwner:   true,
 			},
 		},
 		isError: false,
@@ -87,7 +87,7 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			awsAuthorization: awsAuthorizationMetadata{
 				awsAccessKeyID:     testAWSKinesisAccessKeyID,
 				awsSecretAccessKey: testAWSKinesisSecretAccessKey,
-				podIdentity:        true,
+				podIdentityOwner:   true,
 			},
 		},
 		isError: false,
@@ -105,7 +105,7 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			awsAuthorization: awsAuthorizationMetadata{
 				awsAccessKeyID:     testAWSKinesisAccessKeyID,
 				awsSecretAccessKey: testAWSKinesisSecretAccessKey,
-				podIdentity:        true,
+				podIdentityOwner:   true,
 			},
 		},
 		isError: false,
@@ -146,8 +146,8 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			streamName:       testAWSKinesisStreamName,
 			awsRegion:        testAWSRegion,
 			awsAuthorization: awsAuthorizationMetadata{
-				awsRoleArn:  testAWSKinesisRoleArn,
-				podIdentity: true,
+				awsRoleArn:       testAWSKinesisRoleArn,
+				podIdentityOwner: true,
 			},
 		},
 		isError: false,
@@ -163,7 +163,7 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 			streamName:       testAWSKinesisStreamName,
 			awsRegion:        testAWSRegion,
 			awsAuthorization: awsAuthorizationMetadata{
-				podIdentity: false,
+				podIdentityOwner: false,
 			},
 		},
 		isError: false,

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -154,7 +154,7 @@ func (s *awsSqsQueueScaler) GetAwsSqsQueueLength() (int32, error) {
 	}))
 
 	var sqsClient *sqs.SQS
-	if s.metadata.awsAuthorization.podIdentity {
+	if s.metadata.awsAuthorization.podIdentityOwner {
 		creds := credentials.NewStaticCredentials(s.metadata.awsAuthorization.awsAccessKeyID, s.metadata.awsAuthorization.awsSecretAccessKey, "")
 
 		if s.metadata.awsAuthorization.awsRoleArn != "" {

--- a/pkg/scalers/aws_sqs_queue_test.go
+++ b/pkg/scalers/aws_sqs_queue_test.go
@@ -118,10 +118,10 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		false,
 		"with AWS Role from TriggerAuthentication"},
 	{map[string]string{
-		"queueURL":    testAWSSQSProperQueueURL,
-		"queueLength": "1",
-		"awsRegion":   "eu-west-1",
-		"podIdentity": "false"},
+		"queueURL":      testAWSSQSProperQueueURL,
+		"queueLength":   "1",
+		"awsRegion":     "eu-west-1",
+		"identityOwner": "operator"},
 		map[string]string{
 			"awsAccessKeyId":     "",
 			"awsSecretAccessKey": "",

--- a/pkg/scalers/aws_sqs_queue_test.go
+++ b/pkg/scalers/aws_sqs_queue_test.go
@@ -117,6 +117,17 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		},
 		false,
 		"with AWS Role from TriggerAuthentication"},
+	{map[string]string{
+		"queueURL":    testAWSSQSProperQueueURL,
+		"queueLength": "1",
+		"awsRegion":   "eu-west-1",
+		"podIdentity": "false"},
+		map[string]string{
+			"awsAccessKeyId":     "",
+			"awsSecretAccessKey": "",
+		},
+		false,
+		"with AWS Role assigned on KEDA operator itself"},
 }
 
 func TestSQSParseMetadata(t *testing.T) {


### PR DESCRIPTION
Added `podIdentity` boolean property in the ScaledObject resource under Triggers.Metadata to AWS scalers which tells to Keda operator if use the pod identity or the permissions are assigned on KEDA operator itself (without AssumeRole permissions). If set false use permissions are assigned on KEDA operator itself, if true the behavior will remain as it is today with pod identity. True is default.

example

```
apiVersion: keda.k8s.io/v1alpha1
kind: ScaledObject
spec:
  triggers:
  - metadata:
      **podIdentity: false**
      awsRegion: <REGION>
      queueLength: <LENGTH>
      queueURL: <URL>
    type: aws-sqs-queue
```

Fixes #651