### PR TITLE
RabbitMQ: make queueLength optional

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,8 +58,8 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/operator-framework/operator-sdk v0.0.0-00010101000000-000000000000
 	github.com/pkg/errors v0.8.1
-	github.com/spf13/pflag v1.0.5
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/spf13/pflag v1.0.5
 	github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271
 	github.com/stretchr/testify v1.4.0
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	rabbitQueueLengthMetricName = "queueLength"
+	defaultRabbitMQQueueLength  = 20
 	rabbitMetricType            = "External"
 	rabbitIncludeUnacked        = "includeUnacked"
 	defaultIncludeUnacked       = false
@@ -127,7 +128,7 @@ func parseRabbitMQMetadata(resolvedEnv, metadata, authParams map[string]string) 
 
 		meta.queueLength = queueLength
 	} else {
-		return nil, fmt.Errorf("no queue length given")
+		meta.queueLength = defaultRabbitMQQueueLength
 	}
 
 	return &meta, nil

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -54,6 +54,26 @@ func TestRabbitMQParseMetadata(t *testing.T) {
 	}
 }
 
+var testDefaultQueueLength = []parseRabbitMQMetadataTestData{
+	// use default queueLength
+	{map[string]string{"queueName": "sample", "host": host}, false, map[string]string{}},
+	// use default queueLength with includeUnacked
+	{map[string]string{"queueName": "sample", "apiHost": apiHost, "includeUnacked": "true"}, false, map[string]string{}},
+}
+
+func TestParseDefaultQueueLength(t *testing.T) {
+	for _, testData := range testDefaultQueueLength {
+		metadata, err := parseRabbitMQMetadata(sampleRabbitMqResolvedEnv, testData.metadata, testData.authParams)
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		} else if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		} else if metadata.queueLength != defaultRabbitMQQueueLength {
+			t.Error("Expected default queueLength =", defaultRabbitMQQueueLength, "but got", metadata.queueLength)
+		}
+	}
+}
+
 type getQueueInfoTestData struct {
 	response       string
 	responseStatus int


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

[RabbitMQ Scaler documentation ](https://keda.sh/docs/1.4/scalers/rabbitmq-queue/#trigger-specification) mentiones that `queueLength` should be optional with default value `20`, but the actual code doesn't reflect this.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added

Fixes #880
