### PR TITLE
[v2] Don't generate LiiklusService in each build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,14 +130,14 @@ docker-build: build
 
 # Build KEDA Operator binary
 .PHONY: manager
-manager: generate gofmt govet pkg/scalers/liiklus/LiiklusService.pb.go
+manager: generate gofmt govet
 	${GO_BUILD_VARS} go build \
 	-ldflags "-X=github.com/kedacore/keda/version.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION)" \
 	-o bin/keda main.go
 
 # Build KEDA Metrics Server Adapter binary
 .PHONY: adapter
-adapter: generate gofmt govet pkg/scalers/liiklus/LiiklusService.pb.go
+adapter: generate gofmt govet
 	${GO_BUILD_VARS} go build \
 	-ldflags "-X=github.com/kedacore/keda/version.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION)" \
 	-o bin/keda-adapter adapter/main.go


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

We don't need to generate protobuf code for LiiklusService in each `make build`.

The building of LiiklusService might be obsolete anyway, I have created a separate issue to update this: https://github.com/kedacore/keda/issues/1097

