### PR TITLE
[v2] e2e fix: run Makefile from the project root directory

### DIFF
--- a/tests/cleanup.test.ts
+++ b/tests/cleanup.test.ts
@@ -6,7 +6,7 @@ test.before('setup shelljs', () => {
 })
 
 test('Remove Keda', t => {
-  let result = sh.exec('make undeploy')
+  let result = sh.exec('(cd .. && make undeploy)')
   if (result.code !== 0) {
     t.fail('error removing keda. ' + result)
   }

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -34,7 +34,7 @@ test.serial('Get Kubernetes version', t => {
 })
 
 test.serial('Deploy Keda', t => {
-  let result = sh.exec('make deploy')
+  let result = sh.exec('(cd .. && make deploy)')
   if (result.code !== 0) {
     t.fail('error deploying keda. ' + result)
   }


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Quick fix, I overlooked that the setup files are called from `./tests` directory, ie. `make deploy` from this dir is not working. We need to call the Makefile from the project root directory.