### PR TITLE
Pod identity provider type

### DIFF
--- a/api/v1alpha1/triggerauthentication_types.go
+++ b/api/v1alpha1/triggerauthentication_types.go
@@ -50,11 +50,11 @@ type PodIdentityProvider string
 // PodIdentityProvider<IDENTITY_PROVIDER> specifies other available Identity providers
 const (
 	PodIdentityProviderNone    PodIdentityProvider = "none"
-	PodIdentityProviderAzure                       = "azure"
-	PodIdentityProviderGCP                         = "gcp"
-	PodIdentityProviderSpiffe                      = "spiffe"
-	PodIdentityProviderAwsEKS                      = "aws-eks"
-	PodIdentityProviderAwsKiam                     = "aws-kiam"
+	PodIdentityProviderAzure   PodIdentityProvider = "azure"
+	PodIdentityProviderGCP     PodIdentityProvider = "gcp"
+	PodIdentityProviderSpiffe  PodIdentityProvider = "spiffe"
+	PodIdentityProviderAwsEKS  PodIdentityProvider = "aws-eks"
+	PodIdentityProviderAwsKiam PodIdentityProvider = "aws-kiam"
 )
 
 // PodIdentityAnnotationEKS specifies aws role arn for aws-eks Identity Provider

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -54,8 +54,8 @@ const (
 var artemisLog = logf.Log.WithName("artemis_queue_scaler")
 
 // NewArtemisQueueScaler creates a new artemis queue Scaler
-func NewArtemisQueueScaler(resolvedSecrets, metadata, authParams map[string]string) (Scaler, error) {
-	artemisMetadata, err := parseArtemisMetadata(resolvedSecrets, metadata, authParams)
+func NewArtemisQueueScaler(config *ScalerConfig) (Scaler, error) {
+	artemisMetadata, err := parseArtemisMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing artemis metadata: %s", err)
 	}
@@ -65,38 +65,38 @@ func NewArtemisQueueScaler(resolvedSecrets, metadata, authParams map[string]stri
 	}, nil
 }
 
-func parseArtemisMetadata(resolvedEnv, metadata, authParams map[string]string) (*artemisMetadata, error) {
+func parseArtemisMetadata(config *ScalerConfig) (*artemisMetadata, error) {
 	meta := artemisMetadata{}
 
 	meta.queueLength = defaultArtemisQueueLength
 
-	if val, ok := metadata["restApiTemplate"]; ok && val != "" {
-		meta.restAPITemplate = metadata["restApiTemplate"]
+	if val, ok := config.TriggerMetadata["restApiTemplate"]; ok && val != "" {
+		meta.restAPITemplate = config.TriggerMetadata["restApiTemplate"]
 	} else {
 		meta.restAPITemplate = defaultRestAPITemplate
 	}
 
-	if metadata["managementEndpoint"] == "" {
+	if config.TriggerMetadata["managementEndpoint"] == "" {
 		return nil, errors.New("no management endpoint given")
 	}
-	meta.managementEndpoint = metadata["managementEndpoint"]
+	meta.managementEndpoint = config.TriggerMetadata["managementEndpoint"]
 
-	if metadata["queueName"] == "" {
+	if config.TriggerMetadata["queueName"] == "" {
 		return nil, errors.New("no queue name given")
 	}
-	meta.queueName = metadata["queueName"]
+	meta.queueName = config.TriggerMetadata["queueName"]
 
-	if metadata["brokerName"] == "" {
+	if config.TriggerMetadata["brokerName"] == "" {
 		return nil, errors.New("no broker name given")
 	}
-	meta.brokerName = metadata["brokerName"]
+	meta.brokerName = config.TriggerMetadata["brokerName"]
 
-	if metadata["brokerAddress"] == "" {
+	if config.TriggerMetadata["brokerAddress"] == "" {
 		return nil, errors.New("no broker address given")
 	}
-	meta.brokerAddress = metadata["brokerAddress"]
+	meta.brokerAddress = config.TriggerMetadata["brokerAddress"]
 
-	if val, ok := metadata["queueLength"]; ok {
+	if val, ok := config.TriggerMetadata["queueLength"]; ok {
 		queueLength, err := strconv.Atoi(val)
 		if err != nil {
 			return nil, fmt.Errorf("can't parse queueLength: %s", err)
@@ -105,12 +105,12 @@ func parseArtemisMetadata(resolvedEnv, metadata, authParams map[string]string) (
 		meta.queueLength = queueLength
 	}
 
-	if val, ok := authParams["username"]; ok && val != "" {
+	if val, ok := config.AuthParams["username"]; ok && val != "" {
 		meta.username = val
-	} else if val, ok := metadata["username"]; ok && val != "" {
+	} else if val, ok := config.TriggerMetadata["username"]; ok && val != "" {
 		username := val
 
-		if val, ok := resolvedEnv[username]; ok && val != "" {
+		if val, ok := config.ResolvedEnv[username]; ok && val != "" {
 			meta.username = val
 		} else {
 			meta.username = username
@@ -121,12 +121,12 @@ func parseArtemisMetadata(resolvedEnv, metadata, authParams map[string]string) (
 		return nil, fmt.Errorf("username cannot be empty")
 	}
 
-	if val, ok := authParams["password"]; ok && val != "" {
+	if val, ok := config.AuthParams["password"]; ok && val != "" {
 		meta.password = val
-	} else if val, ok := metadata["password"]; ok && val != "" {
+	} else if val, ok := config.TriggerMetadata["password"]; ok && val != "" {
 		password := val
 
-		if val, ok := resolvedEnv[password]; ok && val != "" {
+		if val, ok := config.ResolvedEnv[password]; ok && val != "" {
 			meta.password = val
 		} else {
 			meta.password = password

--- a/pkg/scalers/artemis_scaler_test.go
+++ b/pkg/scalers/artemis_scaler_test.go
@@ -79,7 +79,7 @@ var testArtemisMetadataWithAuthParams = []parseArtemisMetadataTestData{
 
 func TestArtemisParseMetadata(t *testing.T) {
 	for _, testData := range testArtemisMetadata {
-		_, err := parseArtemisMetadata(sampleArtemisResolvedEnv, testData.metadata, nil)
+		_, err := parseArtemisMetadata(&ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: nil})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -90,7 +90,7 @@ func TestArtemisParseMetadata(t *testing.T) {
 
 	// test with missing auth params should all fail
 	for _, testData := range testArtemisMetadataWithEmptyAuthParams {
-		_, err := parseArtemisMetadata(sampleArtemisResolvedEnv, testData.metadata, emptyArtemisAuthParams)
+		_, err := parseArtemisMetadata(&ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: emptyArtemisAuthParams})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -101,7 +101,7 @@ func TestArtemisParseMetadata(t *testing.T) {
 
 	// test with complete auth params should not fail
 	for _, testData := range testArtemisMetadataWithAuthParams {
-		_, err := parseArtemisMetadata(sampleArtemisResolvedEnv, testData.metadata, artemisAuthParams)
+		_, err := parseArtemisMetadata(&ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: artemisAuthParams})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -113,7 +113,7 @@ func TestArtemisParseMetadata(t *testing.T) {
 
 func TestArtemisGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range artemisMetricIdentifiers {
-		meta, err := parseArtemisMetadata(sampleArtemisResolvedEnv, testData.metadataTestData.metadata, nil)
+		meta, err := parseArtemisMetadata(&ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: nil})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/aws_cloudwatch_test.go
+++ b/pkg/scalers/aws_cloudwatch_test.go
@@ -172,7 +172,7 @@ var awsCloudwatchMetricIdentifiers = []awsCloudwatchMetricIdentifier{
 
 func TestCloudwatchParseMetadata(t *testing.T) {
 	for _, testData := range testAWSCloudwatchMetadata {
-		_, err := parseAwsCloudwatchMetadata(testData.metadata, testAWSCloudwatchResolvedEnv, testData.authParams)
+		_, err := parseAwsCloudwatchMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testAWSCloudwatchResolvedEnv, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Errorf("%s: Expected success but got error %s", testData.comment, err)
 		}
@@ -184,7 +184,7 @@ func TestCloudwatchParseMetadata(t *testing.T) {
 
 func TestAWSCloudwatchGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range awsCloudwatchMetricIdentifiers {
-		meta, err := parseAwsCloudwatchMetadata(testData.metadataTestData.metadata, testAWSCloudwatchResolvedEnv, testData.metadataTestData.authParams)
+		meta, err := parseAwsCloudwatchMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testAWSCloudwatchResolvedEnv, AuthParams: testData.metadataTestData.authParams})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -39,8 +39,8 @@ type awsKinesisStreamMetadata struct {
 var kinesisStreamLog = logf.Log.WithName("aws_kinesis_stream_scaler")
 
 // NewAwsKinesisStreamScaler creates a new awsKinesisStreamScaler
-func NewAwsKinesisStreamScaler(resolvedEnv, metadata map[string]string, authParams map[string]string) (Scaler, error) {
-	meta, err := parseAwsKinesisStreamMetadata(metadata, resolvedEnv, authParams)
+func NewAwsKinesisStreamScaler(config *ScalerConfig) (Scaler, error) {
+	meta, err := parseAwsKinesisStreamMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing Kinesis stream metadata: %s", err)
 	}
@@ -50,11 +50,11 @@ func NewAwsKinesisStreamScaler(resolvedEnv, metadata map[string]string, authPara
 	}, nil
 }
 
-func parseAwsKinesisStreamMetadata(metadata, resolvedEnv, authParams map[string]string) (*awsKinesisStreamMetadata, error) {
+func parseAwsKinesisStreamMetadata(config *ScalerConfig) (*awsKinesisStreamMetadata, error) {
 	meta := awsKinesisStreamMetadata{}
 	meta.targetShardCount = targetShardCountDefault
 
-	if val, ok := metadata["shardCount"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["shardCount"]; ok && val != "" {
 		shardCount, err := strconv.Atoi(val)
 		if err != nil {
 			meta.targetShardCount = targetShardCountDefault
@@ -64,19 +64,19 @@ func parseAwsKinesisStreamMetadata(metadata, resolvedEnv, authParams map[string]
 		}
 	}
 
-	if val, ok := metadata["streamName"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["streamName"]; ok && val != "" {
 		meta.streamName = val
 	} else {
 		return nil, fmt.Errorf("no streamName given")
 	}
 
-	if val, ok := metadata["awsRegion"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["awsRegion"]; ok && val != "" {
 		meta.awsRegion = val
 	} else {
 		return nil, fmt.Errorf("no awsRegion given")
 	}
 
-	auth, err := getAwsAuthorization(authParams, metadata, resolvedEnv)
+	auth, err := getAwsAuthorization(config.AuthParams, config.TriggerMetadata, config.ResolvedEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/aws_kinesis_stream_test.go
+++ b/pkg/scalers/aws_kinesis_stream_test.go
@@ -176,7 +176,7 @@ var awsKinesisMetricIdentifiers = []awsKinesisMetricIdentifier{
 
 func TestKinesisParseMetadata(t *testing.T) {
 	for _, testData := range testAWSKinesisMetadata {
-		result, err := parseAwsKinesisStreamMetadata(testData.metadata, testAWSKinesisAuthentication, testData.authParams)
+		result, err := parseAwsKinesisStreamMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testAWSKinesisAuthentication, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Errorf("Expected success because %s got error, %s", testData.comment, err)
 		}
@@ -192,7 +192,7 @@ func TestKinesisParseMetadata(t *testing.T) {
 
 func TestAWSKinesisGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range awsKinesisMetricIdentifiers {
-		meta, err := parseAwsKinesisStreamMetadata(testData.metadataTestData.metadata, testAWSKinesisAuthentication, testData.metadataTestData.authParams)
+		meta, err := parseAwsKinesisStreamMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testAWSKinesisAuthentication, AuthParams: testData.metadataTestData.authParams})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/aws_sqs_queue_test.go
+++ b/pkg/scalers/aws_sqs_queue_test.go
@@ -136,7 +136,7 @@ var awsSQSMetricIdentifiers = []awsSQSMetricIdentifier{
 
 func TestSQSParseMetadata(t *testing.T) {
 	for _, testData := range testAWSSQSMetadata {
-		_, err := parseAwsSqsQueueMetadata(testData.metadata, testAWSSQSAuthentication, testData.authParams)
+		_, err := parseAwsSqsQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testAWSSQSAuthentication, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Errorf("Expected success because %s got error, %s", testData.comment, err)
 		}
@@ -148,7 +148,7 @@ func TestSQSParseMetadata(t *testing.T) {
 
 func TestAWSSQSGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range awsSQSMetricIdentifiers {
-		meta, err := parseAwsSqsQueueMetadata(testData.metadataTestData.metadata, testAWSSQSAuthentication, testData.metadataTestData.authParams)
+		meta, err := parseAwsSqsQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testAWSSQSAuthentication, AuthParams: testData.metadataTestData.authParams})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/azure/azure_blob.go
+++ b/pkg/scalers/azure/azure_blob.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 // GetAzureBlobListLength returns the count of the blobs in blob container in int
-func GetAzureBlobListLength(ctx context.Context, podIdentity string, connectionString, blobContainerName string, accountName string, blobDelimiter string, blobPrefix string) (int, error) {
+func GetAzureBlobListLength(ctx context.Context, podIdentity kedav1alpha1.PodIdentityProvider, connectionString, blobContainerName string, accountName string, blobDelimiter string, blobPrefix string) (int, error) {
 	credential, endpoint, err := ParseAzureStorageBlobConnection(podIdentity, connectionString, accountName)
 	if err != nil {
 		return -1, err

--- a/pkg/scalers/azure/azure_eventhub.go
+++ b/pkg/scalers/azure/azure_eventhub.go
@@ -13,6 +13,8 @@ import (
 
 	eventhub "github.com/Azure/azure-event-hubs-go"
 	"github.com/Azure/azure-storage-blob-go/azblob"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 type baseCheckpoint struct {
@@ -58,7 +60,7 @@ func GetEventHubClient(info EventHubInfo) (*eventhub.Hub, error) {
 
 // GetCheckpointFromBlobStorage accesses Blob storage and gets checkpoint information of a partition
 func GetCheckpointFromBlobStorage(ctx context.Context, info EventHubInfo, partitionID string) (Checkpoint, error) {
-	blobCreds, storageEndpoint, err := ParseAzureStorageBlobConnection("none", info.StorageConnection, "")
+	blobCreds, storageEndpoint, err := ParseAzureStorageBlobConnection(kedav1alpha1.PodIdentityProviderNone, info.StorageConnection, "")
 	if err != nil {
 		return Checkpoint{}, err
 	}

--- a/pkg/scalers/azure/azure_monitor.go
+++ b/pkg/scalers/azure/azure_monitor.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-03-01/insights"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"k8s.io/klog"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 // Much of the code in this file is taken from the Azure Kubernetes Metrics Adapter
@@ -43,10 +45,10 @@ type MonitorInfo struct {
 }
 
 // GetAzureMetricValue returns the value of an Azure Monitor metric, rounded to the nearest int
-func GetAzureMetricValue(ctx context.Context, info MonitorInfo, podIdentity string) (int32, error) {
+func GetAzureMetricValue(ctx context.Context, info MonitorInfo, podIdentity kedav1alpha1.PodIdentityProvider) (int32, error) {
 	var podIdentityEnabled = true
 
-	if podIdentity == "" || podIdentity == "none" {
+	if podIdentity == "" || podIdentity == kedav1alpha1.PodIdentityProviderNone {
 		podIdentityEnabled = false
 	}
 

--- a/pkg/scalers/azure/azure_queue.go
+++ b/pkg/scalers/azure/azure_queue.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/Azure/azure-storage-queue-go/azqueue"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 // GetAzureQueueLength returns the length of a queue in int
-func GetAzureQueueLength(ctx context.Context, podIdentity string, connectionString, queueName string, accountName string) (int32, error) {
+func GetAzureQueueLength(ctx context.Context, podIdentity kedav1alpha1.PodIdentityProvider, connectionString, queueName string, accountName string) (int32, error) {
 	credential, endpoint, err := ParseAzureStorageQueueConnection(podIdentity, connectionString, accountName)
 	if err != nil {
 		return -1, err

--- a/pkg/scalers/azure/azure_storage.go
+++ b/pkg/scalers/azure/azure_storage.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-queue-go/azqueue"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 /* ParseAzureStorageConnectionString parses a storage account connection string into (endpointProtocol, accountName, key, endpointSuffix)
@@ -40,9 +42,9 @@ func (e StorageEndpointType) Name() string {
 }
 
 // ParseAzureStorageQueueConnection parses queue connection string and returns credential and resource url
-func ParseAzureStorageQueueConnection(podIdentity, connectionString, accountName string) (azqueue.Credential, *url.URL, error) {
+func ParseAzureStorageQueueConnection(podIdentity kedav1alpha1.PodIdentityProvider, connectionString, accountName string) (azqueue.Credential, *url.URL, error) {
 	switch podIdentity {
-	case "azure":
+	case kedav1alpha1.PodIdentityProviderAzure:
 		token, err := GetAzureADPodIdentityToken("https://storage.azure.com/")
 		if err != nil {
 			return nil, nil, err
@@ -55,7 +57,7 @@ func ParseAzureStorageQueueConnection(podIdentity, connectionString, accountName
 		credential := azqueue.NewTokenCredential(token.AccessToken, nil)
 		endpoint, _ := url.Parse(fmt.Sprintf("https://%s.queue.core.windows.net", accountName))
 		return credential, endpoint, nil
-	case "", "none":
+	case "", kedav1alpha1.PodIdentityProviderNone:
 		endpoint, accountName, accountKey, err := parseAzureStorageConnectionString(connectionString, QueueEndpoint)
 		if err != nil {
 			return nil, nil, err
@@ -73,9 +75,9 @@ func ParseAzureStorageQueueConnection(podIdentity, connectionString, accountName
 }
 
 // ParseAzureStorageBlobConnection parses blob connection string and returns credential and resource url
-func ParseAzureStorageBlobConnection(podIdentity, connectionString, accountName string) (azblob.Credential, *url.URL, error) {
+func ParseAzureStorageBlobConnection(podIdentity kedav1alpha1.PodIdentityProvider, connectionString, accountName string) (azblob.Credential, *url.URL, error) {
 	switch podIdentity {
-	case "azure":
+	case kedav1alpha1.PodIdentityProviderAzure:
 		token, err := GetAzureADPodIdentityToken("https://storage.azure.com/")
 		if err != nil {
 			return nil, nil, err
@@ -88,7 +90,7 @@ func ParseAzureStorageBlobConnection(podIdentity, connectionString, accountName 
 		credential := azblob.NewTokenCredential(token.AccessToken, nil)
 		endpoint, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", accountName))
 		return credential, endpoint, nil
-	case "", "none":
+	case "", kedav1alpha1.PodIdentityProviderNone:
 		endpoint, accountName, accountKey, err := parseAzureStorageConnectionString(connectionString, BlobEndpoint)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/scalers/azure_blob_scaler_test.go
+++ b/pkg/scalers/azure_blob_scaler_test.go
@@ -1,6 +1,10 @@
 package scalers
 
-import "testing"
+import (
+	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
+)
 
 var testAzBlobResolvedEnv = map[string]string{
 	"CONNECTION": "SAMPLE",
@@ -11,7 +15,7 @@ type parseAzBlobMetadataTestData struct {
 	isError     bool
 	resolvedEnv map[string]string
 	authParams  map[string]string
-	podIdentity string
+	podIdentity kedav1alpha1.PodIdentityProvider
 }
 
 type azBlobMetricIdentifier struct {
@@ -29,13 +33,13 @@ var testAzBlobMetadata = []parseAzBlobMetadataTestData{
 	// improperly formed blobCount
 	{map[string]string{"connectionFromEnv": "CONNECTION", "blobContainerName": "sample", "blobCount": "AA"}, true, testAzBlobResolvedEnv, map[string]string{}, ""},
 	// podIdentity = azure with account name
-	{map[string]string{"accountName": "sample_acc", "blobContainerName": "sample_container"}, false, testAzBlobResolvedEnv, map[string]string{}, "azure"},
+	{map[string]string{"accountName": "sample_acc", "blobContainerName": "sample_container"}, false, testAzBlobResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// podIdentity = azure without account name
-	{map[string]string{"accountName": "", "blobContainerName": "sample_container"}, true, testAzBlobResolvedEnv, map[string]string{}, "azure"},
+	{map[string]string{"accountName": "", "blobContainerName": "sample_container"}, true, testAzBlobResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// podIdentity = azure without blob container name
-	{map[string]string{"accountName": "sample_acc", "blobContainerName": ""}, true, testAzBlobResolvedEnv, map[string]string{}, "azure"},
+	{map[string]string{"accountName": "sample_acc", "blobContainerName": ""}, true, testAzBlobResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// connection from authParams
-	{map[string]string{"blobContainerName": "sample_container", "blobCount": "5"}, false, testAzBlobResolvedEnv, map[string]string{"connection": "value"}, "none"},
+	{map[string]string{"blobContainerName": "sample_container", "blobCount": "5"}, false, testAzBlobResolvedEnv, map[string]string{"connection": "value"}, kedav1alpha1.PodIdentityProviderNone},
 }
 
 var azBlobMetricIdentifiers = []azBlobMetricIdentifier{

--- a/pkg/scalers/azure_blob_scaler_test.go
+++ b/pkg/scalers/azure_blob_scaler_test.go
@@ -49,7 +49,7 @@ var azBlobMetricIdentifiers = []azBlobMetricIdentifier{
 
 func TestAzBlobParseMetadata(t *testing.T) {
 	for _, testData := range testAzBlobMetadata {
-		_, podIdentity, err := parseAzureBlobMetadata(testData.metadata, testData.resolvedEnv, testData.authParams, testData.podIdentity)
+		_, podIdentity, err := parseAzureBlobMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testData.resolvedEnv, AuthParams: testData.authParams, PodIdentity: testData.podIdentity})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -64,7 +64,7 @@ func TestAzBlobParseMetadata(t *testing.T) {
 
 func TestAzBlobGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azBlobMetricIdentifiers {
-		meta, podIdentity, err := parseAzureBlobMetadata(testData.metadataTestData.metadata, testData.metadataTestData.resolvedEnv, testData.metadataTestData.authParams, testData.metadataTestData.podIdentity)
+		meta, podIdentity, err := parseAzureBlobMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testData.metadataTestData.resolvedEnv, AuthParams: testData.metadataTestData.authParams, PodIdentity: testData.metadataTestData.podIdentity})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -67,7 +67,7 @@ var testEventHubScaler = azureEventHubScaler{
 func TestParseEventHubMetadata(t *testing.T) {
 	// Test first with valid resolved environment
 	for _, testData := range parseEventHubMetadataDataset {
-		_, err := parseAzureEventHubMetadata(testData.metadata, sampleEventHubResolvedEnv, map[string]string{})
+		_, err := parseAzureEventHubMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: sampleEventHubResolvedEnv, AuthParams: map[string]string{}})
 
 		if err != nil && !testData.isError {
 			t.Errorf("Expected success but got error: %s", err)
@@ -411,7 +411,7 @@ func DeleteContainerInStorage(ctx context.Context, endpoint *url.URL, credential
 
 func TestEventHubGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range eventHubMetricIdentifiers {
-		meta, err := parseAzureEventHubMetadata(testData.metadataTestData.metadata, sampleEventHubResolvedEnv, map[string]string{})
+		meta, err := parseAzureEventHubMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: sampleEventHubResolvedEnv, AuthParams: map[string]string{}})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 	kedautil "github.com/kedacore/keda/pkg/util"
 )
 
@@ -87,93 +88,93 @@ var tokenCache = struct {
 var logAnalyticsLog = logf.Log.WithName("azure_log_analytics_scaler")
 
 // NewAzureLogAnalyticsScaler creates a new Azure Log Analytics Scaler
-func NewAzureLogAnalyticsScaler(resolvedSecrets, metadata, authParams map[string]string, podIdentity string, name string, namespace string) (Scaler, error) {
-	azureLogAnalyticsMetadata, err := parseAzureLogAnalyticsMetadata(resolvedSecrets, metadata, authParams, podIdentity)
+func NewAzureLogAnalyticsScaler(config *ScalerConfig) (Scaler, error) {
+	azureLogAnalyticsMetadata, err := parseAzureLogAnalyticsMetadata(config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize Log Analytics scaler. Scaled object: %s. Namespace: %s. Inner Error: %v", name, namespace, err)
+		return nil, fmt.Errorf("failed to initialize Log Analytics scaler. Scaled object: %s. Namespace: %s. Inner Error: %v", config.Name, config.Namespace, err)
 	}
 
 	return &azureLogAnalyticsScaler{
 		metadata:  azureLogAnalyticsMetadata,
 		cache:     &sessionCache{metricValue: -1, metricThreshold: -1},
-		name:      name,
-		namespace: namespace,
+		name:      config.Name,
+		namespace: config.Namespace,
 	}, nil
 }
 
-func parseAzureLogAnalyticsMetadata(resolvedEnv, metadata, authParams map[string]string, podIdentity string) (*azureLogAnalyticsMetadata, error) {
+func parseAzureLogAnalyticsMetadata(config *ScalerConfig) (*azureLogAnalyticsMetadata, error) {
 	meta := azureLogAnalyticsMetadata{}
 
-	if podIdentity == "" || podIdentity == "none" {
+	if config.PodIdentity == "" || config.PodIdentity == kedav1alpha1.PodIdentityProviderNone {
 		//Getting tenantId
-		if val, ok := authParams["tenantId"]; ok && val != "" {
+		if val, ok := config.AuthParams["tenantId"]; ok && val != "" {
 			meta.tenantID = val
-		} else if val, ok := metadata["tenantId"]; ok && val != "" {
+		} else if val, ok := config.TriggerMetadata["tenantId"]; ok && val != "" {
 			meta.tenantID = val
-		} else if val, ok := metadata["tenantIdFromEnv"]; ok && val != "" {
-			meta.tenantID = resolvedEnv[metadata["tenantIdFromEnv"]]
+		} else if val, ok := config.TriggerMetadata["tenantIdFromEnv"]; ok && val != "" {
+			meta.tenantID = config.ResolvedEnv[config.TriggerMetadata["tenantIdFromEnv"]]
 		} else {
 			return nil, fmt.Errorf("error parsing metadata. Details: tenantId was not found in metadata. Check your ScaledObject configuration")
 		}
 
 		//Getting clientId
-		if val, ok := authParams["clientId"]; ok && val != "" {
+		if val, ok := config.AuthParams["clientId"]; ok && val != "" {
 			meta.clientID = val
-		} else if val, ok := metadata["clientId"]; ok && val != "" {
+		} else if val, ok := config.TriggerMetadata["clientId"]; ok && val != "" {
 			meta.clientID = val
-		} else if val, ok := metadata["clientIdFromEnv"]; ok && val != "" {
-			meta.clientID = resolvedEnv[metadata["clientIdFromEnv"]]
+		} else if val, ok := config.TriggerMetadata["clientIdFromEnv"]; ok && val != "" {
+			meta.clientID = config.ResolvedEnv[config.TriggerMetadata["clientIdFromEnv"]]
 		} else {
 			return nil, fmt.Errorf("error parsing metadata. Details: clientId was not found in metadata. Check your ScaledObject configuration")
 		}
 
 		//Getting clientSecret
-		if val, ok := authParams["clientSecret"]; ok && val != "" {
+		if val, ok := config.AuthParams["clientSecret"]; ok && val != "" {
 			meta.clientSecret = val
-		} else if val, ok := metadata["clientSecret"]; ok && val != "" {
+		} else if val, ok := config.TriggerMetadata["clientSecret"]; ok && val != "" {
 			meta.clientSecret = val
-		} else if val, ok := metadata["clientSecretFromEnv"]; ok && val != "" {
-			meta.clientSecret = resolvedEnv[metadata["clientSecretFromEnv"]]
+		} else if val, ok := config.TriggerMetadata["clientSecretFromEnv"]; ok && val != "" {
+			meta.clientSecret = config.ResolvedEnv[config.TriggerMetadata["clientSecretFromEnv"]]
 		} else {
 			return nil, fmt.Errorf("error parsing metadata. Details: clientSecret was not found in metadata. Check your ScaledObject configuration")
 		}
 
 		meta.podIdentity = ""
-	} else if podIdentity == "azure" {
-		meta.podIdentity = podIdentity
+	} else if config.PodIdentity == kedav1alpha1.PodIdentityProviderAzure {
+		meta.podIdentity = string(config.PodIdentity)
 	} else {
-		return nil, fmt.Errorf("error parsing metadata. Details: Log Analytics Scaler doesn't support pod identity %s", podIdentity)
+		return nil, fmt.Errorf("error parsing metadata. Details: Log Analytics Scaler doesn't support pod identity %s", config.PodIdentity)
 	}
 
 	//Getting workspaceId
-	if val, ok := authParams["workspaceId"]; ok && val != "" {
+	if val, ok := config.AuthParams["workspaceId"]; ok && val != "" {
 		meta.workspaceID = val
-	} else if val, ok := metadata["workspaceId"]; ok && val != "" {
+	} else if val, ok := config.TriggerMetadata["workspaceId"]; ok && val != "" {
 		meta.workspaceID = val
-	} else if val, ok := metadata["workspaceIdFromEnv"]; ok && val != "" {
-		meta.workspaceID = resolvedEnv[metadata["workspaceIdFromEnv"]]
+	} else if val, ok := config.TriggerMetadata["workspaceIdFromEnv"]; ok && val != "" {
+		meta.workspaceID = config.ResolvedEnv[config.TriggerMetadata["workspaceIdFromEnv"]]
 	} else {
 		return nil, fmt.Errorf("error parsing metadata. Details: workspaceId was not found in metadata. Check your ScaledObject configuration")
 	}
 
 	//Getting query
-	if val, ok := metadata["query"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["query"]; ok && val != "" {
 		meta.query = val
-	} else if val, ok := metadata["queryFromEnv"]; ok && val != "" {
-		meta.query = resolvedEnv[metadata["queryFromEnv"]]
+	} else if val, ok := config.TriggerMetadata["queryFromEnv"]; ok && val != "" {
+		meta.query = config.ResolvedEnv[config.TriggerMetadata["queryFromEnv"]]
 	} else {
 		return nil, fmt.Errorf("error parsing metadata. Details: query was not found in metadata. Check your ScaledObject configuration")
 	}
 
 	//Getting threshold
-	if val, ok := metadata["threshold"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["threshold"]; ok && val != "" {
 		threshold, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing metadata. Details: can't parse threshold. Inner Error: %v", err)
 		}
 		meta.threshold = threshold
-	} else if val, ok := metadata["thresholdFromEnv"]; ok && val != "" {
-		threshold, err := strconv.ParseInt(resolvedEnv[metadata["thresholdFromEnv"]], 10, 64)
+	} else if val, ok := config.TriggerMetadata["thresholdFromEnv"]; ok && val != "" {
+		threshold, err := strconv.ParseInt(config.ResolvedEnv[config.TriggerMetadata["thresholdFromEnv"]], 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing metadata. Details: can't parse threshold. Inner Error: %v", err)
 		}

--- a/pkg/scalers/azure_log_analytics_scaler_test.go
+++ b/pkg/scalers/azure_log_analytics_scaler_test.go
@@ -97,7 +97,7 @@ var testLogAnalyticsMetadataWithPodIdentity = []parseLogAnalyticsMetadataTestDat
 
 func TestLogAnalyticsParseMetadata(t *testing.T) {
 	for _, testData := range testLogAnalyticsMetadata {
-		_, err := parseAzureLogAnalyticsMetadata(sampleLogAnalyticsResolvedEnv, testData.metadata, nil, "")
+		_, err := parseAzureLogAnalyticsMetadata(&ScalerConfig{ResolvedEnv: sampleLogAnalyticsResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: nil, PodIdentity: ""})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -108,7 +108,7 @@ func TestLogAnalyticsParseMetadata(t *testing.T) {
 
 	// test with missing auth params should all fail
 	for _, testData := range testLogAnalyticsMetadataWithEmptyAuthParams {
-		_, err := parseAzureLogAnalyticsMetadata(sampleLogAnalyticsResolvedEnv, testData.metadata, emptyLogAnalyticsAuthParams, "")
+		_, err := parseAzureLogAnalyticsMetadata(&ScalerConfig{ResolvedEnv: sampleLogAnalyticsResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: emptyLogAnalyticsAuthParams, PodIdentity: ""})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -119,7 +119,7 @@ func TestLogAnalyticsParseMetadata(t *testing.T) {
 
 	// test with complete auth params should not fail
 	for _, testData := range testLogAnalyticsMetadataWithAuthParams {
-		_, err := parseAzureLogAnalyticsMetadata(sampleLogAnalyticsResolvedEnv, testData.metadata, LogAnalyticsAuthParams, "")
+		_, err := parseAzureLogAnalyticsMetadata(&ScalerConfig{ResolvedEnv: sampleLogAnalyticsResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: LogAnalyticsAuthParams, PodIdentity: ""})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -130,7 +130,7 @@ func TestLogAnalyticsParseMetadata(t *testing.T) {
 
 	// test with podIdentity params should not fail
 	for _, testData := range testLogAnalyticsMetadataWithPodIdentity {
-		_, err := parseAzureLogAnalyticsMetadata(sampleLogAnalyticsResolvedEnv, testData.metadata, LogAnalyticsAuthParams, "azure")
+		_, err := parseAzureLogAnalyticsMetadata(&ScalerConfig{ResolvedEnv: sampleLogAnalyticsResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: LogAnalyticsAuthParams, PodIdentity: kedav1alpha1.PodIdentityProviderAzure})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -142,7 +142,7 @@ func TestLogAnalyticsParseMetadata(t *testing.T) {
 
 func TestLogAnalyticsGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range LogAnalyticsMetricIdentifiers {
-		meta, err := parseAzureLogAnalyticsMetadata(sampleLogAnalyticsResolvedEnv, testData.metadataTestData.metadata, nil, "")
+		meta, err := parseAzureLogAnalyticsMetadata(&ScalerConfig{ResolvedEnv: sampleLogAnalyticsResolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: nil, PodIdentity: ""})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/azure_log_analytics_scaler_test.go
+++ b/pkg/scalers/azure_log_analytics_scaler_test.go
@@ -2,6 +2,8 @@ package scalers
 
 import (
 	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 const (

--- a/pkg/scalers/azure_monitor_scaler_test.go
+++ b/pkg/scalers/azure_monitor_scaler_test.go
@@ -1,13 +1,17 @@
 package scalers
 
-import "testing"
+import (
+	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
+)
 
 type parseAzMonitorMetadataTestData struct {
 	metadata    map[string]string
 	isError     bool
 	resolvedEnv map[string]string
 	authParams  map[string]string
-	podIdentity string
+	podIdentity kedav1alpha1.PodIdentityProvider
 }
 
 type azMonitorMetricIdentifier struct {
@@ -54,9 +58,9 @@ var testParseAzMonitorMetadata = []parseAzMonitorMetadataTestData{
 	// connection from authParams
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, false, map[string]string{}, map[string]string{"activeDirectoryClientId": "zzz", "activeDirectoryClientPassword": "password"}, ""},
 	// connection with podIdentity
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, false, map[string]string{}, map[string]string{}, "azure"},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, false, map[string]string{}, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// wrong podIdentity
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, true, map[string]string{}, map[string]string{}, "notAzure"},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, true, map[string]string{}, map[string]string{}, kedav1alpha1.PodIdentityProvider("notAzure")},
 }
 
 var azMonitorMetricIdentifiers = []azMonitorMetricIdentifier{

--- a/pkg/scalers/azure_monitor_scaler_test.go
+++ b/pkg/scalers/azure_monitor_scaler_test.go
@@ -69,7 +69,7 @@ var azMonitorMetricIdentifiers = []azMonitorMetricIdentifier{
 
 func TestAzMonitorParseMetadata(t *testing.T) {
 	for _, testData := range testParseAzMonitorMetadata {
-		_, err := parseAzureMonitorMetadata(testData.metadata, testData.resolvedEnv, testData.authParams, testData.podIdentity)
+		_, err := parseAzureMonitorMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testData.resolvedEnv, AuthParams: testData.authParams, PodIdentity: testData.podIdentity})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -81,7 +81,7 @@ func TestAzMonitorParseMetadata(t *testing.T) {
 
 func TestAzMonitorGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azMonitorMetricIdentifiers {
-		meta, err := parseAzureMonitorMetadata(testData.metadataTestData.metadata, testData.metadataTestData.resolvedEnv, testData.metadataTestData.authParams, testData.metadataTestData.podIdentity)
+		meta, err := parseAzureMonitorMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testData.metadataTestData.resolvedEnv, AuthParams: testData.metadataTestData.authParams, PodIdentity: testData.metadataTestData.podIdentity})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/azure_queue_scaler_test.go
+++ b/pkg/scalers/azure_queue_scaler_test.go
@@ -1,6 +1,10 @@
 package scalers
 
-import "testing"
+import (
+	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
+)
 
 var testAzQueueResolvedEnv = map[string]string{
 	"CONNECTION": "SAMPLE",
@@ -11,7 +15,7 @@ type parseAzQueueMetadataTestData struct {
 	isError     bool
 	resolvedEnv map[string]string
 	authParams  map[string]string
-	podIdentity string
+	podIdentity kedav1alpha1.PodIdentityProvider
 }
 
 type azQueueMetricIdentifier struct {
@@ -35,13 +39,13 @@ var testAzQueueMetadata = []parseAzQueueMetadataTestData{
 	// Deprecated useAAdPodIdentity without queue name
 	{map[string]string{"useAAdPodIdentity": "true", "accountName": "sample_acc", "queueName": ""}, true, testAzQueueResolvedEnv, map[string]string{}, ""},
 	// podIdentity = azure with account name
-	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue"}, false, testAzQueueResolvedEnv, map[string]string{}, "azure"},
+	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue"}, false, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// podIdentity = azure without account name
-	{map[string]string{"accountName": "", "queueName": "sample_queue"}, true, testAzQueueResolvedEnv, map[string]string{}, "azure"},
+	{map[string]string{"accountName": "", "queueName": "sample_queue"}, true, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// podIdentity = azure without queue name
-	{map[string]string{"accountName": "sample_acc", "queueName": ""}, true, testAzQueueResolvedEnv, map[string]string{}, "azure"},
+	{map[string]string{"accountName": "sample_acc", "queueName": ""}, true, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// connection from authParams
-	{map[string]string{"queueName": "sample", "queueLength": "5"}, false, testAzQueueResolvedEnv, map[string]string{"connection": "value"}, "none"},
+	{map[string]string{"queueName": "sample", "queueLength": "5"}, false, testAzQueueResolvedEnv, map[string]string{"connection": "value"}, kedav1alpha1.PodIdentityProviderNone},
 }
 
 var azQueueMetricIdentifiers = []azQueueMetricIdentifier{

--- a/pkg/scalers/azure_queue_scaler_test.go
+++ b/pkg/scalers/azure_queue_scaler_test.go
@@ -55,7 +55,7 @@ var azQueueMetricIdentifiers = []azQueueMetricIdentifier{
 
 func TestAzQueueParseMetadata(t *testing.T) {
 	for _, testData := range testAzQueueMetadata {
-		_, podIdentity, err := parseAzureQueueMetadata(testData.metadata, testData.resolvedEnv, testData.authParams, testData.podIdentity)
+		_, podIdentity, err := parseAzureQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testData.resolvedEnv, AuthParams: testData.authParams, PodIdentity: testData.podIdentity})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -70,7 +70,7 @@ func TestAzQueueParseMetadata(t *testing.T) {
 
 func TestAzQueueGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azQueueMetricIdentifiers {
-		meta, podIdentity, err := parseAzureQueueMetadata(testData.metadataTestData.metadata, testData.metadataTestData.resolvedEnv, testData.metadataTestData.authParams, testData.metadataTestData.podIdentity)
+		meta, podIdentity, err := parseAzureQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testData.metadataTestData.resolvedEnv, AuthParams: testData.metadataTestData.authParams, PodIdentity: testData.metadataTestData.podIdentity})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 const (
@@ -20,7 +22,7 @@ type parseServiceBusMetadataTestData struct {
 	isError     bool
 	entityType  entityType
 	authParams  map[string]string
-	podIdentity string
+	podIdentity kedav1alpha1.PodIdentityProvider
 }
 
 type azServiceBusMetricIdentifier struct {
@@ -56,9 +58,9 @@ var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 	// connection set in auth params
 	{map[string]string{"queueName": queueName}, false, queue, map[string]string{"connection": connectionSetting}, ""},
 	// pod identity but missing namespace
-	{map[string]string{"queueName": queueName}, true, queue, map[string]string{}, "azure"},
+	{map[string]string{"queueName": queueName}, true, queue, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// correct pod identity
-	{map[string]string{"queueName": queueName, "namespace": namespaceName}, false, queue, map[string]string{}, "azure"},
+	{map[string]string{"queueName": queueName, "namespace": namespaceName}, false, queue, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 }
 
 var azServiceBusMetricIdentifiers = []azServiceBusMetricIdentifier{
@@ -81,7 +83,7 @@ var getServiceBusLengthTestScalers = []azureServiceBusScaler{
 		topicName:        topicName,
 		subscriptionName: subscriptionName,
 	},
-		podIdentity: "azure"},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzure},
 }
 
 func TestParseServiceBusMetadata(t *testing.T) {

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -88,7 +88,7 @@ var getServiceBusLengthTestScalers = []azureServiceBusScaler{
 
 func TestParseServiceBusMetadata(t *testing.T) {
 	for _, testData := range parseServiceBusMetadataDataset {
-		meta, err := parseAzureServiceBusMetadata(sampleResolvedEnv, testData.metadata, testData.authParams, testData.podIdentity)
+		meta, err := parseAzureServiceBusMetadata(&ScalerConfig{ResolvedEnv: sampleResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: testData.authParams, PodIdentity: testData.podIdentity})
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -136,7 +136,7 @@ func TestGetServiceBusLength(t *testing.T) {
 
 func TestAzServiceBusGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azServiceBusMetricIdentifiers {
-		meta, err := parseAzureServiceBusMetadata(sampleResolvedEnv, testData.metadataTestData.metadata, testData.metadataTestData.authParams, testData.metadataTestData.podIdentity)
+		meta, err := parseAzureServiceBusMetadata(&ScalerConfig{ResolvedEnv: sampleResolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, PodIdentity: testData.metadataTestData.podIdentity})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -37,8 +37,8 @@ type cronMetadata struct {
 var cronLog = logf.Log.WithName("cron_scaler")
 
 // NewCronScaler creates a new cronScaler
-func NewCronScaler(resolvedEnv, metadata map[string]string) (Scaler, error) {
-	meta, parseErr := parseCronMetadata(metadata)
+func NewCronScaler(config *ScalerConfig) (Scaler, error) {
+	meta, parseErr := parseCronMetadata(config)
 	if parseErr != nil {
 		return nil, fmt.Errorf("error parsing cron metadata: %s", parseErr)
 	}
@@ -62,36 +62,36 @@ func getCronTime(location *time.Location, spec string) (int64, error) {
 	return cronTime, nil
 }
 
-func parseCronMetadata(metadata map[string]string) (*cronMetadata, error) {
-	if len(metadata) == 0 {
-		return nil, fmt.Errorf("invalid Input Metadata. %s", metadata)
+func parseCronMetadata(config *ScalerConfig) (*cronMetadata, error) {
+	if len(config.TriggerMetadata) == 0 {
+		return nil, fmt.Errorf("invalid Input Metadata. %s", config.TriggerMetadata)
 	}
 
 	meta := cronMetadata{}
-	if val, ok := metadata["timezone"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["timezone"]; ok && val != "" {
 		meta.timezone = val
 	} else {
-		return nil, fmt.Errorf("no timezone specified. %s", metadata)
+		return nil, fmt.Errorf("no timezone specified. %s", config.TriggerMetadata)
 	}
-	if val, ok := metadata["start"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["start"]; ok && val != "" {
 		meta.start = val
 	} else {
-		return nil, fmt.Errorf("no start schedule specified. %s", metadata)
+		return nil, fmt.Errorf("no start schedule specified. %s", config.TriggerMetadata)
 	}
-	if val, ok := metadata["end"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["end"]; ok && val != "" {
 		meta.end = val
 	} else {
-		return nil, fmt.Errorf("no end schedule specified. %s", metadata)
+		return nil, fmt.Errorf("no end schedule specified. %s", config.TriggerMetadata)
 	}
-	if val, ok := metadata["desiredReplicas"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["desiredReplicas"]; ok && val != "" {
 		metadataDesiredReplicas, err := strconv.Atoi(val)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing desiredReplicas metadata. %s", metadata)
+			return nil, fmt.Errorf("error parsing desiredReplicas metadata. %s", config.TriggerMetadata)
 		}
 
 		meta.desiredReplicas = int64(metadataDesiredReplicas)
 	} else {
-		return nil, fmt.Errorf("no DesiredReplicas specified. %s", metadata)
+		return nil, fmt.Errorf("no DesiredReplicas specified. %s", config.TriggerMetadata)
 	}
 
 	return &meta, nil

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -42,7 +42,7 @@ var currentDay = time.Now().In(tz).Weekday().String()
 
 func TestCronParseMetadata(t *testing.T) {
 	for _, testData := range testCronMetadata {
-		_, err := parseCronMetadata(testData.metadata)
+		_, err := parseCronMetadata(&ScalerConfig{TriggerMetadata: testData.metadata})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -53,7 +53,7 @@ func TestCronParseMetadata(t *testing.T) {
 }
 
 func TestIsActive(t *testing.T) {
-	scaler, _ := NewCronScaler(map[string]string{}, validCronMetadata)
+	scaler, _ := NewCronScaler(&ScalerConfig{TriggerMetadata: validCronMetadata})
 	isActive, _ := scaler.IsActive(context.TODO())
 	if currentDay == "Thursday" {
 		assert.Equal(t, isActive, true)
@@ -63,7 +63,7 @@ func TestIsActive(t *testing.T) {
 }
 
 func TestGetMetrics(t *testing.T) {
-	scaler, _ := NewCronScaler(map[string]string{}, validCronMetadata)
+	scaler, _ := NewCronScaler(&ScalerConfig{TriggerMetadata: validCronMetadata})
 	metrics, _ := scaler.GetMetrics(context.TODO(), "ReplicaCount", nil)
 	assert.Equal(t, metrics[0].MetricName, "ReplicaCount")
 	if currentDay == "Thursday" {
@@ -75,7 +75,7 @@ func TestGetMetrics(t *testing.T) {
 
 func TestCronGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range cronMetricIdentifiers {
-		meta, err := parseCronMetadata(testData.metadataTestData.metadata)
+		meta, err := parseCronMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -29,7 +29,7 @@ var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
 
 func TestExternalScalerParseMetadata(t *testing.T) {
 	for _, testData := range testExternalScalerMetadata {
-		_, err := parseExternalScalerMetadata(testData.metadata, map[string]string{})
+		_, err := parseExternalScalerMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: map[string]string{}})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -52,7 +52,7 @@ func TestExternalPushScaler_Run(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	for i := 0; i < serverCount*iterationCount; i++ {
 		id := i % serverCount
-		pushScaler, _ := NewExternalPushScaler("app", "namespace", map[string]string{"scalerAddress": servers[id].address}, map[string]string{})
+		pushScaler, _ := NewExternalPushScaler(&ScalerConfig{Name: "app", Namespace: "namespace", TriggerMetadata: map[string]string{"scalerAddress": servers[id].address}, ResolvedEnv: map[string]string{}})
 		go pushScaler.Run(ctx, replyCh[i])
 	}
 

--- a/pkg/scalers/gcp_pub_sub_scaler.go
+++ b/pkg/scalers/gcp_pub_sub_scaler.go
@@ -34,8 +34,8 @@ type pubsubMetadata struct {
 var gcpPubSubLog = logf.Log.WithName("gcp_pub_sub_scaler")
 
 // NewPubSubScaler creates a new pubsubScaler
-func NewPubSubScaler(resolvedEnv, metadata map[string]string) (Scaler, error) {
-	meta, err := parsePubSubMetadata(metadata, resolvedEnv)
+func NewPubSubScaler(config *ScalerConfig) (Scaler, error) {
+	meta, err := parsePubSubMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing PubSub metadata: %s", err)
 	}
@@ -45,11 +45,11 @@ func NewPubSubScaler(resolvedEnv, metadata map[string]string) (Scaler, error) {
 	}, nil
 }
 
-func parsePubSubMetadata(metadata, resolvedEnv map[string]string) (*pubsubMetadata, error) {
+func parsePubSubMetadata(config *ScalerConfig) (*pubsubMetadata, error) {
 	meta := pubsubMetadata{}
 	meta.targetSubscriptionSize = defaultTargetSubscriptionSize
 
-	if val, ok := metadata["subscriptionSize"]; ok {
+	if val, ok := config.TriggerMetadata["subscriptionSize"]; ok {
 		subscriptionSize, err := strconv.Atoi(val)
 		if err != nil {
 			return nil, fmt.Errorf("subscription Size parsing error %s", err.Error())
@@ -58,7 +58,7 @@ func parsePubSubMetadata(metadata, resolvedEnv map[string]string) (*pubsubMetada
 		meta.targetSubscriptionSize = subscriptionSize
 	}
 
-	if val, ok := metadata["subscriptionName"]; ok {
+	if val, ok := config.TriggerMetadata["subscriptionName"]; ok {
 		if val == "" {
 			return nil, fmt.Errorf("no subscription name given")
 		}
@@ -68,8 +68,8 @@ func parsePubSubMetadata(metadata, resolvedEnv map[string]string) (*pubsubMetada
 		return nil, fmt.Errorf("no subscription name given")
 	}
 
-	if metadata["credentialsFromEnv"] != "" {
-		meta.credentials = resolvedEnv[metadata["credentialsFromEnv"]]
+	if config.TriggerMetadata["credentialsFromEnv"] != "" {
+		meta.credentials = config.ResolvedEnv[config.TriggerMetadata["credentialsFromEnv"]]
 	}
 
 	if len(meta.credentials) == 0 {

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -38,7 +38,7 @@ var gcpPubSubMetricIdentifiers = []gcpPubSubMetricIdentifier{
 
 func TestPubSubParseMetadata(t *testing.T) {
 	for _, testData := range testPubSubMetadata {
-		_, err := parsePubSubMetadata(testData.metadata, testPubSubResolvedEnv)
+		_, err := parsePubSubMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testPubSubResolvedEnv})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -50,7 +50,7 @@ func TestPubSubParseMetadata(t *testing.T) {
 
 func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range gcpPubSubMetricIdentifiers {
-		meta, err := parsePubSubMetadata(testData.metadataTestData.metadata, testPubSubResolvedEnv)
+		meta, err := parsePubSubMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/huawei_cloudeye_scaler.go
+++ b/pkg/scalers/huawei_cloudeye_scaler.go
@@ -72,8 +72,8 @@ type huaweiAuthorizationMetadata struct {
 var cloudeyeLog = logf.Log.WithName("huawei_cloudeye_scaler")
 
 // NewHuaweiCloudeyeScaler creates a new huaweiCloudeyeScaler
-func NewHuaweiCloudeyeScaler(metadata, authParams map[string]string) (Scaler, error) {
-	meta, err := parseHuaweiCloudeyeMetadata(metadata, authParams)
+func NewHuaweiCloudeyeScaler(config *ScalerConfig) (Scaler, error) {
+	meta, err := parseHuaweiCloudeyeMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing Cloudeye metadata: %s", err)
 	}
@@ -83,38 +83,38 @@ func NewHuaweiCloudeyeScaler(metadata, authParams map[string]string) (Scaler, er
 	}, nil
 }
 
-func parseHuaweiCloudeyeMetadata(metadata, authParams map[string]string) (*huaweiCloudeyeMetadata, error) {
+func parseHuaweiCloudeyeMetadata(config *ScalerConfig) (*huaweiCloudeyeMetadata, error) {
 	meta := huaweiCloudeyeMetadata{}
 
 	meta.metricCollectionTime = defaultCloudeyeMetricCollectionTime
 	meta.metricFilter = defaultCloudeyeMetricFilter
 	meta.metricPeriod = defaultCloudeyeMetricPeriod
 
-	if val, ok := metadata["namespace"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["namespace"]; ok && val != "" {
 		meta.namespace = val
 	} else {
 		return nil, fmt.Errorf("namespace not given")
 	}
 
-	if val, ok := metadata["metricName"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["metricName"]; ok && val != "" {
 		meta.metricsName = val
 	} else {
 		return nil, fmt.Errorf("metric Name not given")
 	}
 
-	if val, ok := metadata["dimensionName"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["dimensionName"]; ok && val != "" {
 		meta.dimensionName = val
 	} else {
 		return nil, fmt.Errorf("dimension Name not given")
 	}
 
-	if val, ok := metadata["dimensionValue"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["dimensionValue"]; ok && val != "" {
 		meta.dimensionValue = val
 	} else {
 		return nil, fmt.Errorf("dimension Value not given")
 	}
 
-	if val, ok := metadata["targetMetricValue"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["targetMetricValue"]; ok && val != "" {
 		targetMetricValue, err := strconv.ParseFloat(val, 64)
 		if err != nil {
 			cloudeyeLog.Error(err, "Error parsing targetMetricValue metadata")
@@ -125,7 +125,7 @@ func parseHuaweiCloudeyeMetadata(metadata, authParams map[string]string) (*huawe
 		return nil, fmt.Errorf("target Metric Value not given")
 	}
 
-	if val, ok := metadata["minMetricValue"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["minMetricValue"]; ok && val != "" {
 		minMetricValue, err := strconv.ParseFloat(val, 64)
 		if err != nil {
 			cloudeyeLog.Error(err, "Error parsing minMetricValue metadata")
@@ -136,7 +136,7 @@ func parseHuaweiCloudeyeMetadata(metadata, authParams map[string]string) (*huawe
 		return nil, fmt.Errorf("min Metric Value not given")
 	}
 
-	if val, ok := metadata["metricCollectionTime"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["metricCollectionTime"]; ok && val != "" {
 		metricCollectionTime, err := strconv.Atoi(val)
 		if err != nil {
 			cloudeyeLog.Error(err, "Error parsing metricCollectionTime metadata")
@@ -145,11 +145,11 @@ func parseHuaweiCloudeyeMetadata(metadata, authParams map[string]string) (*huawe
 		}
 	}
 
-	if val, ok := metadata["metricFilter"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["metricFilter"]; ok && val != "" {
 		meta.metricFilter = val
 	}
 
-	if val, ok := metadata["metricPeriod"]; ok && val != "" {
+	if val, ok := config.TriggerMetadata["metricPeriod"]; ok && val != "" {
 		_, err := strconv.Atoi(val)
 		if err != nil {
 			cloudeyeLog.Error(err, "Error parsing metricPeriod metadata")
@@ -158,7 +158,7 @@ func parseHuaweiCloudeyeMetadata(metadata, authParams map[string]string) (*huawe
 		}
 	}
 
-	auth, err := gethuaweiAuthorization(authParams)
+	auth, err := gethuaweiAuthorization(config.AuthParams)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/huawei_cloudeye_test.go
+++ b/pkg/scalers/huawei_cloudeye_test.go
@@ -145,7 +145,7 @@ var huaweiCloudeyeMetricIdentifiers = []huaweiCloudeyeMetricIdentifier{
 
 func TestHuaweiCloudeyeParseMetadata(t *testing.T) {
 	for _, testData := range testHuaweiCloudeyeMetadata {
-		_, err := parseHuaweiCloudeyeMetadata(testData.metadata, testData.authParams)
+		_, err := parseHuaweiCloudeyeMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Errorf("%s: Expected success but got error %s", testData.comment, err)
 		}
@@ -157,7 +157,7 @@ func TestHuaweiCloudeyeParseMetadata(t *testing.T) {
 
 func TestHuaweiCloudeyeGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range huaweiCloudeyeMetricIdentifiers {
-		meta, err := parseHuaweiCloudeyeMetadata(testData.metadataTestData.metadata, testData.metadataTestData.authParams)
+		meta, err := parseHuaweiCloudeyeMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -109,7 +109,7 @@ var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
 
 func TestGetBrokers(t *testing.T) {
 	for _, testData := range parseKafkaMetadataTestDataset {
-		meta, err := parseKafkaMetadata(testData.metadata, validWithAuthParams)
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams})
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -133,7 +133,7 @@ func TestGetBrokers(t *testing.T) {
 			t.Errorf("Expected offsetResetPolicy %s but got %s\n", testData.offsetResetPolicy, meta.offsetResetPolicy)
 		}
 
-		meta, err = parseKafkaMetadata(testData.metadata, validWithoutAuthParams)
+		meta, err = parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithoutAuthParams})
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -161,7 +161,7 @@ func TestGetBrokers(t *testing.T) {
 
 func TestKafkaAuthParams(t *testing.T) {
 	for _, testData := range parseKafkaAuthParamsTestDataset {
-		meta, err := parseKafkaMetadata(validKafkaMetadata, testData.authParams)
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams})
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -176,7 +176,7 @@ func TestKafkaAuthParams(t *testing.T) {
 }
 func TestKafkaGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range kafkaMetricIdentifiers {
-		meta, err := parseKafkaMetadata(testData.metadataTestData.metadata, validWithAuthParams)
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: validWithAuthParams})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -39,8 +39,8 @@ const (
 )
 
 // NewLiiklusScaler creates a new liiklusScaler scaler
-func NewLiiklusScaler(resolvedEnv map[string]string, metadata map[string]string) (Scaler, error) {
-	lm, err := parseLiiklusMetadata(metadata)
+func NewLiiklusScaler(config *ScalerConfig) (Scaler, error) {
+	lm, err := parseLiiklusMetadata(config)
 	if err != nil {
 		return nil, err
 	}
@@ -144,10 +144,10 @@ func (s *liiklusScaler) getLag(ctx context.Context) (uint64, map[uint32]uint64, 
 	return totalLag, lags, nil
 }
 
-func parseLiiklusMetadata(metadata map[string]string) (*liiklusMetadata, error) {
+func parseLiiklusMetadata(config *ScalerConfig) (*liiklusMetadata, error) {
 	lagThreshold := defaultLiiklusLagThreshold
 
-	if val, ok := metadata[liiklusLagThresholdMetricName]; ok {
+	if val, ok := config.TriggerMetadata[liiklusLagThresholdMetricName]; ok {
 		t, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %s: %s", liiklusLagThresholdMetricName, err)
@@ -156,7 +156,7 @@ func parseLiiklusMetadata(metadata map[string]string) (*liiklusMetadata, error) 
 	}
 
 	groupVersion := uint32(0)
-	if val, ok := metadata["groupVersion"]; ok {
+	if val, ok := config.TriggerMetadata["groupVersion"]; ok {
 		t, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing groupVersion: %s", err)
@@ -164,18 +164,18 @@ func parseLiiklusMetadata(metadata map[string]string) (*liiklusMetadata, error) 
 		groupVersion = uint32(t)
 	}
 
-	if metadata["topic"] == "" {
+	if config.TriggerMetadata["topic"] == "" {
 		return nil, errors.New("no topic provided")
-	} else if metadata["address"] == "" {
+	} else if config.TriggerMetadata["address"] == "" {
 		return nil, errors.New("no liiklus API address provided")
-	} else if metadata["group"] == "" {
+	} else if config.TriggerMetadata["group"] == "" {
 		return nil, errors.New("no consumer group provided")
 	}
 
 	return &liiklusMetadata{
-		topic:        metadata["topic"],
-		address:      metadata["address"],
-		group:        metadata["group"],
+		topic:        config.TriggerMetadata["topic"],
+		address:      config.TriggerMetadata["address"],
+		group:        config.TriggerMetadata["group"],
 		groupVersion: groupVersion,
 		lagThreshold: lagThreshold,
 	}, nil

--- a/pkg/scalers/liiklus_scaler_test.go
+++ b/pkg/scalers/liiklus_scaler_test.go
@@ -38,7 +38,7 @@ var liiklusMetricIdentifiers = []liiklusMetricIdentifier{
 
 func TestLiiklusParseMetadata(t *testing.T) {
 	for _, testData := range parseLiiklusMetadataTestDataset {
-		meta, err := parseLiiklusMetadata(testData.metadata)
+		meta, err := parseLiiklusMetadata(&ScalerConfig{TriggerMetadata: testData.metadata})
 		if err != nil && testData.err == nil {
 			t.Error("Expected success but got error", err)
 			continue
@@ -77,7 +77,7 @@ func TestLiiklusScalerActiveBehavior(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	lm, _ := parseLiiklusMetadata(map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup"})
+	lm, _ := parseLiiklusMetadata(&ScalerConfig{TriggerMetadata: map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup"}})
 	mockClient := mock_liiklus.NewMockLiiklusServiceClient(ctrl)
 	scaler := &liiklusScaler{
 		metadata: lm,
@@ -121,7 +121,7 @@ func TestLiiklusScalerGetMetricsBehavior(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	lm, _ := parseLiiklusMetadata(map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup"})
+	lm, _ := parseLiiklusMetadata(&ScalerConfig{TriggerMetadata: map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup"}})
 	mockClient := mock_liiklus.NewMockLiiklusServiceClient(ctrl)
 	scaler := &liiklusScaler{
 		metadata: lm,
@@ -165,7 +165,7 @@ func TestLiiklusScalerGetMetricsBehavior(t *testing.T) {
 
 func TestLiiklusGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range liiklusMetricIdentifiers {
-		meta, err := parseLiiklusMetadata(testData.metadataTestData.metadata)
+		meta, err := parseLiiklusMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -58,7 +58,7 @@ var testMetricsAPIAuthMetadata = []metricAPIAuthMetadataTestData{
 
 func TestParseMetricsAPIMetadata(t *testing.T) {
 	for _, testData := range testMetricsAPIMetadata {
-		_, err := metricsAPIMetadata(testData.metadata, map[string]string{})
+		_, err := parseMetricsAPIMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: map[string]string{}})
 		if err != nil && !testData.raisesError {
 			t.Error("Expected success but got error", err)
 		}
@@ -89,7 +89,7 @@ func TestGetValueFromResponse(t *testing.T) {
 
 func TestMetricAPIScalerAuthParams(t *testing.T) {
 	for _, testData := range testMetricsAPIAuthMetadata {
-		meta, err := metricsAPIMetadata(validMetricAPIMetadata, testData.authParams)
+		meta, err := parseMetricsAPIMetadata(&ScalerConfig{TriggerMetadata: validMetricAPIMetadata, AuthParams: testData.authParams})
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -36,8 +36,8 @@ type mySQLMetadata struct {
 var mySQLLog = logf.Log.WithName("mysql_scaler")
 
 // NewMySQLScaler creates a new MySQL scaler
-func NewMySQLScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler, error) {
-	meta, err := parseMySQLMetadata(resolvedEnv, metadata, authParams)
+func NewMySQLScaler(config *ScalerConfig) (Scaler, error) {
+	meta, err := parseMySQLMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing MySQL metadata: %s", err)
 	}
@@ -52,16 +52,16 @@ func NewMySQLScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler
 	}, nil
 }
 
-func parseMySQLMetadata(resolvedEnv, metadata, authParams map[string]string) (*mySQLMetadata, error) {
+func parseMySQLMetadata(config *ScalerConfig) (*mySQLMetadata, error) {
 	meta := mySQLMetadata{}
 
-	if val, ok := metadata["query"]; ok {
+	if val, ok := config.TriggerMetadata["query"]; ok {
 		meta.query = val
 	} else {
 		return nil, fmt.Errorf("no query given")
 	}
 
-	if val, ok := metadata["queryValue"]; ok {
+	if val, ok := config.TriggerMetadata["queryValue"]; ok {
 		queryValue, err := strconv.Atoi(val)
 		if err != nil {
 			return nil, fmt.Errorf("queryValue parsing error %s", err.Error())
@@ -71,38 +71,38 @@ func parseMySQLMetadata(resolvedEnv, metadata, authParams map[string]string) (*m
 		return nil, fmt.Errorf("no queryValue given")
 	}
 
-	if authParams["connectionString"] != "" {
-		meta.connectionString = authParams["connectionString"]
-	} else if metadata["connectionStringFromEnv"] != "" {
-		meta.connectionString = resolvedEnv[metadata["connectionStringFromEnv"]]
+	if config.AuthParams["connectionString"] != "" {
+		meta.connectionString = config.AuthParams["connectionString"]
+	} else if config.TriggerMetadata["connectionStringFromEnv"] != "" {
+		meta.connectionString = config.ResolvedEnv[config.TriggerMetadata["connectionStringFromEnv"]]
 	} else {
 		meta.connectionString = ""
-		if val, ok := metadata["host"]; ok {
+		if val, ok := config.TriggerMetadata["host"]; ok {
 			meta.host = val
 		} else {
 			return nil, fmt.Errorf("no host given")
 		}
-		if val, ok := metadata["port"]; ok {
+		if val, ok := config.TriggerMetadata["port"]; ok {
 			meta.port = val
 		} else {
 			return nil, fmt.Errorf("no port given")
 		}
 
-		if val, ok := metadata["username"]; ok {
+		if val, ok := config.TriggerMetadata["username"]; ok {
 			meta.username = val
 		} else {
 			return nil, fmt.Errorf("no username given")
 		}
-		if val, ok := metadata["dbName"]; ok {
+		if val, ok := config.TriggerMetadata["dbName"]; ok {
 			meta.dbName = val
 		} else {
 			return nil, fmt.Errorf("no dbName given")
 		}
 
-		if authParams["password"] != "" {
-			meta.password = authParams["password"]
-		} else if metadata["passwordFromEnv"] != "" {
-			meta.password = resolvedEnv[metadata["passwordFromEnv"]]
+		if config.AuthParams["password"] != "" {
+			meta.password = config.AuthParams["password"]
+		} else if config.TriggerMetadata["passwordFromEnv"] != "" {
+			meta.password = config.ResolvedEnv[config.TriggerMetadata["passwordFromEnv"]]
 		}
 
 		if len(meta.password) == 0 {

--- a/pkg/scalers/mysql_scaler_test.go
+++ b/pkg/scalers/mysql_scaler_test.go
@@ -36,7 +36,7 @@ var mySQLMetricIdentifiers = []mySQLMetricIdentifier{
 
 func TestParseMySQLMetadata(t *testing.T) {
 	for _, testData := range testMySQLMetadata {
-		_, err := parseMySQLMetadata(testMySQLResolvedEnv, testData.metadata, map[string]string{})
+		_, err := parseMySQLMetadata(&ScalerConfig{ResolvedEnv: testMySQLResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: map[string]string{}})
 		if err != nil && !testData.raisesError {
 			t.Error("Expected success but got error", err)
 		}
@@ -49,7 +49,7 @@ func TestParseMySQLMetadata(t *testing.T) {
 func TestMetadataToConnectionStrUseConnStr(t *testing.T) {
 	// Use existing ConnStr
 	testMeta := map[string]string{"query": "query", "queryValue": "12", "connectionStringFromEnv": "MYSQL_CONN_STR"}
-	meta, _ := parseMySQLMetadata(testMySQLResolvedEnv, testMeta, map[string]string{})
+	meta, _ := parseMySQLMetadata(&ScalerConfig{ResolvedEnv: testMySQLResolvedEnv, TriggerMetadata: testMeta, AuthParams: map[string]string{}})
 	connStr := metadataToConnectionStr(meta)
 	if connStr != testMySQLResolvedEnv["MYSQL_CONN_STR"] {
 		t.Error("Expected success")
@@ -60,7 +60,7 @@ func TestMetadataToConnectionStrBuildNew(t *testing.T) {
 	// Build new ConnStr
 	expected := "test_username:pass@tcp(test_host:test_port)/test_dbname"
 	testMeta := map[string]string{"query": "query", "queryValue": "12", "host": "test_host", "port": "test_port", "username": "test_username", "passwordFromEnv": "MYSQL_PASSWORD", "dbName": "test_dbname"}
-	meta, _ := parseMySQLMetadata(testMySQLResolvedEnv, testMeta, map[string]string{})
+	meta, _ := parseMySQLMetadata(&ScalerConfig{ResolvedEnv: testMySQLResolvedEnv, TriggerMetadata: testMeta, AuthParams: map[string]string{}})
 	connStr := metadataToConnectionStr(meta)
 	if connStr != expected {
 		t.Errorf("%s != %s", expected, connStr)
@@ -69,7 +69,7 @@ func TestMetadataToConnectionStrBuildNew(t *testing.T) {
 
 func TestMySQLGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range mySQLMetricIdentifiers {
-		meta, err := parseMySQLMetadata(testMySQLResolvedEnv, testData.metadataTestData.metadata, nil)
+		meta, err := parseMySQLMetadata(&ScalerConfig{ResolvedEnv: testMySQLResolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: nil})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -38,8 +38,8 @@ type postgreSQLMetadata struct {
 var postgreSQLLog = logf.Log.WithName("postgreSQL_scaler")
 
 // NewPostgreSQLScaler creates a new postgreSQL scaler
-func NewPostgreSQLScaler(resolvedEnv, metadata, authParams map[string]string) (Scaler, error) {
-	meta, err := parsePostgreSQLMetadata(resolvedEnv, metadata, authParams)
+func NewPostgreSQLScaler(config *ScalerConfig) (Scaler, error) {
+	meta, err := parsePostgreSQLMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing postgreSQL metadata: %s", err)
 	}
@@ -54,16 +54,16 @@ func NewPostgreSQLScaler(resolvedEnv, metadata, authParams map[string]string) (S
 	}, nil
 }
 
-func parsePostgreSQLMetadata(resolvedEnv, metadata, authParams map[string]string) (*postgreSQLMetadata, error) {
+func parsePostgreSQLMetadata(config *ScalerConfig) (*postgreSQLMetadata, error) {
 	meta := postgreSQLMetadata{}
 
-	if val, ok := metadata["query"]; ok {
+	if val, ok := config.TriggerMetadata["query"]; ok {
 		meta.query = val
 	} else {
 		return nil, fmt.Errorf("no query given")
 	}
 
-	if val, ok := metadata["targetQueryValue"]; ok {
+	if val, ok := config.TriggerMetadata["targetQueryValue"]; ok {
 		targetQueryValue, err := strconv.Atoi(val)
 		if err != nil {
 			return nil, fmt.Errorf("queryValue parsing error %s", err.Error())
@@ -73,43 +73,43 @@ func parsePostgreSQLMetadata(resolvedEnv, metadata, authParams map[string]string
 		return nil, fmt.Errorf("no targetQueryValue given")
 	}
 
-	if authParams["connection"] != "" {
-		meta.connection = authParams["connection"]
-	} else if metadata["connectionFromEnv"] != "" {
-		meta.connection = resolvedEnv[metadata["connectionFromEnv"]]
+	if config.AuthParams["connection"] != "" {
+		meta.connection = config.AuthParams["connection"]
+	} else if config.TriggerMetadata["connectionFromEnv"] != "" {
+		meta.connection = config.ResolvedEnv[config.TriggerMetadata["connectionFromEnv"]]
 	} else {
 		meta.connection = ""
-		if val, ok := metadata["host"]; ok {
+		if val, ok := config.TriggerMetadata["host"]; ok {
 			meta.host = val
 		} else {
 			return nil, fmt.Errorf("no  host given")
 		}
-		if val, ok := metadata["port"]; ok {
+		if val, ok := config.TriggerMetadata["port"]; ok {
 			meta.port = val
 		} else {
 			return nil, fmt.Errorf("no  port given")
 		}
 
-		if val, ok := metadata["userName"]; ok {
+		if val, ok := config.TriggerMetadata["userName"]; ok {
 			meta.userName = val
 		} else {
 			return nil, fmt.Errorf("no  username given")
 		}
-		if val, ok := metadata["dbName"]; ok {
+		if val, ok := config.TriggerMetadata["dbName"]; ok {
 			meta.dbName = val
 		} else {
 			return nil, fmt.Errorf("no dbname given")
 		}
-		if val, ok := metadata["sslmode"]; ok {
+		if val, ok := config.TriggerMetadata["sslmode"]; ok {
 			meta.sslmode = val
 		} else {
 			return nil, fmt.Errorf("no sslmode name given")
 		}
 
-		if authParams["password"] != "" {
-			meta.password = authParams["password"]
-		} else if metadata["passwordFromEnv"] != "" {
-			meta.password = resolvedEnv[metadata["passwordFromEnv"]]
+		if config.AuthParams["password"] != "" {
+			meta.password = config.AuthParams["password"]
+		} else if config.TriggerMetadata["passwordFromEnv"] != "" {
+			meta.password = config.ResolvedEnv[config.TriggerMetadata["passwordFromEnv"]]
 		}
 	}
 

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -28,7 +28,7 @@ var postgreSQLMetricIdentifiers = []postgreSQLMetricIdentifier{
 
 func TestPosgresSQLGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range postgreSQLMetricIdentifiers {
-		meta, err := parsePostgreSQLMetadata(map[string]string{"test_connection_string": "test_connection_string"}, testData.metadataTestData.metdadata, nil)
+		meta, err := parsePostgreSQLMetadata(&ScalerConfig{ResolvedEnv: map[string]string{"test_connection_string": "test_connection_string"}, TriggerMetadata: testData.metadataTestData.metdadata, AuthParams: nil})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -53,8 +53,8 @@ type promQueryResult struct {
 var prometheusLog = logf.Log.WithName("prometheus_scaler")
 
 // NewPrometheusScaler creates a new prometheusScaler
-func NewPrometheusScaler(resolvedEnv, metadata map[string]string) (Scaler, error) {
-	meta, err := parsePrometheusMetadata(metadata)
+func NewPrometheusScaler(config *ScalerConfig) (Scaler, error) {
+	meta, err := parsePrometheusMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing prometheus metadata: %s", err)
 	}
@@ -64,28 +64,28 @@ func NewPrometheusScaler(resolvedEnv, metadata map[string]string) (Scaler, error
 	}, nil
 }
 
-func parsePrometheusMetadata(metadata map[string]string) (*prometheusMetadata, error) {
+func parsePrometheusMetadata(config *ScalerConfig) (*prometheusMetadata, error) {
 	meta := prometheusMetadata{}
 
-	if val, ok := metadata[promServerAddress]; ok && val != "" {
+	if val, ok := config.TriggerMetadata[promServerAddress]; ok && val != "" {
 		meta.serverAddress = val
 	} else {
 		return nil, fmt.Errorf("no %s given", promServerAddress)
 	}
 
-	if val, ok := metadata[promQuery]; ok && val != "" {
+	if val, ok := config.TriggerMetadata[promQuery]; ok && val != "" {
 		meta.query = val
 	} else {
 		return nil, fmt.Errorf("no %s given", promQuery)
 	}
 
-	if val, ok := metadata[promMetricName]; ok && val != "" {
+	if val, ok := config.TriggerMetadata[promMetricName]; ok && val != "" {
 		meta.metricName = val
 	} else {
 		return nil, fmt.Errorf("no %s given", promMetricName)
 	}
 
-	if val, ok := metadata[promThreshold]; ok && val != "" {
+	if val, ok := config.TriggerMetadata[promThreshold]; ok && val != "" {
 		t, err := strconv.Atoi(val)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %s: %s", promThreshold, err)

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -36,7 +36,7 @@ var prometheusMetricIdentifiers = []prometheusMetricIdentifier{
 
 func TestPrometheusParseMetadata(t *testing.T) {
 	for _, testData := range testPromMetadata {
-		_, err := parsePrometheusMetadata(testData.metadata)
+		_, err := parsePrometheusMetadata(&ScalerConfig{TriggerMetadata: testData.metadata})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -48,7 +48,7 @@ func TestPrometheusParseMetadata(t *testing.T) {
 
 func TestPrometheusGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range prometheusMetricIdentifiers {
-		meta, err := parsePrometheusMetadata(testData.metadataTestData.metadata)
+		meta, err := parsePrometheusMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -54,7 +54,7 @@ var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
 
 func TestRabbitMQParseMetadata(t *testing.T) {
 	for _, testData := range testRabbitMQMetadata {
-		_, err := parseRabbitMQMetadata(sampleRabbitMqResolvedEnv, testData.metadata, testData.authParams)
+		_, err := parseRabbitMQMetadata(&ScalerConfig{ResolvedEnv: sampleRabbitMqResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -73,7 +73,7 @@ var testDefaultQueueLength = []parseRabbitMQMetadataTestData{
 
 func TestParseDefaultQueueLength(t *testing.T) {
 	for _, testData := range testDefaultQueueLength {
-		metadata, err := parseRabbitMQMetadata(sampleRabbitMqResolvedEnv, testData.metadata, testData.authParams)
+		metadata, err := parseRabbitMQMetadata(&ScalerConfig{ResolvedEnv: sampleRabbitMqResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		} else if testData.isError && err == nil {
@@ -128,7 +128,7 @@ func TestGetQueueInfo(t *testing.T) {
 				"protocol":    "http",
 			}
 
-			s, err := NewRabbitMQScaler(resolvedEnv, metadata, map[string]string{})
+			s, err := NewRabbitMQScaler(&ScalerConfig{ResolvedEnv: resolvedEnv, TriggerMetadata: metadata, AuthParams: map[string]string{}})
 
 			if err != nil {
 				t.Error("Expect success", err)
@@ -160,7 +160,7 @@ func TestGetQueueInfo(t *testing.T) {
 
 func TestRabbitMQGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range rabbitMQMetricIdentifiers {
-		meta, err := parseRabbitMQMetadata(map[string]string{"myHostSecret": "myHostSecret"}, testData.metadataTestData.metadata, nil)
+		meta, err := parseRabbitMQMetadata(&ScalerConfig{ResolvedEnv: map[string]string{"myHostSecret": "myHostSecret"}, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: nil})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/redis_scaler_test.go
+++ b/pkg/scalers/redis_scaler_test.go
@@ -56,7 +56,7 @@ var redisMetricIdentifiers = []redisMetricIdentifier{
 func TestRedisParseMetadata(t *testing.T) {
 	testCaseNum := 1
 	for _, testData := range testRedisMetadata {
-		_, err := parseRedisMetadata(testData.metadata, testRedisResolvedEnv, testData.authParams)
+		_, err := parseRedisMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testRedisResolvedEnv, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Errorf("Expected success but got error for unit test # %v", testCaseNum)
 		}
@@ -69,7 +69,7 @@ func TestRedisParseMetadata(t *testing.T) {
 
 func TestRedisGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range redisMetricIdentifiers {
-		meta, err := parseRedisMetadata(testData.metadataTestData.metadata, testRedisResolvedEnv, testData.metadataTestData.authParams)
+		meta, err := parseRedisMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testRedisResolvedEnv, AuthParams: testData.metadataTestData.authParams})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/redis_streams_scaler_test.go
+++ b/pkg/scalers/redis_streams_scaler_test.go
@@ -33,7 +33,7 @@ func TestParseRedisStreamsMetadata(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(te *testing.T) {
-			m, err := parseRedisStreamsMetadata(tc.metadata, tc.resolvedEnv, tc.authParams)
+			m, err := parseRedisStreamsMetadata(&ScalerConfig{TriggerMetadata: tc.metadata, ResolvedEnv: tc.resolvedEnv, AuthParams: tc.authParams})
 			assert.Nil(t, err)
 			assert.Equal(t, m.streamName, tc.metadata[streamNameMetadata])
 			assert.Equal(t, m.consumerGroupName, tc.metadata[consumerGroupNameMetadata])
@@ -91,7 +91,7 @@ func TestParseRedisStreamsMetadataForInvalidCases(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(te *testing.T) {
-			_, err := parseRedisStreamsMetadata(tc.metadata, tc.resolvedEnv, map[string]string{})
+			_, err := parseRedisStreamsMetadata(&ScalerConfig{TriggerMetadata: tc.metadata, ResolvedEnv: tc.resolvedEnv, AuthParams: map[string]string{}})
 			assert.NotNil(t, err)
 		})
 	}
@@ -118,7 +118,7 @@ func TestRedisStreamsGetMetricSpecForScaling(t *testing.T) {
 	}
 
 	for _, testData := range redisStreamMetricIdentifiers {
-		meta, err := parseRedisStreamsMetadata(testData.metadataTestData.metadata, map[string]string{"REDIS_SERVICE": "my-address"}, nil)
+		meta, err := parseRedisStreamsMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: map[string]string{"REDIS_SERVICE": "my-address"}, AuthParams: nil})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -6,6 +6,8 @@ import (
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+
+	kedav1alpha1 "github.com/kedacore/keda/api/v1alpha1"
 )
 
 // Scaler interface
@@ -30,4 +32,25 @@ type PushScaler interface {
 
 	// Run is the only writer to the active channel and must close it once done.
 	Run(ctx context.Context, active chan<- bool)
+}
+
+// ScalerConfig contains config fields common for all scalers
+type ScalerConfig struct {
+	// Name used for external scalers
+	Name string
+
+	// Namespace used for external scalers
+	Namespace string
+
+	// TriggerMetadata
+	TriggerMetadata map[string]string
+
+	// ResolvedEnv
+	ResolvedEnv map[string]string
+
+	// AuthParams
+	AuthParams map[string]string
+
+	// PodIdentity
+	PodIdentity kedav1alpha1.PodIdentityProvider
 }

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -59,8 +59,8 @@ const (
 var stanLog = logf.Log.WithName("stan_scaler")
 
 // NewStanScaler creates a new stanScaler
-func NewStanScaler(resolvedSecrets, metadata map[string]string) (Scaler, error) {
-	stanMetadata, err := parseStanMetadata(metadata)
+func NewStanScaler(config *ScalerConfig) (Scaler, error) {
+	stanMetadata, err := parseStanMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing kafka metadata: %s", err)
 	}
@@ -71,32 +71,32 @@ func NewStanScaler(resolvedSecrets, metadata map[string]string) (Scaler, error) 
 	}, nil
 }
 
-func parseStanMetadata(metadata map[string]string) (stanMetadata, error) {
+func parseStanMetadata(config *ScalerConfig) (stanMetadata, error) {
 	meta := stanMetadata{}
 
-	if metadata["natsServerMonitoringEndpoint"] == "" {
+	if config.TriggerMetadata["natsServerMonitoringEndpoint"] == "" {
 		return meta, errors.New("no monitoring endpoint given")
 	}
-	meta.natsServerMonitoringEndpoint = metadata["natsServerMonitoringEndpoint"]
+	meta.natsServerMonitoringEndpoint = config.TriggerMetadata["natsServerMonitoringEndpoint"]
 
-	if metadata["queueGroup"] == "" {
+	if config.TriggerMetadata["queueGroup"] == "" {
 		return meta, errors.New("no queue group given")
 	}
-	meta.queueGroup = metadata["queueGroup"]
+	meta.queueGroup = config.TriggerMetadata["queueGroup"]
 
-	if metadata["durableName"] == "" {
+	if config.TriggerMetadata["durableName"] == "" {
 		return meta, errors.New("no durable name group given")
 	}
-	meta.durableName = metadata["durableName"]
+	meta.durableName = config.TriggerMetadata["durableName"]
 
-	if metadata["subject"] == "" {
+	if config.TriggerMetadata["subject"] == "" {
 		return meta, errors.New("no subject given")
 	}
-	meta.subject = metadata["subject"]
+	meta.subject = config.TriggerMetadata["subject"]
 
 	meta.lagThreshold = defaultStanLagThreshold
 
-	if val, ok := metadata[lagThresholdMetricName]; ok {
+	if val, ok := config.TriggerMetadata[lagThresholdMetricName]; ok {
 		t, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return meta, fmt.Errorf("error parsing %s: %s", lagThresholdMetricName, err)

--- a/pkg/scalers/stan_scaler_test.go
+++ b/pkg/scalers/stan_scaler_test.go
@@ -33,7 +33,7 @@ var stanMetricIdentifiers = []stanMetricIdentifier{
 
 func TestStanParseMetadata(t *testing.T) {
 	for _, testData := range testStanMetadata {
-		_, err := parseStanMetadata(testData.metadata)
+		_, err := parseStanMetadata(&ScalerConfig{TriggerMetadata: testData.metadata})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -45,7 +45,7 @@ func TestStanParseMetadata(t *testing.T) {
 
 func TestStanGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range stanMetricIdentifiers {
-		meta, err := parseStanMetadata(testData.metadataTestData.metadata)
+		meta, err := parseStanMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -42,9 +42,9 @@ func ResolveContainerEnv(client client.Client, logger logr.Logger, podSpec *core
 
 // ResolveAuthRef provides authentication parameters needed authenticate scaler with the environment.
 // based on authentication method define in TriggerAuthentication, authParams and podIdentity is returned
-func ResolveAuthRef(client client.Client, logger logr.Logger, triggerAuthRef *kedav1alpha1.ScaledObjectAuthRef, podSpec *corev1.PodSpec, namespace string) (map[string]string, string) {
+func ResolveAuthRef(client client.Client, logger logr.Logger, triggerAuthRef *kedav1alpha1.ScaledObjectAuthRef, podSpec *corev1.PodSpec, namespace string) (map[string]string, kedav1alpha1.PodIdentityProvider) {
 	result := make(map[string]string)
-	podIdentity := ""
+	var podIdentity kedav1alpha1.PodIdentityProvider
 
 	if namespace != "" && triggerAuthRef != nil && triggerAuthRef.Name != "" {
 		triggerAuth := &kedav1alpha1.TriggerAuthentication{}
@@ -53,7 +53,7 @@ func ResolveAuthRef(client client.Client, logger logr.Logger, triggerAuthRef *ke
 			logger.Error(err, "Error getting triggerAuth", "triggerAuthRef.Name", triggerAuthRef.Name)
 		} else {
 			if triggerAuth.Spec.PodIdentity != nil {
-				podIdentity = string(triggerAuth.Spec.PodIdentity.Provider)
+				podIdentity = triggerAuth.Spec.PodIdentity.Provider
 			}
 			if triggerAuth.Spec.Env != nil {
 				for _, e := range triggerAuth.Spec.Env {

--- a/pkg/scaling/resolver/scale_resolvers_test.go
+++ b/pkg/scaling/resolver/scale_resolvers_test.go
@@ -137,7 +137,7 @@ func TestResolveAuthRef(t *testing.T) {
 		soar                *kedav1alpha1.ScaledObjectAuthRef
 		podSpec             *corev1.PodSpec
 		expected            map[string]string
-		expectedPodIdentity string
+		expectedPodIdentity kedav1alpha1.PodIdentityProvider
 	}{
 		{
 			name:     "foo",
@@ -205,7 +205,7 @@ func TestResolveAuthRef(t *testing.T) {
 			},
 			soar:                &kedav1alpha1.ScaledObjectAuthRef{Name: triggerAuthenticationName},
 			expected:            map[string]string{"host": secretData},
-			expectedPodIdentity: "none",
+			expectedPodIdentity: kedav1alpha1.PodIdentityProviderNone,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

1. Use `PodIdentityProvider` api type instead of strings throughout the codebase.

  This is the fix according to a discussion in https://github.com/kedacore/keda/pull/1220#issuecomment-703537331


2. Use `ScalerConfig` struct for all scalers 

While I was changing all function definitions to accommodate new type it seemed that if one `ScalerConfig` struct was introduced it would be much easier to do such changes in the future. 

Both changes are in separate commits, so if `ScalerConfig` seems to be undesirable I will drop it from this PR. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

