### PR TITLE
feature[v2]: enabling authentication for metric api scaler

### DIFF
--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/kedacore/keda/pkg/util"
 	"strconv"
 	"strings"
 
@@ -219,7 +218,7 @@ func getKafkaClients(metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin
 
 	if metadata.enableTLS {
 		config.Net.TLS.Enable = true
-		tlsConfig, err := util.NewTLSConfig(metadata.cert, metadata.key, metadata.ca)
+		tlsConfig, err := kedautil.NewTLSConfig(metadata.cert, metadata.key, metadata.ca)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -2,10 +2,9 @@ package scalers
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
+	"github.com/kedacore/keda/pkg/util"
 	"strconv"
 	"strings"
 
@@ -220,7 +219,7 @@ func getKafkaClients(metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin
 
 	if metadata.enableTLS {
 		config.Net.TLS.Enable = true
-		tlsConfig, err := newTLSConfig(metadata.cert, metadata.key, metadata.ca)
+		tlsConfig, err := util.NewTLSConfig(metadata.cert, metadata.key, metadata.ca)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -255,37 +254,6 @@ func getKafkaClients(metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin
 	}
 
 	return client, admin, nil
-}
-
-// newTLSConfig returns a *tls.Config using the given ceClient cert, ceClient key,
-// and CA certificate. If none are appropriate, a nil *tls.Config is returned.
-func newTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
-	valid := false
-
-	config := &tls.Config{}
-
-	if clientCert != "" && clientKey != "" {
-		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
-		if err != nil {
-			return nil, fmt.Errorf("error parse X509KeyPair: %s", err)
-		}
-		config.Certificates = []tls.Certificate{cert}
-		valid = true
-	}
-
-	if caCert != "" {
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM([]byte(caCert))
-		config.RootCAs = caCertPool
-		config.InsecureSkipVerify = true
-		valid = true
-	}
-
-	if !valid {
-		config = nil
-	}
-
-	return config, nil
 }
 
 func (s *kafkaScaler) getPartitions() ([]int32, error) {

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -7,6 +7,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
+	"time"
+
+	neturl "net/url"
 
 	"github.com/tidwall/gjson"
 	"k8s.io/api/autoscaling/v2beta2"
@@ -14,10 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-	neturl "net/url"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
-	"time"
 
 	kedautil "github.com/kedacore/keda/pkg/util"
 )
@@ -66,7 +67,7 @@ var httpLog = logf.Log.WithName("metrics_api_scaler")
 
 // NewMetricsAPIScaler creates a new HTTP scaler
 func NewMetricsAPIScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler, error) {
-	meta, err := metricsAPIMetadata(metadata)
+	meta, err := metricsAPIMetadata(metadata, authParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing metric API metadata: %s", err)
 	}
@@ -90,7 +91,7 @@ func NewMetricsAPIScaler(resolvedEnv, metadata, authParams map[string]string) (S
 	}, nil
 }
 
-func metricsAPIMetadata(metadata map[string]string) (*metricsAPIScalerMetadata, error) {
+func metricsAPIMetadata(metadata map[string]string, authParams map[string]string) (*metricsAPIScalerMetadata, error) {
 	meta := metricsAPIScalerMetadata{}
 
 	if val, ok := metadata["targetValue"]; ok {

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -34,9 +34,9 @@ type metricsAPIScalerMetadata struct {
 
 	//apiKeyAuth
 	enableAPIKeyAuth bool
-	method string // +default is header
-	// +optional default header key is X-API-KEY
-	// default query key is api_key
+	method           string // +default is header
+	// keyParamName  is either header key or query param used for passing apikey
+	// default header is "X-API-KEY", defaul query param is "api_key"
 	keyParamName string
 	apiKey       string
 
@@ -51,6 +51,8 @@ type metricsAPIScalerMetadata struct {
 	key       string
 	ca        string
 }
+
+const defaultTimeOut = 3 * time.Second
 
 type authenticationType string
 
@@ -79,7 +81,7 @@ func NewMetricsAPIScaler(resolvedEnv, metadata, authParams map[string]string) (S
 		return &metricsAPIScaler{
 			metadata: meta,
 			client: &http.Client{
-				Timeout:   3 * time.Second,
+				Timeout:   defaultTimeOut,
 				Transport: transport,
 			},
 		}, nil
@@ -88,7 +90,7 @@ func NewMetricsAPIScaler(resolvedEnv, metadata, authParams map[string]string) (S
 	return &metricsAPIScaler{
 		metadata: meta,
 		client: &http.Client{
-			Timeout: 3 * time.Second,
+			Timeout: defaultTimeOut,
 		},
 	}, nil
 }

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -14,20 +14,59 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	neturl "net/url"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"time"
 
 	kedautil "github.com/kedacore/keda/pkg/util"
 )
 
 type metricsAPIScaler struct {
 	metadata *metricsAPIScalerMetadata
+	client   *http.Client
 }
 
 type metricsAPIScalerMetadata struct {
 	targetValue   int
 	url           string
 	valueLocation string
+
+	//apiKeyAuth
+	enableAPIKeyAuth bool
+	// +default is header
+	method method
+	// +option default header key is X-API-KEY and default query key is api_key
+	keyParamName string
+	apiKey       string
+
+	//base auth
+	enableBaseAuth bool
+	username       string
+	// +optional
+	password string
+
+	//client certification
+	enableTLS bool
+	cert      string
+	key       string
+	ca        string
 }
+
+type authenticationType string
+
+const (
+	apiKeyAuth authenticationType = "apiKeyAuth"
+	basicAuth                     = "basicAuth"
+	tlsAuth                       = "tlsAuth"
+)
+
+type method string
+
+const (
+	header     method = "header"
+	queryParam        = "query"
+)
 
 var httpLog = logf.Log.WithName("metrics_api_scaler")
 
@@ -37,7 +76,29 @@ func NewMetricsAPIScaler(resolvedEnv, metadata, authParams map[string]string) (S
 	if err != nil {
 		return nil, fmt.Errorf("error parsing metric API metadata: %s", err)
 	}
-	return &metricsAPIScaler{metadata: meta}, nil
+
+	if meta.enableTLS {
+		config, err := kedautil.NewTLSConfig(meta.cert, meta.key, meta.ca)
+		if err != nil {
+			return nil, err
+		}
+
+		transport := &http.Transport{TLSClientConfig: config}
+		return &metricsAPIScaler{
+			metadata: meta,
+			client: &http.Client{
+				Timeout:   3 * time.Second,
+				Transport: transport,
+			},
+		}, nil
+	}
+
+	return &metricsAPIScaler{
+		metadata: meta,
+		client: &http.Client{
+			Timeout: 3 * time.Second,
+		},
+	}, nil
 }
 
 func metricsAPIMetadata(metadata map[string]string) (*metricsAPIScalerMetadata, error) {
@@ -65,6 +126,61 @@ func metricsAPIMetadata(metadata map[string]string) (*metricsAPIScalerMetadata, 
 		return nil, fmt.Errorf("no valueLocation given in metadata")
 	}
 
+	// no authMode specified
+	if _, ok := authParams["authMode"]; !ok {
+		return &meta, nil
+	}
+
+	val, _ := authParams["authMode"]
+	authType := authenticationType(strings.TrimSpace(val))
+	if authType == apiKeyAuth {
+		if len(authParams["apiKey"]) == 0 {
+			return nil, errors.New("no apikey provided")
+		}
+
+		meta.apiKey = authParams["apiKey"]
+		// default behaviour is header. only change if query param requested
+		meta.method = header
+		meta.enableAPIKeyAuth = true
+
+		if authParams["method"] == queryParam {
+			meta.method = queryParam
+		}
+
+		if len(authParams["keyParamName"]) > 0 {
+			meta.keyParamName = authParams["keyParamName"]
+		}
+	} else if authType == basicAuth {
+		if authParams["username"] == "" {
+			return nil, errors.New("no username given")
+		}
+
+		meta.username = authParams["username"]
+		// password is optional. For convenience, many application implements basic auth with
+		// username as apikey and password as empty
+		meta.password = authParams["password"]
+		meta.enableBaseAuth = true
+
+	} else if authType == tlsAuth {
+		if authParams["ca"] == "" {
+			return nil, errors.New("no ca given")
+		}
+		meta.ca = authParams["ca"]
+
+		if authParams["cert"] == "" {
+			return nil, errors.New("no cert given")
+		}
+		meta.cert = authParams["cert"]
+
+		if authParams["key"] == "" {
+			return nil, errors.New("no key given")
+		}
+		meta.key = authParams["key"]
+		meta.enableTLS = true
+	} else {
+		return nil, fmt.Errorf("err incorrect value for authMode is given: %s", val)
+	}
+
 	return &meta, nil
 }
 
@@ -79,7 +195,12 @@ func GetValueFromResponse(body []byte, valueLocation string) (int64, error) {
 }
 
 func (s *metricsAPIScaler) getMetricValue() (int64, error) {
-	r, err := http.Get(s.metadata.url)
+	request, err := getMetricAPIServerRequest(s.metadata)
+	if err != nil {
+		return 0, err
+	}
+
+	r, err := s.client.Do(request)
 	if err != nil {
 		return 0, err
 	}
@@ -150,4 +271,53 @@ func (s *metricsAPIScaler) GetMetrics(ctx context.Context, metricName string, me
 	}
 
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
+}
+
+func getMetricAPIServerRequest(meta *metricsAPIScalerMetadata) (*http.Request, error) {
+	var req *http.Request
+	var err error
+
+	if meta.enableAPIKeyAuth {
+		if header == meta.method {
+			req, err = http.NewRequest("GET", meta.url, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(meta.keyParamName) == 0 {
+				req.Header.Add("X-API-KEY", meta.apiKey)
+			} else {
+				req.Header.Add(meta.keyParamName, meta.apiKey)
+			}
+
+		} else if queryParam == meta.method {
+			url, _ := neturl.Parse(meta.url)
+			queryString := url.Query()
+			if len(meta.keyParamName) == 0 {
+				queryString.Set("api_key", meta.apiKey)
+			} else {
+				queryString.Set(meta.keyParamName, meta.apiKey)
+			}
+
+			url.RawQuery = queryString.Encode()
+			req, err = http.NewRequest("GET", url.String(), nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else if meta.enableBaseAuth {
+		req, err = http.NewRequest("GET", meta.url, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.SetBasicAuth(meta.username, meta.password)
+	} else {
+		req, err = http.NewRequest("GET", meta.url, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return req, nil
 }

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -58,7 +58,7 @@ var testMetricsAPIAuthMetadata = []metricAPIAuthMetadataTestData{
 
 func TestParseMetricsAPIMetadata(t *testing.T) {
 	for _, testData := range testMetricsAPIMetadata {
-		_, err := metricsAPIMetadata(testData.metadata)
+		_, err := metricsAPIMetadata(testData.metadata, map[string]string{})
 		if err != nil && !testData.raisesError {
 			t.Error("Expected success but got error", err)
 		}
@@ -89,7 +89,7 @@ func TestGetValueFromResponse(t *testing.T) {
 
 func TestMetricAPIScalerAuthParams(t *testing.T) {
 	for _, testData := range testMetricsAPIAuthMetadata {
-		meta, err := metricsAPIMetadata(nil, validMetricAPIMetadata, testData.authParams)
+		meta, err := metricsAPIMetadata(validMetricAPIMetadata, testData.authParams)
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)

--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+)
+
+// NewTLSConfig returns a *tls.Config using the given ceClient cert, ceClient key,
+// and CA certificate. If none are appropriate, a nil *tls.Config is returned.
+func NewTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
+	valid := false
+
+	config := &tls.Config{}
+
+	if clientCert != "" && clientKey != "" {
+		cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
+		if err != nil {
+			return nil, fmt.Errorf("error parse X509KeyPair: %s", err)
+		}
+		config.Certificates = []tls.Certificate{cert}
+		valid = true
+	}
+
+	if caCert != "" {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(caCert))
+		config.RootCAs = caCertPool
+		config.InsecureSkipVerify = true
+		valid = true
+	}
+
+	if !valid {
+		config = nil
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
Signed-off-by: aman-bansal <bansalaman2905@gmail.com>

This PR is to add authentication for metric_api_scaler. Three methods have been added. They will be identified on the basis of `authMode` parameter.

1. API Key Based auth: auth mode would `apiKeyAuth`. API key needs to be provided. Default behaviour would be to send it in headers. This can be changed via method and header/query param keys can be changed via keyParamName.

2. Basic Auth: auth mode would `basicAuth`. Username is compulsory. Password isn't. This is based on experience over basic auth. Some people just put api key as the username to ease out authentication at their end.

3. Client Certification: auth mode would `tlsAuth`. cert, cacert and key needs to be provided.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Changelog has been updated

Relates to #1082 #1083 #1084 

[Edit]
Docs PR attached https://github.com/kedacore/keda-docs/pull/260