### PR TITLE
[v2] improving controllers log msgs

### DIFF
--- a/controllers/scaledjob_controller.go
+++ b/controllers/scaledjob_controller.go
@@ -44,7 +44,7 @@ func (r *ScaledJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile performs reconciliation on the identified ScaledJob resource based on the request information passed, returns the result and an error (if any).
 func (r *ScaledJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
+	reqLogger := r.Log.WithValues("ScaledJob.Namespace", req.Namespace, "ScaledJob.Name", req.Name)
 
 	// Fetch the ScaledJob instance
 	scaledJob := &kedav1alpha1.ScaledJob{}

--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -103,7 +103,7 @@ func initScaleClient(mgr manager.Manager, clientset *discovery.DiscoveryClient) 
 
 // Reconcile performs reconciliation on the identified ScaledObject resource based on the request information passed, returns the result and an error (if any).
 func (r *ScaledObjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	reqLogger := r.Log.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
+	reqLogger := r.Log.WithValues("ScaledObject.Namespace", req.Namespace, "ScaledObject.Name", req.Name)
 
 	// Fetch the ScaledObject instance
 	scaledObject := &kedav1alpha1.ScaledObject{}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Minor improvement, changing the Controllers log messages, originally they contain `Request.Namespace` and`Request.Name` which is being changed to `ScaledObject/ScaledJob.Namespace` and `ScaledObject/ScaledJob.Name`

Example:
`controllers.ScaledObject	Reconciling ScaledObject	{"Request.Namespace": "default", "Request.Name": "test-scaledobject"}`
->
`controllers.ScaledObject	Reconciling ScaledObject	{"ScaledObject.Namespace": "default", "ScaledObject.Name": "test-scaledobject"}`