### PR TITLE
add support for multiple redis list types in redis list scaler

### DIFF
--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -197,9 +197,30 @@ func getRedisListLength(ctx context.Context, address string, password string, li
 	}
 
 	client := redis.NewClient(options)
+	var listType *redis.StatusCmd
 
-	cmd := client.LLen(listName)
+	listType = client.Type(listName)
+	if listType.Err() != nil {
+		return -1, listType.Err()
+	}
 
+	var cmd *redis.IntCmd
+	switch listType.Val() {
+	case "list":
+		cmd = client.LLen(listName)
+	case "set":
+		cmd = client.SCard(listName)
+	case "hash":
+		cmd = client.HLen(listName)
+	case "zset":
+		cmd = client.ZCard(listName)
+	default:
+		cmd = nil
+	}
+
+	if cmd == nil {
+		return -1, fmt.Errorf("list must be of type:list,set,hash,zset but was %s", listType.Val())
+	}
 	if cmd.Err() != nil {
 		return -1, cmd.Err()
 	}


### PR DESCRIPTION
<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

added support for multiple redis "list" types scaling, including : zset,hash,set and list
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO) (how)
- [ ] Tests have been added -> no real rest can be added(only dal)
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs - done
- [ ] Changelog has been updated - not sure what it this

Fixes #
