### PR TITLE
[v2] add option to restore to original replica count after ScaledObject's deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Adding Standard Resource metrics to KEDA ([#874](https://github.com/kedacore/keda/pull/874))
 - Managed Identity support for Azure Monitor scaler ([#936](https://github.com/kedacore/keda/issues/936))
 - Add support for multiple triggers on ScaledObject ([#476](https://github.com/kedacore/keda/issues/476))
+- Add consumer offset reset policy option to Kafka scaler ([#925](https://github.com/kedacore/keda/pull/925))
+- Add option to restore to original replica count after ScaledObject's deletion ([#219](https://github.com/kedacore/keda-docs/pull/219))
 
 ### Improvements
 
@@ -31,7 +33,6 @@
 - Introduce shortnames for CRDs ([#774](https://github.com/kedacore/keda/issues/774))
 - kubectl get scaledobject should show related trigger authentication ([#777](https://github.com/kedacore/keda/issues/777))
 - kubectl get triggerauthentication should show information about configured parameters ([#778](https://github.com/kedacore/keda/issues/778))
-- Add consumer offset reset policy option to Kafka scaler ([#925](https://github.com/kedacore/keda/pull/925))
 
 ### Breaking Changes
 

--- a/deploy/crds/keda.sh_scaledobjects_crd.yaml
+++ b/deploy/crds/keda.sh_scaledobjects_crd.yaml
@@ -232,6 +232,8 @@ spec:
                         type: object
                       type: array
                   type: object
+                restoreToOriginalReplicaCount:
+                  type: boolean
               type: object
             cooldownPeriod:
               format: int32
@@ -320,6 +322,9 @@ spec:
             lastActiveTime:
               format: date-time
               type: string
+            originalReplicaCount:
+              format: int32
+              type: integer
             scaleTargetGVKR:
               description: GroupVersionKindResource provides unified structure for
                 schema.GroupVersionKind and Resource

--- a/pkg/apis/keda/v1alpha1/scaledobject_types.go
+++ b/pkg/apis/keda/v1alpha1/scaledobject_types.go
@@ -47,7 +47,10 @@ type ScaledObjectSpec struct {
 }
 
 type AdvancedConfig struct {
+	// +optional
 	HorizontalPodAutoscalerConfig *HorizontalPodAutoscalerConfig `json:"horizontalPodAutoscalerConfig,omitempty"`
+	// +optional
+	RestoreToOriginalReplicaCount bool `json:"restoreToOriginalReplicaCount,omitempty"`
 }
 
 type HorizontalPodAutoscalerConfig struct {
@@ -88,6 +91,8 @@ type ScaledObjectStatus struct {
 	ScaleTargetKind string `json:"scaleTargetKind,omitempty"`
 	// +optional
 	ScaleTargetGVKR *GroupVersionKindResource `json:"scaleTargetGVKR,omitempty"`
+	// +optional
+	OriginalReplicaCount *int32 `json:"originalReplicaCount,omitempty"`
 	// +optional
 	LastActiveTime *metav1.Time `json:"lastActiveTime,omitempty"`
 	// +optional

--- a/pkg/apis/keda/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keda/v1alpha1/zz_generated.deepcopy.go
@@ -550,6 +550,11 @@ func (in *ScaledObjectStatus) DeepCopyInto(out *ScaledObjectStatus) {
 		*out = new(GroupVersionKindResource)
 		**out = **in
 	}
+	if in.OriginalReplicaCount != nil {
+		in, out := &in.OriginalReplicaCount, &out.OriginalReplicaCount
+		*out = new(int32)
+		**out = **in
+	}
 	if in.LastActiveTime != nil {
 		in, out := &in.LastActiveTime, &out.LastActiveTime
 		*out = (*in).DeepCopy()

--- a/tests/scalers/azure-queue-restore-original-replicas.test.ts
+++ b/tests/scalers/azure-queue-restore-original-replicas.test.ts
@@ -1,0 +1,149 @@
+import * as fs from 'fs'
+import * as sh from 'shelljs'
+import * as tmp from 'tmp'
+import test from 'ava'
+
+const defaultNamespace = 'azure-queue-restore-original-replicas-test'
+const connectionString = process.env['TEST_STORAGE_CONNECTION_STRING']
+
+test.before(t => {
+  if (!connectionString) {
+    t.fail('TEST_STORAGE_CONNECTION_STRING environment variable is required for queue tests')
+  }
+
+  sh.config.silent = true
+  const base64ConStr = Buffer.from(connectionString).toString('base64')
+  const tmpFile = tmp.fileSync()
+  fs.writeFileSync(tmpFile.name, deployYaml.replace('{{CONNECTION_STRING_BASE64}}', base64ConStr))
+  sh.exec(`kubectl create namespace ${defaultNamespace}`)
+  t.is(
+    0,
+    sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${defaultNamespace}`).code,
+    'creating a deployment should work.'
+  )
+})
+
+test.serial('Deployment should have 2 replicas on start', t => {
+  const replicaCount = sh.exec(
+    `kubectl get deployment.apps/test-deployment --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`
+  ).stdout
+  t.is(replicaCount, '2', 'replica count should start out as 2')
+})
+
+test.serial('Creating ScaledObject should work', t => {
+  const tmpFile = tmp.fileSync()
+  fs.writeFileSync(tmpFile.name, scaledObjectYaml)
+
+  t.is(
+    0,
+    sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${defaultNamespace}`).code,
+    'creating a ScaledObject should work.'
+  )
+})
+
+
+test.serial(
+  'Deployment should scale to 0 and then shold be back to 2 after deletion of ScaledObject',
+  t => {
+    let replicaCount = '100'
+    for (let i = 0; i < 50 && replicaCount !== '0'; i++) {
+      replicaCount = sh.exec(
+        `kubectl get deployment.apps/test-deployment --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`
+      ).stdout
+      if (replicaCount !== '0') {
+        sh.exec('sleep 5s')
+      }
+    }
+    t.is('0', replicaCount, 'Replica count should be 0')
+
+
+    t.is(
+      0,
+      sh.exec(`kubectl delete scaledobject.keda.sh/test-scaledobject --namespace ${defaultNamespace}`).code,
+      'deletion of ScaledObject should work.'
+    )
+
+    for (let i = 0; i < 50 && replicaCount !== '2'; i++) {
+      replicaCount = sh.exec(
+        `kubectl get deployment.apps/test-deployment --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`
+      ).stdout
+      if (replicaCount !== '2') {
+        sh.exec('sleep 5s')
+      }
+    }
+    t.is('2', replicaCount, 'Replica count should be back at orignal 2')
+  }
+)
+
+test.after.always.cb('clean up azure-queue deployment', t => {
+  const resources = [
+    'secret/test-secrets',
+    'deployment.apps/test-deployment',
+    'scaledobject.keda.sh/test-scaledobject',
+  ]
+
+  for (const resource of resources) {
+    sh.exec(`kubectl delete ${resource} --namespace ${defaultNamespace}`)
+  }
+  sh.exec(`kubectl delete namespace ${defaultNamespace}`)
+  t.end()
+})
+
+const deployYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secrets
+  labels:
+data:
+  AzureWebJobsStorage: {{CONNECTION_STRING_BASE64}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  labels:
+    app: test-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test-deployment
+  template:
+    metadata:
+      name:
+      namespace:
+      labels:
+        app: test-deployment
+    spec:
+      containers:
+      - name: test-deployment
+        image: ahmelsayed/queue-consumer:latest
+        resources:
+        ports:
+        env:
+        - name: FUNCTIONS_WORKER_RUNTIME
+          value: node
+        - name: AzureWebJobsStorage
+          valueFrom:
+            secretKeyRef:
+              name: test-secrets
+              key: AzureWebJobsStorage`
+
+
+const scaledObjectYaml = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: test-scaledobject
+spec:
+  advanced:
+    restoreToOriginalReplicaCount: true
+  scaleTargetRef:
+    name: test-deployment
+  pollingInterval: 5
+  maxReplicaCount: 4
+  cooldownPeriod: 10
+  triggers:
+  - type: azure-queue
+    metadata:
+      queueName: queue-name
+      connection: AzureWebJobsStorage`


### PR DESCRIPTION
Adding option to enable restoring to the original replica count after ScaledObject is deleted. The default behavior is the same as the current one, ie. the replicas count remain on the same number.

Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added

Fixes #947
