### PR TITLE
[v2] Improved GCP PubSub Scaler performance by closing the client correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Improve `kubectl get triggerauthentication` to show information about configured parameters ([#778](https://github.com/kedacore/keda/issues/778))
 - Added ScaledObject Status Conditions to display status of scaling ([#750](https://github.com/kedacore/keda/pull/750))
 - Added optional authentication parameters for the Redis Scaler ([#962](https://github.com/kedacore/keda/pull/962))
+- Improved GCP PubSub Scaler performance by closing the client correctly ([#1087](https://github.com/kedacore/keda/pull/1087))
 
 ### Breaking Changes
 

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -54,7 +54,7 @@ func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockGcpPubSubScaler := pubsubScaler{meta}
+		mockGcpPubSubScaler := pubsubScaler{nil, meta}
 
 		metricSpec := mockGcpPubSubScaler.GetMetricSpecForScaling()
 		metricName := metricSpec[0].External.Metric.Name


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Small fix: closing StackDriver client in the GCP PubSub scaler. 

Fixing issue raised in https://github.com/kedacore/keda/issues/1062#issuecomment-686367321
