### PR TITLE
[v2] fix RBAC to allow creating events

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,12 +11,12 @@ rules:
   resources:
   - configmaps
   - configmaps/status
+  - events
   verbs:
   - '*'
 - apiGroups:
   - ""
   resources:
-  - events
   - external
   - pods
   - secrets

--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -32,8 +32,8 @@ import (
 // +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects;scaledobjects/finalizers;scaledobjects/status,verbs="*"
 // +kubebuilder:rbac:groups=keda.sh,resources=triggerauthentications;triggerauthentications/status,verbs="*"
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs="*"
-// +kubebuilder:rbac:groups="",resources=configmaps;configmaps/status,verbs="*"
-// +kubebuilder:rbac:groups="",resources=events;pods;services;services;secrets;external,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps;configmaps/status;events,verbs="*"
+// +kubebuilder:rbac:groups="",resources=pods;services;services;secrets;external,verbs=get;list;watch
 // +kubebuilder:rbac:groups="*",resources="*/scale",verbs="*"
 // +kubebuilder:rbac:groups="*",resources="*",verbs=get
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

RBAC we have recently introduced was too strict, the operator couldn't create events:
```
E0828 08:58:41.025190       1 event.go:260] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"operator.keda.sh.162f62e346a5faf6", GenerateName:"", Namespace:"keda", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"ConfigMap", Namespace:"keda", Name:"operator.keda.sh", UID:"f3c8a322-b11d-4ca1-b6c1-5216124e85ed", APIVersion:"v1", ResourceVersion:"29237", FieldPath:""}, Reason:"LeaderElection", Message:"keda-operator-5b6cb6ff48-b668q_5fcbbe1e-5a2e-43c7-9408-1ff0494b9df7 became leader", Source:v1.EventSource{Component:"keda-operator-5b6cb6ff48-b668q_5fcbbe1e-5a2e-43c7-9408-1ff0494b9df7", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbfca4fb04152b0f6, ext:19724494608, loc:(*time.Location)(0x3290180)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbfca4fb04152b0f6, ext:19724494608, loc:(*time.Location)(0x3290180)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:keda:keda-operator" cannot create resource "events" in API group "" in the namespace "keda": RBAC: role.rbac.authorization.k8s.io "extension-apiserver-authentication-reader" not found' (will not retry!)
```

This minor fix is updating the RBAC.