### PR TITLE
[v2] Unique MetricName for each Trigger in ScaledObject

### DIFF
--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -39,9 +39,8 @@ type artemisMonitoring struct {
 }
 
 const (
-	artemisQueueLengthMetricName = "queueLength"
-	artemisMetricType            = "External"
-	defaultArtemisQueueLength    = 10
+	artemisMetricType         = "External"
+	defaultArtemisQueueLength = 10
 )
 
 var artemisLog = logf.Log.WithName("artemis_queue_scaler")
@@ -184,7 +183,7 @@ func (s *artemisScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: artemisQueueLengthMetricName,
+			Name: fmt.Sprintf("%s-%s-%s", "artemis", s.metadata.brokerName, s.metadata.queueName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -176,8 +176,7 @@ func (c *awsCloudwatchScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(c.metadata.targetMetricValue), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: fmt.Sprintf("%s-%s-%s", strings.ReplaceAll(c.metadata.namespace, "/", "-"),
-				c.metadata.dimensionName, c.metadata.dimensionValue),
+			Name: fmt.Sprintf("%s-%s-%s-%s", "aws-cloudwatch", strings.ReplaceAll(c.metadata.namespace, "/", "-"), c.metadata.dimensionName, c.metadata.dimensionValue),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	awsKinesisStreamMetricName = "ShardCount"
-	targetShardCountDefault    = 2
+	// awsKinesisStreamMetricName = "ShardCount"
+	targetShardCountDefault = 2
 )
 
 type awsKinesisStreamScaler struct {
@@ -104,7 +104,7 @@ func (s *awsKinesisStreamScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec 
 	targetShardCountQty := resource.NewQuantity(int64(s.metadata.targetShardCount), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: fmt.Sprintf("%s-%s-%s", "AWS-Kinesis-Stream", awsKinesisStreamMetricName, s.metadata.streamName),
+			Name: fmt.Sprintf("%s-%s", "AWS-Kinesis-Stream", s.metadata.streamName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	// awsKinesisStreamMetricName = "ShardCount"
 	targetShardCountDefault = 2
 )
 

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -120,7 +120,7 @@ func (s *awsSqsQueueScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: fmt.Sprintf("%s-%s-%s", "AWS-SQS-Queue", awsSqsQueueMetricName, s.metadata.queueName),
+			Name: fmt.Sprintf("%s-%s", "AWS-SQS-Queue", s.metadata.queueName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -155,7 +155,7 @@ func (s *azureBlobScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetBlobCount := resource.NewQuantity(int64(s.metadata.targetBlobCount), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: blobCountMetricName,
+			Name: fmt.Sprintf("%s-%s", "azure-blob", s.metadata.blobContainerName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -209,7 +209,7 @@ func (scaler *AzureEventHubScaler) GetMetricSpecForScaling() []v2beta2.MetricSpe
 	targetMetricVal := resource.NewQuantity(scaler.metadata.threshold, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: thresholdMetricName,
+			Name: fmt.Sprintf("%s-%s-%s", "azure-eventhub", scaler.metadata.eventHubInfo.EventHubConnection, scaler.metadata.eventHubInfo.EventHubConsumerGroup),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -167,7 +167,7 @@ func (s *azureMonitorScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricVal := resource.NewQuantity(int64(s.metadata.targetValue), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: azureMonitorMetricName,
+			Name: fmt.Sprintf("%s-%s-%s-%s", "azure-monitor", s.metadata.azureMonitorInfo.ResourceURI, s.metadata.azureMonitorInfo.ResourceGroupName, s.metadata.azureMonitorInfo.Name),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -136,7 +136,7 @@ func (s *azureQueueScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: queueLengthMetricName,
+			Name: fmt.Sprintf("%s-%s", "azure-queue", s.metadata.queueName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -22,6 +22,11 @@ type parseServiceBusMetadataTestData struct {
 	podIdentity string
 }
 
+type azServiceBusMetricIdentifier struct {
+	metadataTestData *parseServiceBusMetadataTestData
+	name             string
+}
+
 // not testing connections so it doesn't matter what the resolved env value is for this
 var sampleResolvedEnv = map[string]string{
 	connectionSetting: "none",
@@ -49,6 +54,11 @@ var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 	{map[string]string{"queueName": queueName}, true, Queue, map[string]string{}, "azure"},
 	// correct pod identity
 	{map[string]string{"queueName": queueName, "namespace": namespaceName}, false, Queue, map[string]string{}, "azure"},
+}
+
+var azServiceBusMetricIdentifiers = []azServiceBusMetricIdentifier{
+	{&parseServiceBusMetadataDataset[1], "azure-servicebus-testqueue"},
+	{&parseServiceBusMetadataDataset[2], "azure-servicebus-testtopic-testsubscription"},
 }
 
 var getServiceBusLengthTestScalers = []azureServiceBusScaler{
@@ -116,6 +126,22 @@ func TestGetServiceBusLength(t *testing.T) {
 			if length != -1 || err == nil {
 				t.Errorf("Expected error but got success")
 			}
+		}
+	}
+}
+
+func TestAzServiceBusGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range azServiceBusMetricIdentifiers {
+		meta, err := parseAzureServiceBusMetadata(sampleResolvedEnv, testData.metadataTestData.metadata, testData.metadataTestData.authParams, testData.metadataTestData.podIdentity)
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+		mockAzServiceBusScalerScaler := azureServiceBusScaler{meta, testData.metadataTestData.podIdentity}
+
+		metricSpec := mockAzServiceBusScalerScaler.GetMetricSpecForScaling()
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
 		}
 	}
 }

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -128,13 +129,21 @@ func (s *cronScaler) Close() error {
 	return nil
 }
 
+func parseCronTimeFormat(s string) string {
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "*", "x")
+	s = strings.ReplaceAll(s, "/", "(Sl)")
+	s = strings.ReplaceAll(s, "?", "(Qm)")
+	return s
+}
+
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *cronScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	specReplicas := 1
 	targetMetricValue := resource.NewQuantity(int64(specReplicas), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: cronMetricName,
+			Name: fmt.Sprintf("%s-%s-%s-%s", "cron", strings.ReplaceAll(s.metadata.timezone, "/", "-"), parseCronTimeFormat(s.metadata.start), parseCronTimeFormat(s.metadata.end)),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -132,8 +132,8 @@ func (s *cronScaler) Close() error {
 func parseCronTimeFormat(s string) string {
 	s = strings.ReplaceAll(s, " ", "")
 	s = strings.ReplaceAll(s, "*", "x")
-	s = strings.ReplaceAll(s, "/", "(Sl)")
-	s = strings.ReplaceAll(s, "?", "(Qm)")
+	s = strings.ReplaceAll(s, "/", "Sl")
+	s = strings.ReplaceAll(s, "?", "Qm")
 	return s
 }
 

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -12,6 +12,11 @@ type parseCronMetadataTestData struct {
 	isError  bool
 }
 
+type cronMetricIdentifier struct {
+	metadataTestData *parseCronMetadataTestData
+	name             string
+}
+
 // A complete valid metadata example for reference
 var validCronMetadata = map[string]string{
 	"timezone":        "Etc/UTC",
@@ -25,6 +30,10 @@ var testCronMetadata = []parseCronMetadataTestData{
 	{validCronMetadata, false},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45 * * * *"}, true},
 	{map[string]string{"start": "30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
+}
+
+var cronMetricIdentifiers = []cronMetricIdentifier{
+	{&testCronMetadata[1], "cron-Etc-UTC-00xxThu-5923xxThu"},
 }
 
 var tz, _ = time.LoadLocation(validCronMetadata["timezone"])
@@ -60,5 +69,22 @@ func TestGetMetrics(t *testing.T) {
 		assert.Equal(t, metrics[0].Value.Value(), int64(10))
 	} else {
 		assert.Equal(t, metrics[0].Value.Value(), int64(1))
+	}
+}
+
+
+func TestCronGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range cronMetricIdentifiers {
+		meta, err := parseCronMetadata(testData.metadataTestData.metadata, nil)
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+		mockCronScaler := cronScaler{meta}
+
+		metricSpec := mockCronScaler.GetMetricSpecForScaling()
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
+		}
 	}
 }

--- a/pkg/scalers/gcp_pub_sub_scaler.go
+++ b/pkg/scalers/gcp_pub_sub_scaler.go
@@ -14,9 +14,8 @@ import (
 )
 
 const (
-	pubSubSubscriptionSizeMetricName = "GCPPubSubSubscriptionSize"
-	defaultTargetSubscriptionSize    = 5
-	pubSubStackDriverMetricName      = "pubsub.googleapis.com/subscription/num_undelivered_messages"
+	defaultTargetSubscriptionSize = 5
+	pubSubStackDriverMetricName   = "pubsub.googleapis.com/subscription/num_undelivered_messages"
 )
 
 type pubsubScaler struct {
@@ -104,7 +103,7 @@ func (s *pubsubScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: pubSubSubscriptionSizeMetricName,
+			Name: fmt.Sprintf("%s-%s", "gcp", s.metadata.subscriptionName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -13,6 +13,11 @@ type parsePubSubMetadataTestData struct {
 	isError  bool
 }
 
+type gcpPubSubMetricIdentifier struct {
+	metadataTestData *parsePubSubMetadataTestData
+	name             string
+}
+
 var testPubSubMetadata = []parsePubSubMetadataTestData{
 	{map[string]string{}, true},
 	// all properly formed
@@ -27,6 +32,10 @@ var testPubSubMetadata = []parsePubSubMetadataTestData{
 	{map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "AA", "credentials": "SAMPLE_CREDS"}, true},
 }
 
+var gcpPubSubMetricIdentifiers = []gcpPubSubMetricIdentifier{
+	{&testPubSubMetadata[1], "gcp-mysubscription"},
+}
+
 func TestPubSubParseMetadata(t *testing.T) {
 	for _, testData := range testPubSubMetadata {
 		_, err := parsePubSubMetadata(testData.metadata, testPubSubResolvedEnv)
@@ -35,6 +44,22 @@ func TestPubSubParseMetadata(t *testing.T) {
 		}
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")
+		}
+	}
+}
+
+func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range gcpPubSubMetricIdentifiers {
+		meta, err := parsePubSubMetadata(testData.metadataTestData.metadata, testPubSubResolvedEnv)
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+		mockGcpPubSubScaler := pubsubScaler{meta}
+
+		metricSpec := mockGcpPubSubScaler.GetMetricSpecForScaling()
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
 		}
 	}
 }

--- a/pkg/scalers/huawei_cloudeye_scaler.go
+++ b/pkg/scalers/huawei_cloudeye_scaler.go
@@ -242,7 +242,7 @@ func (h *huaweiCloudeyeScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(h.metadata.targetMetricValue), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: fmt.Sprintf("%s-%s-%s-%s", strings.ReplaceAll(h.metadata.namespace, ".", "-"),
+			Name: fmt.Sprintf("%s-%s-%s-%s-%s", "huawei-cloudeye", strings.ReplaceAll(h.metadata.namespace, ".", "-"),
 				h.metadata.metricsName,
 				h.metadata.dimensionName, h.metadata.dimensionValue),
 		},

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -343,7 +343,7 @@ func (s *kafkaScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: lagThresholdMetricName,
+			Name: fmt.Sprintf("%s-%s-%s", "kafka", s.metadata.topic, s.metadata.group),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -81,7 +81,7 @@ func (s *liiklusScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: liiklusLagThresholdMetricName,
+			Name: fmt.Sprintf("%s-%s-%s", "liiklus", s.metadata.topic, s.metadata.group),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -185,9 +185,15 @@ func (s *mySQLScaler) getQueryResult() (int, error) {
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
 func (s *mySQLScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueryValue := resource.NewQuantity(int64(s.metadata.queryValue), resource.DecimalSI)
+	metricName := "mysql"
+	if s.metadata.connectionString != "" {
+		metricName = fmt.Sprintf("%s-%s", metricName, s.metadata.connectionString)
+	} else {
+		metricName = fmt.Sprintf("%s-%s", metricName, s.metadata.dbName)
+	}
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: mySQLMetricName,
+			Name: metricName,
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -184,9 +184,15 @@ func (s *postgreSQLScaler) getActiveNumber() (int, error) {
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
 func (s *postgreSQLScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetQueryValue := resource.NewQuantity(int64(s.metadata.targetQueryValue), resource.DecimalSI)
+	metricName := "postgresql"
+	if s.metadata.connection != "" {
+		metricName = fmt.Sprintf("%s-%s", metricName, s.metadata.connection)
+	} else {
+		metricName = fmt.Sprintf("%s-%s", metricName, s.metadata.dbName)
+	}
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: pgMetricName,
+			Name: metricName,
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -1,0 +1,43 @@
+package scalers
+
+import (
+	"testing"
+)
+
+type parsePostgreSQLMetadataTestData struct {
+	metdadata map[string]string
+	isError   bool
+}
+
+type postgreSQLMetricIdentifier struct {
+	metadataTestData *parsePostgreSQLMetadataTestData
+	name             string
+}
+
+var testPostgreSQLMetdata = []parsePostgreSQLMetadataTestData{
+	// connection
+	{map[string]string{"query": "test_query", "targetQueryValue": "5", "connection": "test_connection_string"}, false},
+	// dbName
+	{map[string]string{"query": "test_query", "targetQueryValue": "5", "host": "test_host", "port": "test_port", "userName": "test_user_name", "dbName": "test_db_name", "sslmode": "test_ssl_mode"}, false},
+}
+
+var postgreSQLMetricIdentifiers = []postgreSQLMetricIdentifier{
+	{&testPostgreSQLMetdata[0], "postgresql-test_connection_string"},
+	{&testPostgreSQLMetdata[1], "postgresql-test_db_name"},
+}
+
+func TestPosgresSQLGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range postgreSQLMetricIdentifiers {
+		meta, err := parsePostgreSQLMetadata(map[string]string{"test_connection_string": "test_connection_string"}, testData.metadataTestData.metdadata, nil)
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+		mockPostgresSQLScaler := postgreSQLScaler{meta, nil}
+
+		metricSpec := mockPostgresSQLScaler.GetMetricSpecForScaling()
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
+		}
+	}
+}

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -113,7 +113,7 @@ func (s *prometheusScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(s.metadata.threshold), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: s.metadata.metricName,
+			Name: fmt.Sprintf("%s-%s-%s", "prometheus", s.metadata.serverAddress, s.metadata.metricName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -9,6 +9,11 @@ type parsePrometheusMetadataTestData struct {
 	isError  bool
 }
 
+type prometheusMetricIdentifier struct {
+	metadataTestData *parsePrometheusMetadataTestData
+	name             string
+}
+
 var testPromMetadata = []parsePrometheusMetadataTestData{
 	{map[string]string{}, true},
 	// all properly formed
@@ -25,6 +30,10 @@ var testPromMetadata = []parsePrometheusMetadataTestData{
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up"}, false},
 }
 
+var prometheusMetricIdentifiers = []prometheusMetricIdentifier{
+	{&testPromMetadata[1], "prometheus-http://localhost:9090-http_requests_total"},
+}
+
 func TestPrometheusParseMetadata(t *testing.T) {
 	for _, testData := range testPromMetadata {
 		_, err := parsePrometheusMetadata(testData.metadata, map[string]string{})
@@ -33,6 +42,22 @@ func TestPrometheusParseMetadata(t *testing.T) {
 		}
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")
+		}
+	}
+}
+
+func TestPrometheusGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range prometheusMetricIdentifiers {
+		meta, err := parsePrometheusMetadata(testData.metadataTestData.metadata, nil)
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+		mockPrometheusScaler := prometheusScaler{meta}
+
+		metricSpec := mockPrometheusScaler.GetMetricSpecForScaling()
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
 		}
 	}
 }

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -237,7 +237,7 @@ func (s *rabbitMQScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: rabbitQueueLengthMetricName,
+			Name: fmt.Sprintf("%s-%s", "rabbitmq", s.metadata.queueName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	listLengthMetricName    = "RedisListLength"
 	defaultTargetListLength = 5
 	defaultRedisAddress     = "redis-master.default.svc.cluster.local:6379"
 	defaultRedisPassword    = ""
@@ -161,7 +160,7 @@ func (s *redisScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetListLengthQty := resource.NewQuantity(int64(s.metadata.targetListLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: listLengthMetricName,
+			Name: fmt.Sprintf("%s-%s", "redis", s.metadata.listName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/redis_streams_scaler.go
+++ b/pkg/scalers/redis_streams_scaler.go
@@ -16,8 +16,6 @@ import (
 )
 
 const (
-	pendingEntriesCountMetricName = "RedisStreamPendingEntriesCount"
-
 	// defaults
 	defaultTargetPendingEntriesCount = 5
 	defaultAddress                   = "redis-master.default.svc.cluster.local:6379"
@@ -214,7 +212,7 @@ func (s *redisStreamsScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetPendingEntriesCount := resource.NewQuantity(int64(s.metadata.targetPendingEntriesCount), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: pendingEntriesCountMetricName,
+			Name: fmt.Sprintf("%s-%s-%s", "redis-streams", s.metadata.streamName, s.metadata.consumerGroupName),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -183,7 +183,7 @@ func (s *stanScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: lagThresholdMetricName,
+			Name: fmt.Sprintf("%s-%s-%s-%s", "stan", s.metadata.queueGroup, s.metadata.durableName, s.metadata.subject),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,


### PR DESCRIPTION
<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Added unique name for every scaler. Multiple metrics for one ScaledObject can be used.

### Checklist

- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added

Fixes #733 
