### PR TITLE
[v2] revive should ignore vendor dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ revive:
 		-exclude pkg/scaling/resolver/hashicorpvault_handler.go \
 		-exclude pkg/scaling/resolver/scale_resolvers.go \
 		-exclude pkg/scaling/resolver/scale_resolvers_test.go \
+		-exclude vendor/... \
 		./...
 
 ##################################################


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

`vendor` dir is sometimes populated during a build. It is being ignored by git, but `revive` should ignore it as well, to prevent failures from vendored packages.