### PR TITLE
Automatically attach packaged deployment YAMLs to GitHub Release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -37,3 +37,34 @@ jobs:
         run: make publish
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
+
+        # Get release information to determine id of the current release
+      - name: Get Release
+        id: get-release-info
+        uses: bruceadams/get-release@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Upload deployment YAML files as ZIP to GitHub release
+      - name: Upload Deployment YAML (zip)
+        id: upload-deployment-yaml-zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://uploads.github.com/repos/kedacore/keda/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_path: keda-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_name: keda-${{ steps.get_version.outputs.VERSION }}.zip
+          asset_content_type: application/zip
+
+      # Upload deployment YAML files as TAR to GitHub release
+      - name: Upload Deployment YAML (tar.gz)
+        id: upload-deployment-yaml-tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://uploads.github.com/repos/kedacore/keda/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_path: keda-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_name: keda-${{ steps.get_version.outputs.VERSION }}.tar.gz
+          asset_content_type: application/tar+gzip

--- a/RELEASE-PROCESS.MD
+++ b/RELEASE-PROCESS.MD
@@ -29,18 +29,13 @@ The Docker Hub repo with all the different images can be seen here: https://hub.
 
 Creating a new release in the the releases page (https://github.com/kedacore/keda/release) will trigger a GitHub workflow which will create a new image with the latest code and tagged with the next version (in this example 1.2.0) and also change the latest tag to point to this image as well.
 
-## 4. Upload release packages
-
-When a new GitHub release is created, upload the tar.gz and zip release package files generated during the release process.
-They are named like `keda-$(VERSION).zip` and `keda-$(VERSION).tar.gz`.
-
-## 5. Publish documentation for new version
+## 4. Publish documentation for new version
 
 Publish documentation for new version on https://keda.sh.
 
 See [docs](https://github.com/kedacore/keda-docs#publishing-a-new-version).
 
-## 6. Update Helm Charts
+## 5. Update Helm Charts
 
 a). Update the version and appVersion here:  https://github.com/kedacore/charts/blob/master/keda/Chart.yaml 
 b). In the image section update the keda and metricsAdapter to point to the docker images from step 1 https://github.com/kedacore/charts/blob/master/keda/values.yaml
@@ -53,6 +48,6 @@ Update the following file:
 https://github.com/Azure/azure-functions-core-tools/blob/dev/src/Azure.Functions.Cli/StaticResources/keda.yaml
 [Search for 1.1.0 etc. and replace it]
 
-## 7. Create Helm release on GitHub
+## 6. Create Helm release on GitHub
 
 Create Helm release on GitHub with changelog of what changed to our Helm chart.


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Automatically attach packaged deployment YAMLs to GitHub Release as part of our release workflow.

### Checklist

- [x] ~A PR is opened to update the documentation on https://github.com/kedacore/keda-docs~
- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [x] ~Tests have been added~
- [X] Manual test was done in separate repo (see [release](https://github.com/tomkerkhove/keda-sandbox/releases/tag/v1.2.1) and [workflow](https://github.com/tomkerkhove/keda-sandbox/runs/684800356?check_suite_focus=true))
- [X] Update release process documentation

Fixes #764
