### PR TITLE
Fix scaleTarget name reference when resolving pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Optimize Kafka scaler's `getLagForPartition` function. ([#1464](https://github.com/kedacore/keda/pull/1464))
 - Reduce unnecessary /scale requests from ScaledObject controller ([#1453](https://github.com/kedacore/keda/pull/1453))
 - Add support for the WATCH_NAMESPACE environment variable to the operator ([#1474](https://github.com/kedacore/keda/pull/1474))
-- Automatically determine the RabbitMQ protocol when possible, and support setting the protocl via TriggerAuthentication ([#1459](https://github.com/kedacore/keda/pulls/1459))
+- Automatically determine the RabbitMQ protocol when possible, and support setting the protocl via TriggerAuthentication ([#1459](https://github.com/kedacore/keda/pulls/1459),[#1483](https://github.com/kedacore/keda/pull/1483))
 - Improve performance when fetching pod information ([#1457](https://github.com/kedacore/keda/pull/1457))
 
 ### Breaking Changes

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -377,7 +377,7 @@ func (h *scaleHandler) getPods(scalableObject interface{}) (*corev1.PodTemplateS
 		// Try to get a real object instance for better cache usage, but fall back to an Unstructured if needed.
 		podTemplateSpec := corev1.PodTemplateSpec{}
 		gvk := obj.Status.ScaleTargetGVKR.GroupVersionKind()
-		objKey := client.ObjectKey{Namespace: obj.Namespace, Name: obj.Status.ScaleTargetGVKR.Resource}
+		objKey := client.ObjectKey{Namespace: obj.Namespace, Name: obj.Spec.ScaleTargetRef.Name}
 		switch {
 		// For core types, use a typed client so we get an informer-cache-backed Get to reduce API load.
 		case gvk.Group == "apps" && gvk.Kind == "Deployment":


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

In https://github.com/kedacore/keda/pull/1457 we have overlooked a small problem, Kubernetes Resource was used to reference the name of the target workload. ie. if we were scaling `Deployment` a string `deployments` was used to reference the name.

Thus scaling is not working, see the log:

```
keda-operator-84f7687cfc-qtkch keda-operator 2021-01-06T11:36:51.713Z	INFO	controllers.ScaledObject	Detected resource targeted for scaling	{"ScaledObject.Namespace": "default", "ScaledObject.Name": "hello-scaledobject", "resource": "apps/v1.Deployment", "name": "hello-keda"}
keda-operator-84f7687cfc-qtkch keda-operator 2021-01-06T11:36:51.713Z	INFO	controllers.ScaledObject	Creating a new HPA	{"ScaledObject.Namespace": "default", "ScaledObject.Name": "hello-scaledobject", "HPA.Namespace": "default", "HPA.Name": "keda-hpa-hello-scaledobject"}
keda-operator-84f7687cfc-qtkch keda-operator 2021-01-06T11:36:51.814Z	ERROR	scalehandler	Target deployment doesn't exist	{"resource": "apps/v1, Kind=Deployment", "name": "deployments", "error": "Deployment.apps \"deployments\" not found"}
keda-operator-84f7687cfc-qtkch keda-operator github.com/go-logr/zapr.(*zapLogger).Error
keda-operator-84f7687cfc-qtkch keda-operator 	/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
keda-operator-84f7687cfc-qtkch keda-operator github.com/kedacore/keda/v2/pkg/scaling.(*scaleHandler).getPods
keda-operator-84f7687cfc-qtkch keda-operator 	/workspace/pkg/scaling/scale_handler.go:387
keda-operator-84f7687cfc-qtkch keda-operator github.com/kedacore/keda/v2/pkg/scaling.(*scaleHandler).GetScalers
keda-operator-84f7687cfc-qtkch keda-operator 	/workspace/pkg/scaling/scale_handler.go:66
keda-operator-84f7687cfc-qtkch keda-operator github.com/kedacore/keda/v2/controllers.(*ScaledObjectReconciler).getScaledObjectMetricSpecs
```


