### PR TITLE
[v2] rbac: allow get on any object

### DIFF
--- a/deploy/10-cluster_role.yaml
+++ b/deploy/10-cluster_role.yaml
@@ -5,7 +5,6 @@ metadata:
     app.kubernetes.io/name: keda-operator
     app.kubernetes.io/version: "2.0.0-alpha1"
     app.kubernetes.io/part-of: keda-operator
-  creationTimestamp: null
   name: keda-operator
 rules:
 - apiGroups:
@@ -62,3 +61,9 @@ rules:
   - "*/scale"
   verbs:
   - "*"
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - "get"


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->
In case we are scaling a CustomResource (eg. Argo Rollout), we need to get environment variables from containers that are inside. To allow that we need to modify RBAC.
