### PR TITLE
Center CNCF logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ KEDA can run on both the cloud and the edge, integrates natively with Kubernetes
 Pod Autoscaler, and has no external dependencies.
 
 We are a Cloud Native Computing Foundation (CNCF) sandbox project.
-<img src="https://raw.githubusercontent.com/kedacore/keda/master/images/logo-cncf.svg" height="75px">
+<p align="center"><img src="https://raw.githubusercontent.com/kedacore/keda/master/images/logo-cncf.svg" height="75px"></p>
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


### PR DESCRIPTION
No strong opinion here but I think centering CNCF logo may look slightly better:

Before
<img width="1077" alt="Screenshot 2020-09-09 at 10 11 16" src="https://user-images.githubusercontent.com/9528307/92572539-dddbdd00-f284-11ea-977d-19e995c13cb8.png">

After
<img width="1077" alt="Screenshot 2020-09-09 at 10 10 57" src="https://user-images.githubusercontent.com/9528307/92572530-d9afbf80-f284-11ea-8a75-1614d116aac6.png">


Signed-off-by: Tomek Urbaszek <tomasz.urbaszek@polidea.com>

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

Fixes #
