### PR TITLE
Resolve authenticationRef for CRD target ref

### DIFF
--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -349,6 +349,9 @@ func (h *scaleHandler) buildScalers(withTriggers *kedav1alpha1.WithTriggers, pod
 			}
 			config.AuthParams = authParams
 			config.PodIdentity = podIdentity
+		} else {
+			authParams, _ := resolver.ResolveAuthRef(h.client, logger, trigger.AuthenticationRef, nil, withTriggers.Namespace)
+			config.AuthParams = authParams
 		}
 
 		scaler, err := buildScaler(trigger.Type, config)


### PR DESCRIPTION
Signed-off-by: Lionel Villard <villard@us.ibm.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

When `scaleTargetRef` references a CRD, the `secretTargetRef` section in `TriggerAuthentication` is ignored. This PR fixes it by not ignoring it.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

