### PR TITLE
eventhub-scaler works on new hubs where initially no storage checkpoint exists

### DIFF
--- a/pkg/scalers/azure/azure_eventhub.go
+++ b/pkg/scalers/azure/azure_eventhub.go
@@ -87,7 +87,7 @@ func GetCheckpointFromBlobStorage(ctx context.Context, info EventHubInfo, partit
 
 	get, err := blobURL.Download(ctx, 0, 0, azblob.BlobAccessConditions{}, false)
 	if err != nil {
-		return Checkpoint{}, fmt.Errorf("unable to download file from blob storage: %s", err)
+		return Checkpoint{}, fmt.Errorf("unable to download file from blob storage: %w", err)
 	}
 
 	blobData := &bytes.Buffer{}


### PR DESCRIPTION
eventhub-scaler can scale even when no storage checkpoint exists. 

To scale up without checkpoint, the first calculation based only on eventhub partition infos. The tricky part was to differentiate between a partition without messages and exactly 1 unprocessed message. 



Fixes #797
