### PR TITLE
Update operator to support the WATCH_NAMESPACE env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Fix memory leak because of unclosed scalers. ([#1413](https://github.com/kedacore/keda/issues/1413))
 - Optimize Kafka scaler's `getLagForPartition` function. ([#1464](https://github.com/kedacore/keda/pull/1464))
 - Reduce unnecessary /scale requests from ScaledObject controller ([#1453](https://github.com/kedacore/keda/pull/1453))
-- Add support for the WATCH_NAMESPACE environment variable to the operator
+- Add support for the WATCH_NAMESPACE environment variable to the operator ([#1474](https://github.com/kedacore/keda/pull/1474))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix memory leak because of unclosed scalers. ([#1413](https://github.com/kedacore/keda/issues/1413))
 - Optimize Kafka scaler's `getLagForPartition` function. ([#1464](https://github.com/kedacore/keda/pull/1464))
 - Reduce unnecessary /scale requests from ScaledObject controller ([#1453](https://github.com/kedacore/keda/pull/1453))
+- Add support for the WATCH_NAMESPACE environment variable to the operator
 
 ### Breaking Changes
 


### PR DESCRIPTION
Signed-off-by: Colton Herinckx <herinckc@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

This PR adds operator support for the `WATCH_NAMESPACE` environment variable; while the adapter currently supports this env var it seems as though the operator itself does not

Let me know if I need to update any tests or docs along with this PR. I didn't see any operator-specific tests or any mention of the `WATCH_NAMESPACE` env var in the keda-docs repo so I haven't done anything for either of those tasks but I'm happy to make more changes if I've missed anything

Addresses https://github.com/kedacore/keda/issues/601#issuecomment-750534901

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated