### PR TITLE
[v2] artemis e2e test: proper cleanup

### DIFF
--- a/tests/scalers/artemis.test.ts
+++ b/tests/scalers/artemis.test.ts
@@ -66,6 +66,8 @@ test.serial(`Deployment should scale to 5 with 1000 messages on the queue then b
   })
 
 test.after.always.cb('clean up artemis deployment', t => {
+    sh.exec(`kubectl -n ${testNamespace} delete scaledobject.keda.sh/kedartemis-consumer-scaled-object`)
+    sh.exec(`kubectl -n ${testNamespace} delete triggerauthentications.sh/trigger-auth-kedartemis`)
     ArtemisHelper.uninstallArtemis(t, artemisNamespace)
     sh.exec(`kubectl delete namespace ${artemisNamespace}`)
     ArtemisHelper.uninstallWorkloads(t, testNamespace)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Artemis e2e test minor fix: delete all resource after the test is done
