### PR TITLE
Set warning for External Push Scaler for ScaledJob

### DIFF
--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -166,8 +166,7 @@ func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav
 					case *kedav1alpha1.ScaledObject:
 						h.scaleExecutor.RequestScale(ctx, obj, active)
 					case *kedav1alpha1.ScaledJob:
-						// TODO: revisit when implementing ScaledJob
-						h.scaleExecutor.RequestJobScale(ctx, obj, active, 1, 1)
+						h.logger.Info("Warning: External Push Scaler does not support ScaledJob", "object", scalableObject)
 					}
 					scalingMutex.Unlock()
 				}


### PR DESCRIPTION
I discuss with @ahmelsayed , There is no usecase for ScaledJob to enalbe Extrenal Push Scalers. 
So we decided to go with just add warning in case customer set it. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
https://github.com/kedacore/keda/issues/1035