### PR TITLE
Not running govet or gofmt in Dockerfile builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,6 @@ repos:
     hooks:
       - id: go-fmt
         name: Run go fmt against the code
-      - id: go-vet
-        name: Run go vet against the code
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
     hooks:
       - id: go-fmt
         name: Run go fmt against the code
+      - id: go-vet
+        name: Run go vet against the code
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY pkg/ pkg/
 COPY .git/ .git/
 
 # Build
-RUN VERSION=${BUILD_VERSION} make manager
+RUN VERSION=${BUILD_VERSION} make manager-dockerfile
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -28,7 +28,7 @@ COPY .git/ .git/
 RUN mkdir -p /apiserver.local.config/certificates && chmod -R 777 /apiserver.local.config
 
 # Build
-RUN VERSION=${BUILD_VERSION} make adapter
+RUN VERSION=${BUILD_VERSION} make adapter-dockerfile
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -136,14 +136,28 @@ docker-build:
 
 # Build KEDA Operator binary
 .PHONY: manager
-manager: generate gofmt govet
+manager: manager-dockerfile gofmt govet
+
+# Build the manager inside the Dockerfile. This elides
+# the gofmt and govet commands. Since code quality checks
+# are already in CI, we don't need to run them every
+# time we build the image
+.PHONY: manager-dockerfile
+manager-dockerfile: generate
 	${GO_BUILD_VARS} go build \
 	-ldflags "-X=github.com/kedacore/keda/version.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION)" \
 	-o bin/keda main.go
 
 # Build KEDA Metrics Server Adapter binary
 .PHONY: adapter
-adapter: generate gofmt govet
+adapter: adapter-dockerfile gofmt govet
+
+# Build the adapter inside the Dockerfile. This elides
+# the gofmt and govet commands. Since code quality checks
+# are already in CI, we don't need to run them every
+# time we build the image
+.PHONY: adapter-dockerfile
+adapter-dockerfile: generate
 	${GO_BUILD_VARS} go build \
 	-ldflags "-X=github.com/kedacore/keda/version.GitCommit=$(GIT_COMMIT) -X=github.com/kedacore/keda/version.Version=$(VERSION)" \
 	-o bin/keda-adapter adapter/main.go


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Since we have code quality checks on the `v2` branch, they will run prior to any docker build operation. That means that the `go fmt` and `go vet` calls inside the Dockerfile are redundant. This change removes them by creating two new makefile targets: `adapter-dockerfile` and `manager-dockerfile`, and changing the adapter and manager dockerfiles to call those two targets, respectively. 

This patch also adds `go vet` to the pre-commit config file.

**Question: should we add go vet to the golangci config file? This way, we can avoid running `go fmt` and `go vet` explicitly in the pre commit file, as it'll be done automatically by the pre-commit golangci hook**

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

Fixes #1070

Notes about TODOs:

- Tests don't need to be added here
- No docs updates needed as well

**Not sure about the changelog**