### PR TITLE
[v2] fix e2e - deploy ScaledJob CRD

### DIFF
--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -34,13 +34,16 @@ test.serial('Deploy Keda', t => {
   }
 
   if (sh.exec('kubectl apply -f ../deploy/crds/keda.sh_scaledobjects_crd.yaml').code !== 0) {
-    t.fail('error deploying keda. ' + result)
+    t.fail('error deploying ScaledObject CRD. ' + result)
+  }
+  if (sh.exec('kubectl apply -f ../deploy/crds/keda.sh_scaledjobs_crd.yaml').code !== 0) {
+    t.fail('error deploying ScaledJob CRD. ' + result)
   }
   if (
     sh.exec('kubectl apply -f ../deploy/crds/keda.sh_triggerauthentications_crd.yaml').code !==
     0
   ) {
-    t.fail('error deploying keda. ' + result)
+    t.fail('error deploying TriggerAuthentication CRD. ' + result)
   }
   if (sh.exec('kubectl apply -f ../deploy/').code !== 0) {
     t.fail('error deploying keda. ' + result)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

The issue prevents KEDA Operator to start -> to run e2e correctly

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->
