### PR TITLE
[v2] Use input metric name consistently when reporting Job metrics

### DIFF
--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	defaultDesiredReplicas = 1
-	cronMetricName         = "ReplicaCount"
 	cronMetricType         = "External"
 )
 
@@ -169,7 +168,7 @@ func (s *cronScaler) GetMetrics(ctx context.Context, metricName string, metricSe
 
 	/*******************************************************************************/
 	metric := external_metrics.ExternalMetricValue{
-		MetricName: cronMetricName,
+		MetricName: metricName,
 		Value:      *resource.NewQuantity(currentReplicas, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	pgMetricName              = "num"
 	defaultPostgreSQLPassword = ""
 )
 
@@ -213,7 +212,7 @@ func (s *postgreSQLScaler) GetMetrics(ctx context.Context, metricName string, me
 	}
 
 	metric := external_metrics.ExternalMetricValue{
-		MetricName: pgMetricName,
+		MetricName: metricName,
 		Value:      *resource.NewQuantity(int64(num), resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -258,7 +258,7 @@ func (s *rabbitMQScaler) GetMetrics(ctx context.Context, metricName string, metr
 	}
 
 	metric := external_metrics.ExternalMetricValue{
-		MetricName: rabbitQueueLengthMetricName,
+		MetricName: metricName,
 		Value:      *resource.NewQuantity(int64(messages), resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}


### PR DESCRIPTION
Signed-off-by: Nikhil Bhargava <993682+nbhargava@users.noreply.github.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Jobs are only created and scaled based on the value of the metric with name "queueLength". In most Scalers, the metric is calculated and assigned the inputted name, but this is not the case for all Scalers. This PR makes this consistent across scalers.

### Checklist

- [X] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added

Fixes #974 
