### PR TITLE
Adding label for metrics service selection

### DIFF
--- a/deploy/12-operator.yaml
+++ b/deploy/12-operator.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         app: keda-operator
+        name: keda-operator
       name: keda-operator
     spec:
       serviceAccountName: keda-operator


### PR DESCRIPTION
The metrics service that is being created by the Operator SDK uses a the name label of the Operator https://github.com/operator-framework/operator-sdk/blob/f50d3f0f8e7d269e583116a666a354f5d931d8a1/pkg/metrics/metrics.go#L112.  Since this label is not currently being added to the pod the service does not have any matching endpoints so metrics would not be able to be scraped from the service.
