### PR TITLE
fix codegen generation a verification on GH Actions

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -37,6 +37,6 @@ if [[ $ret -eq 0 ]]
 then
   echo "${DIFFROOT} up to date."
 else
-  echo "${DIFFROOT} is out of date. Please run make clientset-generate"
+  echo "${DIFFROOT} is out of date. Please run 'make clientset-generate'"
   exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->


At some environments (eg. GitHub Actions), due to $GOPATH setting, the codegen output might not be at the expected path in the project repo, therefore we should force the output to the specific directory (see --output-base) we need to handle (move) the generated files to the correct location in the repo then.

Without this change, we weren't able to catch neccessary updates in the generated code (for example as in #1486).