### PR TITLE
eventhub-scaler calculate total metric count related to partitions like kafka scaler

### DIFF
--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -276,6 +276,22 @@ func TestGetUnprocessedEventCountWithoutCheckpointReturning2Messages(t *testing.
 	}
 }
 
+func TestGetATotalLagOf20For2PartitionsOn100UnprocessedEvents(t *testing.T) {
+	lag := getTotalLagRelatedToPartitionAmount(100, 2, 10)
+
+	if lag != 20 {
+		t.Errorf("Expected a lag of 20 for 2 partitions, got %d", lag)
+	}
+}
+
+func TestGetATotalLagOf100For20PartitionsOn100UnprocessedEvents(t *testing.T) {
+	lag := getTotalLagRelatedToPartitionAmount(100, 20, 10)
+
+	if lag != 100 {
+		t.Errorf("Expected a lag of 100 for 20 partitions, got %d", lag)
+	}
+}
+
 func CreateNewCheckpointInStorage(endpoint *url.URL, credential azblob.Credential, client *eventhub.Hub) (context.Context, error) {
 	urlPath := fmt.Sprintf("%s.servicebus.windows.net/%s/$Default/", testEventHubNamespace, testEventHubName)
 


### PR DESCRIPTION
As mentioned by @ericbottard in issue #373, the kafka- and liiklus-scaler cap the number of replicas based on the number of partitions.

I think this is also important for the eventhub-scaler, which acts very similar like kafka. I suggest to adopting the same logic here.