### PR TITLE
[v2] Kafka: split metadata and config for SASL and TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,9 @@
 
 - Change `apiGroup` from `keda.k8s.io` to `keda.sh` ([#552](https://github.com/kedacore/keda/issues/552))
 - Introduce a separate ScaledObject and ScaledJob([#653](https://github.com/kedacore/keda/issues/653))
-- Remove `New()` and `Close()` from the interface of `service ExternalScaler` in `externalscaler.proto` ([#865](https://github.com/kedacore/keda/pull/865))
+- Remove `New()` and `Close()` from the interface of `service ExternalScaler` in `externalscaler.proto`.
 - Removed deprecated brokerList for Kafka scaler ([#882](https://github.com/kedacore/keda/pull/882))
-- All scalers metadata that is resolved from the scaleTarget environment have suffix `FromEnv` added. e.g: `connection` -> `connectionFromEnv` ([#1072](https://github.com/kedacore/keda/pull/1072))
+- All scalers metadata that is resolved from the scaleTarget environment have suffix `FromEnv` added. e.g: `connection` -> `connectionFromEnv`
 - Kafka: split metadata and config for SASL and TLS ([#1074](https://github.com/kedacore/keda/pull/1074))
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Remove `New()` and `Close()` from the interface of `service ExternalScaler` in `externalscaler.proto` ([#865](https://github.com/kedacore/keda/pull/865))
 - Removed deprecated brokerList for Kafka scaler ([#882](https://github.com/kedacore/keda/pull/882))
 - All scalers metadata that is resolved from the scaleTarget environment have suffix `FromEnv` added. e.g: `connection` -> `connectionFromEnv` ([#1072](https://github.com/kedacore/keda/pull/1072))
+- Kafka: split metadata and config for SASL and TLS ([#1074](https://github.com/kedacore/keda/pull/1074))
 
 ### Other
 - Update Operator SDK and k8s deps ([#1007](https://github.com/kedacore/keda/pull/1007),[#870](https://github.com/kedacore/keda/issues/870))

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Shopify/sarama"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
@@ -32,15 +31,17 @@ type kafkaMetadata struct {
 	lagThreshold      int64
 	offsetResetPolicy offsetResetPolicy
 
-	// auth
-	authMode kafkaAuthMode
-	username string
-	password string
+	// SASL
+	enableSASL bool
+	saslType   kafkaSaslType
+	username   string
+	password   string
 
-	// ssl
-	cert string
-	key  string
-	ca   string
+	// TLS
+	enableTLS bool
+	cert      string
+	key       string
+	ca        string
 }
 
 type offsetResetPolicy string
@@ -50,15 +51,13 @@ const (
 	earliest offsetResetPolicy = "earliest"
 )
 
-type kafkaAuthMode string
+type kafkaSaslType string
 
+// supported SASL types
 const (
-	kafkaAuthModeForNone            kafkaAuthMode = "none"
-	kafkaAuthModeForSaslPlaintext   kafkaAuthMode = "sasl_plaintext"
-	kafkaAuthModeForSaslScramSha256 kafkaAuthMode = "sasl_scram_sha256"
-	kafkaAuthModeForSaslScramSha512 kafkaAuthMode = "sasl_scram_sha512"
-	kafkaAuthModeForSaslSSL         kafkaAuthMode = "sasl_ssl"
-	kafkaAuthModeForSaslSSLPlain    kafkaAuthMode = "sasl_ssl_plain"
+	KafkaSASLTypePlaintext   kafkaSaslType = "plaintext"
+	KafkaSASLTypeSCRAMSHA256 kafkaSaslType = "scram_sha256"
+	KafkaSASLTypeSCRAMSHA512 kafkaSaslType = "scram_sha512"
 )
 
 const (
@@ -130,45 +129,52 @@ func parseKafkaMetadata(resolvedEnv, metadata, authParams map[string]string) (ka
 		meta.lagThreshold = t
 	}
 
-	meta.authMode = kafkaAuthModeForNone
-	if val, ok := authParams["authMode"]; ok {
+	meta.enableSASL = false
+	if val, ok := authParams["sasl"]; ok {
 		val = strings.TrimSpace(val)
-		mode := kafkaAuthMode(val)
+		mode := kafkaSaslType(val)
 
-		if mode != kafkaAuthModeForNone && mode != kafkaAuthModeForSaslPlaintext && mode != kafkaAuthModeForSaslSSL && mode != kafkaAuthModeForSaslSSLPlain && mode != kafkaAuthModeForSaslScramSha256 && mode != kafkaAuthModeForSaslScramSha512 {
-			return meta, fmt.Errorf("err auth mode %s given", mode)
+		if mode == KafkaSASLTypePlaintext || mode == KafkaSASLTypeSCRAMSHA256 || mode == KafkaSASLTypeSCRAMSHA512 {
+			meta.saslType = mode
+
+			if authParams["username"] == "" {
+				return meta, errors.New("no username given")
+			}
+			meta.username = strings.TrimSpace(authParams["username"])
+
+			if authParams["password"] == "" {
+				return meta, errors.New("no password given")
+			}
+			meta.password = strings.TrimSpace(authParams["password"])
+			meta.enableSASL = true
+		} else {
+			return meta, fmt.Errorf("err SASL mode %s given", mode)
 		}
-
-		meta.authMode = mode
 	}
 
-	if meta.authMode != kafkaAuthModeForNone && meta.authMode != kafkaAuthModeForSaslSSL {
-		if authParams["username"] == "" {
-			return meta, errors.New("no username given")
-		}
-		meta.username = strings.TrimSpace(authParams["username"])
+	meta.enableTLS = false
+	if val, ok := authParams["tls"]; ok {
+		val = strings.TrimSpace(val)
 
-		if authParams["password"] == "" {
-			return meta, errors.New("no password given")
-		}
-		meta.password = strings.TrimSpace(authParams["password"])
-	}
+		if val == "enable" {
+			if authParams["ca"] == "" {
+				return meta, errors.New("no ca given")
+			}
+			meta.ca = authParams["ca"]
 
-	if meta.authMode == kafkaAuthModeForSaslSSL {
-		if authParams["ca"] == "" {
-			return meta, errors.New("no ca given")
-		}
-		meta.ca = authParams["ca"]
+			if authParams["cert"] == "" {
+				return meta, errors.New("no cert given")
+			}
+			meta.cert = authParams["cert"]
 
-		if authParams["cert"] == "" {
-			return meta, errors.New("no cert given")
+			if authParams["key"] == "" {
+				return meta, errors.New("no key given")
+			}
+			meta.key = authParams["key"]
+			meta.enableTLS = true
+		} else {
+			return meta, fmt.Errorf("err incorrect value for TLS given: %s", val)
 		}
-		meta.cert = authParams["cert"]
-
-		if authParams["key"] == "" {
-			return meta, errors.New("no key given")
-		}
-		meta.key = authParams["key"]
 	}
 
 	return meta, nil
@@ -206,56 +212,33 @@ func getKafkaClients(metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin
 	config := sarama.NewConfig()
 	config.Version = sarama.V1_0_0_0
 
-	if ok := metadata.authMode == kafkaAuthModeForSaslPlaintext || metadata.authMode == kafkaAuthModeForSaslSSLPlain || metadata.authMode == kafkaAuthModeForSaslScramSha256 || metadata.authMode == kafkaAuthModeForSaslScramSha512; ok {
+	if metadata.enableSASL {
 		config.Net.SASL.Enable = true
 		config.Net.SASL.User = metadata.username
 		config.Net.SASL.Password = metadata.password
 	}
 
-	if metadata.authMode == kafkaAuthModeForSaslSSLPlain {
-		config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypePlaintext)
-
-		tlsConfig := &tls.Config{
-			InsecureSkipVerify: true,
-			ClientAuth:         0,
-		}
-
+	if metadata.enableTLS {
 		config.Net.TLS.Enable = true
-		config.Net.TLS.Config = tlsConfig
-		config.Net.DialTimeout = 10 * time.Second
-	}
-
-	if metadata.authMode == kafkaAuthModeForSaslSSL {
-		cert, err := tls.X509KeyPair([]byte(metadata.cert), []byte(metadata.key))
+		tlsConfig, err := newTLSConfig(metadata.cert, metadata.key, metadata.ca)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error parse X509KeyPair: %s", err)
+			return nil, nil, err
 		}
-
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM([]byte(metadata.ca))
-
-		tlsConfig := &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			RootCAs:      caCertPool,
-		}
-
-		config.Net.TLS.Enable = true
 		config.Net.TLS.Config = tlsConfig
 	}
 
-	if metadata.authMode == kafkaAuthModeForSaslScramSha256 {
-		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
-		config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA256)
-	}
-
-	if metadata.authMode == kafkaAuthModeForSaslScramSha512 {
-		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
-		config.Net.SASL.Mechanism = sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512)
-	}
-
-	if metadata.authMode == kafkaAuthModeForSaslPlaintext {
+	if metadata.saslType == KafkaSASLTypePlaintext {
 		config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
-		config.Net.TLS.Enable = true
+	}
+
+	if metadata.saslType == KafkaSASLTypeSCRAMSHA256 {
+		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA256} }
+		config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+	}
+
+	if metadata.saslType == KafkaSASLTypeSCRAMSHA512 {
+		config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient { return &XDGSCRAMClient{HashGeneratorFcn: SHA512} }
+		config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
 	}
 
 	client, err := sarama.NewClient(metadata.bootstrapServers, config)
@@ -272,6 +255,37 @@ func getKafkaClients(metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin
 	}
 
 	return client, admin, nil
+}
+
+// newTLSConfig returns a *tls.Config using the given ceClient cert, ceClient key,
+// and CA certificate. If none are appropriate, a nil *tls.Config is returned.
+func newTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
+	valid := false
+
+	config := &tls.Config{}
+
+	if clientCert != "" && clientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
+		if err != nil {
+			return nil, fmt.Errorf("error parse X509KeyPair: %s", err)
+		}
+		config.Certificates = []tls.Certificate{cert}
+		valid = true
+	}
+
+	if caCert != "" {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(caCert))
+		config.RootCAs = caCertPool
+		config.InsecureSkipVerify = true
+		valid = true
+	}
+
+	if !valid {
+		config = nil
+	}
+
+	return config, nil
 }
 
 func (s *kafkaScaler) getPartitions() ([]int32, error) {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -18,7 +18,6 @@ type parseKafkaMetadataTestData struct {
 type parseKafkaAuthParamsTestData struct {
 	authParams map[string]string
 	isError    bool
-	enableSASL bool
 	enableTLS  bool
 }
 
@@ -65,43 +64,43 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 
 var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	// success, SASL only
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin"}, false, true, false},
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin"}, false, false},
 	// success, SASL only
-	{map[string]string{"sasl": "scram_sha256", "username": "admin", "password": "admin"}, false, true, false},
+	{map[string]string{"sasl": "scram_sha256", "username": "admin", "password": "admin"}, false, false},
 	// success, SASL only
-	{map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, false, true, false},
+	{map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, false, false},
 	// success, TLS only
-	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, false, true},
+	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
 	// success, SASL + TLS
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true, true},
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
 	// failure, SASL incorrect type
-	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin"}, true, false, false},
+	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin"}, true, false},
 	// failure, SASL missing username
-	{map[string]string{"sasl": "plaintext", "password": "admin"}, true, false, false},
+	{map[string]string{"sasl": "plaintext", "password": "admin"}, true, false},
 	// failure, SASL missing password
-	{map[string]string{"sasl": "plaintext", "username": "admin"}, true, false, false},
+	{map[string]string{"sasl": "plaintext", "username": "admin"}, true, false},
 	// failure, TLS incorrect
-	{map[string]string{"tls": "yes", "cert": "ceert", "key": "keey"}, true, false, false},
+	{map[string]string{"tls": "yes", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, TLS missing ca
-	{map[string]string{"tls": "yes", "ca": "caaa", "key": "keey"}, true, false, false},
+	{map[string]string{"tls": "yes", "ca": "caaa", "key": "keey"}, true, false},
 	// failure, TLS missing cert
-	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, TLS missing key
-	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert"}, true, false, false},
+	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert"}, true, false},
 	// failure, SASL + TLS, incorrect sasl
-	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, incorrect tls
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "foo", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, true, false},
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "foo", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing username
-	{map[string]string{"sasl": "plaintext", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	{map[string]string{"sasl": "plaintext", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing password
-	{map[string]string{"sasl": "plaintext", "username": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	{map[string]string{"sasl": "plaintext", "username": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing ca
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "cert": "ceert", "key": "keey"}, true, true, false},
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing cert
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "key": "keey"}, true, true, false},
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing key
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert"}, true, true, false},
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert"}, true, false},
 }
 
 var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
@@ -169,9 +168,6 @@ func TestKafkaAuthParams(t *testing.T) {
 		}
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")
-		}
-		if meta.enableSASL != testData.enableSASL {
-			t.Errorf("Expected enableSASL to be set to %v but got %v\n", testData.enableSASL, meta.enableSASL)
 		}
 		if meta.enableTLS != testData.enableTLS {
 			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -15,13 +15,20 @@ type parseKafkaMetadataTestData struct {
 	offsetResetPolicy offsetResetPolicy
 }
 
+type parseKafkaAuthParamsTestData struct {
+	authParams map[string]string
+	isError    bool
+	enableSASL bool
+	enableTLS  bool
+}
+
 type kafkaMetricIdentifier struct {
 	metadataTestData *parseKafkaMetadataTestData
 	name             string
 }
 
 // A complete valid metadata example for reference
-var validMetadata = map[string]string{
+var validKafkaMetadata = map[string]string{
 	"bootstrapServers": "broker1:9092,broker2:9092",
 	"consumerGroup":    "my-group",
 	"topic":            "my-topic",
@@ -29,7 +36,7 @@ var validMetadata = map[string]string{
 
 // A complete valid authParams example for sasl, with username and passwd
 var validWithAuthParams = map[string]string{
-	"authMode": "sasl_plaintext",
+	"sasl":     "plaintext",
 	"username": "admin",
 	"password": "admin",
 }
@@ -54,6 +61,47 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "foo"}, true, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", ""},
 	// success, offsetResetPolicy policy earliest
 	{map[string]string{"bootstrapServers": "foo:9092,bar:9092", "consumerGroup": "my-group", "topic": "my-topic", "offsetResetPolicy": "earliest"}, false, 2, []string{"foo:9092", "bar:9092"}, "my-group", "my-topic", offsetResetPolicy("earliest")},
+}
+
+var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
+	// success, SASL only
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin"}, false, true, false},
+	// success, SASL only
+	{map[string]string{"sasl": "scram_sha256", "username": "admin", "password": "admin"}, false, true, false},
+	// success, SASL only
+	{map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, false, true, false},
+	// success, TLS only
+	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, false, true},
+	// success, SASL + TLS
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true, true},
+	// failure, SASL incorrect type
+	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin"}, true, false, false},
+	// failure, SASL missing username
+	{map[string]string{"sasl": "plaintext", "password": "admin"}, true, false, false},
+	// failure, SASL missing password
+	{map[string]string{"sasl": "plaintext", "username": "admin"}, true, false, false},
+	// failure, TLS incorrect
+	{map[string]string{"tls": "yes", "cert": "ceert", "key": "keey"}, true, false, false},
+	// failure, TLS missing ca
+	{map[string]string{"tls": "yes", "ca": "caaa", "key": "keey"}, true, false, false},
+	// failure, TLS missing cert
+	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	// failure, TLS missing key
+	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert"}, true, false, false},
+	// failure, SASL + TLS, incorrect sasl
+	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	// failure, SASL + TLS, incorrect tls
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "foo", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, true, false},
+	// failure, SASL + TLS, missing username
+	{map[string]string{"sasl": "plaintext", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	// failure, SASL + TLS, missing password
+	{map[string]string{"sasl": "plaintext", "username": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false, false},
+	// failure, SASL + TLS, missing ca
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "cert": "ceert", "key": "keey"}, true, true, false},
+	// failure, SASL + TLS, missing cert
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "key": "keey"}, true, true, false},
+	// failure, SASL + TLS, missing key
+	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert"}, true, true, false},
 }
 
 var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
@@ -112,6 +160,24 @@ func TestGetBrokers(t *testing.T) {
 	}
 }
 
+func TestKafkaAuthParams(t *testing.T) {
+	for _, testData := range parseKafkaAuthParamsTestDataset {
+		meta, err := parseKafkaMetadata(nil, validKafkaMetadata, testData.authParams)
+
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+		if meta.enableSASL != testData.enableSASL {
+			t.Errorf("Expected enableSASL to be set to %v but got %v\n", testData.enableSASL, meta.enableSASL)
+		}
+		if meta.enableTLS != testData.enableTLS {
+			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
+		}
+	}
+}
 func TestKafkaGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range kafkaMetricIdentifiers {
 		meta, err := parseKafkaMetadata(nil, testData.metadataTestData.metadata, validWithAuthParams)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Splitting Kafka Auth mode to a separate sections for SASL and TLS. This is IMHO more convenient.



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs/pull/242
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/1043
