### PR TITLE
update tests for v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7)
 GIT_COMMIT  = $(shell git rev-list -1 HEAD)
 DATE        = $(shell date -u +"%Y.%m.%d.%H.%M.%S")
 
-TEST_CLUSTER_NAME ?= keda-nightly-run
+TEST_CLUSTER_NAME ?= keda-nightly-run-2
 
 ##################################################
 # All                                            #
@@ -117,7 +117,7 @@ generate-api:
 	$(GO_BUILD_VARS) operator-sdk generate crds --crd-version=v1beta1
 	# withTriggers and withPods are only used for duck typing so we only need the deepcopy methods
 	# However operator-sdk generate doesn't appear to have an option for that
-	# until this issue is fixed: https://github.com/kubernetes-sigs/controller-tools/issues/398 
+	# until this issue is fixed: https://github.com/kubernetes-sigs/controller-tools/issues/398
 	rm deploy/crds/keda.sh_withtriggers_crd.yaml
 	rm deploy/crds/keda.sh_withpods_crd.yaml
 
@@ -134,7 +134,7 @@ pkg/scalers/liiklus/mocks/mock_liiklus.go: pkg/scalers/liiklus/LiiklusService.pb
 verify-clientset:
 	$(GO_BUILD_VARS) go mod vendor
 	./hack/verify-codegen.sh
-	
+
 .PHONY: generate-clientset
 generate-clientset:
 	$(GO_BUILD_VARS) go mod vendor

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,8 +11,7 @@
       "ts-node/register"
     ]
   },
-  "scripts": {
-  },
+  "scripts": {},
   "dependencies": {
     "@kubernetes/client-node": "^0.10.3",
     "@types/async": "^3.0.3",

--- a/tests/scalers/azure-blob.test.ts
+++ b/tests/scalers/azure-blob.test.ts
@@ -31,12 +31,12 @@ test.serial('Deployment should have 0 replicas on start', t => {
     t.is(replicaCount, '0', 'replica count should start out as 0')
 })
 
-test.serial.cb('Deployment should scale to 2 with 2000 blobs on the blob container then back to 0', t => {
+test.serial.cb('Deployment should scale to 2 with 150 blobs on the blob container then back to 0', t => {
     // add 2000 files
     const blobSvc = azure.createBlobService(connectionString)
     blobSvc.createContainerIfNotExists('container-name', err => {
         t.falsy(err, 'unable to create blob')
-        async.mapLimit(Array(2000).keys(), 500, (n, cb) => blobSvc.createBlockBlobFromText('container-name',`blobsubpath/blob-name-${n}`,'test text', cb), () => {
+        async.mapLimit(Array(150).keys(), 50, (n, cb) => blobSvc.createBlockBlobFromText('container-name',`blobsubpath/blob-name-${n}`,'test text', cb), () => {
             let replicaCount = '0'
             for (let i = 0; i < 40 && replicaCount !== '2'; i++) {
                 replicaCount = sh.exec(`kubectl get deployment.apps/test-deployment --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`).stdout

--- a/tests/scalers/kafka.test.ts
+++ b/tests/scalers/kafka.test.ts
@@ -242,6 +242,6 @@ spec:
   - type: kafka
     metadata:
       topic: ${defaultTopic}
-      brokerList: ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092
+      bootstrapServers: ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092
       consumerGroup: functions
       lagThreshold: '1'`

--- a/tests/scalers/mysql.test.ts
+++ b/tests/scalers/mysql.test.ts
@@ -37,7 +37,7 @@ test.before(t => {
     const mysqlPod = sh.exec(`kubectl get po -n ${mySQLNamespace} -o jsonpath='{.items[0].metadata.name}'`).stdout
     t.not(mysqlPod, '')
     sh.exec( `kubectl exec -n ${mySQLNamespace} ${mysqlPod} -- mysql -u${mySQLUsername} -p${mySQLPassword} -e \"${createTableSQL}\"`)
-    
+
     sh.config.silent = true
 
     sh.exec(`kubectl create namespace ${testNamespace}`)
@@ -95,7 +95,7 @@ test.serial(`Deployment should scale to 5 (the max) then back to 0`, t => {
         sh.exec('sleep 5s')
       }
     }
-  
+
     t.is('0', replicaCount, 'Replica count should be 0 after 3 minutes')
 })
 
@@ -160,7 +160,7 @@ type: Opaque
 data:
   mysql_conn_str: {{MYSQL_CONNECTION_STRING}}
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: keda-trigger-auth-mysql-secret
@@ -170,13 +170,13 @@ spec:
     name: mysql-secrets
     key: mysql_conn_str
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: mysql-scaledobject
 spec:
   scaleTargetRef:
-    deploymentName: worker
+    name: worker
   pollingInterval: 5
   cooldownPeriod:  10
   minReplicaCount: 0
@@ -241,7 +241,7 @@ spec:
         name: mysql
         env:
           - name: MYSQL_ROOT_PASSWORD
-            value: {{MYSQL_ROOT_PASSWORD}} 
+            value: {{MYSQL_ROOT_PASSWORD}}
           - name: MYSQL_USER
             value: {{MYSQL_USER}}
           - name: MYSQL_PASSWORD

--- a/tests/scalers/redis-lists.test.ts
+++ b/tests/scalers/redis-lists.test.ts
@@ -126,7 +126,7 @@ test.serial('Deployment for redis host and port env vars should have 0 replica o
 
 
 test.serial(`Deployment using redis host port env vars should max and scale to 5 with ${itemsToWrite} items written to list and back to 0`, t => {
-    
+
     runWriteJob(t, writeJobNameForHostPortRef, listNameForHostPortRef)
 
     let replicaCount = '0'
@@ -166,7 +166,7 @@ test.serial('Deployment for redis address env var should have 0 replica on start
 
 
 test.serial(`Deployment using redis address env var should max and scale to 5 with ${itemsToWrite} items written to list and back to 0`, t => {
-    
+
     runWriteJob(t, writeJobNameForAddressRef, listNameForAddressRef)
 
     let replicaCount = '0'
@@ -206,7 +206,7 @@ test.serial('Deployment for redis host and port in the trigger auth should have 
 
 
 test.serial(`Deployment using redis host port in triggerAuth should max and scale to 5 with ${itemsToWrite} items written to list and back to 0`, t => {
-    
+
     runWriteJob(t, writeJobNameForHostPortInTriggerAuth, listNameForHostPortTriggerAuth)
 
     let replicaCount = '0'
@@ -357,16 +357,14 @@ spec:
         - name: READ_PROCESS_TIME
           value: "200"
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{DEPLOYMENT_NAME}}
-  labels:
-    deploymentName: {{DEPLOYMENT_NAME}}
 spec:
   scaleTargetRef:
-    deploymentName: {{DEPLOYMENT_NAME}}
-  pollingInterval: 5 
+    name: {{DEPLOYMENT_NAME}}
+  pollingInterval: 5
   cooldownPeriod: 30
   minReplicaCount: 0
   maxReplicaCount: 5
@@ -375,7 +373,7 @@ spec:
     metadata:
       host: REDIS_HOST
       port: REDIS_PORT
-      listName: {{LIST_NAME}} 
+      listName: {{LIST_NAME}}
       listLength: "5"
     authenticationRef:
       name: keda-redis-list-triggerauth
@@ -413,16 +411,14 @@ spec:
         - name: READ_PROCESS_TIME
           value: "500"
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{DEPLOYMENT_NAME}}
-  labels:
-    deploymentName: {{DEPLOYMENT_NAME}}
 spec:
   scaleTargetRef:
-    deploymentName: {{DEPLOYMENT_NAME}}
-  pollingInterval: 5 
+    name: {{DEPLOYMENT_NAME}}
+  pollingInterval: 5
   cooldownPeriod: 30
   minReplicaCount: 0
   maxReplicaCount: 5
@@ -430,7 +426,7 @@ spec:
   - type: redis
     metadata:
       address: REDIS_ADDRESS
-      listName: {{LIST_NAME}} 
+      listName: {{LIST_NAME}}
       listLength: "5"
     authenticationRef:
       name: keda-redis-list-triggerauth
@@ -469,23 +465,21 @@ spec:
         - name: READ_PROCESS_TIME
           value: "200"
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{DEPLOYMENT_NAME}}
-  labels:
-    deploymentName: {{DEPLOYMENT_NAME}}
 spec:
   scaleTargetRef:
-    deploymentName: {{DEPLOYMENT_NAME}}
-  pollingInterval: 5 
+    name: {{DEPLOYMENT_NAME}}
+  pollingInterval: 5
   cooldownPeriod: 30
   minReplicaCount: 0
   maxReplicaCount: 5
   triggers:
   - type: redis
     metadata:
-      listName: {{LIST_NAME}} 
+      listName: {{LIST_NAME}}
       listLength: "5"
     authenticationRef:
       name: keda-redis-list-triggerauth-host-port
@@ -501,7 +495,7 @@ data:
   redisHost: {{REDIS_HOST}}
   redisPort: {{REDIS_PORT}}
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: keda-redis-list-triggerauth-host-port
@@ -526,7 +520,7 @@ type: Opaque
 data:
   password: {{REDIS_PASSWORD}}
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: keda-redis-list-triggerauth
@@ -549,7 +543,7 @@ spec:
       - name: redis
         image: {{CONTAINER_IMAGE}}
         imagePullPolicy: IfNotPresent
-        env: 
+        env:
         - name: REDIS_ADDRESS
           value: {{REDIS_ADDRESS}}
         - name: REDIS_PASSWORD

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -111,7 +111,7 @@ test.serial('verifyKeda', t => {
     const parsedMetrics = parseInt(resultMetrics.stdout, 10)
     if (isNaN(parsedOperator) || parsedOperator != 1 || isNaN(parsedMetrics) || parsedMetrics != 1) {
       t.log(`Keda is not ready. sleeping`)
-      sh.exec('sleep 1s')
+      sh.exec('sleep 5s')
     } else if (parsedOperator == 1 && parsedMetrics == 1) {
       t.log('keda is running 1 pod for operator and 1 pod for metrics server')
       success = true


### PR DESCRIPTION
This fixes a couple of tests for v2, however the following tests are still failing. 


### 1. kafka

I think this is failing because of the changes from https://github.com/kedacore/keda/pull/925. The scaler is always returning false. I spent sometime debugging it, but I'm not sure I understand the reasoning [behind this part?](https://github.com/kedacore/keda/blob/ff053e03261148d8005fc40b39b61bf9e3725d9c/pkg/scalers/kafka_scaler.go#L304-L328)


### 2. prometheus and mysql

I think these 2 are failing because of the change in #966 (/cc @samuelmacko)

```json
{
  "level":"error",
  "ts":1597102313.4967065,
  "logger":"controller",
  "msg":"Reconciler error",
  "controller":"scaledobject-controller",
  "name":"prometheus-scaledobject",
  "namespace":"prometheus-test",
  "error":"HorizontalPodAutoscaler.autoscaling \"keda-hpa-prometheus-scaledobject\" is invalid: spec.metrics[0].external.metric.name: Invalid value: \"prometheus-http://prometheus-server.monitoring.svc-http_requests_total\": may not contain '/'",
  "stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:237\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90"
}

```
```json
{
  "level":"error",
  "ts":1597104011.5299907,
  "logger":"controller",
  "msg":"Reconciler error",
  "controller":"scaledobject-controller",
  "name":"mysql-scaledobject",
  "namespace":"mysql-test",
  "error":"HorizontalPodAutoscaler.autoscaling \"keda-hpa-mysql-scaledobject\" is invalid: spec.metrics[0].external.metric.name: Invalid value: \"mysql-test-user:test-password@tcp(mysql.mysql.svc.cluster.local:3306)/test_db\": may not contain '/'",
  "stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:237\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90"
}
```


### 3. artemis and redis-streams

I think those 2 are failing because #888 and #765 haven't been merged into v2 

```json
{
  "level":"error",
  "ts":1597101822.6062894,
  "logger":"controller_scaledobject",
  "msg":"Failed to ensure HPA is correctly created for ScaledObject",
  "Request.Namespace":"kedartemis",
  "Request.Name":"kedartemis-consumer-scaled-object",
  "error":"error getting scaler for trigger #0: no scaler found for type: artemis-queue",
  "stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/kedacore/keda/pkg/controller/scaledobject.(*ReconcileScaledObject).Reconcile\n\tkeda/pkg/controller/scaledobject/scaledobject_controller.go:179\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:235\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90"
}

```
```json
scalers/redis-streams.test.ts
{
  "level":"error",
  "ts":1597102144.675794,
  "logger":"controller",
  "msg":"Reconciler error",
  "controller":"scaledobject-controller",
  "name":"redis-streams-scaledobject",
  "namespace":"redis-streams-ns",
  "error":"error getting scaler for trigger #0: no scaler found for type: redis-streams",
  "stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:237\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90"
}

```


### Checklist

- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added

Fixes #
