### PR TITLE
Add graceful cleanup for redis cluster e2e test

### DIFF
--- a/tests/scalers/redis-cluster-lists.test.ts
+++ b/tests/scalers/redis-cluster-lists.test.ts
@@ -251,8 +251,8 @@ test.after.always.cb('clean up deployment', t => {
         `scaledobject.keda.sh/${redisWorkerHostPortRefDeploymentName}`,
         `scaledobject.keda.sh/${redisWorkerAddressRefDeploymentName}`,
         `scaledobject.keda.sh/${redisWorkerHostPortRefTriggerAuthDeploymentName}`,
-        'triggerauthentication.keda.sh/keda-redis-list-triggerauth',
-        'triggerauthentication.keda.sh/keda-redis-list-triggerauth-host-port',
+        'triggerauthentication.keda.sh/keda-redis-cluster-list-triggerauth',
+        'triggerauthentication.keda.sh/keda-redis-cluster-list-triggerauth-host-port',
         `deployment/${redisWorkerAddressRefDeploymentName}`,
         `deployment/${redisWorkerHostPortRefTriggerAuthDeploymentName}`,
         `deployment/${redisWorkerHostPortRefDeploymentName}`,
@@ -264,6 +264,7 @@ test.after.always.cb('clean up deployment', t => {
     }
     sh.exec(`kubectl delete namespace ${testNamespace}`)
 
+    sh.exec(`helm delete ${redisClusterName} --namespace ${redisNamespace}`)
     sh.exec(`kubectl delete namespace ${redisNamespace}`)
     t.end()
 })

--- a/tests/scalers/redis-cluster-streams.test.ts
+++ b/tests/scalers/redis-cluster-streams.test.ts
@@ -10,8 +10,6 @@ const redisService = 'redis-cluster-streams'
 const testNamespace = 'redis-cluster-streams-test'
 const redisPassword = 'foobared'
 let redisHost = ''
-let redisAddress = ''
-const redisPort = 6379
 const numMessages = 100
 
 test.before(t => {
@@ -35,7 +33,6 @@ test.before(t => {
 
     // Get Redis cluster address.
     redisHost = sh.exec(`kubectl get svc ${redisService} -n ${redisNamespace} -o jsonpath='{.spec.clusterIP}'`)
-    redisAddress = `${redisHost}:${redisPort}`
 
     // Create test namespace.
     sh.exec(`kubectl create namespace ${testNamespace}`)
@@ -114,6 +111,7 @@ test.after.always.cb('clean up deployment', t => {
     'triggerauthentications.keda.sh/keda-redis-stream-triggerauth',
     'secret/redis-password',
     'deployment/redis-streams-consumer',
+    'job/redis-streams-producer',
   ]
 
   for (const resource of resources) {
@@ -121,6 +119,7 @@ test.after.always.cb('clean up deployment', t => {
   }
   sh.exec(`kubectl delete namespace ${testNamespace}`)
 
+  sh.exec(`helm delete ${redisClusterName} --namespace ${redisNamespace}`)
   sh.exec(`kubectl delete namespace ${redisNamespace}`)
   t.end()
 })


### PR DESCRIPTION
Signed-off-by: Deepak <sah.sslpu@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

This adds graceful clean-up of redis cluster for `redis-cluster` and `redis-cluster-streams` scalers e2e tests.
Also, fixes names of unavailable resources inside `redis-cluster-lists.test.ts` .

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [N/A] Tests have been added
- [N/A] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [N/A] Changelog has been updated
