### PR TITLE
[v2] Consolidate apiHost & host for RabbitMQ scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Removed deprecated brokerList for Kafka scaler ([#882](https://github.com/kedacore/keda/pull/882))
 - All scalers metadata that is resolved from the scaleTarget environment have suffix `FromEnv` added. e.g: `connection` -> `connectionFromEnv`
 - Kafka: split metadata and config for SASL and TLS ([#1074](https://github.com/kedacore/keda/pull/1074))
+- Use `host` instead of `apiHost` in `rabbitmq` scaler. Add `protocol` in trigger spec to specify which protocol should be used ([#1115](https://github.com/kedacore/keda/pull/1115))
 
 ### Other
 - Update Operator SDK and k8s deps ([#1007](https://github.com/kedacore/keda/pull/1007),[#870](https://github.com/kedacore/keda/issues/870))

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -39,8 +39,8 @@ type rabbitMQScaler struct {
 
 type rabbitMQMetadata struct {
 	queueName   string
-	host        string // connection string for either HTTP or AMQP protocol
 	queueLength int
+	host        string // connection string for either HTTP or AMQP protocol
 	protocol    string // either http or amqp protocol
 }
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -23,8 +23,12 @@ const (
 	rabbitQueueLengthMetricName = "queueLength"
 	defaultRabbitMQQueueLength  = 20
 	rabbitMetricType            = "External"
-	rabbitIncludeUnacked        = "includeUnacked"
-	defaultIncludeUnacked       = false
+)
+
+const (
+	httpProtocol    = "http"
+	amqpProtocol    = "amqp"
+	defaultProtocol = amqpProtocol
 )
 
 type rabbitMQScaler struct {
@@ -34,11 +38,10 @@ type rabbitMQScaler struct {
 }
 
 type rabbitMQMetadata struct {
-	queueName      string
-	host           string // connection string for AMQP protocol
-	apiHost        string // connection string for management API requests
-	queueLength    int
-	includeUnacked bool // if true uses HTTP API and requires apiHost, if false uses AMQP and requires host
+	queueName   string
+	host        string // connection string for either HTTP or AMQP protocol
+	queueLength int
+	protocol    string // either http or amqp protocol
 }
 
 type queueInfo struct {
@@ -56,7 +59,7 @@ func NewRabbitMQScaler(resolvedEnv, metadata, authParams map[string]string) (Sca
 		return nil, fmt.Errorf("error parsing rabbitmq metadata: %s", err)
 	}
 
-	if meta.includeUnacked {
+	if meta.protocol == httpProtocol {
 		return &rabbitMQScaler{metadata: meta}, nil
 	}
 
@@ -75,47 +78,35 @@ func NewRabbitMQScaler(resolvedEnv, metadata, authParams map[string]string) (Sca
 func parseRabbitMQMetadata(resolvedEnv, metadata, authParams map[string]string) (*rabbitMQMetadata, error) {
 	meta := rabbitMQMetadata{}
 
-	meta.includeUnacked = defaultIncludeUnacked
-	if val, ok := metadata[rabbitIncludeUnacked]; ok {
-		includeUnacked, err := strconv.ParseBool(val)
-		if err != nil {
-			return nil, fmt.Errorf("includeUnacked parsing error %s", err.Error())
+	// Resolve protocol type
+	meta.protocol = defaultProtocol
+	if val, ok := metadata["protocol"]; ok {
+		if val == amqpProtocol || val == httpProtocol {
+			meta.protocol = val
+		} else {
+			return nil, fmt.Errorf("the protocol has to be either `%s` or `%s` but is `%s`", amqpProtocol, httpProtocol, val)
 		}
-		meta.includeUnacked = includeUnacked
 	}
 
-	if meta.includeUnacked {
-		if authParams["apiHost"] != "" {
-			meta.apiHost = authParams["apiHost"]
-		} else if metadata["apiHost"] != "" {
-			meta.apiHost = metadata["apiHost"]
-		} else if metadata["apiHostFromEnv"] != "" {
-			meta.apiHost = resolvedEnv[metadata["apiHostFromEnv"]]
-		}
-
-		if meta.apiHost == "" {
-			return nil, fmt.Errorf("no apiHost setting given")
-		}
+	// Resolve host value
+	if authParams["host"] != "" {
+		meta.host = authParams["host"]
+	} else if metadata["host"] != "" {
+		meta.host = metadata["host"]
+	} else if metadata["hostFromEnv"] != "" {
+		meta.host = resolvedEnv[metadata["hostFromEnv"]]
 	} else {
-		if authParams["host"] != "" {
-			meta.host = authParams["host"]
-		} else if metadata["host"] != "" {
-			meta.host = metadata["host"]
-		} else if metadata["hostFromEnv"] != "" {
-			meta.host = resolvedEnv[metadata["hostFromEnv"]]
-		}
-
-		if meta.host == "" {
-			return nil, fmt.Errorf("no host setting given")
-		}
+		return nil, fmt.Errorf("no host setting given")
 	}
 
+	// Resolve queueName
 	if val, ok := metadata["queueName"]; ok {
 		meta.queueName = val
 	} else {
 		return nil, fmt.Errorf("no queue name given")
 	}
 
+	// Resolve queueLength
 	if val, ok := metadata[rabbitQueueLengthMetricName]; ok {
 		queueLength, err := strconv.Atoi(val)
 		if err != nil {
@@ -167,7 +158,7 @@ func (s *rabbitMQScaler) IsActive(ctx context.Context) (bool, error) {
 }
 
 func (s *rabbitMQScaler) getQueueMessages() (int, error) {
-	if s.metadata.includeUnacked {
+	if s.metadata.protocol == httpProtocol {
 		info, err := s.getQueueInfoViaHTTP()
 		if err != nil {
 			return -1, err
@@ -202,7 +193,7 @@ func getJSON(url string, target interface{}) error {
 }
 
 func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
-	parsedURL, err := url.Parse(s.metadata.apiHost)
+	parsedURL, err := url.Parse(s.metadata.host)
 
 	if err != nil {
 		return nil, err

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	host    = "myHostSecret"
-	apiHost = "myApiHostSecret"
+	host = "myHostSecret"
 )
 
 type parseRabbitMQMetadataTestData struct {
@@ -26,8 +25,7 @@ type rabbitMQMetricIdentifier struct {
 }
 
 var sampleRabbitMqResolvedEnv = map[string]string{
-	host:    "amqp://user:sercet@somehost.com:5236/vhost",
-	apiHost: "https://user:secret@somehost.com/vhost",
+	host: "amqp://user:sercet@somehost.com:5236/vhost",
 }
 
 var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
@@ -43,8 +41,8 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	{map[string]string{"queueLength": "10", "hostFromEnv": host}, true, map[string]string{}},
 	// host defined in authParams
 	{map[string]string{"queueLength": "10"}, true, map[string]string{"host": host}},
-	// properly formed metadata with includeUnacked
-	{map[string]string{"queueLength": "10", "queueName": "sample", "apiHostFromEnv": apiHost, "includeUnacked": "true"}, false, map[string]string{}},
+	// properly formed metadata with http protocol
+	{map[string]string{"queueLength": "10", "queueName": "sample", "host": host, "protocol": "http"}, false, map[string]string{}},
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
@@ -67,7 +65,7 @@ var testDefaultQueueLength = []parseRabbitMQMetadataTestData{
 	// use default queueLength
 	{map[string]string{"queueName": "sample", "host": host}, false, map[string]string{}},
 	// use default queueLength with includeUnacked
-	{map[string]string{"queueName": "sample", "apiHost": apiHost, "includeUnacked": "true"}, false, map[string]string{}},
+	{map[string]string{"queueName": "sample", "host": host, "protocol": "http"}, false, map[string]string{}},
 }
 
 func TestParseDefaultQueueLength(t *testing.T) {
@@ -118,12 +116,12 @@ func TestGetQueueInfo(t *testing.T) {
 				w.Write([]byte(testData.response))
 			}))
 
-			resolvedEnv := map[string]string{apiHost: fmt.Sprintf("%s%s", apiStub.URL, vhostPath)}
+			resolvedEnv := map[string]string{host: fmt.Sprintf("%s%s", apiStub.URL, vhostPath)}
 
 			metadata := map[string]string{
 				"queueLength":    "10",
 				"queueName":      "evaluate_trials",
-				"apiHostFromEnv": apiHost,
+				"hostFromEnv":    host,
 				"includeUnacked": "true",
 			}
 

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -100,16 +100,16 @@ var vhostPathes = []string{"/myhost", "", "/", "//", "/%2F"}
 func TestGetQueueInfo(t *testing.T) {
 	for _, testData := range testQueueInfoTestData {
 		for _, vhostPath := range vhostPathes {
-			expecedVhost := "myhost"
+			expectedVhost := "myhost"
 
 			if vhostPath != "/myhost" {
-				expecedVhost = "%2F"
+				expectedVhost = "%2F"
 			}
 
 			var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				expecedPath := "/api/queues/" + expecedVhost + "/evaluate_trials"
-				if r.RequestURI != expecedPath {
-					t.Error("Expect request path to =", expecedPath, "but it is", r.RequestURI)
+				expectedPath := "/api/queues/" + expectedVhost + "/evaluate_trials"
+				if r.RequestURI != expectedPath {
+					t.Error("Expect request path to =", expectedPath, "but it is", r.RequestURI)
 				}
 
 				w.WriteHeader(testData.responseStatus)
@@ -119,10 +119,10 @@ func TestGetQueueInfo(t *testing.T) {
 			resolvedEnv := map[string]string{host: fmt.Sprintf("%s%s", apiStub.URL, vhostPath)}
 
 			metadata := map[string]string{
-				"queueLength":    "10",
-				"queueName":      "evaluate_trials",
-				"hostFromEnv":    host,
-				"includeUnacked": "true",
+				"queueLength": "10",
+				"queueName":   "evaluate_trials",
+				"hostFromEnv": host,
+				"protocol":    "http",
 			}
 
 			s, err := NewRabbitMQScaler(resolvedEnv, metadata, map[string]string{})

--- a/tests/scalers/rabbitmq-queue-http.test.ts
+++ b/tests/scalers/rabbitmq-queue-http.test.ts
@@ -126,6 +126,6 @@ spec:
   - type: rabbitmq
     metadata:
       queueName: {{QUEUE_NAME}}
-      apiHostFromEnv: RabbitApiHost
-      includeUnacked: "true"
+      hostFromEnv: RabbitApiHost
+      protocol: http
       queueLength: '50'`


### PR DESCRIPTION
Signed-off-by: Tomek Urbaszek <tomasz.urbaszek@polidea.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Consolidate apiHost & host for RabbitMQ scaler

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Changelog has been updated

Relates to #711
