### PR TITLE
Wrong aws_iam_authorization access key id setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@
 
 ## Unreleased
 
-- Bug fix in aws_iam_authorization to utilize correct secret from env key name ([PR #1332](https://github.com/kedacore/keda/pull/1332))
-
 ### New
 
 ### Improvements
+
+- Bug fix in aws_iam_authorization to utilize correct secret from env key name ([PR #1332](https://github.com/kedacore/keda/pull/1332))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ## Unreleased
 
+- Bug fix in aws_iam_authorization to utilize correct secret from env key name ([PR #1332](https://github.com/kedacore/keda/pull/1332))
+
 ### New
 
 ### Improvements

--- a/pkg/scalers/aws_iam_authorization.go
+++ b/pkg/scalers/aws_iam_authorization.go
@@ -30,7 +30,7 @@ func getAwsAuthorization(authParams, metadata, resolvedEnv map[string]string) (a
 			if metadata["awsAccessKeyID"] != "" {
 				meta.awsAccessKeyID = metadata["awsAccessKeyID"]
 			} else if metadata["awsAccessKeyIDFromEnv"] != "" {
-				meta.awsAccessKeyID = resolvedEnv[metadata["awsAccessKeyID"]]
+				meta.awsAccessKeyID = resolvedEnv[metadata["awsAccessKeyIDFromEnv"]]
 			}
 
 			if len(meta.awsAccessKeyID) == 0 {


### PR DESCRIPTION
When getting the ACCESS_KEY_ID for AWS from Environment variables (which is currently the only working option), the `aws_iam_authorization` scaler would check if metadata.awsAccessKeyIDFromEnv was set, but it would then utilize the metadata.awsAccessKeyId for the name... while in the secretAccessKey it would then use the `FromEnv` one. This fixes that

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

Fixes #
