### PR TITLE
Fix conversion between integer types

### DIFF
--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -185,7 +185,7 @@ func (s *awsSqsQueueScaler) GetAwsSqsQueueLength() (int32, error) {
 		return -1, err
 	}
 
-	approximateNumberOfMessages, err := strconv.Atoi(*output.Attributes[awsSqsQueueMetricName])
+	approximateNumberOfMessages, err := strconv.ParseInt(*output.Attributes[awsSqsQueueMetricName], 10, 32)
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/scalers/cpu_memory_scaler.go
+++ b/pkg/scalers/cpu_memory_scaler.go
@@ -58,7 +58,7 @@ func parseResourceMetadata(config *ScalerConfig) (*cpuMemoryMetadata, error) {
 		averageValueQuantity := resource.MustParse(value)
 		meta.AverageValue = &averageValueQuantity
 	case v2beta2.UtilizationMetricType:
-		valueNum, err := strconv.Atoi(value)
+		valueNum, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -164,7 +164,7 @@ func parseRedisMetadata(config *ScalerConfig, parserFn redisAddressParser) (*red
 
 	meta.databaseIndex = defaultDBIdx
 	if val, ok := config.TriggerMetadata["databaseIndex"]; ok {
-		dbIndex, err := strconv.ParseInt(val, 10, 64)
+		dbIndex, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("databaseIndex: parsing error %s", err.Error())
 		}

--- a/pkg/scalers/redis_streams_scaler.go
+++ b/pkg/scalers/redis_streams_scaler.go
@@ -153,7 +153,7 @@ func parseRedisStreamsMetadata(config *ScalerConfig, parseFn redisAddressParser)
 
 	meta.databaseIndex = defaultDBIndex
 	if val, ok := config.TriggerMetadata[databaseIndexMetadata]; ok {
-		dbIndex, err := strconv.ParseInt(val, 10, 64)
+		dbIndex, err := strconv.ParseInt(val, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing redis database index %v", err)
 		}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->
 
As per [CodeQL checks](https://github.com/kedacore/keda/security/code-scanning/8?query=ref%3Arefs%2Fheads%2Fmain) there are a couple of incorrect conversions between integer types, I don't think that these parts of the code actually caused any errors (as the parsed int's aren't big enough to overflow the 32bits), but I think that it is proper to fix that.

- [x] Commits are signed with Developer Certificate of Origin (DCO)
