### PR TITLE
BugFix: Azure Log Analytics E2E test failed.

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -43,4 +43,5 @@ jobs:
           AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
           AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
           TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
+          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
         run: make e2e-test

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -22,4 +22,5 @@ jobs:
           AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
           AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
           TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
+          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
         run: make e2e-test


### PR DESCRIPTION
This fix is related to this bug: https://github.com/kedacore/keda/issues/1150
The problem is that "TEST_LOG_ANALYTICS_WORKSPACE_ID" env. variable not exposed in "nightly-e2e.yml" and "master-build.yml"

Signed-off-by: Sergiy Poplavskyi <spopla@microsoft.com>