### PR TITLE
Makefile: cleanup vendor because it is needed only for clientset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,11 +254,13 @@ clientset-prepare:
 clientset-verify: clientset-prepare
 	./hack/verify-codegen.sh
 	rm -rf api/keda
+	rm -rf vendor
 
 .PHONY: clientset-generate
 clientset-generate: clientset-prepare
 	./hack/update-codegen.sh
 	rm -rf api/keda
+	rm -rf vendor
 
 ##################################################
 # Build Tools Image                              #


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Very minor nit: Let's cleanup `vendor` after clientset generation/verification, as it is not used anywhere else and may cause problems in other steps.

Related to https://github.com/kedacore/keda/pull/1512#discussion_r560910942