### PR TITLE
[v2] fix e2e tests to use the new deployment style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ e2e-test:
 		--resource-group $(AZURE_RESOURCE_GROUP)
 	npm install --prefix tests
 
-	IMAGE_CONTROLLER=$(IMAGE_CONTROLLER) IMAGE_ADAPTER=$(IMAGE_ADAPTER) ./tests/run-all.sh
+	./tests/run-all.sh
 
 ##################################################
 # PUBLISH                                        #

--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -1,5 +1,4 @@
 import * as sh from 'shelljs'
-import chalk from 'chalk'
 import test from 'ava'
 
 test.before('setup shelljs', () => {
@@ -7,37 +6,9 @@ test.before('setup shelljs', () => {
 })
 
 test('Remove Keda', t => {
-  const resources = [
-    'apiservice.apiregistration.k8s.io/v1beta1.external.metrics.k8s.io',
-    'deployment.apps/keda-operator',
-    'deployment.apps/keda-metrics-apiserver',
-    'clusterrole.rbac.authorization.k8s.io/keda-operator',
-    'clusterrole.rbac.authorization.k8s.io/keda-external-metrics-reader',
-    'clusterrolebinding.rbac.authorization.k8s.io/keda-operator',
-    'clusterrolebinding.rbac.authorization.k8s.io/keda:system:auth-delegator',
-    'clusterrolebinding.rbac.authorization.k8s.io/keda-hpa-controller-external-metrics',
-    'service/keda-metrics-apiserver',
-    'serviceaccount/keda-operator',
-  ]
-
-  for (const resource of resources) {
-    const result = sh.exec(`kubectl delete ${resource} --namespace keda`)
-    if (result.code !== 0) {
-      t.log(chalk.red(`error deleting ${resource}. ${result}`))
-    }
-  }
-
-  let result = sh.exec(
-    'kubectl delete rolebinding.rbac.authorization.k8s.io/keda-auth-reader --namespace kube-system'
-  )
+  let result = sh.exec('make undeploy')
   if (result.code !== 0) {
-    t.log(chalk.red(`error deleting rolebinding. ${result}`))
+    t.fail('error removing keda. ' + result)
   }
-
-  result = sh.exec('kubectl delete namespace keda')
-  if (result.code !== 0) {
-    t.log(chalk.red(`error deleting keda namespace. ${result}`))
-  }
-
-  t.pass()
+  t.pass('Keda undeployed successfully using make undeploy command')
 })


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Use `make deploy` and `make undeploy` in e2e tests setup/cleanup.