### PR TITLE
[v2] Kafka scaler isactive latest

### DIFF
--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -188,7 +188,7 @@ func (s *kafkaScaler) IsActive(ctx context.Context) (bool, error) {
 
 	for _, partition := range partitions {
 		lag, err := s.getLagForPartition(partition, offsets)
-		if err != nil {
+		if err != nil && lag == invalidOffset {
 			return true, nil
 		}
 		kafkaLog.V(1).Info(fmt.Sprintf("Group %s has a lag of %d for topic %s and partition %d\n", s.metadata.group, lag, s.metadata.topic, partition))

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -190,7 +190,7 @@ func (s *kafkaScaler) IsActive(ctx context.Context) (bool, error) {
 		kafkaLog.V(1).Info(fmt.Sprintf("Group %s has a lag of %d for topic %s and partition %d\n", s.metadata.group, lag, s.metadata.topic, partition))
 
 		// Return as soon as a lag was detected for any partition
-		if lag > 0 {
+		if s.metadata.offsetResetPolicy == earliest && lag > 0 || s.metadata.offsetResetPolicy == latest && lag != 0 {
 			return true, nil
 		}
 	}
@@ -317,7 +317,7 @@ func (s *kafkaScaler) getLagForPartition(partition int32, offsets *sarama.Offset
 
 	if consumerOffset == sarama.OffsetNewest || consumerOffset == sarama.OffsetOldest {
 		if s.metadata.offsetResetPolicy == latest {
-			lag = 0
+			lag = sarama.OffsetNewest
 		} else {
 			lag = latestOffset
 		}

--- a/tests/scalers/kafka.test.ts
+++ b/tests/scalers/kafka.test.ts
@@ -185,7 +185,7 @@ test.serial('Latest Scale object should scale with new messages', t => {
 
     t.is(r.toString(), sh.exec(commandToCheckReplicas).stdout, `Replica count should be ${r}.`)
   }
-})  
+})
 
 test.after.always('Clean up, delete created resources.', t => {
   const resources = [
@@ -197,7 +197,7 @@ test.after.always('Clean up, delete created resources.', t => {
     `${kafkaClusterYamlFile.name}`,
     `${strimziOperatroYamlFile}`
   ]
-  
+
   for (const resource of resources) {
     sh.exec(`kubectl delete ${resource} --namespace ${defaultNamespace}`)
   }


### PR DESCRIPTION
<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Hello, while implementing the e2e tests requested here: https://github.com/kedacore/keda/pull/985
I've come across a new issue that is not making the scaler behave correctly when the offset reset policy is set to latest (default).

When a new consumer is created, meaning it has no offsets committed, the sarama offset fetch will return a value of -1 for all the partitions of the topic it consumes from. If we set the lag to 0, as in the previous solution, the isActive method will always return false resulting in the scaling to never occur even if new messages are written in the topic.

In order to fix this, I propose the following: 

1. return sarama.OffsetNewest (-1) when the new consumer with latest policy has no committed offset, for every partition.
2. This will result to have a negative lag at consumer creation.
3. The isActive method changes the logic in returning true so that if the offset policy is latest, the negative lag would make the scaling active. Scaling the deployment to the minimum number of pods.
4. When new messages arrive the running consumer pod will consume these messages, committing offsets, so that it is now able to scale to 0 and the logic in getLagForPartition will now return the correct lag offset when a new message is written in the topic.

With that in mind I also changed E2E tests so that:

- They have a consumer that actually consumes from the topic, the previous twitter-function didn't.
- They consider the earliest offset reset policy.
- They test the behaviour introduced with the fix.

### Checklist

- A PR is opened to update the documentation on https://github.com/kedacore/keda-docs (probably not needed, bugfix)
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added

Fixes #
