### PR TITLE
[v2] don't use generated ScaledJob CRD in e2e tests

### DIFF
--- a/.github/workflows/v2-build.yml
+++ b/.github/workflows/v2-build.yml
@@ -32,8 +32,14 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
 
+      - name: Backup the original ScaledJob CRD
+        run: cp deploy/crds/keda.sh_scaledjobs_crd.yaml deploy/crds/keda.sh_scaledjobs_crd.yaml.orig
+
       - name: Publish
         run: make publish
+
+      - name: Use the original ScaledJob CRD
+        run: mv -f deploy/crds/keda.sh_scaledjobs_crd.yaml.orig deploy/crds/keda.sh_scaledjobs_crd.yaml
 
       - name: Run end to end tests
         env:

--- a/deploy/crds/keda.sh_scaledjobs_crd.yaml
+++ b/deploy/crds/keda.sh_scaledjobs_crd.yaml
@@ -49,7 +49,7 @@ spec:
         spec:
           description: ScaledJobSpec defines the desired state of ScaledJob
           properties:
-            cooldownPeriod:
+            failedJobsHistoryLimit:
               format: int32
               type: integer
             jobTargetRef:
@@ -6174,10 +6174,10 @@ spec:
             maxReplicaCount:
               format: int32
               type: integer
-            minReplicaCount:
+            pollingInterval:
               format: int32
               type: integer
-            pollingInterval:
+            successfulJobsHistoryLimit:
               format: int32
               type: integer
             triggers:


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

The current e2e running on v2 as part of build action [is failing](https://github.com/kedacore/keda/runs/954078597), because before the e2e tests, ScaledJob CRD is regenerated and this generated CRD can't be deployed on k8s v1.18 #927 

We need to manually add some properties to in order to deploy this CRD on cluster. 

For now I am replacing the generated CRD with the original one to enable the deployment, till #927 is fixed.
