### PR TITLE
update version.go properly during make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ publish: docker-build
 # Release                                        #
 ##################################################
 .PHONY: release
-release: manifests kustomize
+release: manifests kustomize set-version
 	cd config/manager && \
 	$(KUSTOMIZE) edit set image docker.io/kedacore/keda=${IMAGE_CONTROLLER}
 	cd config/metrics-server && \


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

When we are doing release (ie. `make release`), a version in version.go wasn't updated, because the proper make target wasn't called. Therefore the version displayed in pods logs wasn't correct (it shows `v2` instead of `2.0.0-beta` for the Beta release).