### PR TITLE
Allow setting test cluster name through env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ GIT_VERSION = $(shell git describe --always --abbrev=7)
 GIT_COMMIT  = $(shell git rev-list -1 HEAD)
 DATE        = $(shell date -u +"%Y.%m.%d.%H.%M.%S")
 
+TEST_CLUSTER_NAME ?= keda-nightly-run
+
 ##################################################
 # All                                            #
 ##################################################
@@ -35,7 +37,7 @@ e2e-test:
 	TERM=linux
 	@az login --service-principal -u $(AZURE_SP_ID) -p "$(AZURE_SP_KEY)" --tenant $(AZURE_SP_TENANT)
 	@az aks get-credentials \
-		--name keda-nightly-run \
+		--name $(TEST_CLUSTER_NAME) \
 		--subscription $(AZURE_SUBSCRIPTION) \
 		--resource-group $(AZURE_RESOURCE_GROUP)
 	npm install --prefix tests


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

`keda-nightly-run` got sick during an upgrade for some reason. I created another one (`keda-nightly-run-2`) to use for now until I can follow up with support about what happened there. This PR allows that setting to overridden through environment variables

### Checklist

- [ N/A] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ N/A ] Tests have been added
