### PR TITLE
Fix support of blank path without trailing slash for RMQ HTTP scaler

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -212,7 +212,7 @@ func (s *rabbitMQScaler) getQueueInfoViaHttp() (*queueInfo, error) {
 
 	vhost := parsedUrl.Path
 
-	if vhost == "/" || vhost == "//" {
+	if vhost == "" || vhost == "/" || vhost == "//" {
 		vhost = "/%2F"
 	}
 

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -68,14 +68,14 @@ var testQueueInfoTestData = []getQueueInfoTestData{
 	{`Password is incorrect`, http.StatusUnauthorized, false},
 }
 
-var vhosts = []string{"myhost", "", "/", "%2F"}
+var vhost_pathes = []string{"/myhost", "", "/", "//", "/%2F"}
 
 func TestGetQueueInfo(t *testing.T) {
 	for _, testData := range testQueueInfoTestData {
-		for _, vhost := range vhosts {
-			expeced_vhost := vhost
+		for _, vhost_path := range vhost_pathes {
+			expeced_vhost := "myhost"
 
-			if vhost != "myhost" {
+			if vhost_path != "/myhost" {
 				expeced_vhost = "%2F"
 			}
 
@@ -89,7 +89,7 @@ func TestGetQueueInfo(t *testing.T) {
 				w.Write([]byte(testData.response))
 			}))
 
-			resolvedEnv := map[string]string{apiHost: fmt.Sprintf("%s/%s", apiStub.URL, vhost)}
+			resolvedEnv := map[string]string{apiHost: fmt.Sprintf("%s%s", apiStub.URL, vhost_path)}
 
 			metadata := map[string]string{
 				"queueLength":    "10",


### PR DESCRIPTION
Resolves #790 
