### PR TITLE
Metrics Server: print versions during startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ release: release_prepare release_file release_pkg
 
 .PHONY: release_file
 release_file:
-	@sed -i 's@Version =.*@Version = "$(VERSION)"@g' ./version/version.go;
+	@sed -i 's@Version   =.*@Version   = "$(VERSION)"@g' ./version/version.go;
 	@for file in $(K8S_DEPLOY_FILES); do \
 	sed -i 's@app.kubernetes.io/version:.*@app.kubernetes.io/version: "$(VERSION)"@g' $$file; \
 	sed -i 's@image: docker.io/kedacore/keda:.*@image: docker.io/kedacore/keda:$(VERSION)@g' $$file; \
@@ -98,12 +98,12 @@ build: checkenv build-adapter build-controller
 .PHONY: build-controller
 build-controller: generate-api pkg/scalers/liiklus/LiiklusService.pb.go
 	$(GO_BUILD_VARS) operator-sdk build $(IMAGE_CONTROLLER) \
-		--go-build-args "-ldflags -X=main.GitCommit=$(GIT_COMMIT) -ldflags -X=github.com/kedacore/keda/version.Version=$(VERSION) -o build/_output/bin/keda"
+		--go-build-args "-ldflags -X=github.com/kedacore/keda/version.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION) -o build/_output/bin/keda"
 
 .PHONY: build-adapter
 build-adapter: generate-api pkg/scalers/liiklus/LiiklusService.pb.go
 	$(GO_BUILD_VARS) go build \
-		-ldflags "-X=main.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION)" \
+		-ldflags "-X=github.com/kedacore/keda/version.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION)" \
 		-o build/_output/bin/keda-adapter \
 		cmd/adapter/main.go
 	docker build -f build/Dockerfile.adapter -t $(IMAGE_ADAPTER) .

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ build: checkenv build-adapter build-controller
 .PHONY: build-controller
 build-controller: generate-api pkg/scalers/liiklus/LiiklusService.pb.go
 	$(GO_BUILD_VARS) operator-sdk build $(IMAGE_CONTROLLER) \
-		--go-build-args "-ldflags -X=github.com/kedacore/keda/version.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION) -o build/_output/bin/keda"
+		--go-build-args "-ldflags -X=github.com/kedacore/keda/version.Version=$(VERSION) -o build/_output/bin/keda"
 
 .PHONY: build-adapter
 build-adapter: generate-api pkg/scalers/liiklus/LiiklusService.pb.go

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/kedacore/keda/pkg/handler"
 	kedaprovider "github.com/kedacore/keda/pkg/provider"
+	"github.com/kedacore/keda/version"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
@@ -70,8 +73,17 @@ func (a *Adapter) makeProviderOrDie() provider.MetricsProvider {
 	return kedaprovider.NewProvider(logger, handler, kubeclient, namespace)
 }
 
+func printVersion() {
+	logger.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
+	logger.Info(fmt.Sprintf("KEDA Commit: %s", version.GitCommit))
+	logger.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	logger.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+}
+
 func main() {
 	defer klog.Flush()
+
+	printVersion()
 
 	cmd := &Adapter{}
 	cmd.Flags().StringVar(&cmd.Message, "msg", "starting adapter...", "startup message")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/kedacore/keda/pkg/apis"
+	"github.com/kedacore/keda/version"
 	"github.com/kedacore/keda/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -32,7 +33,6 @@ import (
 
 // Change below variables to serve metrics on different host or port.
 var (
-	GitCommit           string
 	metricsHost               = "0.0.0.0"
 	metricsPort         int32 = 8383
 	operatorMetricsPort int32 = 8686
@@ -40,10 +40,11 @@ var (
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
+	log.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
+	log.Info(fmt.Sprintf("KEDA Commit: %s", version.GitCommit))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
-	log.Info(fmt.Sprintf("Keda Commit: %s", GitCommit))
 }
 
 func main() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -41,7 +41,7 @@ var log = logf.Log.WithName("cmd")
 
 func printVersion() {
 	log.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
-	log.Info(fmt.Sprintf("KEDA Commit: %s", version.GitCommit))
+	//log.Info(fmt.Sprintf("KEDA Commit: %s", version.GitCommit))	// multiple -ldflags doesn't work with operator-sdk v0.12, let's reenable this for KEDA v2
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 package version
 
 var (
-	Version = "1.3.0"
+	Version   = "1.3.0"
+	GitCommit string
 )


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Minor improvement for Metric Server -  let's print version info during startup, the same way KEDA Operator is doing currently