### PR TITLE
Enbale depguard and dogsled Linters in .golangcli.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,8 +28,8 @@ linters:
     - scopelint
     - structcheck
     - deadcode
-    #- depguard
-    #- dogsled
+    - depguard
+    - dogsled
     #- errcheck
     #- funlen
     - goconst


### PR DESCRIPTION
Signed-off-by: Shubham82 <shubham.kuchhal@india.nec.com>


_Provide a description of what has been changed_
This PR enable depguard and  dogsled linters in golangcli.yml.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated

PartiallyFixes #1158