### PR TITLE
[v2] autoscaling v2beta1 -> v2beta2 and minor refactoring

### DIFF
--- a/deploy/24-metrics-api_service.yaml
+++ b/deploy/24-metrics-api_service.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   labels:

--- a/pkg/controller/scaledobject/scaledobject_finalizer.go
+++ b/pkg/controller/scaledobject/scaledobject_finalizer.go
@@ -3,52 +3,52 @@ package scaledobject
 import (
 	"context"
 
-	"github.com/go-logr/logr"
-	"k8s.io/client-go/tools/cache"
-
 	kedav1alpha1 "github.com/kedacore/keda/pkg/apis/keda/v1alpha1"
+
+	"github.com/go-logr/logr"
 )
 
 const (
 	scaledObjectFinalizer = "finalizer.keda.sh"
 )
 
-// finalizeScaledObject is stopping ScaleLoop for the respective ScaleObject
+// finalizeScaledObject runs finalization logic on ScaledObject if there's finalizer
 func (r *ReconcileScaledObject) finalizeScaledObject(logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) error {
-	key, err := cache.MetaNamespaceKeyFunc(scaledObject)
-	if err != nil {
-		logger.Error(err, "Error getting key for scaledObject (%s/%s)", scaledObject.GetNamespace(), scaledObject.GetName())
-		return err
-	}
 
-	// store ScaledObject's current Generation
-	r.scaledObjectsGenerations.Delete(key)
-
-	result, ok := r.scaleLoopContexts.Load(key)
-	if ok {
-		cancel, ok := result.(context.CancelFunc)
-		if ok {
-			cancel()
+	if contains(scaledObject.GetFinalizers(), scaledObjectFinalizer) {
+		// Run finalization logic for scaledObjectFinalizer. If the
+		// finalization logic fails, don't remove the finalizer so
+		// that we can retry during the next reconciliation.
+		if err := r.stopScaleLoop(logger, scaledObject); err != nil {
+			return  err
 		}
-		r.scaleLoopContexts.Delete(key)
-	} else {
-		logger.V(1).Info("ScaleObject was not found in controller cache", "key", key)
+
+		// Remove scaledObjectFinalizer. Once all finalizers have been
+		// removed, the object will be deleted.
+		scaledObject.SetFinalizers(remove(scaledObject.GetFinalizers(), scaledObjectFinalizer))
+		if err := r.client.Update(context.TODO(), scaledObject); err != nil {
+			logger.Error(err, "Failed to update ScaledObject after removing a finalizer", "finalizer", scaledObjectFinalizer)
+			return err
+		}
 	}
 
 	logger.Info("Successfully finalized ScaledObject")
 	return nil
 }
 
-// addFinalizer adds finalizer to the ScaledObject
-func (r *ReconcileScaledObject) addFinalizer(logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) error {
-	logger.Info("Adding Finalizer for the ScaledObject")
-	scaledObject.SetFinalizers(append(scaledObject.GetFinalizers(), scaledObjectFinalizer))
+// ensureFinalizer check there is finalizer present on the ScaledObject, if not it adds one
+func (r *ReconcileScaledObject) ensureFinalizer(logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) error {
 
-	// Update CR
-	err := r.client.Update(context.TODO(), scaledObject)
-	if err != nil {
-		logger.Error(err, "Failed to update ScaledObject with finalizer")
-		return err
+	if !contains(scaledObject.GetFinalizers(), scaledObjectFinalizer) {
+		logger.Info("Adding Finalizer for the ScaledObject")
+		scaledObject.SetFinalizers(append(scaledObject.GetFinalizers(), scaledObjectFinalizer))
+
+		// Update CR
+		err := r.client.Update(context.TODO(), scaledObject)
+		if err != nil {
+			logger.Error(err, "Failed to update ScaledObject with a finalizer", "finalizer", scaledObjectFinalizer)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/handler/scale_handler.go
+++ b/pkg/handler/scale_handler.go
@@ -21,7 +21,7 @@ import (
 // each ScaledObject and making the final scale decision and operation
 type ScaleHandler struct {
 	client           client.Client
-	scaleClient      scale.ScalesGetter // TODO pointer
+	scaleClient      *scale.ScalesGetter
 	logger           logr.Logger
 	reconcilerScheme *runtime.Scheme
 }
@@ -34,7 +34,7 @@ const (
 )
 
 // NewScaleHandler creates a ScaleHandler object
-func NewScaleHandler(client client.Client, scaleClient scale.ScalesGetter, reconcilerScheme *runtime.Scheme) *ScaleHandler {
+func NewScaleHandler(client client.Client, scaleClient *scale.ScalesGetter, reconcilerScheme *runtime.Scheme) *ScaleHandler {
 	handler := &ScaleHandler{
 		client:           client,
 		scaleClient:      scaleClient,

--- a/pkg/handler/scale_loop.go
+++ b/pkg/handler/scale_loop.go
@@ -58,7 +58,7 @@ func (h *ScaleHandler) handleScaleJob(ctx context.Context, scaledObject *kedav1a
 
 		var metricValue int64
 		for _, metric := range metricSpecs {
-			metricValue, _ = metric.External.TargetAverageValue.AsInt64()
+			metricValue, _ = metric.External.Target.AverageValue.AsInt64()
 			maxValue += metricValue
 		}
 		scalerLogger.Info("Scaler max value", "MaxValue", maxValue)

--- a/pkg/handler/scale_scaledobjects.go
+++ b/pkg/handler/scale_scaledobjects.go
@@ -175,11 +175,11 @@ func (h *ScaleHandler) scaleFromZero(scaledObject *kedav1alpha1.ScaledObject, sc
 }
 
 func (h *ScaleHandler) getScaleTargetScale(scaledObject *kedav1alpha1.ScaledObject) (*autoscalingv1.Scale, error) {
-	return h.scaleClient.Scales(scaledObject.Namespace).Get(scaledObject.Status.ScaleTargetGVKR.GroupResource(), scaledObject.Spec.ScaleTargetRef.Name)
+	return (*h.scaleClient).Scales(scaledObject.Namespace).Get(scaledObject.Status.ScaleTargetGVKR.GroupResource(), scaledObject.Spec.ScaleTargetRef.Name)
 }
 
 func (h *ScaleHandler) updateScaleOnScaleTarget(scaledObject *kedav1alpha1.ScaledObject, scale *autoscalingv1.Scale) error {
-	_, err := h.scaleClient.Scales(scaledObject.Namespace).Update(scaledObject.Status.ScaleTargetGVKR.GroupResource(), scale)
+	_, err := (*h.scaleClient).Scales(scaledObject.Namespace).Update(scaledObject.Status.ScaleTargetGVKR.GroupResource(), scale)
 	return err
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -88,7 +88,7 @@ func (p *KedaProvider) GetExternalMetric(namespace string, metricSelector labels
 
 		for _, metricSpec := range metricSpecs {
 			// Filter only the desired metric
-			if strings.EqualFold(metricSpec.External.MetricName, info.Metric) {
+			if strings.EqualFold(metricSpec.External.Metric.Name, info.Metric) {
 				metrics, err := scaler.GetMetrics(context.TODO(), info.Metric, metricSelector)
 				if err != nil {
 					logger.Error(err, "error getting metric for scaler", "ScaledObject.Namespace", scaledObject.Namespace, "ScaledObject.Name", scaledObject.Name, "Scaler", scaler)

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -172,13 +172,20 @@ func (c *awsCloudwatchScaler) GetMetrics(ctx context.Context, metricName string,
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (c *awsCloudwatchScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (c *awsCloudwatchScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(c.metadata.targetMetricValue), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: fmt.Sprintf("%s-%s-%s", strings.ReplaceAll(c.metadata.namespace, "/", "-"),
-		c.metadata.dimensionName, c.metadata.dimensionValue),
-		TargetAverageValue: targetMetricValue}
-	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta1.MetricSpec{metricSpec}
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: fmt.Sprintf("%s-%s-%s", strings.ReplaceAll(c.metadata.namespace, "/", "-"),
+				c.metadata.dimensionName, c.metadata.dimensionValue),
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricValue,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 func (c *awsCloudwatchScaler) IsActive(ctx context.Context) (bool, error) {

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -100,12 +100,19 @@ func (s *awsKinesisStreamScaler) Close() error {
 	return nil
 }
 
-func (s *awsKinesisStreamScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *awsKinesisStreamScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetShardCountQty := resource.NewQuantity(int64(s.metadata.targetShardCount), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: fmt.Sprintf("%s-%s-%s", "AWS-Kinesis-Stream", awsKinesisStreamMetricName, s.metadata.streamName),
-		TargetAverageValue: targetShardCountQty}
-	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta1.MetricSpec{metricSpec}
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: fmt.Sprintf("%s-%s-%s", "AWS-Kinesis-Stream", awsKinesisStreamMetricName, s.metadata.streamName),
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetShardCountQty,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -116,12 +116,19 @@ func (s *awsSqsQueueScaler) Close() error {
 	return nil
 }
 
-func (s *awsSqsQueueScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *awsSqsQueueScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueLength), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: fmt.Sprintf("%s-%s-%s", "AWS-SQS-Queue", awsSqsQueueMetricName, s.metadata.queueName),
-		TargetAverageValue: targetQueueLengthQty}
-	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta1.MetricSpec{metricSpec}
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: fmt.Sprintf("%s-%s-%s", "AWS-SQS-Queue", awsSqsQueueMetricName, s.metadata.queueName),
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetQueueLengthQty,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -8,7 +8,7 @@ import (
 
 	eventhub "github.com/Azure/azure-event-hubs-go"
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -173,16 +173,19 @@ func (scaler *AzureEventHubScaler) IsActive(ctx context.Context) (bool, error) {
 }
 
 // GetMetricSpecForScaling returns metric spec
-func (scaler *AzureEventHubScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
-	return []v2beta1.MetricSpec{
-		{
-			External: &v2beta1.ExternalMetricSource{
-				MetricName:         thresholdMetricName,
-				TargetAverageValue: resource.NewQuantity(scaler.metadata.threshold, resource.DecimalSI),
-			},
-			Type: eventHubMetricType,
+func (scaler *AzureEventHubScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetMetricVal := resource.NewQuantity(scaler.metadata.threshold, resource.DecimalSI)
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: thresholdMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricVal,
 		},
 	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: eventHubMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns metric using total number of unprocessed events in event hub

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -169,11 +169,19 @@ func (s *azureMonitorScaler) Close() error {
 	return nil
 }
 
-func (s *azureMonitorScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *azureMonitorScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricVal := resource.NewQuantity(int64(s.metadata.targetValue), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: azureMonitorMetricName, TargetAverageValue: targetMetricVal}
-	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta1.MetricSpec{metricSpec}
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: azureMonitorMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricVal,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -131,11 +131,19 @@ func (s *azureQueueScaler) Close() error {
 	return nil
 }
 
-func (s *azureQueueScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *azureQueueScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueLength), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: queueLengthMetricName, TargetAverageValue: targetQueueLengthQty}
-	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta1.MetricSpec{metricSpec}
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: queueLengthMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetQueueLengthQty,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -8,7 +8,7 @@ import (
 	servicebus "github.com/Azure/azure-service-bus-go"
 
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -143,11 +143,19 @@ func (s *azureServiceBusScaler) Close() error {
 }
 
 // Returns the metric spec to be used by the HPA
-func (s *azureServiceBusScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *azureServiceBusScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetLengthQty := resource.NewQuantity(int64(s.metadata.targetLength), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: queueLengthMetricName, TargetAverageValue: targetLengthQty}
-	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta1.MetricSpec{metricSpec}
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: queueLengthMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetLengthQty,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // Returns the current metrics to be served to the HPA

--- a/pkg/scalers/gcp_pub_sub_scaler.go
+++ b/pkg/scalers/gcp_pub_sub_scaler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -97,23 +97,28 @@ func (s *pubsubScaler) Close() error {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *pubsubScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *pubsubScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 
 	// Construct the target subscription size as a quantity
 	targetSubscriptionSizeQty := resource.NewQuantity(int64(s.metadata.targetSubscriptionSize), resource.DecimalSI)
 
-	externalMetric := &v2beta1.ExternalMetricSource{
-		MetricName:         pubSubSubscriptionSizeMetricName,
-		TargetAverageValue: targetSubscriptionSizeQty,
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: pubSubSubscriptionSizeMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetSubscriptionSizeQty,
+		},
 	}
 
 	// Create the metric spec for the HPA
-	metricSpec := v2beta1.MetricSpec{
+	metricSpec := v2beta2.MetricSpec{
 		External: externalMetric,
 		Type:     externalMetricType,
 	}
 
-	return []v2beta1.MetricSpec{metricSpec}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // GetMetrics connects to Stack Driver and finds the size of the pub sub subscription

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -326,16 +326,19 @@ func (s *kafkaScaler) Close() error {
 	return nil
 }
 
-func (s *kafkaScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
-	return []v2beta1.MetricSpec{
-		{
-			External: &v2beta1.ExternalMetricSource{
-				MetricName:         lagThresholdMetricName,
-				TargetAverageValue: resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI),
-			},
-			Type: kafkaMetricType,
+func (s *kafkaScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: lagThresholdMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricValue,
 		},
 	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: kafkaMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -9,7 +9,7 @@ import (
 	liiklus_service "github.com/kedacore/keda/pkg/scalers/liiklus"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -77,16 +77,19 @@ func (s *liiklusScaler) GetMetrics(ctx context.Context, metricName string, metri
 
 }
 
-func (s *liiklusScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
-	return []v2beta1.MetricSpec{
-		{
-			External: &v2beta1.ExternalMetricSource{
-				MetricName:         liiklusLagThresholdMetricName,
-				TargetAverageValue: resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI),
-			},
-			Type: liiklusMetricType,
+func (s *liiklusScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: liiklusLagThresholdMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricValue,
 		},
 	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: liiklusMetricType}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 func (s *liiklusScaler) Close() error {

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/go-sql-driver/mysql"
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -183,16 +183,21 @@ func (s *mySQLScaler) getQueryResult() (int, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *mySQLScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *mySQLScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueryValue := resource.NewQuantity(int64(s.metadata.queryValue), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{
-		MetricName:         mySQLMetricName,
-		TargetAverageValue: targetQueryValue,
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: mySQLMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetQueryValue,
+		},
 	}
-	metricSpec := v2beta1.MetricSpec{
+	metricSpec := v2beta2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta1.MetricSpec{metricSpec}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	_ "github.com/lib/pq"
-	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -182,16 +182,21 @@ func (s *postgreSQLScaler) getActiveNumber() (int, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *postgreSQLScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *postgreSQLScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueryValue := resource.NewQuantity(int64(s.metadata.targetQueryValue), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{
-		MetricName:         pgMetricName,
-		TargetAverageValue: targetQueryValue,
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: pgMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetQueryValue,
+		},
 	}
-	metricSpec := v2beta1.MetricSpec{
+	metricSpec := v2beta2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
 	}
-	return []v2beta1.MetricSpec{metricSpec}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -101,7 +101,7 @@ func (s *prometheusScaler) IsActive(ctx context.Context) (bool, error) {
 		prometheusLog.Error(err, "error executing prometheus query")
 		return false, err
 	}
-	
+
 	return val > -1, nil
 }
 
@@ -109,16 +109,21 @@ func (s *prometheusScaler) Close() error {
 	return nil
 }
 
-func (s *prometheusScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
-	return []v2beta1.MetricSpec{
-		{
-			External: &v2beta1.ExternalMetricSource{
-				TargetAverageValue: resource.NewQuantity(int64(s.metadata.threshold), resource.DecimalSI),
-				MetricName:         s.metadata.metricName,
-			},
-			Type: externalMetricType,
+func (s *prometheusScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetMetricValue := resource.NewQuantity(int64(s.metadata.threshold), resource.DecimalSI)
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: s.metadata.metricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricValue,
 		},
 	}
+	metricSpec := v2beta2.MetricSpec{
+		External: externalMetric, Type: externalMetricType,
+	}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 func (s *prometheusScaler) ExecutePromQuery() (float64, error) {

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/streadway/amqp"
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -133,16 +133,21 @@ func (s *rabbitMQScaler) getQueueMessages() (int, error) {
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
-func (s *rabbitMQScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
-	return []v2beta1.MetricSpec{
-		{
-			External: &v2beta1.ExternalMetricSource{
-				MetricName:         rabbitQueueLengthMetricName,
-				TargetAverageValue: resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI),
-			},
-			Type: rabbitMetricType,
+func (s *rabbitMQScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetMetricValue := resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI)
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: rabbitQueueLengthMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricValue,
 		},
 	}
+	metricSpec := v2beta2.MetricSpec{
+		External: externalMetric, Type: rabbitMetricType,
+	}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // GetMetrics returns value for a supported metric and an error if there is a problem getting the metric

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/go-redis/redis"
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -157,11 +157,21 @@ func (s *redisScaler) Close() error {
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
-func (s *redisScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
+func (s *redisScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetListLengthQty := resource.NewQuantity(int64(s.metadata.targetListLength), resource.DecimalSI)
-	externalMetric := &v2beta1.ExternalMetricSource{MetricName: listLengthMetricName, TargetAverageValue: targetListLengthQty}
-	metricSpec := v2beta1.MetricSpec{External: externalMetric, Type: externalMetricType}
-	return []v2beta1.MetricSpec{metricSpec}
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: listLengthMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetListLengthQty,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{
+		External: externalMetric, Type: externalMetricType,
+	}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 // GetMetrics connects to Redis and finds the length of the list

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -3,7 +3,7 @@ package scalers
 import (
 	"context"
 
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 )
@@ -15,7 +15,7 @@ type Scaler interface {
 
 	// Returns the metrics based on which this scaler determines that the ScaleTarget scales. This is used to contruct the HPA spec that is created for
 	// this scaled object. The labels used should match the selectors used in GetMetrics
-	GetMetricSpecForScaling() []v2beta1.MetricSpec
+	GetMetricSpecForScaling() []v2beta2.MetricSpec
 
 	IsActive(ctx context.Context) (bool, error)
 

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -156,7 +156,7 @@ func (s *stanScaler) getMaxMsgLag() int64 {
 	return s.channelInfo.LastSequence - maxValue
 }
 
-func (s *stanScaler) hasPendingMessage() bool {	
+func (s *stanScaler) hasPendingMessage() bool {
 	subscriberFound := false
 	combinedQueueName := s.metadata.durableName + ":" + s.metadata.queueGroup
 
@@ -179,16 +179,21 @@ func (s *stanScaler) hasPendingMessage() bool {
 	return false
 }
 
-func (s *stanScaler) GetMetricSpecForScaling() []v2beta1.MetricSpec {
-	return []v2beta1.MetricSpec{
-		{
-			External: &v2beta1.ExternalMetricSource{
-				MetricName:         lagThresholdMetricName,
-				TargetAverageValue: resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI),
-			},
-			Type: stanMetricType,
+func (s *stanScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: lagThresholdMetricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetMetricValue,
 		},
 	}
+	metricSpec := v2beta2.MetricSpec{
+		External: externalMetric, Type: stanMetricType,
+	}
+	return []v2beta2.MetricSpec{metricSpec}
 }
 
 //GetMetrics returns value for a supported metric and an error if there is a problem getting the metric


### PR DESCRIPTION
- changing autoscaling version from `v2beta1` to `v2beta2`, in fact it is an API change, shouldn't affect functionality.
- minor refactoring of finalizer on ScaledObject
- updating apiregistration/APIService used by Metrics server to `v1` (`v1beta1` was used previously and could be potentionaly deprecated soon, `v1` is supported on kubernetes >= v1.11, so no problems on this side wrt compatibility).


Fixes #721
