### PR TITLE
resolve broken link to community standup section in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ would love to become a maintainer to support our project please create an issue 
 
 ## Getting Help
 
-If you have a question about KEDA or how best to contribute, the [#KEDA](https://kubernetes.slack.com/archives/CKZJ36A5D) channel on the Kubernetes slack channel ([get an invite if you don't have one already](https://slack.k8s.io/)) is a good place to start.  We also have regular [community stand-ups](https://github.com/kedacore/keda#community-standup) to track ongoing work and discuss areas of contribution.  For any issues with the product you can [create an issue](https://github.com/kedacore/keda/issues/new) in this repo.
+If you have a question about KEDA or how best to contribute, the [#KEDA](https://kubernetes.slack.com/archives/CKZJ36A5D) channel on the Kubernetes slack channel ([get an invite if you don't have one already](https://slack.k8s.io/)) is a good place to start.  We also have regular [community stand-ups](https://github.com/kedacore/keda#community) to track ongoing work and discuss areas of contribution.  For any issues with the product you can [create an issue](https://github.com/kedacore/keda/issues/new) in this repo.
 
 ## Contributing Scalers
 


### PR DESCRIPTION
Signed-off-by: Girish Ramnani <girishramnani95@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

The current link to community standup in `contributing.md` seems to be pointing to a non-existent section in `README.md`, so changed that.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [X] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
      - link https://github.com/kedacore/keda-docs/pull/308 
- [ ] Changelog has been updated

No issue
