### PR TITLE
[v2] temporary fix to be able to deploy ScaledJob on k8s 1.18

### DIFF
--- a/deploy/crds/keda.sh_scaledjobs_crd.yaml
+++ b/deploy/crds/keda.sh_scaledjobs_crd.yaml
@@ -1416,6 +1416,7 @@ spec:
                                       type: string
                                   required:
                                   - containerPort
+                                  - protocol
                                   type: object
                                 type: array
                                 x-kubernetes-list-map-keys:
@@ -2623,6 +2624,7 @@ spec:
                                       type: string
                                   required:
                                   - containerPort
+                                  - protocol
                                   type: object
                                 type: array
                               readinessProbe:
@@ -3835,6 +3837,7 @@ spec:
                                       type: string
                                   required:
                                   - containerPort
+                                  - protocol
                                   type: object
                                 type: array
                                 x-kubernetes-list-map-keys:


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

We need to manually modify generated ScaledJob CRD, to be able to deploy it on k8s v 1.18. 

There were validation improvements brought in k8s 1.18 and operator-sdk is not able to generate the CRD correctly. 
Issue details: https://github.com/kedacore/keda/issues/927

This should help with e2e tests failures on v2 branch

