### PR TITLE
Support vhost=/ for HTTP mode in RabbitMQ scaler

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -211,6 +211,11 @@ func (s *rabbitMQScaler) getQueueInfoViaHttp() (*queueInfo, error) {
 	}
 
 	vhost := parsedUrl.Path
+
+	if vhost == "/" || vhost == "//" {
+		vhost = "/%2F"
+	}
+
 	parsedUrl.Path = ""
 
 	getQueueInfoManagementURI := fmt.Sprintf("%s/%s%s/%s", parsedUrl.String(), "api/queues", vhost, s.metadata.queueName)

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -68,51 +68,61 @@ var testQueueInfoTestData = []getQueueInfoTestData{
 	{`Password is incorrect`, http.StatusUnauthorized, false},
 }
 
+var vhosts = []string{"myhost", "", "/", "%2F"}
+
 func TestGetQueueInfo(t *testing.T) {
 	for _, testData := range testQueueInfoTestData {
-		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expeced_path := "/api/queues/myhost/evaluate_trials"
-			if r.RequestURI != expeced_path {
-				t.Error("Expect request path to =", expeced_path, "but it is", r.RequestURI)
+		for _, vhost := range vhosts {
+			expeced_vhost := vhost
+
+			if vhost != "myhost" {
+				expeced_vhost = "%2F"
 			}
 
-			w.WriteHeader(testData.responseStatus)
-			w.Write([]byte(testData.response))
-		}))
+			var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expeced_path := "/api/queues/" + expeced_vhost + "/evaluate_trials"
+				if r.RequestURI != expeced_path {
+					t.Error("Expect request path to =", expeced_path, "but it is", r.RequestURI)
+				}
 
-		resolvedEnv := map[string]string{apiHost: fmt.Sprintf("%s/%s", apiStub.URL, "myhost")}
+				w.WriteHeader(testData.responseStatus)
+				w.Write([]byte(testData.response))
+			}))
 
-		metadata := map[string]string{
-			"queueLength":    "10",
-			"queueName":      "evaluate_trials",
-			"apiHost":        apiHost,
-			"includeUnacked": "true",
-		}
+			resolvedEnv := map[string]string{apiHost: fmt.Sprintf("%s/%s", apiStub.URL, vhost)}
 
-		s, err := NewRabbitMQScaler(resolvedEnv, metadata, map[string]string{})
+			metadata := map[string]string{
+				"queueLength":    "10",
+				"queueName":      "evaluate_trials",
+				"apiHost":        apiHost,
+				"includeUnacked": "true",
+			}
 
-		if err != nil {
-			t.Error("Expect success", err)
-		}
+			s, err := NewRabbitMQScaler(resolvedEnv, metadata, map[string]string{})
 
-		ctx := context.TODO()
-		active, err := s.IsActive(ctx)
-
-		if testData.responseStatus == http.StatusOK {
 			if err != nil {
 				t.Error("Expect success", err)
 			}
 
-			if active != testData.isActive {
-				if testData.isActive {
-					t.Error("Expect to be active")
-				} else {
-					t.Error("Expect to not be active")
+			ctx := context.TODO()
+			active, err := s.IsActive(ctx)
+
+			if testData.responseStatus == http.StatusOK {
+				if err != nil {
+					t.Error("Expect success", err)
 				}
-			}
-		} else {
-			if !strings.Contains(err.Error(), testData.response) {
-				t.Error("Expect error to be like '", testData.response, "' but it's '", err, "'")
+
+				if active != testData.isActive {
+					if testData.isActive {
+						t.Error("Expect to be active")
+					} else {
+						t.Error("Expect to not be active")
+					}
+				}
+			} else {
+				if !strings.Contains(err.Error(), testData.response) {
+					t.Error("Expect error to be like '", testData.response, "' but it's '", err, "'")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/kedacore/keda/issues/768
