### PR TITLE
[v2] generate CRD shortnames

### DIFF
--- a/deploy/crds/keda.sh_scaledjobs_crd.yaml
+++ b/deploy/crds/keda.sh_scaledjobs_crd.yaml
@@ -3,11 +3,26 @@ kind: CustomResourceDefinition
 metadata:
   name: scaledjobs.keda.sh
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.triggers[*].type
+    name: Triggers
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Active")].status
+    name: Active
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: keda.sh
   names:
     kind: ScaledJob
     listKind: ScaledJobList
     plural: scaledjobs
+    shortNames:
+    - sj
     singular: scaledjob
   scope: Namespaced
   subresources:

--- a/deploy/crds/keda.sh_scaledobjects_crd.yaml
+++ b/deploy/crds/keda.sh_scaledobjects_crd.yaml
@@ -27,6 +27,8 @@ spec:
     kind: ScaledObject
     listKind: ScaledObjectList
     plural: scaledobjects
+    shortNames:
+    - so
     singular: scaledobject
   scope: Namespaced
   subresources:

--- a/deploy/crds/keda.sh_triggerauthentications_crd.yaml
+++ b/deploy/crds/keda.sh_triggerauthentications_crd.yaml
@@ -8,6 +8,9 @@ spec:
     kind: TriggerAuthentication
     listKind: TriggerAuthenticationList
     plural: triggerauthentications
+    shortNames:
+    - ta
+    - triggerauth
     singular: triggerauthentication
   scope: Namespaced
   validation:

--- a/pkg/apis/keda/v1alpha1/scaledjob_types.go
+++ b/pkg/apis/keda/v1alpha1/scaledjob_types.go
@@ -12,7 +12,7 @@ import (
 // ScaledJob is the Schema for the scaledjobs API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=scaledobjects,scope=Namespaced
+// +kubebuilder:resource:path=scaledjobs,scope=Namespaced,shortName=sj
 // +kubebuilder:printcolumn:name="Triggers",type="string",JSONPath=".spec.triggers[*].type"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
 // +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.conditions[?(@.type==\"Active\")].status"

--- a/pkg/apis/keda/v1alpha1/scaledobject_types.go
+++ b/pkg/apis/keda/v1alpha1/scaledobject_types.go
@@ -10,7 +10,7 @@ import (
 // ScaledObject is a specification for a ScaledObject resource
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=scaledobjects,scope=Namespaced
+// +kubebuilder:resource:path=scaledobjects,scope=Namespaced,shortName=so
 // +kubebuilder:printcolumn:name="ScaleTargetKind",type="string",JSONPath=".status.scaleTargetKind"
 // +kubebuilder:printcolumn:name="ScaleTargetName",type="string",JSONPath=".spec.scaleTargetRef.name"
 // +kubebuilder:printcolumn:name="Triggers",type="string",JSONPath=".spec.triggers[*].type"

--- a/pkg/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/pkg/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -4,6 +4,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TriggerAuthentication defines how a trigger can authenticate
+// +genclient
+// +k8s:openapi-gen=true
+// +kubebuilder:resource:path=triggerauthentications,scope=Namespaced,shortName=ta;triggerauth
+type TriggerAuthentication struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec TriggerAuthenticationSpec `json:"spec"`
+}
+
 // TriggerAuthenticationSpec defines the various ways to authenticate
 // +k8s:openapi-gen=true
 type TriggerAuthenticationSpec struct {
@@ -15,19 +28,6 @@ type TriggerAuthenticationSpec struct {
 
 	// +optional
 	Env []AuthEnvironment `json:"env"`
-}
-
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-// TriggerAuthentication defines how a trigger can authenticate
-// +genclient
-// +k8s:openapi-gen=true
-// +kubebuilder:resource:path=triggerauthentications,scope=Namespaced
-type TriggerAuthentication struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec TriggerAuthenticationSpec `json:"spec"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Generate CRD shortnames so they can be used with `kubectl get`

scaledObject -  so
scaledJob - sj
triggerAuthentication - ta, triggerauth

Fixes #774 
