### PR TITLE
Fix scalers leaking

### DIFF
--- a/pkg/handler/scale_handler.go
+++ b/pkg/handler/scale_handler.go
@@ -221,7 +221,7 @@ func (h *ScaleHandler) GetDeploymentScalers(scaledObject *kedav1alpha1.ScaledObj
 			err = h.client.Get(context.TODO(), types.NamespacedName{Name: serviceAccountName, Namespace: scaledObject.GetNamespace()}, serviceAccount)
 			if err != nil {
 				closeScalers(scalersRes)
-				return []scalers.Scaler{}, nil, fmt.Errorf("error getting deployment: %s", err)
+				return []scalers.Scaler{}, nil, fmt.Errorf("error getting service account: %s", err)
 			}
 			authParams["awsRoleArn"] = serviceAccount.Annotations[kedav1alpha1.PodIdentityAnnotationEKS]
 		} else if podIdentity == kedav1alpha1.PodIdentityProviderAwsKiam {


### PR DESCRIPTION
We are using Keda with RabbitMQ, after 30 days running of `keda-operator` pod we have more than 1000 open connections in RabbitMQ console. It wasn't our app or something else, we checked it by restarting step by step. Connections were dropped only after `keda-operator` restart.

Fixes:

In case of error `GetDeploymentScalers` and `getJobScalers` returns acquired scalers, but callers of these methods doesn't use them or close them. So it doesn't make sense to return scalers at all in case of error, and it should close all already opened scalers to avoid leaking.