### PR TITLE
Limit concurrent e2e tests to 10

### DIFF
--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -512,8 +512,10 @@ func (s *azureLogAnalyticsScaler) runHTTP(request *http.Request, caller string) 
 	request.Header.Add("User-Agent", "keda/2.0.0")
 
 	resp, err := s.httpClient.Do(request)
-	if err != nil {
+	if err != nil && resp != nil {
 		return nil, resp.StatusCode, fmt.Errorf("error calling %s. Inner Error: %v", caller, err)
+	} else if err != nil {
+		return nil, 0, fmt.Errorf("error calling %s. Inner Error: %v", caller, err)
 	}
 
 	defer resp.Body.Close()

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -4,6 +4,7 @@ set -eu
 DIR=$(dirname "$0")
 cd $DIR
 
+concurrent_tests_limit=10
 pids=()
 lookup=()
 failed_count=0
@@ -15,13 +16,22 @@ function run_setup {
 }
 
 function run_tests {
-    for test_case in $(find scalers -name "*.test.ts")
+    counter=0
+    # randomize tests order using shuf
+    for test_case in $(find scalers -name "*.test.ts" | shuf)
     do
+        counter=$((counter+1))
         ./node_modules/.bin/ava $test_case > "${test_case}.log" 2>&1 &
         pid=$!
         echo "Running $test_case with pid: $pid"
         pids+=($pid)
         lookup[$pid]=$test_case
+        # limit concurrent runs
+        if [[ "$counter" -gt "$concurrent_tests_limit" ]]; then
+            wait_for_jobs
+            counter=0
+            pids=()
+        fi
     done
 }
 

--- a/tests/scalers/azure-queue-restore-original-replicas.test.ts
+++ b/tests/scalers/azure-queue-restore-original-replicas.test.ts
@@ -117,7 +117,7 @@ spec:
     spec:
       containers:
       - name: test-deployment
-        image: ahmelsayed/queue-consumer:latest
+        image: docker.io/kedacore/tests-azure-queue:824031e
         resources:
         ports:
         env:

--- a/tests/scalers/azure-queue-trigger-auth.test.ts
+++ b/tests/scalers/azure-queue-trigger-auth.test.ts
@@ -124,7 +124,7 @@ spec:
     spec:
       containers:
       - name: test-deployment
-        image: ahmelsayed/queue-consumer:latest
+        image: docker.io/kedacore/tests-azure-queue:824031e
         resources:
         ports:
         env:

--- a/tests/scalers/azure-queue.test.ts
+++ b/tests/scalers/azure-queue.test.ts
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: test-deployment
-        image: ahmelsayed/queue-consumer:latest
+        image: docker.io/kedacore/tests-azure-queue:824031e
         resources:
         ports:
         env:

--- a/tests/scalers/mysql.test.ts
+++ b/tests/scalers/mysql.test.ts
@@ -137,7 +137,7 @@ spec:
         app: mysql-update-worker
     spec:
       containers:
-      - image: docker.io/kedacore/tests-mysql:59fd59b
+      - image: docker.io/kedacore/tests-mysql:824031e
         imagePullPolicy: Always
         name: mysql-processor-test
         command:
@@ -202,7 +202,7 @@ spec:
         app: mysql-insert-job
     spec:
       containers:
-      - image: docker.io/tbickford/keda-mysql-e2e:latest
+      - image: docker.io/kedacore/tests-mysql:824031e
         imagePullPolicy: Always
         name: mysql-processor-test
         command:


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

- Fix the image name used for azure queue tests
- Fix a nil dereference error in azure_log_analytics_scaler.go 
- limit concurrent test runs to 10

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [N/A] Tests have been added
- [N/A] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [N/A] Changelog has been updated

