### PR TITLE
[v2] add FromEnv suffix to metadata resolved from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Introduce a separate ScaledObject and ScaledJob([#653](https://github.com/kedacore/keda/issues/653))
 - Remove `New()` and `Close()` from the interface of `service ExternalScaler` in `externalscaler.proto`.
 - Removed deprecated brokerList for Kafka scaler ([#882](https://github.com/kedacore/keda/pull/882))
+- All scalers metadata that is resolved from the scaleTarget environment have suffix `FromEnv` added. e.g: `connection` -> `connectionFromEnv`
 
 ### Other
 - Update Operator SDK and k8s deps ([#1007](https://github.com/kedacore/keda/pull/1007),[#870](https://github.com/kedacore/keda/issues/870))

--- a/pkg/scalers/aws_iam_authorization.go
+++ b/pkg/scalers/aws_iam_authorization.go
@@ -5,7 +5,6 @@ import "fmt"
 const (
 	awsAccessKeyIDEnvVar     = "AWS_ACCESS_KEY_ID"
 	awsSecretAccessKeyEnvVar = "AWS_SECRET_ACCESS_KEY"
-	awsSessionTokenEnvVar    = "AWS_SESSION_TOKEN"
 )
 
 type awsAuthorizationMetadata struct {
@@ -34,23 +33,24 @@ func getAwsAuthorization(authParams, metadata, resolvedEnv map[string]string) (a
 			}
 			meta.awsSecretAccessKey = authParams["awsSecretAccessKey"]
 		} else {
-			var keyName string
-			if keyName = metadata["awsAccessKeyID"]; keyName == "" {
-				keyName = awsAccessKeyIDEnvVar
-			}
-			if val, ok := resolvedEnv[keyName]; ok && val != "" {
-				meta.awsAccessKeyID = val
-			} else {
-				return meta, fmt.Errorf("'%s' doesn't exist in the deployment environment", keyName)
+			if metadata["awsAccessKeyID"] != "" {
+				meta.awsAccessKeyID = metadata["awsAccessKeyID"]
+			} else if metadata["awsAccessKeyIDFromEnv"] != "" {
+				meta.awsAccessKeyID = resolvedEnv[metadata["awsAccessKeyID"]]
 			}
 
-			if keyName = metadata["awsSecretAccessKey"]; keyName == "" {
-				keyName = awsSecretAccessKeyEnvVar
+			if len(meta.awsAccessKeyID) == 0 {
+				return meta, fmt.Errorf("awsAccessKeyID not found")
 			}
-			if val, ok := resolvedEnv[keyName]; ok && val != "" {
-				meta.awsSecretAccessKey = val
-			} else {
-				return meta, fmt.Errorf("'%s' doesn't exist in the deployment environment", keyName)
+
+			if metadata["awsSecretAccessKey"] != "" {
+				meta.awsSecretAccessKey = metadata["awsSecretAccessKey"]
+			} else if metadata["awsSecretAccessKeyFromEnv"] != "" {
+				meta.awsSecretAccessKey = resolvedEnv[metadata["awsSecretAccessKeyFromEnv"]]
+			}
+
+			if len(meta.awsSecretAccessKey) == 0 {
+				return meta, fmt.Errorf("awsSecretAccessKey not found")
 			}
 		}
 	}

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	blobCountMetricName          = "blobCount"
-	defaultTargetBlobCount       = 5
-	defaultBlobDelimiter         = "/"
-	defaultBlobPrefix            = ""
-	defaultBlobConnectionSetting = "AzureWebJobsStorage"
+	blobCountMetricName    = "blobCount"
+	defaultTargetBlobCount = 5
+	defaultBlobDelimiter   = "/"
+	defaultBlobPrefix      = ""
 )
 
 type azureBlobScaler struct {
@@ -74,22 +73,17 @@ func parseAzureBlobMetadata(metadata, resolvedEnv, authParams map[string]string,
 		return nil, "", fmt.Errorf("no blobContainerName given")
 	}
 
-	if val, ok := metadata["blobDelimiter"]; ok {
-		if val != "" {
-			meta.blobDelimiter = val
-		}
+	if val, ok := metadata["blobDelimiter"]; ok && val != "" {
+		meta.blobDelimiter = val
 	}
 
-	if val, ok := metadata["blobPrefix"]; ok {
-		if val != "" {
-			meta.blobPrefix = val + meta.blobDelimiter
-		}
+	if val, ok := metadata["blobPrefix"]; ok && val != "" {
+		meta.blobPrefix = val + meta.blobDelimiter
 	}
+
 	// before triggerAuthentication CRD, pod identity was configured using this property
-	if val, ok := metadata["useAAdPodIdentity"]; ok && podAuth == "" {
-		if val == "true" {
-			podAuth = "azure"
-		}
+	if val, ok := metadata["useAAdPodIdentity"]; ok && podAuth == "" && val == "true" {
+		podAuth = "azure"
 	}
 
 	// If the Use AAD Pod Identity is not present, or set to "none"
@@ -97,21 +91,16 @@ func parseAzureBlobMetadata(metadata, resolvedEnv, authParams map[string]string,
 	if podAuth == "" || podAuth == "none" {
 		// Azure Blob Scaler expects a "connection" parameter in the metadata
 		// of the scaler or in a TriggerAuthentication object
-		connection := authParams["connection"]
-		if connection != "" {
-			// Found the connection in a parameter from TriggerAuthentication
-			meta.connection = connection
-		} else {
-			connectionSetting := defaultBlobConnectionSetting
-			if val, ok := metadata["connection"]; ok && val != "" {
-				connectionSetting = val
-			}
+		if authParams["connection"] != "" {
+			meta.connection = authParams["connection"]
+		} else if metadata["connection"] != "" {
+			meta.connection = metadata["connection"]
+		} else if metadata["connectionFromEnv"] != "" {
+			meta.connection = resolvedEnv[metadata["connectionFromEnv"]]
+		}
 
-			if val, ok := resolvedEnv[connectionSetting]; ok {
-				meta.connection = val
-			} else {
-				return nil, "", fmt.Errorf("no connection setting given")
-			}
+		if len(meta.connection) == 0 {
+			return nil, "", fmt.Errorf("no connection setting given")
 		}
 	} else if podAuth == "azure" {
 		// If the Use AAD Pod Identity is present then check account name

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -20,13 +20,11 @@ import (
 )
 
 const (
-	defaultEventHubMessageThreshold  = 64
-	eventHubMetricType               = "External"
-	thresholdMetricName              = "unprocessedEventThreshold"
-	defaultEventHubConsumerGroup     = "$Default"
-	defaultEventHubConnectionSetting = "EventHub"
-	defaultStorageConnectionSetting  = "AzureWebJobsStorage"
-	defaultBlobContainer             = ""
+	defaultEventHubMessageThreshold = 64
+	eventHubMetricType              = "External"
+	thresholdMetricName             = "unprocessedEventThreshold"
+	defaultEventHubConsumerGroup    = "$Default"
+	defaultBlobContainer            = ""
 )
 
 var eventhubLog = logf.Log.WithName("azure_eventhub_scaler")
@@ -42,8 +40,8 @@ type EventHubMetadata struct {
 }
 
 // NewAzureEventHubScaler creates a new scaler for eventHub
-func NewAzureEventHubScaler(resolvedEnv, metadata map[string]string) (Scaler, error) {
-	parsedMetadata, err := parseAzureEventHubMetadata(metadata, resolvedEnv)
+func NewAzureEventHubScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler, error) {
+	parsedMetadata, err := parseAzureEventHubMetadata(metadata, resolvedEnv, authParams)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get eventhub metadata: %s", err)
 	}
@@ -60,7 +58,7 @@ func NewAzureEventHubScaler(resolvedEnv, metadata map[string]string) (Scaler, er
 }
 
 // parseAzureEventHubMetadata parses metadata
-func parseAzureEventHubMetadata(metadata, resolvedEnv map[string]string) (*EventHubMetadata, error) {
+func parseAzureEventHubMetadata(metadata, resolvedEnv, authParams map[string]string) (*EventHubMetadata, error) {
 	meta := EventHubMetadata{
 		eventHubInfo: azure.EventHubInfo{},
 	}
@@ -75,25 +73,27 @@ func parseAzureEventHubMetadata(metadata, resolvedEnv map[string]string) (*Event
 		meta.threshold = threshold
 	}
 
-	storageConnectionSetting := defaultStorageConnectionSetting
-	if val, ok := metadata["storageConnection"]; ok && val != "" {
-		storageConnectionSetting = val
+	if authParams["storageConnection"] != "" {
+		meta.eventHubInfo.StorageConnection = authParams["storageConnection"]
+	} else if metadata["storageConnection"] != "" {
+		meta.eventHubInfo.StorageConnection = metadata["storageConnection"]
+	} else if metadata["storageConnectionFromEnv"] != "" {
+		meta.eventHubInfo.StorageConnection = resolvedEnv[metadata["storageConnectionFromEnv"]]
 	}
 
-	if val, ok := resolvedEnv[storageConnectionSetting]; ok {
-		meta.eventHubInfo.StorageConnection = val
-	} else {
+	if len(meta.eventHubInfo.StorageConnection) == 0 {
 		return nil, fmt.Errorf("no storage connection string given")
 	}
 
-	eventHubConnectionSetting := defaultEventHubConnectionSetting
-	if val, ok := metadata["connection"]; ok && val != "" {
-		eventHubConnectionSetting = val
+	if authParams["connection"] != "" {
+		meta.eventHubInfo.EventHubConnection = authParams["connection"]
+	} else if metadata["connection"] != "" {
+		meta.eventHubInfo.EventHubConnection = metadata["connection"]
+	} else if metadata["connectionFromEnv"] != "" {
+		meta.eventHubInfo.EventHubConnection = resolvedEnv[metadata["connectionFromEnv"]]
 	}
 
-	if val, ok := resolvedEnv[eventHubConnectionSetting]; ok {
-		meta.eventHubInfo.EventHubConnection = val
-	} else {
+	if len(meta.eventHubInfo.EventHubConnection) == 0 {
 		return nil, fmt.Errorf("no event hub connection string given")
 	}
 

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -43,17 +43,17 @@ var sampleEventHubResolvedEnv = map[string]string{eventHubConnectionSetting: "no
 var parseEventHubMetadataDataset = []parseEventHubMetadataTestData{
 	{map[string]string{}, true},
 	// properly formed event hub metadata
-	{map[string]string{"storageConnection": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connection": eventHubConnectionSetting, "unprocessedEventThreshold": "15"}, false},
+	{map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connectionFromEnv": eventHubConnectionSetting, "unprocessedEventThreshold": "15"}, false},
 	// missing event hub connection setting
-	{map[string]string{"storageConnection": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15"}, true},
+	{map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15"}, true},
 	// missing storage connection setting
-	{map[string]string{"consumerGroup": eventHubConsumerGroup, "connection": eventHubConnectionSetting, "unprocessedEventThreshold": "15"}, true},
+	{map[string]string{"consumerGroup": eventHubConsumerGroup, "connectionFromEnv": eventHubConnectionSetting, "unprocessedEventThreshold": "15"}, true},
 	// missing event hub consumer group - should replace with default
-	{map[string]string{"storageConnection": storageConnectionSetting, "connection": eventHubConnectionSetting, "unprocessedEventThreshold": "15"}, false},
+	{map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "connectionFromEnv": eventHubConnectionSetting, "unprocessedEventThreshold": "15"}, false},
 	// missing unprocessed event threshold - should replace with default
-	{map[string]string{"storageConnection": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connection": eventHubConnectionSetting}, false},
+	{map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connectionFromEnv": eventHubConnectionSetting}, false},
 	// added blob container details
-	{map[string]string{"storageConnection": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connection": eventHubConnectionSetting, "blobContainer": testContainerName}, false},
+	{map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connectionFromEnv": eventHubConnectionSetting, "blobContainer": testContainerName}, false},
 }
 
 var eventHubMetricIdentifiers = []eventHubMetricIdentifier{
@@ -72,7 +72,7 @@ var testEventHubScaler = AzureEventHubScaler{
 func TestParseEventHubMetadata(t *testing.T) {
 	// Test first with valid resolved environment
 	for _, testData := range parseEventHubMetadataDataset {
-		_, err := parseAzureEventHubMetadata(testData.metadata, sampleEventHubResolvedEnv)
+		_, err := parseAzureEventHubMetadata(testData.metadata, sampleEventHubResolvedEnv, map[string]string{})
 
 		if err != nil && !testData.isError {
 			t.Errorf("Expected success but got error: %s", err)
@@ -419,7 +419,7 @@ func DeleteContainerInStorage(ctx context.Context, endpoint *url.URL, credential
 
 func TestEventHubGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range eventHubMetricIdentifiers {
-		meta, err := parseAzureEventHubMetadata(testData.metadataTestData.metadata, sampleEventHubResolvedEnv)
+		meta, err := parseAzureEventHubMetadata(testData.metadataTestData.metadata, sampleEventHubResolvedEnv, map[string]string{})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -17,10 +17,8 @@ import (
 )
 
 const (
-	azureMonitorMetricName       = "metricName"
-	targetValueName              = "targetValue"
-	defaultClientIDSetting       = ""
-	defaultClientPasswordSetting = ""
+	azureMonitorMetricName = "metricName"
+	targetValueName        = "targetValue"
 )
 
 type azureMonitorScaler struct {
@@ -119,34 +117,28 @@ func parseAzureMonitorMetadata(metadata, resolvedEnv, authParams map[string]stri
 	}
 
 	if podIdentity == "" || podIdentity == "none" {
-		if val, ok := authParams["activeDirectoryClientId"]; ok && val != "" {
-			meta.azureMonitorInfo.ClientID = val
-		} else {
-			clientIDSetting := defaultClientIDSetting
-			if val, ok := metadata["activeDirectoryClientId"]; ok && val != "" {
-				clientIDSetting = val
-			}
-
-			if val, ok := resolvedEnv[clientIDSetting]; ok {
-				meta.azureMonitorInfo.ClientID = val
-			} else {
-				return nil, fmt.Errorf("no activeDirectoryClientId given")
-			}
+		if authParams["activeDirectoryClientId"] != "" {
+			meta.azureMonitorInfo.ClientID = authParams["activeDirectoryClientId"]
+		} else if metadata["activeDirectoryClientId"] != "" {
+			meta.azureMonitorInfo.ClientID = metadata["activeDirectoryClientId"]
+		} else if metadata["activeDirectoryClientIdFromEnv"] != "" {
+			meta.azureMonitorInfo.ClientID = resolvedEnv[metadata["activeDirectoryClientIdFromEnv"]]
 		}
 
-		if val, ok := authParams["activeDirectoryClientPassword"]; ok && val != "" {
-			meta.azureMonitorInfo.ClientPassword = val
-		} else {
-			clientPasswordSetting := defaultClientPasswordSetting
-			if val, ok := metadata["activeDirectoryClientPassword"]; ok && val != "" {
-				clientPasswordSetting = val
-			}
+		if len(meta.azureMonitorInfo.ClientID) == 0 {
+			return nil, fmt.Errorf("no activeDirectoryClientId given")
+		}
 
-			if val, ok := resolvedEnv[clientPasswordSetting]; ok {
-				meta.azureMonitorInfo.ClientPassword = val
-			} else {
-				return nil, fmt.Errorf("no activeDirectoryClientPassword given")
-			}
+		if authParams["activeDirectoryClientPassword"] != "" {
+			meta.azureMonitorInfo.ClientPassword = authParams["activeDirectoryClientPassword"]
+		} else if metadata["activeDirectoryClientPassword"] != "" {
+			meta.azureMonitorInfo.ClientPassword = metadata["activeDirectoryClientPassword"]
+		} else if metadata["activeDirectoryClientPasswordFromEnv"] != "" {
+			meta.azureMonitorInfo.ClientPassword = resolvedEnv[metadata["activeDirectoryClientPasswordFromEnv"]]
+		}
+
+		if len(meta.azureMonitorInfo.ClientPassword) == 0 {
+			return nil, fmt.Errorf("no activeDirectoryClientPassword given")
 		}
 	} else if podIdentity != "azure" {
 		return nil, fmt.Errorf("Azure Monitor doesn't support pod identity %s", podIdentity)

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -101,17 +101,15 @@ func parseAzureServiceBusMetadata(resolvedEnv, metadata, authParams map[string]s
 
 	if podIdentity == "" || podIdentity == "none" {
 		// get servicebus connection string
-		if val, ok := authParams["connection"]; ok {
-			meta.connection = val
-		} else if val, ok := metadata["connection"]; ok {
-			connectionSetting := val
-
-			if val, ok := resolvedEnv[connectionSetting]; ok {
-				meta.connection = val
-			}
+		if authParams["connection"] != "" {
+			meta.connection = authParams["connection"]
+		} else if metadata["connection"] != "" {
+			meta.connection = metadata["connection"]
+		} else if metadata["connectionFromEnv"] != "" {
+			meta.connection = resolvedEnv[metadata["connectionFromEnv"]]
 		}
 
-		if meta.connection == "" {
+		if len(meta.connection) == 0 {
 			return nil, fmt.Errorf("no connection setting given")
 		}
 	} else if podIdentity == "azure" {

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -30,7 +30,7 @@ var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
 
 func TestExternalScalerParseMetadata(t *testing.T) {
 	for _, testData := range testExternalScalerMetadata {
-		_, err := parseExternalScalerMetadata(testData.metadata)
+		_, err := parseExternalScalerMetadata(testData.metadata, map[string]string{})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -53,7 +53,7 @@ func TestExternalPushScaler_Run(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	for i := 0; i < serverCount*iterationCount; i++ {
 		id := i % serverCount
-		pushScaler, _ := NewExternalPushScaler("app", "namespace", map[string]string{"scalerAddress": servers[id].address})
+		pushScaler, _ := NewExternalPushScaler("app", "namespace", map[string]string{"scalerAddress": servers[id].address}, map[string]string{})
 		go pushScaler.Run(ctx, replyCh[i])
 	}
 

--- a/pkg/scalers/gcp_pub_sub_scaler.go
+++ b/pkg/scalers/gcp_pub_sub_scaler.go
@@ -65,13 +65,13 @@ func parsePubSubMetadata(metadata, resolvedEnv map[string]string) (*pubsubMetada
 		return nil, fmt.Errorf("no subscription name given")
 	}
 
-	if val, ok := metadata["credentials"]; ok && val != "" {
-		if creds, ok := resolvedEnv[val]; ok {
-			meta.credentials = creds
-		} else {
-			return nil, fmt.Errorf("could not resolve environment variable for credentials")
-		}
-	} else {
+	if metadata["credentials"] != "" {
+		meta.credentials = metadata["credentials"]
+	} else if metadata["credentialsFromEnv"] != "" {
+		meta.credentials = resolvedEnv[metadata["credentialsFromEnv"]]
+	}
+
+	if len(meta.credentials) == 0 {
 		return nil, fmt.Errorf("no credentials given. Need GCP service account credentials in json format")
 	}
 

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -27,7 +27,7 @@ var testPubSubMetadata = []parsePubSubMetadataTestData{
 	// missing credentials
 	{map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7", "credentials": ""}, true},
 	// incorrect credentials
-	{map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7", "credentials": "WRONG_CREDS"}, true},
+	{map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "WRONG_CREDS"}, true},
 	// malformed subscriptionSize
 	{map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "AA", "credentials": "SAMPLE_CREDS"}, true},
 }

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	mySQLMetricName      = "MySQLQueryValue"
-	defaultMySQLPassword = ""
+	mySQLMetricName = "MySQLQueryValue"
 )
 
 type mySQLScaler struct {
@@ -74,13 +73,12 @@ func parseMySQLMetadata(resolvedEnv, metadata, authParams map[string]string) (*m
 		return nil, fmt.Errorf("no queryValue given")
 	}
 
-	if val, ok := authParams["connectionString"]; ok {
-		meta.connectionString = val
-	} else if val, ok := metadata["connectionString"]; ok {
-		hostSetting := val
-		if val, ok := resolvedEnv[hostSetting]; ok {
-			meta.connectionString = val
-		}
+	if authParams["connectionString"] != "" {
+		meta.connectionString = authParams["connectionString"]
+	} else if metadata["connectionString"] != "" {
+		meta.connectionString = metadata["connectionString"]
+	} else if metadata["connectionStringFromEnv"] != "" {
+		meta.connectionString = resolvedEnv[metadata["connectionStringFromEnv"]]
 	} else {
 		meta.connectionString = ""
 		if val, ok := metadata["host"]; ok {
@@ -104,13 +102,17 @@ func parseMySQLMetadata(resolvedEnv, metadata, authParams map[string]string) (*m
 		} else {
 			return nil, fmt.Errorf("no dbName given")
 		}
-		meta.password = defaultMySQLPassword
-		if val, ok := authParams["password"]; ok {
-			meta.password = val
-		} else if val, ok := metadata["password"]; ok && val != "" {
-			if pass, ok := resolvedEnv[val]; ok {
-				meta.password = pass
-			}
+
+		if authParams["password"] != "" {
+			meta.password = authParams["password"]
+		} else if metadata["password"] != "" {
+			meta.password = metadata["password"]
+		} else if metadata["passwordFromEnv"] != "" {
+			meta.password = resolvedEnv[metadata["passwordFromEnv"]]
+		}
+
+		if len(meta.password) == 0 {
+			return nil, fmt.Errorf("no password given")
 		}
 	}
 

--- a/pkg/scalers/mysql_scaler_test.go
+++ b/pkg/scalers/mysql_scaler_test.go
@@ -47,7 +47,7 @@ func TestParseMySQLMetadata(t *testing.T) {
 
 func TestMetadataToConnectionStrUseConnStr(t *testing.T) {
 	// Use existing ConnStr
-	testMeta := map[string]string{"query": "query", "queryValue": "12", "connectionString": "MYSQL_CONN_STR"}
+	testMeta := map[string]string{"query": "query", "queryValue": "12", "connectionStringFromEnv": "MYSQL_CONN_STR"}
 	meta, _ := parseMySQLMetadata(testMySQLResolvedEnv, testMeta, map[string]string{})
 	connStr := metadataToConnectionStr(meta)
 	if connStr != testMySQLResolvedEnv["MYSQL_CONN_STR"] {
@@ -58,7 +58,7 @@ func TestMetadataToConnectionStrUseConnStr(t *testing.T) {
 func TestMetadataToConnectionStrBuildNew(t *testing.T) {
 	// Build new ConnStr
 	expected := "test_username:pass@tcp(test_host:test_port)/test_dbname"
-	testMeta := map[string]string{"query": "query", "queryValue": "12", "host": "test_host", "port": "test_port", "username": "test_username", "password": "MYSQL_PASSWORD", "dbName": "test_dbname"}
+	testMeta := map[string]string{"query": "query", "queryValue": "12", "host": "test_host", "port": "test_port", "username": "test_username", "passwordFromEnv": "MYSQL_PASSWORD", "dbName": "test_dbname"}
 	meta, _ := parseMySQLMetadata(testMySQLResolvedEnv, testMeta, map[string]string{})
 	connStr := metadataToConnectionStr(meta)
 	if connStr != expected {

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultPostgreSQLPassword = ""
+	pgMetricName = "num"
 )
 
 type postgreSQLScaler struct {
@@ -73,14 +73,12 @@ func parsePostgreSQLMetadata(resolvedEnv, metadata, authParams map[string]string
 		return nil, fmt.Errorf("no targetQueryValue given")
 	}
 
-	if val, ok := authParams["connection"]; ok {
-		meta.connection = val
-	} else if val, ok := metadata["connection"]; ok {
-		hostSetting := val
-
-		if val, ok := resolvedEnv[hostSetting]; ok {
-			meta.connection = val
-		}
+	if authParams["connection"] != "" {
+		meta.connection = authParams["connection"]
+	} else if metadata["connection"] != "" {
+		meta.connection = metadata["connection"]
+	} else if metadata["connectionFromEnv"] != "" {
+		meta.connection = resolvedEnv[metadata["connectionFromEnv"]]
 	} else {
 		meta.connection = ""
 		if val, ok := metadata["host"]; ok {
@@ -109,13 +107,13 @@ func parsePostgreSQLMetadata(resolvedEnv, metadata, authParams map[string]string
 		} else {
 			return nil, fmt.Errorf("no sslmode name given")
 		}
-		meta.password = defaultPostgreSQLPassword
-		if val, ok := authParams["password"]; ok {
-			meta.password = val
-		} else if val, ok := metadata["password"]; ok && val != "" {
-			if passd, ok := resolvedEnv[val]; ok {
-				meta.password = passd
-			}
+
+		if authParams["password"] != "" {
+			meta.password = authParams["password"]
+		} else if metadata["password"] != "" {
+			meta.password = metadata["password"]
+		} else if metadata["passwordFromEnv"] != "" {
+			meta.password = resolvedEnv[metadata["passwordFromEnv"]]
 		}
 	}
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -85,28 +85,24 @@ func parseRabbitMQMetadata(resolvedEnv, metadata, authParams map[string]string) 
 	}
 
 	if meta.includeUnacked {
-		if val, ok := authParams["apiHost"]; ok {
-			meta.apiHost = val
-		} else if val, ok := metadata["apiHost"]; ok {
-			hostSetting := val
-
-			if val, ok := resolvedEnv[hostSetting]; ok {
-				meta.apiHost = val
-			}
+		if authParams["apiHost"] != "" {
+			meta.apiHost = authParams["apiHost"]
+		} else if metadata["apiHost"] != "" {
+			meta.apiHost = metadata["apiHost"]
+		} else if metadata["apiHostFromEnv"] != "" {
+			meta.apiHost = resolvedEnv[metadata["apiHostFromEnv"]]
 		}
 
 		if meta.apiHost == "" {
 			return nil, fmt.Errorf("no apiHost setting given")
 		}
 	} else {
-		if val, ok := authParams["host"]; ok {
-			meta.host = val
-		} else if val, ok := metadata["host"]; ok {
-			hostSetting := val
-
-			if val, ok := resolvedEnv[hostSetting]; ok {
-				meta.host = val
-			}
+		if authParams["host"] != "" {
+			meta.host = authParams["host"]
+		} else if metadata["host"] != "" {
+			meta.host = metadata["host"]
+		} else if metadata["hostFromEnv"] != "" {
+			meta.host = resolvedEnv[metadata["hostFromEnv"]]
 		}
 
 		if meta.host == "" {

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -34,17 +34,17 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	// nothing passed
 	{map[string]string{}, true, map[string]string{}},
 	// properly formed metadata
-	{map[string]string{"queueLength": "10", "queueName": "sample", "host": host}, false, map[string]string{}},
+	{map[string]string{"queueLength": "10", "queueName": "sample", "hostFromEnv": host}, false, map[string]string{}},
 	// malformed queueLength
-	{map[string]string{"queueLength": "AA", "queueName": "sample", "host": host}, true, map[string]string{}},
+	{map[string]string{"queueLength": "AA", "queueName": "sample", "hostFromEnv": host}, true, map[string]string{}},
 	// missing host
 	{map[string]string{"queueLength": "AA", "queueName": "sample"}, true, map[string]string{}},
 	// missing queueName
-	{map[string]string{"queueLength": "10", "host": host}, true, map[string]string{}},
+	{map[string]string{"queueLength": "10", "hostFromEnv": host}, true, map[string]string{}},
 	// host defined in authParams
 	{map[string]string{"queueLength": "10"}, true, map[string]string{"host": host}},
 	// properly formed metadata with includeUnacked
-	{map[string]string{"queueLength": "10", "queueName": "sample", "apiHost": apiHost, "includeUnacked": "true"}, false, map[string]string{}},
+	{map[string]string{"queueLength": "10", "queueName": "sample", "apiHostFromEnv": apiHost, "includeUnacked": "true"}, false, map[string]string{}},
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
@@ -123,7 +123,7 @@ func TestGetQueueInfo(t *testing.T) {
 			metadata := map[string]string{
 				"queueLength":    "10",
 				"queueName":      "evaluate_trials",
-				"apiHost":        apiHost,
+				"apiHostFromEnv": apiHost,
 				"includeUnacked": "true",
 			}
 

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -17,27 +17,27 @@ import (
 
 const (
 	defaultTargetListLength = 5
-	defaultRedisAddress     = "redis-master.default.svc.cluster.local:6379"
-	defaultRedisPassword    = ""
 	defaultDbIdx            = 0
 	defaultEnableTLS        = false
-	defaultHost             = ""
-	defaultPort             = ""
 )
 
 type redisScaler struct {
 	metadata *redisMetadata
 }
 
+type redisConnectionInfo struct {
+	address   string
+	password  string
+	host      string
+	port      string
+	enableTLS bool
+}
+
 type redisMetadata struct {
 	targetListLength int
 	listName         string
-	address          string
-	password         string
-	host             string
-	port             string
 	databaseIndex    int
-	enableTLS        bool
+	connectionInfo   redisConnectionInfo
 }
 
 var redisLog = logf.Log.WithName("redis_scaler")
@@ -55,7 +55,13 @@ func NewRedisScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler
 }
 
 func parseRedisMetadata(metadata, resolvedEnv, authParams map[string]string) (*redisMetadata, error) {
-	meta := redisMetadata{}
+	connInfo, err := parseRedisAddress(metadata, resolvedEnv, authParams)
+	if err != nil {
+		return nil, err
+	}
+	meta := redisMetadata{
+		connectionInfo: connInfo,
+	}
 	meta.targetListLength = defaultTargetListLength
 
 	if val, ok := metadata["listLength"]; ok {
@@ -72,51 +78,6 @@ func parseRedisMetadata(metadata, resolvedEnv, authParams map[string]string) (*r
 		return nil, fmt.Errorf("no list name given")
 	}
 
-	if val, ok := authParams["address"]; ok {
-		meta.address = val
-	} else if addressEnvName, ok := metadata["address"]; ok && addressEnvName != "" {
-		if val, ok := resolvedEnv[addressEnvName]; ok {
-			meta.address = val
-		}
-		if meta.address == "" {
-			return nil, fmt.Errorf("no address given")
-		}
-	} else {
-		if val, ok := authParams["host"]; ok {
-			meta.host = val
-		} else if hostEnvName, ok := metadata["host"]; ok && hostEnvName != "" {
-			if val, ok := resolvedEnv[hostEnvName]; ok {
-				meta.host = val
-			} else {
-				return nil, fmt.Errorf("no host given. Address should be in the format of host:port or you should provide both host and port")
-			}
-		} else {
-			return nil, fmt.Errorf("no host given. address should be in the format of host:port or you should set the host/port values")
-		}
-		if val, ok := authParams["port"]; ok {
-			meta.port = val
-		} else if portEnvName, ok := metadata["port"]; ok && portEnvName != "" {
-			if val, ok := resolvedEnv[portEnvName]; ok {
-				meta.port = val
-			} else {
-				return nil, fmt.Errorf("no port given. Address should be in the format of host:port or you should provide both host and port")
-			}
-		} else {
-			return nil, fmt.Errorf("no port given. address should be in the format of host:port or you should set the host/port values")
-		}
-
-		meta.address = fmt.Sprintf("%s:%s", meta.host, meta.port)
-	}
-
-	meta.password = defaultRedisPassword
-	if val, ok := authParams["password"]; ok {
-		meta.password = val
-	} else if val, ok := metadata["password"]; ok && val != "" {
-		if passd, ok := resolvedEnv[val]; ok {
-			meta.password = passd
-		}
-	}
-
 	meta.databaseIndex = defaultDbIdx
 	if val, ok := metadata["databaseIndex"]; ok {
 		dbIndex, err := strconv.ParseInt(val, 10, 64)
@@ -126,15 +87,6 @@ func parseRedisMetadata(metadata, resolvedEnv, authParams map[string]string) (*r
 		meta.databaseIndex = int(dbIndex)
 	}
 
-	meta.enableTLS = defaultEnableTLS
-	if val, ok := metadata["enableTLS"]; ok {
-		tls, err := strconv.ParseBool(val)
-		if err != nil {
-			return nil, fmt.Errorf("enableTLS parsing error %s", err.Error())
-		}
-		meta.enableTLS = tls
-	}
-
 	return &meta, nil
 }
 
@@ -142,7 +94,7 @@ func parseRedisMetadata(metadata, resolvedEnv, authParams map[string]string) (*r
 func (s *redisScaler) IsActive(ctx context.Context) (bool, error) {
 
 	length, err := getRedisListLength(
-		ctx, s.metadata.address, s.metadata.password, s.metadata.listName, s.metadata.databaseIndex, s.metadata.enableTLS)
+		ctx, s.metadata.connectionInfo.address, s.metadata.connectionInfo.password, s.metadata.listName, s.metadata.databaseIndex, s.metadata.connectionInfo.enableTLS)
 
 	if err != nil {
 		redisLog.Error(err, "error")
@@ -176,7 +128,7 @@ func (s *redisScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 
 // GetMetrics connects to Redis and finds the length of the list
 func (s *redisScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
-	listLen, err := getRedisListLength(ctx, s.metadata.address, s.metadata.password, s.metadata.listName, s.metadata.databaseIndex, s.metadata.enableTLS)
+	listLen, err := getRedisListLength(ctx, s.metadata.connectionInfo.address, s.metadata.connectionInfo.password, s.metadata.listName, s.metadata.databaseIndex, s.metadata.connectionInfo.enableTLS)
 
 	if err != nil {
 		redisLog.Error(err, "error getting list length")
@@ -234,4 +186,58 @@ func getRedisListLength(ctx context.Context, address string, password string, li
 		return -1, cmd.Err()
 	}
 	return cmd.Result()
+}
+
+func parseRedisAddress(metadata, resolvedEnv, authParams map[string]string) (redisConnectionInfo, error) {
+	info := redisConnectionInfo{}
+	if authParams["address"] != "" {
+		info.address = authParams["address"]
+	} else if metadata["address"] != "" {
+		info.address = metadata["address"]
+	} else if metadata["addressFromEnv"] != "" {
+		info.address = resolvedEnv[metadata["addressFromEnv"]]
+	} else {
+		if authParams["host"] != "" {
+			info.host = authParams["host"]
+		} else if metadata["host"] != "" {
+			info.host = metadata["host"]
+		} else if metadata["hostFromEnv"] != "" {
+			info.host = resolvedEnv[metadata["hostFromEnv"]]
+		}
+
+		if authParams["port"] != "" {
+			info.port = authParams["port"]
+		} else if metadata["port"] != "" {
+			info.port = metadata["port"]
+		} else if metadata["portFromEnv"] != "" {
+			info.port = resolvedEnv[metadata["portFromEnv"]]
+		}
+
+		if len(info.host) != 0 && len(info.port) != 0 {
+			info.address = fmt.Sprintf("%s:%s", info.host, info.port)
+		}
+	}
+
+	if len(info.address) == 0 {
+		return info, fmt.Errorf("no address or host given. address should be in the format of host:port or you should set the host/port values")
+	}
+
+	if authParams["password"] != "" {
+		info.password = authParams["password"]
+	} else if metadata["password"] != "" {
+		info.password = metadata["password"]
+	} else if metadata["passwordFromEnv"] != "" {
+		info.password = resolvedEnv[metadata["passwordFromEnv"]]
+	}
+
+	info.enableTLS = defaultEnableTLS
+	if val, ok := metadata["enableTLS"]; ok {
+		tls, err := strconv.ParseBool(val)
+		if err != nil {
+			return info, fmt.Errorf("enableTLS parsing error %s", err.Error())
+		}
+		info.enableTLS = tls
+	}
+
+	return info, nil
 }

--- a/pkg/scalers/redis_scaler_test.go
+++ b/pkg/scalers/redis_scaler_test.go
@@ -26,21 +26,21 @@ var testRedisMetadata = []parseRedisMetadataTestData{
 	// nothing passed
 	{map[string]string{}, true, map[string]string{}},
 	// properly formed listName
-	{map[string]string{"listName": "mylist", "listLength": "10", "address": "REDIS_HOST", "password": "REDIS_PASSWORD"}, false, map[string]string{}},
+	{map[string]string{"listName": "mylist", "listLength": "10", "addressFromEnv": "REDIS_HOST", "passwordFromEnv": "REDIS_PASSWORD"}, false, map[string]string{}},
 	// properly formed hostPort
-	{map[string]string{"listName": "mylist", "listLength": "10", "host": "REDIS_HOST", "port": "REDIS_PORT", "password": "REDIS_PASSWORD"}, false, map[string]string{}},
+	{map[string]string{"listName": "mylist", "listLength": "10", "hostFromEnv": "REDIS_HOST", "portFromEnv": "REDIS_PORT", "passwordFromEnv": "REDIS_PASSWORD"}, false, map[string]string{}},
 	// properly formed hostPort
-	{map[string]string{"listName": "mylist", "listLength": "10", "address": "REDIS_HOST", "host": "REDIS_HOST", "port": "REDIS_PORT", "password": "REDIS_PASSWORD"}, false, map[string]string{}},
+	{map[string]string{"listName": "mylist", "listLength": "10", "addressFromEnv": "REDIS_HOST", "host": "REDIS_HOST", "port": "REDIS_PORT", "passwordFromEnv": "REDIS_PASSWORD"}, false, map[string]string{}},
 	// improperly formed hostPort
-	{map[string]string{"listName": "mylist", "listLength": "10", "host": "REDIS_HOST", "password": "REDIS_PASSWORD"}, true, map[string]string{}},
+	{map[string]string{"listName": "mylist", "listLength": "10", "hostFromEnv": "REDIS_HOST", "passwordFromEnv": "REDIS_PASSWORD"}, true, map[string]string{}},
 	// properly formed listName, empty address
 	{map[string]string{"listName": "mylist", "listLength": "10", "address": "", "password": ""}, true, map[string]string{}},
 	// improperly formed listLength
-	{map[string]string{"listName": "mylist", "listLength": "AA", "address": "REDIS_HOST", "password": ""}, true, map[string]string{}},
+	{map[string]string{"listName": "mylist", "listLength": "AA", "addressFromEnv": "REDIS_HOST", "password": ""}, true, map[string]string{}},
 	// address does not resolve
-	{map[string]string{"listName": "mylist", "listLength": "0", "address": "REDIS_WRONG", "password": ""}, true, map[string]string{}},
+	{map[string]string{"listName": "mylist", "listLength": "0", "addressFromEnv": "REDIS_WRONG", "password": ""}, true, map[string]string{}},
 	// password is defined in the authParams
-	{map[string]string{"listName": "mylist", "listLength": "0", "address": "REDIS_WRONG"}, true, map[string]string{"password": ""}},
+	{map[string]string{"listName": "mylist", "listLength": "0", "addressFromEnv": "REDIS_WRONG"}, true, map[string]string{"password": ""}},
 	// address is defined in the authParams
 	{map[string]string{"listName": "mylist", "listLength": "0"}, false, map[string]string{"address": "localhost:6379"}},
 	// host and port is defined in the authParams

--- a/pkg/scalers/redis_streams_scaler_test.go
+++ b/pkg/scalers/redis_streams_scaler_test.go
@@ -19,12 +19,12 @@ func TestParseRedisStreamsMetadata(t *testing.T) {
 	authParams := map[string]string{"password": "foobarred"}
 
 	testCases := []testCase{
-		{"with address", map[string]string{"stream": "my-stream", "consumerGroup": "my-stream-consumer-group", "pendingEntriesCount": "5", "address": "REDIS_SERVICE", "password": "REDIS_PASSWORD", "databaseIndex": "0", "enableTLS": "true"}, map[string]string{
+		{"with address", map[string]string{"stream": "my-stream", "consumerGroup": "my-stream-consumer-group", "pendingEntriesCount": "5", "addressFromEnv": "REDIS_SERVICE", "passwordFromEnv": "REDIS_PASSWORD", "databaseIndex": "0", "enableTLS": "true"}, map[string]string{
 			"REDIS_SERVICE":  "myredis:6379",
 			"REDIS_PASSWORD": "foobarred",
 		}, nil},
 
-		{"with host and port", map[string]string{"stream": "my-stream", "consumerGroup": "my-stream-consumer-group", "pendingEntriesCount": "15", "host": "REDIS_HOST", "port": "REDIS_PORT", "databaseIndex": "0", "enableTLS": "false"}, map[string]string{
+		{"with host and port", map[string]string{"stream": "my-stream", "consumerGroup": "my-stream-consumer-group", "pendingEntriesCount": "15", "hostFromEnv": "REDIS_HOST", "port": "REDIS_PORT", "passwordFromEnv": "REDIS_PASSWORD", "databaseIndex": "0", "enableTLS": "false"}, map[string]string{
 			"REDIS_HOST":     "myredis",
 			"REDIS_PORT":     "6379",
 			"REDIS_PASSWORD": "foobarred",
@@ -41,15 +41,15 @@ func TestParseRedisStreamsMetadata(t *testing.T) {
 			assert.Equal(t, strconv.Itoa(m.targetPendingEntriesCount), tc.metadata[pendingEntriesCountMetadata])
 			if authParams != nil {
 				//if authParam is used
-				assert.Equal(t, m.password, authParams[passwordMetadata])
+				assert.Equal(t, m.connectionInfo.password, authParams[passwordMetadata])
 			} else {
 				//if metadata is used to pass password env var name
-				assert.Equal(t, m.password, tc.resolvedEnv[tc.metadata[passwordMetadata]])
+				assert.Equal(t, m.connectionInfo.password, tc.resolvedEnv[tc.metadata[passwordMetadata]])
 			}
 			assert.Equal(t, strconv.Itoa(m.databaseIndex), tc.metadata[databaseIndexMetadata])
 			b, err := strconv.ParseBool(tc.metadata[enableTLSMetadata])
 			assert.Nil(t, err)
-			assert.Equal(t, m.enableTLS, b)
+			assert.Equal(t, m.connectionInfo.enableTLS, b)
 		})
 	}
 }

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -377,7 +377,7 @@ func buildScaler(name, namespace, triggerType string, resolvedEnv, triggerMetada
 	case "azure-blob":
 		return scalers.NewAzureBlobScaler(resolvedEnv, triggerMetadata, authParams, podIdentity)
 	case "azure-eventhub":
-		return scalers.NewAzureEventHubScaler(resolvedEnv, triggerMetadata)
+		return scalers.NewAzureEventHubScaler(resolvedEnv, triggerMetadata, authParams)
 	case "azure-monitor":
 		return scalers.NewAzureMonitorScaler(resolvedEnv, triggerMetadata, authParams, podIdentity)
 	case "azure-queue":
@@ -387,9 +387,9 @@ func buildScaler(name, namespace, triggerType string, resolvedEnv, triggerMetada
 	case "cron":
 		return scalers.NewCronScaler(resolvedEnv, triggerMetadata)
 	case "external":
-		return scalers.NewExternalScaler(name, namespace, triggerMetadata)
+		return scalers.NewExternalScaler(name, namespace, triggerMetadata, resolvedEnv)
 	case "external-push":
-		return scalers.NewExternalPushScaler(name, namespace, triggerMetadata)
+		return scalers.NewExternalPushScaler(name, namespace, triggerMetadata, authParams)
 	case "gcp-pubsub":
 		return scalers.NewPubSubScaler(resolvedEnv, triggerMetadata)
 	case "huawei-cloudeye":


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

| Scaler | values | update |
|--------|--------|--------|
| `azure-blob` | `connection` (**Default**: `AzureWebJobsStorage`) | `connectionFromEnv` |
| `azure-monitor` | `activeDirectoryClientId` <br /> `activeDirectoryClientPassword` | `activeDirectoryClientIdFromEnv` <br /> `activeDirectoryClientPasswordFromEnv` |
| `azure-queue` | `connection` (**Default**: AzureWebJobsStorage) | `connectionFromEnv` |
| `azure-servicebus` | `connection` | `connectionFromEnv` |
| `azure-eventhub` | `storageConnection` (**Default**: `AzureWebJobsStorage`) <br /> `connection` (**Default**: `EventHub`) | `storageConnectionFromEnv` <br /> `connectionFromEnv` |
| `aws-sqs-queue` <br /> `aws-cloudwatch` <br /> `aws-kinesis-stream` | `awsAccessKeyID` (**Default**: `AWS_ACCESS_KEY_ID`) <br /> `awsSecretAccessKey` (**Default**: `AWS_SECRET_ACCESS_KEY`) | `awsAccessKeyIDFromEnv` (**Default**: `AWS_ACCESS_KEY_ID`) <br /> `awsSecretAccessKeyFromEnv` (**Default**: `AWS_SECRET_ACCESS_KEY`) |
| `kafka` | _(none)_ | _(none)_
| `rabbitmq` | `apiHost` <br /> `host` | `apiHostFromEnv` <br /> `host` |
| `prometheus` | _(none)_ | _(none)_ |
| `cron` | _(none)_ | _(none)_ |
| `redis` <br /> `redis-streams` | `address` <br /> `host` <br /> `port` <br /> `password` | `addressFromEnv` <br /> `hostFromEnv` <br /> `portFromEnv` <br /> `passwordFromEnv`
| `gcp-pubsub` | `credentials` | `credentialsFromEnv` |
| `external` | _(any matching value)_ | _(any matching value with `FromEnv` suffix)_
| `liiklus` | _(none)_ | _(none)_ |
| `stan` | _(none)_ | _(none)_ |
| `huawei-cloudeye` | _(none)_ | _(none)_ |
| `postgresql` | `connection` <br /> `password` | `connectionFromEnv` <br /> `passwordFromEnv` |
| `mysql` | `connectionString` <br /> `password` | `connectionStringFromEnv` <br /> `passwordFromEnv` |

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

Fixes #1044 
