### PR TITLE
Ensure that all scalers are closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add metricName field to postgres scaler and auto generate if not defined. ([PR #1381](https://github.com/kedacore/keda/pull/1381))
 - Mask password in postgres scaler auto generated metricName. ([PR #1381](https://github.com/kedacore/keda/pull/1381))
 - Bug fix for pending jobs in ScaledJob's accurateScalingStrategy . ([#1323](https://github.com/kedacore/keda/issues/1323))
+- Fix memory leak because of unclosed scalers. ([#1413](https://github.com/kedacore/keda/issues/1413))
 
 ### Breaking Changes
 

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -199,7 +199,7 @@ func (h *scaleHandler) checkScalers(ctx context.Context, scalableObject interfac
 
 func (h *scaleHandler) checkScaledObjectScalers(ctx context.Context, scalers []scalers.Scaler) bool {
 	isActive := false
-	for _, scaler := range scalers {
+	for i, scaler := range scalers {
 		isTriggerActive, err := scaler.IsActive(ctx)
 		scaler.Close()
 
@@ -214,6 +214,7 @@ func (h *scaleHandler) checkScaledObjectScalers(ctx context.Context, scalers []s
 			if scaler.GetMetricSpecForScaling()[0].Resource != nil {
 				h.logger.V(1).Info("Scaler for scaledObject is active", "Metrics Name", scaler.GetMetricSpecForScaling()[0].Resource.Name)
 			}
+			closeScalers(scalers[i+1:])
 			break
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Maxence Boutet <mboutet@explorance.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

In [`checkScaledObjectScalers`](https://github.com/kedacore/keda/blob/76fb858175075ab21328ebdf3726d6d1f7af064c/pkg/scaling/scale_handler.go#L200), as soon as one active scaler is encountered, all the remaining scalers are not closed leading to ever increasing memory usage. This PR ensures that all the remaining scalers are closed after one active scaler has been found.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs (no doc to update)
- [X] Changelog has been updated

Fixes #1413 
