### PR TITLE
Prometheus Server Deployment and Load Generation Changes

### DIFF
--- a/tests/scalers/prometheus-deployment.yaml
+++ b/tests/scalers/prometheus-deployment.yaml
@@ -270,25 +270,6 @@ data:
     {}
     
 ---
-# Source: prometheus/templates/server-pvc.yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  labels:
-    component: "server"
-    app: prometheus
-    release: prometheus
-    chart: prometheus-11.1.0
-    heritage: Tiller
-  name: prometheus-server
-spec:
-  accessModes:
-    - ReadWriteOnce
-    
-  resources:
-    requests:
-      storage: "8Gi"
----
 # Source: prometheus/templates/server-serviceaccount.yaml
 
 apiVersion: v1
@@ -485,8 +466,7 @@ spec:
           configMap:
             name: prometheus-server
         - name: storage-volume
-          persistentVolumeClaim:
-            claimName: prometheus-server
+          emptyDir: {}
 ---
 # Source: prometheus/templates/alertmanager-clusterrole.yaml
 


### PR DESCRIPTION
Fixes:

I noticed that I was not validating that the Prometheus server was up and running so I have added an assertion for it's deployment. The Prometheus deployment itself was incorrectly using a PVC so that was removed from the deployment in case that is causing an issue on the remote cluster the End to End tests are running in.  Additionally, I changed the HTTP request generation to be less impactful load at once and more spread out over time so there is more consistent and steady load for Prometheus to scrape.