### PR TITLE
Add section on KEDA operator logs for bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve
 labels: bug
 ---
 
-A clear and concise description of what the bug is.
+*A clear and concise description of what the bug is.*
 
 ## Expected Behavior
 
@@ -17,6 +17,14 @@ A clear and concise description of what the bug is.
   1.
   2.
   3.
+
+## Logs from KEDA operator
+
+*Provide logs from KEDA operator, if need be.*
+
+```
+example
+```
 
 ## Specifications
 


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Add section on KEDA operator logs for bug template.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
