### PR TITLE
[v2] don't inspect other scalers if one is active

### DIFF
--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -208,7 +208,8 @@ func (h *scaleHandler) checkScaledObjectScalers(ctx context.Context, scalers []s
 			continue
 		} else if isTriggerActive {
 			isActive = true
-			h.logger.V(1).Info("Scaler for scaledObject is active", "Scaler", scaler)
+			h.logger.V(1).Info("Scaler for scaledObject is active", "Metrics Name", scaler.GetMetricSpecForScaling()[0].External.Metric.Name)
+			break
 		}
 	}
 	return isActive


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Minor optimization, in case there are multiple scalers in ScaledObject, we can end the loop for checking scaler's status after the first Active one.
