### PR TITLE
[v2] use go 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kedacore/keda
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go v0.62.0

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -23,7 +23,7 @@ const (
 
 func (e *scaleExecutor) RequestJobScale(ctx context.Context, scaledJob *kedav1alpha1.ScaledJob, isActive bool, scaleTo int64, maxScale int64) {
 	logger := e.logger.WithValues("scaledJob.Name", scaledJob.Name, "scaledJob.Namespace", scaledJob.Namespace)
-	
+
 	runningJobCount := e.getRunningJobCount(scaledJob, maxScale)
 	logger.Info("Scaling Jobs", "Number of running Jobs", runningJobCount)
 

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -26,9 +26,9 @@ RUN curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-19.03
     rm -rf docker docker-19.03.2.tgz
 
 # Install golang
-RUN GO_VERSION=1.14.7 && \
+RUN GO_VERSION=1.15 && \
     curl -LO https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
-    go_sha256=4a7fa60f323ee1416a4b1425aefc37ea359e9d64df19c326a58953a97ad41ea5 && \
+    go_sha256=2d75848ac606061efe52a8068d0e647b35ce487a15bb52272c427df485193602 && \
     echo "$go_sha256 go${GO_VERSION}.linux-amd64.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xvzf go${GO_VERSION}.linux-amd64.tar.gz && \
     rm -rf go${GO_VERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!
     
     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Go 1.15 was [released](https://blog.golang.org/go1.15) and brings some nice internal optimizations, I think it is good time to move to the new version

