### PR TITLE
minor e2e tests tweaks

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -75,7 +75,7 @@ function run_cleanup {
 }
 
 function print_failed {
-    echo "$failed_count tests failed"
+    echo "$failed_count e2e tests failed"
     for failed_test in "${failed_lookup[@]}"; do
         echo $failed_test
     done

--- a/tests/scalers/argo-rollouts.test.ts
+++ b/tests/scalers/argo-rollouts.test.ts
@@ -26,8 +26,7 @@ test.before(t => {
 
   // install argo-rollouts
   sh.exec(`kubectl create namespace ${argoRolloutsNamespace}`)
-  const argoRolloutsYaml = sh.exec(`curl -L https://raw.githubusercontent.com/argoproj/argo-rollouts/stable/manifests/install.yaml`).stdout
-  fs.writeFileSync(argoRolloutsYamlFile.name, argoRolloutsYaml)
+  sh.exec(`curl -L https://raw.githubusercontent.com/argoproj/argo-rollouts/stable/manifests/install.yaml > ${argoRolloutsYamlFile.name}`)
 	t.is(
 		0,
 		sh.exec(`kubectl apply -f ${argoRolloutsYamlFile.name} --namespace ${argoRolloutsNamespace}`).code,


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

- argo rollout test -  no need to log Argo installation resources, they are pretty huge and making the log unnecessary long
- minor edit in the result print message
