### PR TITLE
[v2]adds consumer offset reset policy option to keda kafka scaler

### DIFF
--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -65,7 +65,7 @@ const (
 	lagThresholdMetricName   = "lagThreshold"
 	kafkaMetricType          = "External"
 	defaultKafkaLagThreshold = 10
-	defaultOffsetReset       = latest
+	defaultOffsetReset       = earliest
 )
 
 var kafkaLog = logf.Log.WithName("kafka_scaler")

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -112,9 +112,9 @@ func parseKafkaMetadata(resolvedEnv, metadata, authParams map[string]string) (ka
 	meta.consumerOffsetReset = defaultOffsetReset
 
 	if metadata["consumerOffsetReset"] != "" {
-		policy := offsetResetPolicy(metadata["offsetReset"])
+		policy := offsetResetPolicy(metadata["consumerOffsetReset"])
 		if policy != earliest && policy != latest {
-			return meta, fmt.Errorf("err offsetReset policy %s given", policy)
+			return meta, fmt.Errorf("err consumerOffsetReset policy %s given", policy)
 		}
 		meta.consumerOffsetReset = policy
 	}

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -12,7 +12,7 @@ type parseKafkaMetadataTestData struct {
 	brokers             []string
 	group               string
 	topic               string
-	consumerOffsetReset string
+	consumerOffsetReset offsetResetPolicy
 }
 
 // A complete valid metadata example for reference
@@ -38,17 +38,17 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 	// failure, no consumer group
 	{map[string]string{"bootstrapServers": "foobar:9092"}, true, 1, []string{"foobar:9092"}, "", "", "earliest"},
 	// failure, no topic
-	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group"}, true, 1, []string{"foobar:9092"}, "my-group", "", "earliest"},
+	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group"}, true, 1, []string{"foobar:9092"}, "my-group", "", offsetResetPolicy("earliest")},
 	// success
-	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic", "earliest"},
+	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
 	// success, more brokers
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", "earliest"},
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
 	// success, consumerOffsetReset policy earliest
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "earliest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", "earliest"},
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "earliest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
 	// failure, consumerOffsetReset policy wrong
 	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "foo"}, true, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", ""},
 	// success, consumerOffsetReset policy latest
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "latest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", "latest"},
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "latest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("latest")},
 }
 
 func TestGetBrokers(t *testing.T) {
@@ -73,7 +73,7 @@ func TestGetBrokers(t *testing.T) {
 		if meta.topic != testData.topic {
 			t.Errorf("Expected topic %s but got %s\n", testData.topic, meta.topic)
 		}
-		if err == nil && meta.consumerOffsetReset != offsetResetPolicy(testData.consumerOffsetReset) {
+		if err == nil && meta.consumerOffsetReset != testData.consumerOffsetReset {
 			t.Errorf("Expected consumerOffsetReset %s but got %s\n", testData.consumerOffsetReset, meta.consumerOffsetReset)
 		}
 
@@ -97,7 +97,7 @@ func TestGetBrokers(t *testing.T) {
 		if meta.topic != testData.topic {
 			t.Errorf("Expected topic %s but got %s\n", testData.topic, meta.topic)
 		}
-		if err == nil && meta.consumerOffsetReset != offsetResetPolicy(testData.consumerOffsetReset) {
+		if err == nil && meta.consumerOffsetReset != testData.consumerOffsetReset {
 			t.Errorf("Expected consumerOffsetReset %s but got %s\n", testData.consumerOffsetReset, meta.consumerOffsetReset)
 		}
 	}

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -6,13 +6,13 @@ import (
 )
 
 type parseKafkaMetadataTestData struct {
-	metadata            map[string]string
-	isError             bool
-	numBrokers          int
-	brokers             []string
-	group               string
-	topic               string
-	consumerOffsetReset offsetResetPolicy
+	metadata          map[string]string
+	isError           bool
+	numBrokers        int
+	brokers           []string
+	group             string
+	topic             string
+	offsetResetPolicy offsetResetPolicy
 }
 
 // A complete valid metadata example for reference
@@ -43,12 +43,12 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
 	// success, more brokers
 	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
-	// success, consumerOffsetReset policy earliest
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "earliest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
-	// failure, consumerOffsetReset policy wrong
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "foo"}, true, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", ""},
-	// success, consumerOffsetReset policy latest
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "consumerOffsetReset": "latest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("latest")},
+	// success, offsetResetPolicy policy earliest
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "earliest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
+	// failure, offsetResetPolicy policy wrong
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "foo"}, true, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", ""},
+	// success, offsetResetPolicy policy latest
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "latest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("latest")},
 }
 
 func TestGetBrokers(t *testing.T) {
@@ -73,8 +73,8 @@ func TestGetBrokers(t *testing.T) {
 		if meta.topic != testData.topic {
 			t.Errorf("Expected topic %s but got %s\n", testData.topic, meta.topic)
 		}
-		if err == nil && meta.consumerOffsetReset != testData.consumerOffsetReset {
-			t.Errorf("Expected consumerOffsetReset %s but got %s\n", testData.consumerOffsetReset, meta.consumerOffsetReset)
+		if err == nil && meta.offsetResetPolicy != testData.offsetResetPolicy {
+			t.Errorf("Expected offsetResetPolicy %s but got %s\n", testData.offsetResetPolicy, meta.offsetResetPolicy)
 		}
 
 		meta, err = parseKafkaMetadata(nil, testData.metadata, validWithoutAuthParams)
@@ -97,8 +97,8 @@ func TestGetBrokers(t *testing.T) {
 		if meta.topic != testData.topic {
 			t.Errorf("Expected topic %s but got %s\n", testData.topic, meta.topic)
 		}
-		if err == nil && meta.consumerOffsetReset != testData.consumerOffsetReset {
-			t.Errorf("Expected consumerOffsetReset %s but got %s\n", testData.consumerOffsetReset, meta.consumerOffsetReset)
+		if err == nil && meta.offsetResetPolicy != testData.offsetResetPolicy {
+			t.Errorf("Expected offsetResetPolicy %s but got %s\n", testData.offsetResetPolicy, meta.offsetResetPolicy)
 		}
 	}
 }

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -36,19 +36,19 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 	// failure, no bootstrapServers
 	{map[string]string{}, true, 0, nil, "", "", ""},
 	// failure, no consumer group
-	{map[string]string{"bootstrapServers": "foobar:9092"}, true, 1, []string{"foobar:9092"}, "", "", "earliest"},
+	{map[string]string{"bootstrapServers": "foobar:9092"}, true, 1, []string{"foobar:9092"}, "", "", "latest"},
 	// failure, no topic
-	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group"}, true, 1, []string{"foobar:9092"}, "my-group", "", offsetResetPolicy("earliest")},
+	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group"}, true, 1, []string{"foobar:9092"}, "my-group", "", offsetResetPolicy("latest")},
 	// success
-	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
+	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic", offsetResetPolicy("latest")},
 	// success, more brokers
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
-	// success, offsetResetPolicy policy earliest
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "earliest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
-	// failure, offsetResetPolicy policy wrong
-	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "foo"}, true, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", ""},
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("latest")},
 	// success, offsetResetPolicy policy latest
 	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "latest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("latest")},
+	// failure, offsetResetPolicy policy wrong
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "foo"}, true, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", ""},
+	// success, offsetResetPolicy policy earliest
+	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "earliest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
 }
 
 func TestGetBrokers(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: grassiale <alessandro.grassi01@gmail.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

This PR is aimed at solving how Keda Kafka scaler handles the absence of committed offset with relation to the offset policy the consumer is following.
At the moment, if you create a scaledobject for a new consumer group having no committed offset, keda scaler will return a lag value equal to the latest offset in the topic it is consuming from. This often causes the scaler to scale relative deployment replicas to the max, because the latest offset in the topic is probably higher than the lagTreshold. This is fine for consumers having auto.offset.reset=earliest, since they will start to consume right-away all the messages in the topic; but is wrong for 
auto.offset.reset=latest consumers, that will only consume new messages on the topic. The lag for this kind of consumer is now initially set to 0.

### Checklist

- [X] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
