### PR TITLE
fixes for tests

### DIFF
--- a/pkg/metrics/prometheus_metrics.go
+++ b/pkg/metrics/prometheus_metrics.go
@@ -98,7 +98,7 @@ func (metricsServer PrometheusMetricServer) RecordHPAScalerError(namespace strin
 		return
 	}
 	// initialize metric with 0 if not already set
-	_, errscaler := scalerErrorsTotal.GetMetricWith(getLabels(namespace, scaledObject, scaler, scalerIndex, metric))
+	_, errscaler := scalerErrors.GetMetricWith(getLabels(namespace, scaledObject, scaler, scalerIndex, metric))
 	if errscaler != nil {
 		log.Fatalf("Unable to write to serve custom metrics: %v", errscaler)
 	}

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -39,10 +39,9 @@ type artemisMetadata struct {
 //revive:enable:var-naming
 
 type artemisMonitoring struct {
-	Request   string `json:"request"`
-	MsgCount  int    `json:"value"`
-	Status    int    `json:"status"`
-	Timestamp int64  `json:"timestamp"`
+	MsgCount  int   `json:"value"`
+	Status    int   `json:"status"`
+	Timestamp int64 `json:"timestamp"`
 }
 
 const (

--- a/tests/scalers/influxdb.test.ts
+++ b/tests/scalers/influxdb.test.ts
@@ -57,7 +57,7 @@ test.before((t) => {
 
     // Wait for influxdb instance to be ready
     let influxdbStatus = 'false'
-    for (let i = 0; i < 15; i++) {
+    for (let i = 0; i < 25; i++) {
         influxdbStatus = sh.exec(`kubectl get pod ${influxdbPodName} --namespace ${influxdbNamespaceName} -o jsonpath='{.status.containerStatuses[0].started}'`).stdout
         if (influxdbStatus !== 'true') {
             sh.exec('sleep 2s')
@@ -98,7 +98,7 @@ test.serial('Should start off deployment with 0 replicas and scale to 2 replicas
     t.is(numReplicasAfter, '2', 'Number of replicas should have scaled to 2')
 })
 
-test.after((t) => {
+test.after.always((t) => {
     t.is(0, sh.exec(`kubectl delete namespace ${influxdbNamespaceName}`).code, 'Should delete influxdb namespace')
 })
 


### PR DESCRIPTION
I added some comments below to explain the changes. However, influxdb test is still failing. It's failing to scale beyond 1 replica, and I see this error from the metrics server

```
E1215 07:57:59.134382       1 status.go:71] apiserver received an error that is not an metav1.Status: &errors.errorString{s:"No matching metrics found for influxdb-my-org-1608019063"}
E1215 07:58:14.170619       1 status.go:71] apiserver received an error that is not an metav1.Status: &errors.errorString{s:"No matching metrics found for influxdb-my-org-1608019079"}
```

not sure if it's related, but haven't looked further into this one yet. 



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [N/A] Tests have been added
- [N/A] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [N/A ] Changelog has been updated

