### PR TITLE
Add link to GOVERNANCE.md in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,5 +112,4 @@ pre-commit run
 To run all checks on all files, run:
 ```bash
 pre-commit run --all-files
-
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,15 +8,20 @@ There are many areas we can use contributions - ranging from code, documentation
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of contents**
 
+- [Project governance](#project-governance)
 - [Getting Help](#getting-help)
 - [Contributing Scalers](#contributing-scalers)
 - [Including Documentation Changes](#including-documentation-changes)
 - [Creating and building a local environment](#creating-and-building-a-local-environment)
 - [Developer Certificate of Origin: Signing your work](#developer-certificate-of-origin-signing-your-work)
 - [Code Quality](#code-quality)
-- [Project governance](#project-governance)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Project governance
+
+KEDA project is an open source project governed according to rules described in [`GOVERNANCE`](GOVERNANCE.md). If you
+would love to become a maintainer to support our project please create an issue as described in [`GOVERNANCE`](GOVERNANCE.md).
 
 ## Getting Help
 
@@ -109,7 +114,3 @@ To run all checks on all files, run:
 pre-commit run --all-files
 
 ```
-## Project governance
-
-KEDA project is an open source project governed according to rules described in [`GOVERNANCE`](GOVERNANCE.md). If you
-would love to become a maintainer to support our project please create an issue as described in [`GOVERNANCE`](GOVERNANCE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ There are many areas we can use contributions - ranging from code, documentation
 - [Creating and building a local environment](#creating-and-building-a-local-environment)
 - [Developer Certificate of Origin: Signing your work](#developer-certificate-of-origin-signing-your-work)
 - [Code Quality](#code-quality)
+- [Project governance](#project-governance)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -106,4 +107,9 @@ pre-commit run
 To run all checks on all files, run:
 ```bash
 pre-commit run --all-files
+
 ```
+## Project governance
+
+KEDA project is an open source project governed according to rules described in [`GOVERNANCE`](GOVERNANCE.md). If you
+would love to become a maintainer to support our project please create an issue as described in [`GOVERNANCE`](GOVERNANCE.md).


### PR DESCRIPTION
It seems that the GOVERNANCE.md file is not linked anywhere in
common files like README or CONTRIBUTING.

Signed-off-by: Tomek Urbaszek <tomasz.urbaszek@polidea.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

Fixes #
