### PR TITLE
GCP Pub Scaler should not panic

### DIFF
--- a/pkg/scalers/gcp_pub_sub_scaler.go
+++ b/pkg/scalers/gcp_pub_sub_scaler.go
@@ -85,7 +85,7 @@ func (s *pubsubScaler) IsActive(ctx context.Context) (bool, error) {
 	size, err := s.GetSubscriptionSize(ctx)
 
 	if err != nil {
-		gcpPubSubLog.Error(err, "error")
+		gcpPubSubLog.Error(err, "error getting Active Status")
 		return false, err
 	}
 

--- a/pkg/scalers/stackdriver_client.go
+++ b/pkg/scalers/stackdriver_client.go
@@ -26,13 +26,12 @@ func NewStackDriverClient(ctx context.Context, credentials string) (*StackDriver
 	var gcpCredentials GoogleApplicationCredentials
 
 	if err := json.Unmarshal([]byte(credentials), &gcpCredentials); err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	clientOption := option.WithCredentialsJSON([]byte(credentials))
 
 	client, err := monitoring.NewMetricClient(ctx, clientOption)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

GCP Pub Scaler should not panic on invalid credentials

Fixes #616
