### PR TITLE
Rename `queueLength` to `messageCount` for Azure Service Bus scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Removed deprecated brokerList for Kafka scaler ([#882](https://github.com/kedacore/keda/pull/882))
 - All scalers metadata that is resolved from the scaleTarget environment have suffix `FromEnv` added. e.g: `connection` -> `connectionFromEnv`
 - Kafka: split metadata and config for SASL and TLS ([#1074](https://github.com/kedacore/keda/pull/1074))
+- Service Bus: `queueLength` is now called `messageCount` ([#1109](https://github.com/kedacore/keda/issues/1109))
 
 ### Other
 - Update Operator SDK and k8s deps ([#1007](https://github.com/kedacore/keda/pull/1007),[#870](https://github.com/kedacore/keda/issues/870))

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -20,9 +20,9 @@ import (
 type entityType int
 
 const (
-	none         entityType = 0
-	queue        entityType = 1
-	subscription entityType = 2
+	none           entityType = 0
+	queue          entityType = 1
+	subscription   entityType = 2
 	messageCountMetricName    = "messageCount"
 	defaultTargetMessageCount = 5
 )

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/kedacore/keda/pkg/scalers/azure"
-
-	servicebus "github.com/Azure/azure-service-bus-go"
-
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
+	servicebus "github.com/Azure/azure-service-bus-go"
+	"github.com/kedacore/keda/pkg/scalers/azure"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -3,8 +3,9 @@ package scalers
 import (
 	"context"
 	"fmt"
-	"github.com/kedacore/keda/pkg/scalers/azure"
 	"strconv"
+
+	"github.com/kedacore/keda/pkg/scalers/azure"
 
 	servicebus "github.com/Azure/azure-service-bus-go"
 
@@ -20,11 +21,11 @@ import (
 type entityType int
 
 const (
-	none           entityType = 0
-	queue          entityType = 1
-	subscription   entityType = 2
-	messageCountMetricName    = "messageCount"
-	defaultTargetMessageCount = 5
+	none                      entityType = 0
+	queue                     entityType = 1
+	subscription              entityType = 2
+	messageCountMetricName               = "messageCount"
+	defaultTargetMessageCount            = 5
 )
 
 var azureServiceBusLog = logf.Log.WithName("azure_servicebus_scaler")

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -23,6 +23,8 @@ const (
 	none         entityType = 0
 	queue        entityType = 1
 	subscription entityType = 2
+	messageCountMetricName    = "messageCount"
+	defaultTargetMessageCount = 5
 )
 
 var azureServiceBusLog = logf.Log.WithName("azure_servicebus_scaler")
@@ -59,15 +61,15 @@ func NewAzureServiceBusScaler(resolvedEnv, metadata, authParams map[string]strin
 func parseAzureServiceBusMetadata(resolvedEnv, metadata, authParams map[string]string, podIdentity string) (*azureServiceBusMetadata, error) {
 	meta := azureServiceBusMetadata{}
 	meta.entityType = none
-	meta.targetLength = defaultTargetQueueLength
+	meta.targetLength = defaultTargetMessageCount
 
 	// get target metric value
-	if val, ok := metadata[queueLengthMetricName]; ok {
-		queueLength, err := strconv.Atoi(val)
+	if val, ok := metadata[messageCountMetricName]; ok {
+		messageCount, err := strconv.Atoi(val)
 		if err != nil {
-			azureServiceBusLog.Error(err, "Error parsing azure queue metadata", "queueLengthMetricName", queueLengthMetricName)
+			azureServiceBusLog.Error(err, "Error parsing azure queue metadata", "messageCount", messageCountMetricName)
 		} else {
-			meta.targetLength = queueLength
+			meta.targetLength = messageCount
 		}
 	}
 

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -63,7 +63,7 @@ var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 
 var azServiceBusMetricIdentifiers = []azServiceBusMetricIdentifier{
 	{&parseServiceBusMetadataDataset[1], "azure-servicebus-testqueue"},
-	{&parseServiceBusMetadataDataset[2], "azure-servicebus-testtopic-testsubscription"},
+	{&parseServiceBusMetadataDataset[3], "azure-servicebus-testtopic-testsubscription"},
 }
 
 var getServiceBusLengthTestScalers = []azureServiceBusScaler{

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -12,6 +12,7 @@ const (
 	queueName         = "testqueue"
 	connectionSetting = "none"
 	namespaceName     = "ns"
+	messageCount      = "1000"
 )
 
 type parseServiceBusMetadataTestData struct {
@@ -36,8 +37,16 @@ var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 	{map[string]string{}, true, none, map[string]string{}, ""},
 	// properly formed queue
 	{map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting}, false, queue, map[string]string{}, ""},
+	// properly formed queue with message count
+	{map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting, "messageCount": messageCount}, false, queue, map[string]string{}, ""},
+	// properly formed queue with message count as nil
+	{map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting, "messageCount": nil}, true, queue, map[string]string{}, ""},
 	// properly formed topic & subscription
 	{map[string]string{"topicName": topicName, "subscriptionName": subscriptionName, "connectionFromEnv": connectionSetting}, false, subscription, map[string]string{}, ""},
+	// properly formed topic & subscription with message count
+	{map[string]string{"topicName": topicName, "subscriptionName": subscriptionName, "connectionFromEnv": connectionSetting, "messageCount": messageCount}, false, subscription, map[string]string{}, ""},
+	// properly formed topic & subscription with message count
+	{map[string]string{"topicName": topicName, "subscriptionName": subscriptionName, "connectionFromEnv": connectionSetting, "messageCount": nil}, true, subscription, map[string]string{}, ""},
 	// queue and topic specified
 	{map[string]string{"queueName": queueName, "topicName": topicName, "connectionFromEnv": connectionSetting}, true, none, map[string]string{}, ""},
 	// queue and subscription specified

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -39,14 +39,10 @@ var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 	{map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting}, false, queue, map[string]string{}, ""},
 	// properly formed queue with message count
 	{map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting, "messageCount": messageCount}, false, queue, map[string]string{}, ""},
-	// properly formed queue with message count as nil
-	{map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting, "messageCount": nil}, true, queue, map[string]string{}, ""},
 	// properly formed topic & subscription
 	{map[string]string{"topicName": topicName, "subscriptionName": subscriptionName, "connectionFromEnv": connectionSetting}, false, subscription, map[string]string{}, ""},
 	// properly formed topic & subscription with message count
 	{map[string]string{"topicName": topicName, "subscriptionName": subscriptionName, "connectionFromEnv": connectionSetting, "messageCount": messageCount}, false, subscription, map[string]string{}, ""},
-	// properly formed topic & subscription with message count
-	{map[string]string{"topicName": topicName, "subscriptionName": subscriptionName, "connectionFromEnv": connectionSetting, "messageCount": nil}, true, subscription, map[string]string{}, ""},
 	// queue and topic specified
 	{map[string]string{"queueName": queueName, "topicName": topicName, "connectionFromEnv": connectionSetting}, true, none, map[string]string{}, ""},
 	// queue and subscription specified


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Rename `queueLength` to `messageCount` for Azure Service Bus scaler since this is confusing when using topics.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Changelog has been updated

I'll open a doc PR when this is agreed and merged. ([depends on this PR as well](https://github.com/kedacore/keda-docs/pull/251))

Relates to #1109
