### PR TITLE
[v2] Update PR build action for v2

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,7 +5,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: kedacore/build-tools:latest
+    container: kedacore/build-tools:v2
     steps:
       - name: Check out code
         uses: actions/checkout@v1


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmed@elsayed.io>

This change sets the image used for PR validation to `kedacore/build-tools:v2`, which is built from the `build-tools.Dockerfile` in the v2 branch