### PR TITLE
prometheus scaler: handle errors from Prometheus server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Automatically determine the RabbitMQ protocol when possible, and support setting the protocl via TriggerAuthentication ([#1459](https://github.com/kedacore/keda/pulls/1459),[#1483](https://github.com/kedacore/keda/pull/1483))
 - Improve performance when fetching pod information ([#1457](https://github.com/kedacore/keda/pull/1457))
 - Improve performance when fetching current scaling information on Deployments ([#1458](https://github.com/kedacore/keda/pull/1458))
+- Improve error reporting in prometheus scaler ([PR #1497](https://github.com/kedacore/keda/pull/1497))
 
 ### Breaking Changes
 

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -149,6 +149,10 @@ func (s *prometheusScaler) ExecutePromQuery() (float64, error) {
 	}
 	r.Body.Close()
 
+	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
+		return -1, fmt.Errorf("prometheus query api returned error. status: %d response: %s", r.StatusCode, string(b))
+	}
+
 	var result promQueryResult
 	err = json.Unmarshal(b, &result)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Suresh Kumar <sureshkumar.pp@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

When there is a typo or some other error in prometheus query, prometheus server returns
non-2xx response, which is being ignored silently. This checks for response
code and returns appropriate error

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated


