### PR TITLE
[v2] triggerauth CRD: show configured parameters

### DIFF
--- a/deploy/crds/keda.sh_triggerauthentications_crd.yaml
+++ b/deploy/crds/keda.sh_triggerauthentications_crd.yaml
@@ -3,6 +3,16 @@ kind: CustomResourceDefinition
 metadata:
   name: triggerauthentications.keda.sh
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.podIdentity.provider
+    name: PodIdentity
+    type: string
+  - JSONPath: .spec.secretTargetRef[*].name
+    name: Secret
+    type: string
+  - JSONPath: .spec.env[*].name
+    name: Env
+    type: string
   group: keda.sh
   names:
     kind: TriggerAuthentication
@@ -13,6 +23,7 @@ spec:
     - triggerauth
     singular: triggerauthentication
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: TriggerAuthentication defines how a trigger can authenticate

--- a/pkg/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/pkg/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -10,6 +10,9 @@ import (
 // +genclient
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=triggerauthentications,scope=Namespaced,shortName=ta;triggerauth
+// +kubebuilder:printcolumn:name="PodIdentity",type="string",JSONPath=".spec.podIdentity.provider"
+// +kubebuilder:printcolumn:name="Secret",type="string",JSONPath=".spec.secretTargetRef[*].name"
+// +kubebuilder:printcolumn:name="Env",type="string",JSONPath=".spec.env[*].name"
 type TriggerAuthentication struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

`kubect get ta` prints these columns:
```bash
NAME     PODIDENTITY   SECRET   ENV
taname   azure                  
```

Fixes #778
