### PR TITLE
Fix a connection issue to a Kafka broker in SASL_SSL mode

### DIFF
--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -130,7 +130,7 @@ func parseKafkaMetadata(resolvedEnv, metadata, authParams map[string]string) (ka
 		meta.authMode = mode
 	}
 
-	if meta.authMode != kafkaAuthModeForNone {
+	if meta.authMode != kafkaAuthModeForNone && meta.authMode != kafkaAuthModeForSaslSSL {
 		if authParams["username"] == "" {
 			return meta, errors.New("no username given")
 		}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -191,7 +191,7 @@ func getKafkaClients(metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin
 	config := sarama.NewConfig()
 	config.Version = sarama.V1_0_0_0
 
-	if ok := metadata.authMode == kafkaAuthModeForSaslPlaintext || metadata.authMode == kafkaAuthModeForSaslSSL || metadata.authMode == kafkaAuthModeForSaslSSLPlain || metadata.authMode == kafkaAuthModeForSaslScramSha256 || metadata.authMode == kafkaAuthModeForSaslScramSha512; ok {
+	if ok := metadata.authMode == kafkaAuthModeForSaslPlaintext || metadata.authMode == kafkaAuthModeForSaslSSLPlain || metadata.authMode == kafkaAuthModeForSaslScramSha256 || metadata.authMode == kafkaAuthModeForSaslScramSha512; ok {
 		config.Net.SASL.Enable = true
 		config.Net.SASL.User = metadata.username
 		config.Net.SASL.Password = metadata.password


### PR DESCRIPTION
This PR fixes the connection issue to a Kafka broker in **SASL_SSL** mode.
In this mode, the user authenticates with the broker with its client certificate. There is no need for a user name or password.

The sarama **config.Net.SASL** must also be disabled in this mode.

### Checklist

- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Tests have been added


Fixes #669
