### PR TITLE
enable golangci-lint: interfacer, staticcheck (#1158)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     #- gocritic
     #- gocyclo
     - gosimple
-    - staticcheck
     - stylecheck
     - unused
     - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
     - unconvert
     - ineffassign
     - staticcheck
-    #- interfacer
+    - interfacer
     #- scopelint
     #- structcheck
     - deadcode
@@ -36,7 +36,7 @@ linters:
     #- gocritic
     #- gocyclo
     - gosimple
-    #- staticcheck
+    - staticcheck
     - stylecheck
     - unused
     - varcheck
@@ -53,6 +53,7 @@ issues:
       linters:
         - gomnd
         - dupl
+        - interfacer
 
     # https://github.com/go-critic/go-critic/issues/926
     - linters:

--- a/controllers/util/status.go
+++ b/controllers/util/status.go
@@ -12,7 +12,7 @@ import (
 )
 
 // SetStatusConditions patches given object with passed list of conditions based on the object's type or returns an error.
-func SetStatusConditions(client runtimeclient.Client, logger logr.Logger, object interface{}, conditions *kedav1alpha1.Conditions) error {
+func SetStatusConditions(client runtimeclient.StatusClient, logger logr.Logger, object interface{}, conditions *kedav1alpha1.Conditions) error {
 	var patch runtimeclient.Patch
 
 	runtimeObj := object.(runtime.Object)
@@ -37,7 +37,7 @@ func SetStatusConditions(client runtimeclient.Client, logger logr.Logger, object
 }
 
 // UpdateScaledObjectStatus patches the given ScaledObject with the updated status passed to it or returns an error.
-func UpdateScaledObjectStatus(client runtimeclient.Client, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, status *kedav1alpha1.ScaledObjectStatus) error {
+func UpdateScaledObjectStatus(client runtimeclient.StatusClient, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, status *kedav1alpha1.ScaledObjectStatus) error {
 	patch := runtimeclient.MergeFrom(scaledObject.DeepCopy())
 	scaledObject.Status = *status
 	err := client.Status().Patch(context.TODO(), scaledObject, patch)

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -120,7 +120,7 @@ func (h *scaleHandler) DeleteScalableObject(scalableObject interface{}) error {
 }
 
 // startScaleLoop blocks forever and checks the scaledObject based on its pollingInterval
-func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, scalableObject interface{}, scalingMutex *sync.Mutex) {
+func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, scalableObject interface{}, scalingMutex sync.Locker) {
 	logger := h.logger.WithValues("type", withTriggers.Kind, "namespace", withTriggers.Namespace, "name", withTriggers.Name)
 
 	// kick off one check to the scalers now
@@ -140,7 +140,7 @@ func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1a
 	}
 }
 
-func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, scalableObject interface{}, scalingMutex *sync.Mutex) {
+func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, scalableObject interface{}, scalingMutex sync.Locker) {
 	logger := h.logger.WithValues("type", withTriggers.Kind, "namespace", withTriggers.Namespace, "name", withTriggers.Name)
 	ss, err := h.GetScalers(scalableObject)
 	if err != nil {
@@ -178,7 +178,7 @@ func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav
 
 // checkScalers contains the main logic for the ScaleHandler scaling logic.
 // It'll check each trigger active status then call RequestScale
-func (h *scaleHandler) checkScalers(ctx context.Context, scalableObject interface{}, scalingMutex *sync.Mutex) {
+func (h *scaleHandler) checkScalers(ctx context.Context, scalableObject interface{}, scalingMutex sync.Locker) {
 	scalers, err := h.GetScalers(scalableObject)
 	if err != nil {
 		h.logger.Error(err, "Error getting scalers", "object", scalableObject)


### PR DESCRIPTION
Signed-off-by: akartasov <agneum@gmail.com>

Enables golangci-lint for interfacer and staticcheck.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

Fixes #1158
