### PR TITLE
Cleanup v1.3 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,23 @@
 # Changelog
 
-## v1.3
-
-### Deprecations
+## Deprecations
 
 - As of v1.3, support for `brokerList` is deprecated for our Kafka topic scaler and will be removed in v2.0 ([#632](https://github.com/kedacore/keda/issues/632))
+
+## v1.3
 
 ### New
 
 - Add Azure monitor scaler ([#584](https://github.com/kedacore/keda/pull/584))
+- Introduce changelog ([#664](https://github.com/kedacore/keda/pull/664))
+- Introduce support for AWS pod identity ([#499](https://github.com/kedacore/keda/pull/499))
 
 ### Improvements
 
 - Make targetQueryValue configurable in postgreSQL scaler ([#643](https://github.com/kedacore/keda/pull/643))
 - Added bootstrapServers to deprecate brokerList ([#621](https://github.com/kedacore/keda/pull/621))
+- Removed the need for deploymentName label ([#644](https://github.com/kedacore/keda/pull/644))
+- Adding Kubernetes recommended labels to resources ([#596](https://github.com/kedacore/keda/pull/596))
 
 ### Breaking Changes
 
@@ -21,23 +25,7 @@ None.
 
 ### Other
 
-- Changed exiting in a warning when GOROOT is not defined ([#607](https://github.com/kedacore/keda/pull/607))
-- Adding Kubernetes recommended labels to resources ([#596](https://github.com/kedacore/keda/pull/596))
-- Create make release target to update versions ([#610](https://github.com/kedacore/keda/pull/610))
-- Update release-build.yml ([#612](https://github.com/kedacore/keda/pull/612))
-- Added successful tests ([#619](https://github.com/kedacore/keda/pull/619))
-- Fixed command to log keda-operator ([#622](https://github.com/kedacore/keda/pull/622))
-- Update documentation to link to new Openshift 4 sample ([#625](https://github.com/kedacore/keda/pull/625))
-- Change 'create' to 'push' in release action ([#627](https://github.com/kedacore/keda/pull/627))
-- Document logging levels for Operator and Metrics Server ([#633](https://github.com/kedacore/keda/pull/633))
-- Provide "Support" issue template ([#634](https://github.com/kedacore/keda/pull/634))
-- Removed the need for deploymentName label ([#644](https://github.com/kedacore/keda/pull/644))
-- Check presence of scaleTargetRef or jobTargetRef ([#648](https://github.com/kedacore/keda/pull/648))
-- Add AWS pod identity support ([#499](https://github.com/kedacore/keda/pull/499))
 - Updating license to Apache per CNCF donation ([#661](https://github.com/kedacore/keda/pull/661))
-- Introduce changelog for KEDA ([#664](https://github.com/kedacore/keda/pull/664))
-- Add vector keda logos ([#665](https://github.com/kedacore/keda/pull/665))
-- readme: community call update ([#675](https://github.com/kedacore/keda/pull/675))
 
 ## v1.2
 

--- a/RELEASE-PROCESS.MD
+++ b/RELEASE-PROCESS.MD
@@ -19,7 +19,9 @@ The next version will thus be 1.2.0
 
 **2) Changelog**
 
-Provide a new section in `CHANGELOG.md` for the new version that is being released along with the new features, patches and deprecations it introduces.
+Provide a new section in `CHANGELOG.md` for the new version that is being released along with the new features, patches and deprecations it introduces. 
+
+It should not include every single change but solely what matters to our customers, for example issue template that has changed is not important.
 
 **3) Deploy the new KEDA images to Docker Hub**
 


### PR DESCRIPTION
Cleanup v1.3 in changelog to only focus on the features that changed and not the internal working such as labels, etc.

Deprecations were moved back to an h2 as it is a general section.