### PR TITLE
Enable gloangcilint: ineffassign, staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,8 +22,8 @@ linters:
     - misspell
     - bodyclose
     - unconvert
+    - ineffassign
     #- interfacer
-    #- ineffassign
     #- scopelint
     #- structcheck
     - deadcode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - bodyclose
     - unconvert
     - ineffassign
+    - staticcheck
     #- interfacer
     #- scopelint
     #- structcheck

--- a/api/v1alpha1/triggerauthentication_types.go
+++ b/api/v1alpha1/triggerauthentication_types.go
@@ -50,11 +50,11 @@ type PodIdentityProvider string
 // PodIdentityProvider<IDENTITY_PROVIDER> specifies other available Identity providers
 const (
 	PodIdentityProviderNone    PodIdentityProvider = "none"
-	PodIdentityProviderAzure                       = "azure"
-	PodIdentityProviderGCP                         = "gcp"
-	PodIdentityProviderSpiffe                      = "spiffe"
-	PodIdentityProviderAwsEKS                      = "aws-eks"
-	PodIdentityProviderAwsKiam                     = "aws-kiam"
+	PodIdentityProviderAzure   PodIdentityProvider = "azure"
+	PodIdentityProviderGCP     PodIdentityProvider = "gcp"
+	PodIdentityProviderSpiffe  PodIdentityProvider = "spiffe"
+	PodIdentityProviderAwsEKS  PodIdentityProvider = "aws-eks"
+	PodIdentityProviderAwsKiam PodIdentityProvider = "aws-kiam"
 )
 
 // PodIdentityAnnotationEKS specifies aws role arn for aws-eks Identity Provider
@@ -118,7 +118,7 @@ type VaultAuthentication string
 // Client authenticating to Vault
 const (
 	VaultAuthenticationToken      VaultAuthentication = "token"
-	VaultAuthenticationKubernetes                     = "kubernetes"
+	VaultAuthenticationKubernetes VaultAuthentication = "kubernetes"
 	// VaultAuthenticationAWS                            = "aws"
 )
 

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -162,9 +162,8 @@ func (s *artemisScaler) getMonitoringEndpoint() string {
 }
 
 func (s *artemisScaler) getQueueMessageCount() (int, error) {
-	var messageCount int
 	var monitoringInfo *artemisMonitoring
-	messageCount = 0
+	messageCount := 0
 
 	client := &http.Client{
 		Timeout: time.Second * 3,

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -271,7 +271,7 @@ func getTotalLagRelatedToPartitionAmount(unprocessedEventsCount int64, partition
 // Close closes Azure Event Hub Scaler
 func (scaler *azureEventHubScaler) Close() error {
 	if scaler.client != nil {
-		err := scaler.client.Close(nil)
+		err := scaler.client.Close(context.TODO())
 		if err != nil {
 			eventhubLog.Error(err, "error closing azure event hub client")
 			return err

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -312,6 +312,9 @@ func (s *azureLogAnalyticsScaler) executeQuery(query string, tokenInfo tokenData
 	//Handle expired token
 	if statusCode == 403 || (len(body) > 0 && strings.Contains(string(body), "TokenExpired")) {
 		tokenInfo, err := s.refreshAccessToken()
+		if err != nil {
+			return metricsData{}, err
+		}
 
 		if s.metadata.podIdentity == "" {
 			logAnalyticsLog.V(1).Info("Token for Service Principal has been refreshed", "clientID", s.metadata.clientID, "scaler name", s.name, "namespace", s.namespace)
@@ -434,7 +437,11 @@ func (s *azureLogAnalyticsScaler) refreshAccessToken() (tokenData, error) {
 }
 
 func (s *azureLogAnalyticsScaler) getAuthorizationToken() (tokenData, error) {
-	body, statusCode, err, tokenInfo := []byte{}, 0, *new(error), tokenData{}
+	var body []byte
+	var statusCode int
+	var err error
+	var tokenInfo tokenData
+
 	if s.metadata.podIdentity == "" {
 		body, statusCode, err = s.executeAADApicall()
 	} else {

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -306,8 +306,11 @@ func (s *azureLogAnalyticsScaler) getAccessToken() (tokenData, error) {
 
 func (s *azureLogAnalyticsScaler) executeQuery(query string, tokenInfo tokenData) (metricsData, error) {
 	queryData := queryResult{}
+	var body []byte
+	var statusCode int
+	var err error
 
-	body, statusCode, err := s.executeLogAnalyticsREST(query, tokenInfo)
+	body, statusCode, err = s.executeLogAnalyticsREST(query, tokenInfo)
 
 	//Handle expired token
 	if statusCode == 403 || (len(body) > 0 && strings.Contains(string(body), "TokenExpired")) {

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -314,7 +314,7 @@ func (s *azureLogAnalyticsScaler) executeQuery(query string, tokenInfo tokenData
 
 	//Handle expired token
 	if statusCode == 403 || (len(body) > 0 && strings.Contains(string(body), "TokenExpired")) {
-		tokenInfo, err := s.refreshAccessToken()
+		tokenInfo, err = s.refreshAccessToken()
 		if err != nil {
 			return metricsData{}, err
 		}

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -33,9 +33,12 @@ type liiklusMetadata struct {
 }
 
 const (
-	defaultLiiklusLagThreshold    int64 = 10
-	liiklusLagThresholdMetricName       = "lagThreshold"
-	liiklusMetricType                   = "External"
+	defaultLiiklusLagThreshold int64 = 10
+)
+
+const (
+	liiklusLagThresholdMetricName = "lagThreshold"
+	liiklusMetricType             = "External"
 )
 
 // NewLiiklusScaler creates a new liiklusScaler scaler

--- a/pkg/scaling/resolver/hashicorpvault_handler.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler.go
@@ -29,6 +29,9 @@ func NewHashicorpVaultHandler(v *kedav1alpha1.HashiCorpVault) *HashicorpVaultHan
 func (vh *HashicorpVaultHandler) Initialize(logger logr.Logger) error {
 	config := vaultApi.DefaultConfig()
 	client, err := vaultApi.NewClient(config)
+	if err != nil {
+		return err
+	}
 
 	err = client.SetAddress(vh.vault.Address)
 	if err != nil {

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -314,7 +314,8 @@ func (h *scaleHandler) buildScalers(withTriggers *kedav1alpha1.WithTriggers, pod
 
 	for i, trigger := range withTriggers.Spec.Triggers {
 		authParams, podIdentity := resolver.ResolveAuthRef(h.client, logger, trigger.AuthenticationRef, &podTemplateSpec.Spec, withTriggers.Namespace)
-		if podIdentity == kedav1alpha1.PodIdentityProviderAwsEKS {
+
+		if kedav1alpha1.PodIdentityProvider(podIdentity) == kedav1alpha1.PodIdentityProviderAwsEKS {
 			serviceAccountName := podTemplateSpec.Spec.ServiceAccountName
 			serviceAccount := &corev1.ServiceAccount{}
 			err = h.client.Get(context.TODO(), types.NamespacedName{Name: serviceAccountName, Namespace: withTriggers.Namespace}, serviceAccount)
@@ -323,7 +324,7 @@ func (h *scaleHandler) buildScalers(withTriggers *kedav1alpha1.WithTriggers, pod
 				return []scalers.Scaler{}, fmt.Errorf("error getting service account: %s", err)
 			}
 			authParams["awsRoleArn"] = serviceAccount.Annotations[kedav1alpha1.PodIdentityAnnotationEKS]
-		} else if podIdentity == kedav1alpha1.PodIdentityProviderAwsKiam {
+		} else if kedav1alpha1.PodIdentityProvider(podIdentity) == kedav1alpha1.PodIdentityProviderAwsKiam {
 			authParams["awsRoleArn"] = podTemplateSpec.ObjectMeta.Annotations[kedav1alpha1.PodIdentityAnnotationKiam]
 		}
 

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -432,31 +432,29 @@ func buildScaler(name, namespace, triggerType string, resolvedEnv, triggerMetada
 }
 
 func asDuckWithTriggers(scalableObject interface{}) (*kedav1alpha1.WithTriggers, error) {
-	withTriggers := &kedav1alpha1.WithTriggers{}
 	switch obj := scalableObject.(type) {
 	case *kedav1alpha1.ScaledObject:
-		withTriggers = &kedav1alpha1.WithTriggers{
+		return &kedav1alpha1.WithTriggers{
 			TypeMeta:   obj.TypeMeta,
 			ObjectMeta: obj.ObjectMeta,
 			Spec: kedav1alpha1.WithTriggersSpec{
 				PollingInterval: obj.Spec.PollingInterval,
 				Triggers:        obj.Spec.Triggers,
 			},
-		}
+		}, nil
 	case *kedav1alpha1.ScaledJob:
-		withTriggers = &kedav1alpha1.WithTriggers{
+		return &kedav1alpha1.WithTriggers{
 			TypeMeta:   obj.TypeMeta,
 			ObjectMeta: obj.ObjectMeta,
 			Spec: kedav1alpha1.WithTriggersSpec{
 				PollingInterval: obj.Spec.PollingInterval,
 				Triggers:        obj.Spec.Triggers,
 			},
-		}
+		}, nil
 	default:
 		// here could be the conversion from unknown Duck type potentially in the future
 		return nil, fmt.Errorf("unknown scalable object type %v", scalableObject)
 	}
-	return withTriggers, nil
 }
 
 func closeScalers(scalers []scalers.Scaler) {


### PR DESCRIPTION
Adding ineffassign and staticcheck linter together because they both have some overlapping checks.

Looks like `PodIdentityProvider*` constants were all meant to be of `PodIdentityProvider` type, but this was missed. For now I worked around this by adding a couple of type casts. Should I instead propagate this change and use `PodIdentityProvider` instead of `string` for pod identity everywhere?

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

Part of #1158
