### PR TITLE
IsActive() should return true only for val > 0

### DIFF
--- a/pkg/scalers/prometheus.go
+++ b/pkg/scalers/prometheus.go
@@ -102,7 +102,7 @@ func (s *prometheusScaler) IsActive(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	
-	return val > -1, nil
+	return val > 0, nil
 }
 
 func (s *prometheusScaler) Close() error {


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

This PR https://github.com/kedacore/keda/pull/695 brought regression in Prometheus scaler -> it marks the scaler as active even if there's no metrics in Prometheus, see the issue for details.

Fixes https://github.com/kedacore/keda/issues/770
