### PR TITLE
Updating deprecated Stackdriver dependency

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,10 +60,6 @@ issues:
     - path: _finalizer.go
       linters:
         - interfacer
-    # Excluding the stackdriver_client scaler until it is fixed: https://github.com/kedacore/keda/pull/1512#issuecomment-763454243
-    - path: pkg/scalers/stackdriver_client.go
-      linters:
-        - staticcheck
     # https://github.com/go-critic/go-critic/issues/926
     - linters:
         - gocritic

--- a/pkg/scalers/stackdriver_client.go
+++ b/pkg/scalers/stackdriver_client.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	"google.golang.org/api/iterator"
 	option "google.golang.org/api/option"


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->
` SA1019: package cloud.google.com/go/monitoring/apiv3 is deprecated: Please use cloud.google.com/go/monitoring/apiv3/v2.`