### PR TITLE
[v2] return from RequestScale() in case of error

### DIFF
--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -18,7 +18,8 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 
 	currentScale, err := e.getScaleTargetScale(ctx, scaledObject)
 	if err != nil {
-		logger.Error(err, "Error getting Scale")
+		logger.Error(err, "Error getting information on the current Scale (ie. replias count) on the scaleTarget")
+		return
 	}
 
 	if currentScale.Spec.Replicas == 0 && isActive {


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->
Minor bugfix.

If `e.getScaleTargetScale(ctx, scaledObject)` returns error, we should return from this function, to not operate on a possibly not initialized `currentScale` property -> that would result in panic.


