### PR TITLE
Add redis host and port parameter to the scaler with tests

### DIFF
--- a/pkg/scalers/redis_scaler_test.go
+++ b/pkg/scalers/redis_scaler_test.go
@@ -6,6 +6,7 @@ import (
 
 var testRedisResolvedEnv = map[string]string{
 	"REDIS_HOST":     "none",
+	"REDIS_PORT":     "6379",
 	"REDIS_PASSWORD": "none",
 }
 
@@ -20,6 +21,12 @@ var testRedisMetadata = []parseRedisMetadataTestData{
 	{map[string]string{}, true, map[string]string{}},
 	// properly formed listName
 	{map[string]string{"listName": "mylist", "listLength": "10", "address": "REDIS_HOST", "password": "REDIS_PASSWORD"}, false, map[string]string{}},
+	// properly formed hostPort
+	{map[string]string{"listName": "mylist", "listLength": "10", "host": "REDIS_HOST", "port": "REDIS_PORT", "password": "REDIS_PASSWORD"}, false, map[string]string{}},
+	// properly formed hostPort
+	{map[string]string{"listName": "mylist", "listLength": "10", "address": "REDIS_HOST", "host": "REDIS_HOST", "port": "REDIS_PORT", "password": "REDIS_PASSWORD"}, false, map[string]string{}},
+	// improperly formed hostPort
+	{map[string]string{"listName": "mylist", "listLength": "10", "host": "REDIS_HOST", "password": "REDIS_PASSWORD"}, true, map[string]string{}},
 	// properly formed listName, empty address
 	{map[string]string{"listName": "mylist", "listLength": "10", "address": "", "password": ""}, true, map[string]string{}},
 	// improperly formed listLength


### PR DESCRIPTION
This should implement #694
(same code as PR #710 )
How does it works:

now the redis scaler accept 2 new parameters: host and port in addition of the already existing.

If address is specified it use the address, otherwise it checks the host and port parameters, they must be difned both, otherwise an error will be returned.

If address and host and port are all specified, address will get priority.

### Checklist

- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Tests have been added


Fixes #
