### PR TITLE
[v2] refactor Dockerfiles that they can share layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.15 as builder
 
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -10,15 +11,17 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY Makefile Makefile
-COPY .git/ .git/
 
 # Copy the go source
 COPY hack/ hack/
 COPY version/ version/
 COPY main.go main.go
+COPY adapter/ adapter/
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
+
+COPY .git/ .git/
 
 # Build
 RUN make manager

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -3,8 +3,6 @@ FROM golang:1.15 as builder
 
 WORKDIR /workspace
 
-RUN mkdir -p /apiserver.local.config/certificates && chmod -R 777 /apiserver.local.config
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -13,14 +11,19 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY Makefile Makefile
-COPY .git/ .git/
 
 # Copy the go source
 COPY hack/ hack/
 COPY version/ version/
-COPY api/ api/
+COPY main.go main.go
 COPY adapter/ adapter/
+COPY api/ api/
+COPY controllers/ controllers/
 COPY pkg/ pkg/
+
+COPY .git/ .git/
+
+RUN mkdir -p /apiserver.local.config/certificates && chmod -R 777 /apiserver.local.config
 
 # Build
 RUN make adapter


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Refactoring Dockerfiles, that they can share layers between KEDA Operator and Metrics Server image, this should speed up the build a little bit (which is currently quite slow, due to the multistage build & builder image use).