### PR TITLE
use the latest extension id for golang in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,6 @@
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
-		"ms-vscode.go"
+		"golang.go"
 	]
 }


### PR DESCRIPTION
Signed-off-by: Girish Ramnani <girishramnani95@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

As part of https://github.com/kedacore/keda/issues/1114, use the latest `golang.go` id for golang plugin for vscode in the devcontainer.json

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs.
- [ ] Changelog has been updated


Fixes https://github.com/kedacore/keda/issues/1114
