### PR TITLE
[v2] during installation ignore ScaledJob CRD validation erros

### DIFF
--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -36,7 +36,7 @@ test.serial('Deploy Keda', t => {
   if (sh.exec('kubectl apply -f ../deploy/crds/keda.sh_scaledobjects_crd.yaml').code !== 0) {
     t.fail('error deploying ScaledObject CRD. ' + result)
   }
-  if (sh.exec('kubectl apply -f ../deploy/crds/keda.sh_scaledjobs_crd.yaml').code !== 0) {
+  if (sh.exec('kubectl apply -f ../deploy/crds/keda.sh_scaledjobs_crd.yaml --validate=false').code !== 0) {
     t.fail('error deploying ScaledJob CRD. ' + result)
   }
   if (


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>


ScaledJob CRD validation errors on some k8s version prevents KEDA operator to start before e2e tests. We can ingore those errors because ScaledJob is not implemented yet.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

