### PR TITLE
make release+set version before publishing images

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -33,13 +33,13 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
 
-      - name: Publish KEDA images to Docker Hub
-        run: make publish
+      - name: Release Deployment YAML file
+        run: make release
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 
-      - name: Release Deployment YAML file
-        run: make release
+      - name: Publish KEDA images to Docker Hub
+        run: make publish
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->
We should make the release and change version string in the [code](https://github.com/kedacore/keda/blob/a9e118f76d846a87d19d224a858009e7650f2fc5/version/version.go#L5) before publishing the images (so they contain the updated version string, which is then shown in the KEDA logs)