### PR TITLE
[v2] Correcting set-version target & removing temp files produced by sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ clientset-generate: clientset-prepare
 	./hack/update-codegen.sh
 	find ./pkg/generated -type f -name "*.go" |\
 	xargs sed -i".out" -e "s#github.com/kedacore/keda/api/keda/v1alpha1#github.com/kedacore/keda/api/v1alpha1#g"
+	find ./pkg/generated -type f -name "*.go.out" | xargs rm -rf
 	rm -rf api/keda
 
 ##################################################

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ release: manifests kustomize
 
 .PHONY: set-version
 set-version:
-	@sed -i".out" -e 's@Version[ ]*=.*@Version   = "$(VERSION)"@g' ./version/version.go;
+	@sed -i".out" -e 's@Version[ ]*=.*@Version = "$(VERSION)"@g' ./version/version.go;
+	rm -rf ./version/version.go.out
 
 ##################################################
 # RUN / (UN)INSTALL / DEPLOY                     #


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Minor fixes:
- cleaning temp file introduced by https://github.com/kedacore/keda/pull/1071
- correcting the sed regex pattern
- cleaning temp file in clientset-generate target as well
