### PR TITLE
Avoid exception when CRD doesn't follow Pod spec shape

### DIFF
--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -58,6 +58,10 @@ func ResolveAuthRef(client client.Client, logger logr.Logger, triggerAuthRef *ke
 			}
 			if triggerAuth.Spec.Env != nil {
 				for _, e := range triggerAuth.Spec.Env {
+					if podSpec == nil {
+						result[e.Parameter] = ""
+						continue
+					}
 					env, err := ResolveContainerEnv(client, logger, podSpec, e.ContainerName, namespace)
 					if err != nil {
 						result[e.Parameter] = ""

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -306,11 +306,7 @@ func (h *scaleHandler) buildScalers(withTriggers *kedav1alpha1.WithTriggers, pod
 	}
 
 	for i, trigger := range withTriggers.Spec.Triggers {
-		var authParams map[string]string
-		var podIdentity string
-		if podTemplateSpec != nil {
-			authParams, podIdentity = resolver.ResolveAuthRef(h.client, logger, trigger.AuthenticationRef, &podTemplateSpec.Spec, withTriggers.Namespace)
-		}
+		authParams, podIdentity := resolver.ResolveAuthRef(h.client, logger, trigger.AuthenticationRef, &podTemplateSpec.Spec, withTriggers.Namespace)
 		if podIdentity == kedav1alpha1.PodIdentityProviderAwsEKS {
 			serviceAccountName := podTemplateSpec.Spec.ServiceAccountName
 			serviceAccount := &corev1.ServiceAccount{}
@@ -353,8 +349,7 @@ func (h *scaleHandler) getPods(scalableObject interface{}) (*corev1.PodTemplateS
 		}
 
 		if withPods.Spec.Template.Spec.Containers == nil {
-			h.logger.Info("There aren't any containers in the ScaleTarget", "resource", obj.Status.ScaleTargetGVKR.GVKString(), "name", obj.Spec.ScaleTargetRef.Name)
-			h.logger.Info("You may not be able to use all scaler types")
+			h.logger.V(1).Info("There aren't any containers found in the ScaleTarget, therefore it is no possible to inject environment properties", "resource", obj.Status.ScaleTargetGVKR.GVKString(), "name", obj.Spec.ScaleTargetRef.Name)
 			return nil, "", nil
 		}
 


### PR DESCRIPTION
Signed-off-by: Ang Gao <ang.gao87@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Patches to avoid exception when CRD doesn't follow Pod spec shape

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #1194
