### PR TITLE
Fix DevContainer Build issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,9 +50,10 @@ RUN apt-get update \
         golang.org/x/tools/gopls \
         github.com/alecthomas/gometalinter \
         honnef.co/go/tools/... \
-        github.com/golangci/golangci-lint/cmd/golangci-lint \
         github.com/mgechev/revive \
         github.com/derekparker/delve/cmd/dlv 2>&1 \
+    # Install golangci-lint
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0 \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
When I tried DevContainer, It failed. I investigate the root cause is the `golangci-lint` install failed.
According to the official documentation, they don't recommend to install with `go get` instead they recommend, binary install. so that I change it to the binary install now it works fine. 

https://golangci-lint.run/usage/install/

### Checklist

- [-] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [-] Tests have been added

This is a PR for the bug fix of Dockerfile. these are N/A. I don't know if I satisfy DCO. I'll try to create a PR and have a look at the test.

Fixes #

No issue written. Small fix. 