### PR TITLE
Init helm client in e2e tests

### DIFF
--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -10,7 +10,7 @@ test.before('configure shelljs', () => {
 })
 
 test.serial('Verify all commands', t => {
-  for (const command of ['kubectl']) {
+  for (const command of ['kubectl', 'helm']) {
     if (!sh.which(command)) {
       t.fail(`${command} is required for setup`)
     }
@@ -21,6 +21,10 @@ test.serial('Verify all commands', t => {
 test.serial('Verify environment variables', t => {
   const cluster = kc.getCurrentCluster()
   t.truthy(cluster, 'Make sure kubectl is logged into a cluster.')
+})
+
+test.serial('Init helm client', t => {
+  t.is(0, sh.exec('helm init --client-only').code)
 })
 
 test.serial('Deploy Keda', t => {


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

I think this is needed because #831 uses helm client. 

### Checklist

- [N/A] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [N/A] Tests have been added


