### PR TITLE
[v2] support HPA configurable scaling behavior on k8s >= 1.18

### DIFF
--- a/deploy/crds/keda.sh_scaledobjects_crd.yaml
+++ b/deploy/crds/keda.sh_scaledobjects_crd.yaml
@@ -55,6 +55,118 @@ spec:
         spec:
           description: ScaledObjectSpec is the spec for a ScaledObject resource
           properties:
+            behavior:
+              description: HorizontalPodAutoscalerBehavior configures the scaling
+                behavior of the target in both Up and Down directions (scaleUp and
+                scaleDown fields respectively).
+              properties:
+                scaleDown:
+                  description: scaleDown is scaling policy for scaling Down. If not
+                    set, the default value is to allow to scale down to minReplicas
+                    pods, with a 300 second stabilization window (i.e., the highest
+                    recommendation for the last 300sec is used).
+                  properties:
+                    policies:
+                      description: policies is a list of potential scaling polices
+                        which can be used during scaling. At least one policy must
+                        be specified, otherwise the HPAScalingRules will be discarded
+                        as invalid
+                      items:
+                        description: HPAScalingPolicy is a single policy which must
+                          hold true for a specified past interval.
+                        properties:
+                          periodSeconds:
+                            description: PeriodSeconds specifies the window of time
+                              for which the policy should hold true. PeriodSeconds
+                              must be greater than zero and less than or equal to
+                              1800 (30 min).
+                            format: int32
+                            type: integer
+                          type:
+                            description: Type is used to specify the scaling policy.
+                            type: string
+                          value:
+                            description: Value contains the amount of change which
+                              is permitted by the policy. It must be greater than
+                              zero
+                            format: int32
+                            type: integer
+                        required:
+                        - periodSeconds
+                        - type
+                        - value
+                        type: object
+                      type: array
+                    selectPolicy:
+                      description: selectPolicy is used to specify which policy should
+                        be used. If not set, the default value MaxPolicySelect is
+                        used.
+                      type: string
+                    stabilizationWindowSeconds:
+                      description: 'StabilizationWindowSeconds is the number of seconds
+                        for which past recommendations should be considered while
+                        scaling up or scaling down. StabilizationWindowSeconds must
+                        be greater than or equal to zero and less than or equal to
+                        3600 (one hour). If not set, use the default values: - For
+                        scale up: 0 (i.e. no stabilization is done). - For scale down:
+                        300 (i.e. the stabilization window is 300 seconds long).'
+                      format: int32
+                      type: integer
+                  type: object
+                scaleUp:
+                  description: 'scaleUp is scaling policy for scaling Up. If not set,
+                    the default value is the higher of:   * increase no more than
+                    4 pods per 60 seconds   * double the number of pods per 60 seconds
+                    No stabilization is used.'
+                  properties:
+                    policies:
+                      description: policies is a list of potential scaling polices
+                        which can be used during scaling. At least one policy must
+                        be specified, otherwise the HPAScalingRules will be discarded
+                        as invalid
+                      items:
+                        description: HPAScalingPolicy is a single policy which must
+                          hold true for a specified past interval.
+                        properties:
+                          periodSeconds:
+                            description: PeriodSeconds specifies the window of time
+                              for which the policy should hold true. PeriodSeconds
+                              must be greater than zero and less than or equal to
+                              1800 (30 min).
+                            format: int32
+                            type: integer
+                          type:
+                            description: Type is used to specify the scaling policy.
+                            type: string
+                          value:
+                            description: Value contains the amount of change which
+                              is permitted by the policy. It must be greater than
+                              zero
+                            format: int32
+                            type: integer
+                        required:
+                        - periodSeconds
+                        - type
+                        - value
+                        type: object
+                      type: array
+                    selectPolicy:
+                      description: selectPolicy is used to specify which policy should
+                        be used. If not set, the default value MaxPolicySelect is
+                        used.
+                      type: string
+                    stabilizationWindowSeconds:
+                      description: 'StabilizationWindowSeconds is the number of seconds
+                        for which past recommendations should be considered while
+                        scaling up or scaling down. StabilizationWindowSeconds must
+                        be greater than or equal to zero and less than or equal to
+                        3600 (one hour). If not set, use the default values: - For
+                        scale up: 0 (i.e. no stabilization is done). - For scale down:
+                        300 (i.e. the stabilization window is 300 seconds long).'
+                      format: int32
+                      type: integer
+                  type: object
+              type: object
             cooldownPeriod:
               format: int32
               type: integer

--- a/pkg/apis/keda/v1alpha1/scaledobject_types.go
+++ b/pkg/apis/keda/v1alpha1/scaledobject_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,8 +39,11 @@ type ScaledObjectSpec struct {
 	// +optional
 	MinReplicaCount *int32 `json:"minReplicaCount,omitempty"`
 	// +optional
-	MaxReplicaCount *int32          `json:"maxReplicaCount,omitempty"`
-	Triggers        []ScaleTriggers `json:"triggers"`
+	MaxReplicaCount *int32 `json:"maxReplicaCount,omitempty"`
+	// +optional
+	Behavior *autoscalingv2beta2.HorizontalPodAutoscalerBehavior `json:"behavior,omitempty"`
+
+	Triggers []ScaleTriggers `json:"triggers"`
 }
 
 //ScaleTarget holds the a reference to the scale target Object

--- a/pkg/apis/keda/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keda/v1alpha1/zz_generated.deepcopy.go
@@ -20,6 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/batch/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -424,6 +425,11 @@ func (in *ScaledObjectSpec) DeepCopyInto(out *ScaledObjectSpec) {
 		in, out := &in.MaxReplicaCount, &out.MaxReplicaCount
 		*out = new(int32)
 		**out = **in
+	}
+	if in.Behavior != nil {
+		in, out := &in.Behavior, &out.Behavior
+		*out = new(v2beta2.HorizontalPodAutoscalerBehavior)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Triggers != nil {
 		in, out := &in.Triggers, &out.Triggers

--- a/pkg/util/k8sversion.go
+++ b/pkg/util/k8sversion.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+type K8sVersion struct {
+	Version       *version.Info
+	MinorVersion  int
+	PrettyVersion string
+	Parsed        bool
+}
+
+func NewK8sVersion(version *version.Info) K8sVersion {
+	minorTrimmed := ""
+	if len(version.Minor) > 2 {
+		minorTrimmed = version.Minor[:2]
+	}
+
+	parsed := false
+	minor, err := strconv.Atoi(minorTrimmed)
+	if err == nil {
+		parsed = true
+	}
+
+	k8sVersion := new(K8sVersion)
+	k8sVersion.Parsed = parsed
+	k8sVersion.Version = version
+	k8sVersion.MinorVersion = minor
+	k8sVersion.PrettyVersion = version.Major + "." + version.Minor
+
+	return *k8sVersion
+}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Adding support for configurable scaling behavior in HPA which was introduced in v2beta2 in kubernetes 1.18

On kubernetes < 1.18 is this option ignored

Fixes #802
