### PR TITLE
Minor e2e fix: keda-auth-reader role is deleted in kube-system namespace

### DIFF
--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -15,7 +15,6 @@ test('Remove Keda', t => {
     'clusterrole.rbac.authorization.k8s.io/keda-external-metrics-reader',
     'clusterrolebinding.rbac.authorization.k8s.io/keda-operator',
     'clusterrolebinding.rbac.authorization.k8s.io/keda:system:auth-delegator',
-    'rolebinding.rbac.authorization.k8s.io/keda-auth-reader',
     'clusterrolebinding.rbac.authorization.k8s.io/keda-hpa-controller-external-metrics',
     'service/keda-metrics-apiserver',
     'serviceaccount/keda-operator',


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Cleanup script shouldn't try to delete `keda-auth-reader` role in `keda` namespace, it is correctly deleted later in the script in `kube-system` namespace
