### PR TITLE
[v2]. Azure Log Analytics scaler: solve AAD throttling limitation. Changed log messages.

### DIFF
--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -342,7 +342,7 @@ func (s *azureLogAnalyticsScaler) executeQuery(query string, tokenInfo tokenData
 
 	err = json.NewDecoder(bytes.NewReader(body)).Decode(&queryData)
 	if err != nil {
-		return metricsData{}, fmt.Errorf("Error processing Log Analytics request. Details: can't decode responce body to JSON from REST API result. HTTP code: %d. Inner Error: %v. Body: %s", statusCode, err, string(body))
+		return metricsData{}, fmt.Errorf("Error processing Log Analytics request. Details: can't decode response body to JSON from REST API result. HTTP code: %d. Inner Error: %v. Body: %s", statusCode, err, string(body))
 	}
 
 	if statusCode == 200 {
@@ -449,7 +449,7 @@ func (s *azureLogAnalyticsScaler) getAuthorizationToken() (tokenData, error) {
 
 	err = json.NewDecoder(bytes.NewReader(body)).Decode(&tokenInfo)
 	if err != nil {
-		return tokenData{}, fmt.Errorf("Error getting access token. Details: can't decode responce body to JSON after getting access token. HTTP code: %d. Inner Error: %v. Body: %s", statusCode, err, string(body))
+		return tokenData{}, fmt.Errorf("Error getting access token. Details: can't decode response body to JSON after getting access token. HTTP code: %d. Inner Error: %v. Body: %s", statusCode, err, string(body))
 	}
 
 	if statusCode == 200 {
@@ -526,14 +526,13 @@ func (s *azureLogAnalyticsScaler) runHTTP(request *http.Request, caller string) 
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("Error reading %s responce body: Inner Error: %v", caller, err)
+		return nil, resp.StatusCode, fmt.Errorf("Error reading %s response body: Inner Error: %v", caller, err)
 	}
 
 	return body, resp.StatusCode, nil
 }
 
 func getTokenFromCache(clientID string, clientSecret string) (tokenData, error) {
-
 	key, err := getHash(clientID, clientSecret)
 	if err != nil {
 		return tokenData{}, fmt.Errorf("Error calculating sha1 hash. Inner Error: %v", err)
@@ -551,7 +550,6 @@ func getTokenFromCache(clientID string, clientSecret string) (tokenData, error) 
 }
 
 func setTokenInCache(clientID string, clientSecret string, tokenInfo tokenData) error {
-
 	key, err := getHash(clientID, clientSecret)
 	if err != nil {
 		return err

--- a/pkg/scalers/azure_log_analytics_scaler_test.go
+++ b/pkg/scalers/azure_log_analytics_scaler_test.go
@@ -145,7 +145,7 @@ func TestLogAnalyticsGetMetricSpecForScaling(t *testing.T) {
 			t.Fatal("Could not parse metadata:", err)
 		}
 		cache := &sessionCache{metricValue: 1, metricThreshold: 2}
-		mockLogAnalyticsScaler := azureLogAnalyticsScaler{meta, cache}
+		mockLogAnalyticsScaler := azureLogAnalyticsScaler{meta, cache, "test-so", "test-ns"}
 
 		metricSpec := mockLogAnalyticsScaler.GetMetricSpecForScaling()
 		metricName := metricSpec[0].External.Metric.Name

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -379,7 +379,7 @@ func buildScaler(name, namespace, triggerType string, resolvedEnv, triggerMetada
 	case "azure-eventhub":
 		return scalers.NewAzureEventHubScaler(resolvedEnv, triggerMetadata, authParams)
 	case "azure-log-analytics":
-		return scalers.NewAzureLogAnalyticsScaler(resolvedEnv, triggerMetadata, authParams, podIdentity)
+		return scalers.NewAzureLogAnalyticsScaler(resolvedEnv, triggerMetadata, authParams, podIdentity, name, namespace)
 	case "azure-monitor":
 		return scalers.NewAzureMonitorScaler(resolvedEnv, triggerMetadata, authParams, podIdentity)
 	case "azure-queue":


### PR DESCRIPTION
### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [X] Tests have been added
- [X] A PR [#269](https://github.com/kedacore/keda-docs/pull/269) is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

This PR to address an AAD throttling limitation (200 AAD requests per 30 secs).
in memory cache to store AAD tokens has been introduced. So now, tokens will not be requested for each pooling interval. Instead, they will be stored in memory and refreshed once expired.

Also, log messages has been updated to follow the same messaging pattern and provide more information on error occured.

Signed-off-by: Sergiy Poplavskyi <spopla@microsoft.com>