### PR TITLE
resolve k8s Minor version correctly

### DIFF
--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -64,7 +64,7 @@ func (r *ScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	version, err := clientset.ServerVersion()
 	if err == nil {
 		r.kubeVersion = kedautil.NewK8sVersion(version)
-		r.Log.Info("Running on Kubernetes " + r.kubeVersion.PrettyVersion)
+		r.Log.Info("Running on Kubernetes "+r.kubeVersion.PrettyVersion, "version", version)
 	} else {
 		r.Log.Error(err, "Not able to get Kubernetes version")
 	}

--- a/pkg/util/k8sversion.go
+++ b/pkg/util/k8sversion.go
@@ -17,8 +17,10 @@ type K8sVersion struct {
 // NewK8sVersion will parse a version info and return a struct
 func NewK8sVersion(version *version.Info) K8sVersion {
 	minorTrimmed := ""
-	if len(version.Minor) > 2 {
+	if len(version.Minor) >= 2 {
 		minorTrimmed = version.Minor[:2]
+	} else {
+		minorTrimmed = version.Minor
 	}
 
 	parsed := false

--- a/pkg/util/k8sversion_test.go
+++ b/pkg/util/k8sversion_test.go
@@ -1,0 +1,78 @@
+package util
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+type testMetadata struct {
+	comment        string
+	expectedMinor  int
+	expectedPretty string
+	version        *version.Info
+}
+
+var testMetadatas = []testMetadata{
+	{
+		comment:        "Testing 1.18+",
+		expectedMinor:  18,
+		expectedPretty: "1.18+",
+		version: &version.Info{
+			Major: "1",
+			Minor: "18+",
+		},
+	},
+	{
+		comment:        "Testing 1.18",
+		expectedMinor:  18,
+		expectedPretty: "1.18",
+		version: &version.Info{
+			Major: "1",
+			Minor: "18",
+		},
+	},
+	{
+		comment:        "Testing 1.19.84324.2",
+		expectedMinor:  19,
+		expectedPretty: "1.19.84324.2",
+		version: &version.Info{
+			Major: "1",
+			Minor: "19.84324.2",
+		},
+	},
+	{
+		comment:        "Testing 2.1",
+		expectedMinor:  1,
+		expectedPretty: "2.1",
+		version: &version.Info{
+			Major: "2",
+			Minor: "1",
+		},
+	},
+	{
+		comment:        "Testing 2.",
+		expectedMinor:  0,
+		expectedPretty: "2.",
+		version: &version.Info{
+			Major: "2",
+			Minor: "",
+		},
+	},
+}
+
+func TestResolveK8sVersion(t *testing.T) {
+
+	for _, testData := range testMetadatas {
+
+		version := NewK8sVersion(testData.version)
+
+		if version.MinorVersion != testData.expectedMinor {
+			t.Error("Failed to resolve k8s Minor Version correctly", "wants", testData.expectedMinor, "got", version.MinorVersion)
+		}
+
+		if version.PrettyVersion != testData.expectedPretty {
+			t.Error("Failed to resolve k8s Pretty Version correctly", "wants", testData.expectedPretty, "got", version.PrettyVersion)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->


k8s version wasn't correctly resolved if `len(Minor) <= 2` 
For example: `18+` vs `19` or `18`

Adding tests

Fixes #1176 

