### PR TITLE
Adding a wait for the test app deployment to start up on initialization

### DIFF
--- a/tests/scalers/prometheus.test.ts
+++ b/tests/scalers/prometheus.test.ts
@@ -32,6 +32,12 @@ test.before(t => {
     sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
     'creating a deployment should work.'
   )
+  for (let i = 0; i < 10; i++) {
+    const readyReplicaCount = sh.exec(`kubectl get deployment.apps/test-app --namespace ${testNamespace} -o jsonpath="{.status.readyReplicas}`).stdout
+    if (readyReplicaCount != '2') {
+      sh.exec('sleep 2s')
+    }
+  }
 })
 
 test.serial('Deployment should have 0 replicas on start', t => {
@@ -51,6 +57,7 @@ test.serial(`Deployment should scale to 5 (the max) with HTTP Requests exceeding
     sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
     'creating job should work.'
   )
+
   t.is(
     '1',
     sh.exec(

--- a/tests/scalers/prometheus.test.ts
+++ b/tests/scalers/prometheus.test.ts
@@ -34,7 +34,7 @@ test.before(t => {
   )
   for (let i = 0; i < 10; i++) {
     const readyReplicaCount = sh.exec(`kubectl get deployment.apps/test-app --namespace ${testNamespace} -o jsonpath="{.status.readyReplicas}`).stdout
-    if (readyReplicaCount != '2') {
+    if (readyReplicaCount != '1') {
       sh.exec('sleep 2s')
     }
   }


### PR DESCRIPTION
Fixes #

Prometheus e2e - Giving time for the test-app container to pull and load before the tests start. I believe this is why the assertion failed in the prior PR - the pod was not ready because the container was still pulling.