### PR TITLE
KEDA release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@
 
 - As of v1.3, support for `brokerList` is deprecated for our Kafka topic scaler and will be removed in v2.0 ([#632](https://github.com/kedacore/keda/issues/632))
 
+## v1.3
+
+### New
+
+- Add Azure monitor scaler ([#584](https://github.com/kedacore/keda/pull/584))
+
+### Improvements
+
+- Make targetQueryValue configurable in postgreSQL scaler ([#643](https://github.com/kedacore/keda/pull/643))
+- Added bootstrapServers to deprecate brokerList ([#621](https://github.com/kedacore/keda/pull/621))
+
+### Breaking Changes
+
+None.
+
+### Other
+
+- Changed exiting in a warning when GOROOT is not defined ([#607](https://github.com/kedacore/keda/pull/607))
+- Adding Kubernetes recommended labels to resources ([#596](https://github.com/kedacore/keda/pull/596))
+- Create make release target to update versions ([#610](https://github.com/kedacore/keda/pull/610))
+- Update release-build.yml ([#612](https://github.com/kedacore/keda/pull/612))
+- Added successful tests ([#619](https://github.com/kedacore/keda/pull/619))
+- Fixed command to log keda-operator ([#622](https://github.com/kedacore/keda/pull/622))
+- Update documentation to link to new Openshift 4 sample ([#625](https://github.com/kedacore/keda/pull/625))
+- Change 'create' to 'push' in release action ([#627](https://github.com/kedacore/keda/pull/627))
+- Document logging levels for Operator and Metrics Server ([#633](https://github.com/kedacore/keda/pull/633))
+- Provide "Support" issue template ([#634](https://github.com/kedacore/keda/pull/634))
+- Removed the need for deploymentName label ([#644](https://github.com/kedacore/keda/pull/644))
+- Check presence of scaleTargetRef or jobTargetRef ([#648](https://github.com/kedacore/keda/pull/648))
+- Add AWS pod identity support ([#499](https://github.com/kedacore/keda/pull/499))
+- Updating license to Apache per CNCF donation ([#661](https://github.com/kedacore/keda/pull/661))
+- Introduce changelog for KEDA ([#664](https://github.com/kedacore/keda/pull/664))
+- Add vector keda logos ([#665](https://github.com/kedacore/keda/pull/665))
+- readme: community call update ([#675](https://github.com/kedacore/keda/pull/675))
+
 ## v1.2
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Deprecations
+## v1.3
+
+### Deprecations
 
 - As of v1.3, support for `brokerList` is deprecated for our Kafka topic scaler and will be removed in v2.0 ([#632](https://github.com/kedacore/keda/issues/632))
-
-## v1.3
 
 ### New
 

--- a/deploy/00-namespace.yaml
+++ b/deploy/00-namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   labels:
     app.kubernetes.io/name: keda
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda

--- a/deploy/01-service_account.yaml
+++ b/deploy/01-service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: keda-operator
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda-operator
   namespace: keda

--- a/deploy/10-cluster_role.yaml
+++ b/deploy/10-cluster_role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keda-operator
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   creationTimestamp: null
   name: keda-operator

--- a/deploy/11-role_binding.yaml
+++ b/deploy/11-role_binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keda-operator
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda-operator
 roleRef:

--- a/deploy/12-operator.yaml
+++ b/deploy/12-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: keda-operator
     app.kubernetes.io/name: keda-operator
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/component: operator
     app.kubernetes.io/part-of: keda-operator
   name: keda-operator
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: keda-operator
       containers:
         - name: keda-operator
-          image: docker.io/kedacore/keda:1.2.0
+          image: docker.io/kedacore/keda:1.3.0
           command:
           - keda
           args:

--- a/deploy/20-metrics-cluster_role.yaml
+++ b/deploy/20-metrics-cluster_role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: keda-external-metrics-reader
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   creationTimestamp: null
   name: keda-external-metrics-reader

--- a/deploy/21-metrics-role_binding.yaml
+++ b/deploy/21-metrics-role_binding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keda-system-auth-delegator
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda:system:auth-delegator
 roleRef:
@@ -20,7 +20,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keda-auth-reader
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda-auth-reader
   namespace: kube-system
@@ -38,7 +38,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keda-hpa-controller-external-metrics
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda-hpa-controller-external-metrics
 roleRef:

--- a/deploy/22-metrics-deployment.yaml
+++ b/deploy/22-metrics-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: keda-metrics-apiserver
     app.kubernetes.io/name: keda-metrics-apiserver
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda-metrics-apiserver
   namespace: keda
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: keda-operator
       containers:
         - name: keda-metrics-apiserver
-          image: docker.io/kedacore/keda-metrics-adapter:1.2.0
+          image: docker.io/kedacore/keda-metrics-adapter:1.3.0
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/23-metrics-service.yaml
+++ b/deploy/23-metrics-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: keda-metrics-apiserver
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: keda-metrics-apiserver
   namespace: keda

--- a/deploy/24-metrics-api_service.yaml
+++ b/deploy/24-metrics-api_service.yaml
@@ -3,7 +3,7 @@ kind: APIService
 metadata:
   labels:
     app.kubernetes.io/name: v1beta1.external.metrics.k8s.io
-    app.kubernetes.io/version: "1.2.0"
+    app.kubernetes.io/version: "1.3.0"
     app.kubernetes.io/part-of: keda-operator
   name: v1beta1.external.metrics.k8s.io
 spec:

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.2.0"
+	Version = "1.3.0"
 )


### PR DESCRIPTION
Scalers:

Add Azure monitor scaler (#584)

Scalers improvments:

Make targetQueryValue configurable in postgreSQL scaler (#643)
Added bootstrapServers to deprecate brokerList (#621)

Misc:

Changed exiting in a warning when GOROOT is not defined (#607)
Adding Kubernetes recommended labels to resources (#596)
Create make release target to update versions (#610)
Update release-build.yml (#612)
Added successful tests (#619)
Fixed command to log keda-operator (#622)
Update documentation to link to new Openshift 4 sample (#625)
Change 'create' to 'push' in release action (#627)
Document logging levels for Operator and Metrics Server (#633)
Provide "Support" issue template (#634)
Removed the need for deploymentName label (#644)
Check presence of scaleTargetRef or jobTargetRef (#648)
Add AWS pod identity support (#499)
Updating license to Apache per CNCF donation (#661)
Introduce changelog for KEDA (#664)
Add vector keda logos (#665)
readme: community call update (#675)