### PR TITLE
Fixing link to deployment documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We are a Cloud Native Computing Foundation (CNCF) sandbox project.
 
 ## Deploying KEDA
 
-There are many ways to [deploy KEDA including Helm, Operator Hub and YAML files](https://keda.sh/deploy/).
+There are many ways to [deploy KEDA including Helm, Operator Hub and YAML files](https://keda.sh/docs/deploy/).
 
 ## Documentation
 


### PR DESCRIPTION
Looks like the deployment docs link changed on keda.sh. Updating to fix broken link.