### PR TITLE
Postgres: optional metricName & mask passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 ### Improvements
 - Support add ScaledJob's label to its job ([#1311](https://github.com/kedacore/keda/issues/1311))
 - Bug fix in aws_iam_authorization to utilize correct secret from env key name ([PR #1332](https://github.com/kedacore/keda/pull/1332))
+- Add metricName field to postgres scaler and auto generate if not defined. ([PR #1381](https://github.com/kedacore/keda/pull/1381))
+- Mask password in postgres scaler auto generated metricName. ([PR #1381](https://github.com/kedacore/keda/pull/1381))
 
 ### Breaking Changes
 

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -43,7 +43,7 @@ func TestPosgresSQLGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range postgreSQLMetricIdentifiers {
 		meta, err := parsePostgreSQLMetadata(&ScalerConfig{ResolvedEnv: testData.resolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.authParam})
 		if err != nil {
-			t.Fatal("Could not parse n:", err)
+			t.Fatal("Could not parse metadata:", err)
 		}
 		mockPostgresSQLScaler := postgreSQLScaler{meta, nil}
 

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -10,26 +10,40 @@ type parsePostgreSQLMetadataTestData struct {
 
 type postgreSQLMetricIdentifier struct {
 	metadataTestData *parsePostgreSQLMetadataTestData
+	resolvedEnv      map[string]string
+	authParam        map[string]string
 	name             string
 }
 
 var testPostgreSQLMetdata = []parsePostgreSQLMetadataTestData{
-	// connection
+	// connection with username and password
 	{metadata: map[string]string{"query": "test_query", "targetQueryValue": "5", "connectionFromEnv": "test_connection_string"}},
+	// connection with username
+	{metadata: map[string]string{"query": "test_query", "targetQueryValue": "5", "connectionFromEnv": "test_connection_string2"}},
+	// connection without username and password
+	{metadata: map[string]string{"query": "test_query", "targetQueryValue": "5", "connection": "postgresql://localhost:5432"}},
+	// connection with password + metricname
+	{metadata: map[string]string{"query": "test_query", "targetQueryValue": "5", "connection": "postgresql://username:password@localhost:5432", "metricName": "scaler_sql_data2"}},
 	// dbName
 	{metadata: map[string]string{"query": "test_query", "targetQueryValue": "5", "host": "test_host", "port": "test_port", "userName": "test_user_name", "dbName": "test_db_name", "sslmode": "test_ssl_mode"}},
+	// dbName + metricName
+	{metadata: map[string]string{"query": "test_query", "targetQueryValue": "5", "host": "test_host", "port": "test_port", "userName": "test_user_name", "dbName": "test_db_name", "sslmode": "test_ssl_mode", "metricName": "scaler_sql_data"}},
 }
 
 var postgreSQLMetricIdentifiers = []postgreSQLMetricIdentifier{
-	{&testPostgreSQLMetdata[0], "postgresql-test_connection_string"},
-	{&testPostgreSQLMetdata[1], "postgresql-test_db_name"},
+	{&testPostgreSQLMetdata[0], map[string]string{"test_connection_string": "postgresql://localhost:5432"}, nil, "postgresql-postgresql---localhost-5432"},
+	{&testPostgreSQLMetdata[1], map[string]string{"test_connection_string2": "postgresql://test@localhost"}, nil, "postgresql-postgresql---test@localhost"},
+	{&testPostgreSQLMetdata[2], nil, map[string]string{"connection": "postgresql://user:password@localhost:5432/dbname"}, "postgresql-postgresql---user-xxx@localhost-5432-dbname"},
+	{&testPostgreSQLMetdata[3], nil, map[string]string{"connection": "postgresql://Username123:secret@localhost"}, "postgresql-scaler_sql_data2"},
+	{&testPostgreSQLMetdata[4], nil, map[string]string{"connection": "postgresql://user:password@localhost:5432/dbname?app_name=test"}, "postgresql-postgresql---user-xxx@localhost-5432-dbname?app_name=test"},
+	{&testPostgreSQLMetdata[5], nil, map[string]string{"connection": "postgresql://Username123:secret@localhost"}, "postgresql-scaler_sql_data"},
 }
 
 func TestPosgresSQLGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range postgreSQLMetricIdentifiers {
-		meta, err := parsePostgreSQLMetadata(&ScalerConfig{ResolvedEnv: map[string]string{"test_connection_string": "test_connection_string"}, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: nil})
+		meta, err := parsePostgreSQLMetadata(&ScalerConfig{ResolvedEnv: testData.resolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.authParam})
 		if err != nil {
-			t.Fatal("Could not parse metadata:", err)
+			t.Fatal("Could not parse n:", err)
 		}
 		mockPostgresSQLScaler := postgreSQLScaler{meta, nil}
 

--- a/pkg/util/normalize_string.go
+++ b/pkg/util/normalize_string.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"net/url"
 	"strings"
 )
 
@@ -11,4 +12,18 @@ func NormalizeString(s string) string {
 	s = strings.ReplaceAll(s, ":", "-")
 	s = strings.ReplaceAll(s, "%", "-")
 	return s
+}
+
+// MaskPassword will parse a url and returned a masked version or an error
+func MaskPassword(s string) (string, error) {
+	url, err := url.Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	if password, ok := url.User.Password(); ok {
+		return strings.ReplaceAll(s, password, "xxx"), nil
+	}
+
+	return s, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Added `metricName` as an optional meta field to the Postgres scaler. When not provided one is generated as before but with passwords masked as `xxx`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Changelog has been updated

Issue #1200 
