### PR TITLE
[v2] Enable local debugging for RabbitMQ

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -99,11 +99,15 @@ func parseRabbitMQMetadata(resolvedEnv, metadata, authParams map[string]string) 
 			return nil, fmt.Errorf("no apiHost setting given")
 		}
 	} else {
-		if val, ok := authParams["host"]; ok {
+		if val, ok := metadata["localhost"]; ok {
+			hostSetting := val
+			if val, ok := resolvedEnv[hostSetting]; ok {
+				meta.host = val
+			}
+		} else if val, ok := authParams["host"]; ok {
 			meta.host = val
 		} else if val, ok := metadata["host"]; ok {
 			hostSetting := val
-
 			if val, ok := resolvedEnv[hostSetting]; ok {
 				meta.host = val
 			}

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -10,14 +10,19 @@ import (
 )
 
 const (
-	host    = "myHostSecret"
-	apiHost = "myApiHostSecret"
+	host         = "myHostSecret"
+	apiHost      = "myApiHostSecret"
+	localHost    = "myLocalHostSecret"
+	hostURL      = "amqp://user:sercet@somehost.com:5236/vhost"
+	apiHostURL   = "https://user:secret@somehost.com/vhost"
+	localHostURL = "amqp://user:PASSWORD@127.0.0.1:5672"
 )
 
 type parseRabbitMQMetadataTestData struct {
-	metadata   map[string]string
-	isError    bool
-	authParams map[string]string
+	metadata     map[string]string
+	isError      bool
+	authParams   map[string]string
+	expectedHost string
 }
 
 type rabbitMQMetricIdentifier struct {
@@ -26,25 +31,30 @@ type rabbitMQMetricIdentifier struct {
 }
 
 var sampleRabbitMqResolvedEnv = map[string]string{
-	host:    "amqp://user:sercet@somehost.com:5236/vhost",
-	apiHost: "https://user:secret@somehost.com/vhost",
+	host:      hostURL,
+	apiHost:   apiHostURL,
+	localHost: localHostURL,
 }
 
 var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	// nothing passed
-	{map[string]string{}, true, map[string]string{}},
+	{map[string]string{}, true, map[string]string{}, ""},
 	// properly formed metadata
-	{map[string]string{"queueLength": "10", "queueName": "sample", "host": host}, false, map[string]string{}},
+	{map[string]string{"queueLength": "10", "queueName": "sample", "host": host}, false, map[string]string{}, hostURL},
 	// malformed queueLength
-	{map[string]string{"queueLength": "AA", "queueName": "sample", "host": host}, true, map[string]string{}},
+	{map[string]string{"queueLength": "AA", "queueName": "sample", "host": host}, true, map[string]string{}, ""},
+	// properly formed metadata
+	{map[string]string{"queueLength": "10", "queueName": "sample", "host": host, "localhost": localHost}, false, map[string]string{}, localHostURL},
+	// malformed queueLength
+	{map[string]string{"queueLength": "AA", "queueName": "sample", "host": host, "localhost": localHost}, true, map[string]string{}, ""},
 	// missing host
-	{map[string]string{"queueLength": "AA", "queueName": "sample"}, true, map[string]string{}},
+	{map[string]string{"queueLength": "AA", "queueName": "sample"}, true, map[string]string{}, ""},
 	// missing queueName
-	{map[string]string{"queueLength": "10", "host": host}, true, map[string]string{}},
+	{map[string]string{"queueLength": "10", "host": host}, true, map[string]string{}, ""},
 	// host defined in authParams
-	{map[string]string{"queueLength": "10"}, true, map[string]string{"host": host}},
+	{map[string]string{"queueLength": "10"}, true, map[string]string{"host": host}, ""},
 	// properly formed metadata with includeUnacked
-	{map[string]string{"queueLength": "10", "queueName": "sample", "apiHost": apiHost, "includeUnacked": "true"}, false, map[string]string{}},
+	{map[string]string{"queueLength": "10", "queueName": "sample", "apiHost": apiHost, "includeUnacked": "true"}, false, map[string]string{}, ""},
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
@@ -53,21 +63,26 @@ var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
 
 func TestRabbitMQParseMetadata(t *testing.T) {
 	for _, testData := range testRabbitMQMetadata {
-		_, err := parseRabbitMQMetadata(sampleRabbitMqResolvedEnv, testData.metadata, testData.authParams)
+		metadata, err := parseRabbitMQMetadata(sampleRabbitMqResolvedEnv, testData.metadata, testData.authParams)
+		t.Logf("%v", metadata)
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")
 		}
+		if metadata != nil && metadata.host != testData.expectedHost {
+			t.Error("Unmatch Expected hostname: metadata.host: ", metadata.host, " expectedHost:", testData.expectedHost)
+		}
+
 	}
 }
 
 var testDefaultQueueLength = []parseRabbitMQMetadataTestData{
 	// use default queueLength
-	{map[string]string{"queueName": "sample", "host": host}, false, map[string]string{}},
+	{map[string]string{"queueName": "sample", "host": host}, false, map[string]string{}, hostURL},
 	// use default queueLength with includeUnacked
-	{map[string]string{"queueName": "sample", "apiHost": apiHost, "includeUnacked": "true"}, false, map[string]string{}},
+	{map[string]string{"queueName": "sample", "apiHost": apiHost, "includeUnacked": "true"}, false, map[string]string{}, ""},
 }
 
 func TestParseDefaultQueueLength(t *testing.T) {


### PR DESCRIPTION
V2 branch had a force push, so I migrate the PR to this one. 
The change is added by cherry pick. 

Refer to the discussion on the PR.
https://github.com/kedacore/keda/pull/953

Added local debugging feature for the RabbitMQ. 
For the test of the RabbitMQ, usually we use Rabbit MQ on k8s. 
In this case, we need to modify code to test it locally. 
This fix will enable us to debug locally by setting yaml as localhost.  This is the example.  You can specify the localhost, that will be the proxy address of the kubectl. The base64 decoded value is `amqp://user:PASSWORD@127.0.0.1:5672` if you run `kubectl port-forward service/rabbitmq 5672`. 


```yaml
apiVersion: v1
kind: Secret
metadata:
  name: rabbitmq-consumer
data:
  RabbitMqHost: YW1xcDovL3VzZXI6UEFTU1dPUkRAcmFiYml0bXEuZGVmYXVsdC5zdmMuY2x1c3Rlci5sb2NhbDo1Njcy
  LocalHost: YW1xcDovL3VzZXI6UEFTU1dPUkRAMTI3LjAuMC4xOjU2NzI=
---
apiVersion: keda.sh/v1alpha1
kind: ScaledJob
metadata:
  name: rabbitmq-consumer
  namespace: default
spec:
  jobTargetRef:
    template:
      spec:
        containers:
        - name: rabbitmq-client
          image: tsuyoshiushio/rabbitmq-client:dev3
          imagePullPolicy: Always
          command: ["receive",  "amqp://user:PASSWORD@rabbitmq.default.svc.cluster.local:5672", "job"]
          envFrom:
            - secretRef:
                name: rabbitmq-consumer
        restartPolicy: Never
    backoffLimit: 4  
  pollingInterval: 5   # Optional. Default: 30 seconds
  cooldownPeriod: 30   # Optional. Default: 300 seconds
  maxReplicaCount: 30  # Optional. Default: 100
  triggers:
  - type: rabbitmq
    metadata:
      queueName: hello
      host: RabbitMqHost
      localhost: LocalHost
      queueLength  : '5'
```

This PR is for V2 branch. Do we need to modify docs? 

### Checklist

- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [-] Commits are signed with Developer Certificate of Origin (DCO)
- [-] Tests have been added

Fixes #
