### PR TITLE
fix link to keda slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If interested in contributing or participating in the direction of KEDA, you can
 * **Meeting agenda:** [https://hackmd.io/s/r127ErYiN](https://hackmd.io/s/r127ErYiN)
 
 Just want to learn or chat about KEDA? Feel free to join the conversation in 
-**[#KEDA](kubernetes.slack.com/messages/CKZJ36A5D)** on the **[Kubernetes Slack](https://slack.k8s.io/)**!
+**[#KEDA](https://kubernetes.slack.com/messages/CKZJ36A5D)** on the **[Kubernetes Slack](https://slack.k8s.io/)**!
 
 ## Building: Quick start with [Visual Studio Code Remote - Containers](https://code.visualstudio.com/docs/remote/containers)
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

The link get's resolved as https://github.com/kedacore/keda/blob/master/kubernetes.slack.com/messages/CKZJ36A5D instead of https://kubernetes.slack.com/messages/CKZJ36A5D