### PR TITLE
fix: ScaledJob Target Average Value

### DIFF
--- a/pkg/scaling/scale_hander_test.go
+++ b/pkg/scaling/scale_hander_test.go
@@ -1,0 +1,51 @@
+package scaling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestTargetAverageValue(t *testing.T) {
+	// count = 0
+	specs := []v2beta2.MetricSpec{}
+	targetAverageValue := getTargetAverageValue(specs)
+	assert.Equal(t, int64(0), targetAverageValue)
+	// 1 1
+	specs = []v2beta2.MetricSpec{
+		createMetricSpec(1),
+		createMetricSpec(1),
+	}
+	targetAverageValue = getTargetAverageValue(specs)
+	assert.Equal(t, int64(1), targetAverageValue)
+	// 5 5 3
+	specs = []v2beta2.MetricSpec{
+		createMetricSpec(5),
+		createMetricSpec(5),
+		createMetricSpec(3),
+	}
+	targetAverageValue = getTargetAverageValue(specs)
+	assert.Equal(t, int64(4), targetAverageValue)
+
+	// 5 5 4
+	specs = []v2beta2.MetricSpec{
+		createMetricSpec(5),
+		createMetricSpec(5),
+		createMetricSpec(3),
+	}
+	targetAverageValue = getTargetAverageValue(specs)
+	assert.Equal(t, int64(4), targetAverageValue)
+}
+
+func createMetricSpec(averageValue int) v2beta2.MetricSpec {
+	qty := resource.NewQuantity(int64(averageValue), resource.DecimalSI)
+	return v2beta2.MetricSpec{
+		External: &v2beta2.ExternalMetricSource{
+			Target: v2beta2.MetricTarget{
+				AverageValue: qty,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Thank you for the bug report on slack. 
https://kubernetes.slack.com/archives/CKZJ36A5D/p1602028423055600

Target Average Value was wrong for the Scaled Jobs if they use multiple triggers. 

I tested by ServiceBus scaler. 
https://github.com/TsuyoshiUshio/sample-go-servicebus-queue
### Checklist

- [-] Commits are signed with Developer Certificate of Origin (DCO)
- [-] Tests have been added
