### PR TITLE
[v2] use patch to update Status.LastActiveTime

### DIFF
--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -74,7 +74,7 @@ func (e *scaleExecutor) scaleJobs(ctx context.Context, scaledJob *kedav1alpha1.S
 		e.logger.V(1).Info("At least one scaler is active")
 		now := metav1.Now()
 		scaledJob.Status.LastActiveTime = &now
-		e.updateLastActiveTime(ctx, scaledJob)
+		e.updateLastActiveTime(ctx, e.logger, scaledJob)
 		e.createJobs(scaledJob, scaleTo, effectiveMaxScale)
 
 	} else {

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -66,7 +66,7 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scalers []scalers.Scal
 	} else if isActive {
 		// triggers are active, but we didn't need to scale (replica count > 0)
 		// Update LastActiveTime to now.
-		e.updateLastActiveTime(ctx, scaledObject)
+		e.updateLastActiveTime(ctx, logger, scaledObject)
 	} else {
 		logger.V(1).Info("ScaleTarget no change")
 	}
@@ -132,7 +132,7 @@ func (e *scaleExecutor) scaleFromZero(ctx context.Context, logger logr.Logger, s
 			"New Replicas Count", scale.Spec.Replicas)
 
 		// Scale was successful. Update lastScaleTime and lastActiveTime on the scaledObject
-		e.updateLastActiveTime(ctx, scaledObject)
+		e.updateLastActiveTime(ctx, logger, scaledObject)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

if we use `client.Status().Patch()` instead of `client.Status().Update()` we shouldn't hit the issue with modifying old resource anymore. Pach is merging only those fields that were updated. I have tested it and it seems like it is working correctly. We can revert back to the loop mechanism if there are going to be any issues.
