### PR TITLE
update the setup-go step from v2-beta to v2

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.15.3
       - name: Get golangci


### PR DESCRIPTION
Signed-off-by: Girish Ramnani <girishramnani95@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Currently observing this error in the `Static Checks` CI step due to use of `v2-beta` setup-go version. Updating that to `v2`

<img width="707" alt="Screenshot" src="https://user-images.githubusercontent.com/6551988/99303903-a5a1dd80-2877-11eb-8637-ade34d3f5f2e.png">


### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

CI should pass