### PR TITLE
Emit kubernetes events from KEDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Global authentication credentials can be managed using `ClusterTriggerAuthentication` objects ([#1452](https://github.com/kedacore/keda/pull/1452))
 - Introducing OpenStack Swift scaler ([#1342](https://github.com/kedacore/keda/issues/1342))
 - Introducing MongoDB scaler ([#1467](https://github.com/kedacore/keda/pull/1467))
+- Emit Kubernetes Events on KEDA events ([#1523]())
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [v1.0.0](#v100)
 
 ## Unreleased
+- Emit Kubernetes Events on KEDA events ([#1523](https://github.com/kedacore/keda/pull/1523))
 
 ### New
 
@@ -43,7 +44,6 @@
 - Global authentication credentials can be managed using `ClusterTriggerAuthentication` objects ([#1452](https://github.com/kedacore/keda/pull/1452))
 - Introducing OpenStack Swift scaler ([#1342](https://github.com/kedacore/keda/issues/1342))
 - Introducing MongoDB scaler ([#1467](https://github.com/kedacore/keda/pull/1467))
-- Emit Kubernetes Events on KEDA events ([#1523](https://github.com/kedacore/keda/pull/1523)):wq
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Global authentication credentials can be managed using `ClusterTriggerAuthentication` objects ([#1452](https://github.com/kedacore/keda/pull/1452))
 - Introducing OpenStack Swift scaler ([#1342](https://github.com/kedacore/keda/issues/1342))
 - Introducing MongoDB scaler ([#1467](https://github.com/kedacore/keda/pull/1467))
-- Emit Kubernetes Events on KEDA events ([#1523]())
+- Emit Kubernetes Events on KEDA events ([#1523](https://github.com/kedacore/keda/pull/1523)):wq
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@
 - [v1.0.0](#v100)
 
 ## Unreleased
-- Emit Kubernetes Events on KEDA events ([#1523](https://github.com/kedacore/keda/pull/1523))
 
 ### New
 
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- Emit Kubernetes Events on KEDA events ([#1523](https://github.com/kedacore/keda/pull/1523))
 
 ### Improvements
 

--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -115,6 +115,13 @@ func (c *Conditions) GetActiveCondition() Condition {
 	return c.getCondition(ConditionActive)
 }
 
+func (c *Conditions) GetReadyCondition() Condition {
+	if *c == nil {
+		c = GetInitializedConditions()
+	}
+	return c.getCondition(ConditionReady)
+}
+
 func (c Conditions) getCondition(conditionType ConditionType) Condition {
 	for i := range c {
 		if c[i].Type == conditionType {

--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -115,6 +115,7 @@ func (c *Conditions) GetActiveCondition() Condition {
 	return c.getCondition(ConditionActive)
 }
 
+// GetReadyCondition returns Condition of type Ready
 func (c *Conditions) GetReadyCondition() Condition {
 	if *c == nil {
 		c = GetInitializedConditions()

--- a/controllers/scaledjob_controller.go
+++ b/controllers/scaledjob_controller.go
@@ -3,9 +3,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/kedacore/keda/v2/pkg/eventreason"
 	corev1 "k8s.io/api/core/v1"
-	"time"
 
 	"k8s.io/client-go/tools/record"
 

--- a/controllers/scaledjob_finalizer.go
+++ b/controllers/scaledjob_finalizer.go
@@ -3,6 +3,9 @@ package controllers
 import (
 	"context"
 
+	"github.com/kedacore/keda/v2/pkg/eventreason"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/go-logr/logr"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
@@ -33,6 +36,7 @@ func (r *ScaledJobReconciler) finalizeScaledJob(logger logr.Logger, scaledJob *k
 	}
 
 	logger.Info("Successfully finalized ScaledJob")
+	r.Recorder.Event(scaledJob, corev1.EventTypeNormal, eventreason.Deleted, "ScaledJob was deleted")
 	return nil
 }
 

--- a/controllers/scaledjob_finalizer.go
+++ b/controllers/scaledjob_finalizer.go
@@ -36,7 +36,7 @@ func (r *ScaledJobReconciler) finalizeScaledJob(logger logr.Logger, scaledJob *k
 	}
 
 	logger.Info("Successfully finalized ScaledJob")
-	r.Recorder.Event(scaledJob, corev1.EventTypeNormal, eventreason.Deleted, "ScaledJob was deleted")
+	r.Recorder.Event(scaledJob, corev1.EventTypeNormal, eventreason.ScaledJobDeleted, "ScaledJob was deleted")
 	return nil
 }
 

--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -96,7 +96,7 @@ func (r *ScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Init the rest of ScaledObjectReconciler
 	r.restMapper = mgr.GetRESTMapper()
 	r.scaledObjectsGenerations = &sync.Map{}
-	r.scaleHandler = scaling.NewScaleHandler(mgr.GetClient(), r.scaleClient, mgr.GetScheme(), r.GlobalHTTPTimeout, mgr.GetEventRecorderFor("scale-handler"))
+	r.scaleHandler = scaling.NewScaleHandler(mgr.GetClient(), r.scaleClient, mgr.GetScheme(), r.GlobalHTTPTimeout, r.Recorder)
 
 	// Start controller
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/scaledobject_finalizer.go
+++ b/controllers/scaledobject_finalizer.go
@@ -57,7 +57,7 @@ func (r *ScaledObjectReconciler) finalizeScaledObject(logger logr.Logger, scaled
 	}
 
 	logger.Info("Successfully finalized ScaledObject")
-	r.Recorder.Event(scaledObject, corev1.EventTypeNormal, eventreason.Deleted, "ScaledObject was deleted")
+	r.Recorder.Event(scaledObject, corev1.EventTypeNormal, eventreason.ScaledObjectDeleted, "ScaledObject was deleted")
 	return nil
 }
 

--- a/controllers/scaledobject_finalizer.go
+++ b/controllers/scaledobject_finalizer.go
@@ -3,6 +3,9 @@ package controllers
 import (
 	"context"
 
+	"github.com/kedacore/keda/v2/pkg/eventreason"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +57,7 @@ func (r *ScaledObjectReconciler) finalizeScaledObject(logger logr.Logger, scaled
 	}
 
 	logger.Info("Successfully finalized ScaledObject")
+	r.Recorder.Event(scaledObject, corev1.EventTypeNormal, eventreason.Deleted, "ScaledObject was deleted")
 	return nil
 }
 

--- a/controllers/triggerauthentication_controller.go
+++ b/controllers/triggerauthentication_controller.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/eventreason"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// +kubebuilder:rbac:groups=keda.sh,resources=triggerauthentications;triggerauthentications/status,verbs="*"
+
+// TriggerAuthenticationReconciler reconciles a TriggerAuthentication object
+type TriggerAuthenticationReconciler struct {
+	Client   client.Client
+	Log      logr.Logger
+	Recorder record.EventRecorder
+}
+
+func (r *TriggerAuthenticationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	reqLogger := r.Log.WithValues("TriggerAuthentication.Namespace", req.Namespace, "TriggerAuthentication.Name", req.Name)
+
+	triggerAuthentication := &kedav1alpha1.TriggerAuthentication{}
+	err := r.Client.Get(context.TODO(), req.NamespacedName, triggerAuthentication)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		reqLogger.Error(err, "Failed ot get TriggerAuthentication")
+		return ctrl.Result{}, err
+	}
+
+	if triggerAuthentication.GetDeletionTimestamp() != nil {
+		r.Recorder.Event(triggerAuthentication, corev1.EventTypeNormal, eventreason.TriggerAuthenticationDeleted, "TriggerAuthentication was deleted")
+		return ctrl.Result{}, nil
+	}
+
+	if triggerAuthentication.ObjectMeta.Generation == 1 {
+		r.Recorder.Event(triggerAuthentication, corev1.EventTypeNormal, eventreason.TriggerAuthenticationAdded, "New TriggerAuthentication configured")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *TriggerAuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kedav1alpha1.TriggerAuthentication{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Complete(r)
+}

--- a/controllers/triggerauthentication_controller.go
+++ b/controllers/triggerauthentication_controller.go
@@ -23,6 +23,7 @@ type TriggerAuthenticationReconciler struct {
 	Recorder record.EventRecorder
 }
 
+// Reconcile performs reconciliation on the identified TriggerAuthentication resource based on the request information passed, returns the result and an error (if any).
 func (r *TriggerAuthenticationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := r.Log.WithValues("TriggerAuthentication.Namespace", req.Namespace, "TriggerAuthentication.Name", req.Name)
 
@@ -48,6 +49,7 @@ func (r *TriggerAuthenticationReconciler) Reconcile(req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager initializes the TriggerAuthenticationReconciler instance and starts a new controller managed by the passed Manager instance.
 func (r *TriggerAuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kedav1alpha1.TriggerAuthentication{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/controllers/triggerauthentication_controller.go
+++ b/controllers/triggerauthentication_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/eventreason"

--- a/go.sum
+++ b/go.sum
@@ -958,6 +958,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/kedacore/keda v1.5.0 h1:c8xA1Vo3H7rPwFiWUX3CBXnjBSrbYDmUs9iEfDlf4bQ=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 		Log:               ctrl.Log.WithName("controllers").WithName("ScaledObject"),
 		Scheme:            mgr.GetScheme(),
 		GlobalHTTPTimeout: globalHTTPTimeout,
-		Recorder: mgr.GetEventRecorderFor("scaledobject-controller"),
+		Recorder:          mgr.GetEventRecorderFor("scaledobject-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScaledObject")
 		os.Exit(1)
@@ -139,9 +139,17 @@ func main() {
 		Log:               ctrl.Log.WithName("controllers").WithName("ScaledJob"),
 		Scheme:            mgr.GetScheme(),
 		GlobalHTTPTimeout: globalHTTPTimeout,
-		Recorder: mgr.GetEventRecorderFor("scaledjob-controller"),
+		Recorder:          mgr.GetEventRecorderFor("scaledjob-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScaledJob")
+		os.Exit(1)
+	}
+	if err = (&controllers.TriggerAuthenticationReconciler{
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("TriggerAuthentication"),
+		Recorder: mgr.GetEventRecorderFor("triggerauthentication-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "TriggerAuthentication")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder

--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func main() {
 		Log:               ctrl.Log.WithName("controllers").WithName("ScaledObject"),
 		Scheme:            mgr.GetScheme(),
 		GlobalHTTPTimeout: globalHTTPTimeout,
+		Recorder: mgr.GetEventRecorderFor("scaledobject-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScaledObject")
 		os.Exit(1)
@@ -138,6 +139,7 @@ func main() {
 		Log:               ctrl.Log.WithName("controllers").WithName("ScaledJob"),
 		Scheme:            mgr.GetScheme(),
 		GlobalHTTPTimeout: globalHTTPTimeout,
+		Recorder: mgr.GetEventRecorderFor("scaledjob-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScaledJob")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -123,13 +123,14 @@ func main() {
 	}
 
 	globalHTTPTimeout := time.Duration(globalHTTPTimeoutMS) * time.Millisecond
+	eventRecorder := mgr.GetEventRecorderFor("keda-operator")
 
 	if err = (&controllers.ScaledObjectReconciler{
 		Client:            mgr.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("ScaledObject"),
 		Scheme:            mgr.GetScheme(),
 		GlobalHTTPTimeout: globalHTTPTimeout,
-		Recorder:          mgr.GetEventRecorderFor("scaledobject-controller"),
+		Recorder:          eventRecorder,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScaledObject")
 		os.Exit(1)
@@ -139,7 +140,7 @@ func main() {
 		Log:               ctrl.Log.WithName("controllers").WithName("ScaledJob"),
 		Scheme:            mgr.GetScheme(),
 		GlobalHTTPTimeout: globalHTTPTimeout,
-		Recorder:          mgr.GetEventRecorderFor("scaledjob-controller"),
+		Recorder:          eventRecorder,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ScaledJob")
 		os.Exit(1)
@@ -147,7 +148,7 @@ func main() {
 	if err = (&controllers.TriggerAuthenticationReconciler{
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName("TriggerAuthentication"),
-		Recorder: mgr.GetEventRecorderFor("triggerauthentication-controller"),
+		Recorder: eventRecorder,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TriggerAuthentication")
 		os.Exit(1)

--- a/pkg/eventreason/eventreason.go
+++ b/pkg/eventreason/eventreason.go
@@ -17,36 +17,51 @@ limitations under the License.
 package eventreason
 
 const (
-	// Ready is for event when ScaledObject or ScaledJob is ready
-	Ready = "Ready"
+	// ScaledObjectReady is for event when a new ScaledObject is ready
+	ScaledObjectReady = "ScaledObjectReady"
 
-	// CheckFailed is for event when ScaledObject or ScaledJob validation check failed
-	CheckFailed = "CheckFailed"
+	// ScaledJobReady is for event when a new ScaledJob is ready
+	ScaledJobReady = "ScaledJobReady"
 
-	// Deleted is for event when ScaledObject or ScaledJob is deleted
-	Deleted = "Deleted"
+	// ScaledObjectCheckFailed is for event when ScaledObject validation check fails
+	ScaledObjectCheckFailed = "ScaledObjectCheckFailed"
 
-	// ScalersStarted is for event when scalers watch started for ScaledObject or ScaledJob
-	ScalersStarted = "ScalersStarted"
+	// ScaledJobCheckFailed is for event when ScaledJob validation check fails
+	ScaledJobCheckFailed = "ScaledJobCheckFailed"
 
-	// ScalersRestarted is for event when scalers watch was restarted for ScaledObject or ScaledJob
-	ScalersRestarted = "ScalersRestarted"
+	// ScaledObjectDeleted is for event when ScaledObject is deleted
+	ScaledObjectDeleted = "ScaledObjectDeleted"
 
-	// ScalersStopped is for event when scalers watch was stopped for ScaledObject or ScaledJob
-	ScalersStopped = "ScalersStopped"
+	// ScaledJobDeleted is for event when ScaledJob is deleted
+	ScaledJobDeleted = "ScaledJobDeleted"
+
+	// KEDAScalersStarted is for event when scalers watch started for ScaledObject or ScaledJob
+	KEDAScalersStarted = "KEDAScalersStarted"
+
+	// KEDAScalersStopped is for event when scalers watch was stopped for ScaledObject or ScaledJob
+	KEDAScalersStopped = "KEDAScalersStopped"
+
+	// KEDAScalerFailed is for event when a scaler fails for a ScaledJob or a ScaledObject
+	KEDAScalerFailed = "KEDAScalerFailed"
 
 	// ScaleTargetActivated is for event when the scale target of ScaledObject was activated
-	ScaleTargetActivated = "ScaleTargetActivated"
+	KEDAScaleTargetActivated = "KEDAScaleTargetActivated"
 
 	// ScaleTargetDeactivated is for event when the scale target for ScaledObject was deactivated
-	ScaleTargetDeactivated = "ScaleTargetDeactivated"
+	KEDAScaleTargetDeactivated = "KEDAScaleTargetDeactivated"
 
 	// ScaleTargetActivationFailed is for event when the activation the scale target for ScaledObject fails
-	ScaleTargetActivationFailed = "ScaleTargetActivationFailed"
+	KEDAScaleTargetActivationFailed = "KEDAScaleTargetActivationFailed"
 
 	// ScaleTargetDeactivationFailed is for event when the deactivation of the scale target for ScaledObject fails
-	ScaleTargetDeactivationFailed = "ScaleTargetDeactivationFailed"
+	KEDAScaleTargetDeactivationFailed = "KEDAScaleTargetDeactivationFailed"
 
 	// JobsCreated is for event when jobs for ScaledJob are created
-	JobsCreated = "JobsCreated"
+	KEDAJobsCreated = "KEDAJobsCreated"
+
+	// TriggerAuthenticationDeleted is for event when a TriggerAuthentication is deleted
+	TriggerAuthenticationDeleted = "TriggerAuthenticationDeleted"
+
+	// TriggerAuthenticationAdded is for event when a TriggerAuthentication is added
+	TriggerAuthenticationAdded = "TriggerAuthenticationAdded"
 )

--- a/pkg/eventreason/eventreason.go
+++ b/pkg/eventreason/eventreason.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventreason
+
+const (
+	// Ready is for event when ScaledObject or ScaledJob is ready
+	Ready = "Ready"
+
+	// CheckFailed is for event when ScaledObject or ScaledJob validation check failed
+	CheckFailed = "CheckFailed"
+
+	// Deleted is for event when ScaledObject or ScaledJob is deleted
+	Deleted = "Deleted"
+
+	// ScalersStarted is for event when scalers watch started for ScaledObject or ScaledJob
+	ScalersStarted = "ScalersStarted"
+
+	// ScalersRestarted is for event when scalers watch was restarted for ScaledObject or ScaledJob
+	ScalersRestarted = "ScalersRestarted"
+
+	// ScalersStopped is for event when scalers watch was stopped for ScaledObject or ScaledJob
+	ScalersStopped = "ScalersStopped"
+
+	// ScaleTargetActivated is for event when the scale target of ScaledObject was activated
+	ScaleTargetActivated = "ScaleTargetActivated"
+
+	// ScaleTargetDeactivated is for event when the scale target for ScaledObject was deactivated
+	ScaleTargetDeactivated = "ScaleTargetDeactivated"
+
+	// ScaleTargetActivationFailed is for event when the activation the scale target for ScaledObject fails
+	ScaleTargetActivationFailed = "ScaleTargetActivationFailed"
+
+	// ScaleTargetDeactivationFailed is for event when the deactivation of the scale target for ScaledObject fails
+	ScaleTargetDeactivationFailed = "ScaleTargetDeactivationFailed"
+
+	// JobsCreated is for event when jobs for ScaledJob are created
+	JobsCreated = "JobsCreated"
+)

--- a/pkg/eventreason/eventreason.go
+++ b/pkg/eventreason/eventreason.go
@@ -44,19 +44,19 @@ const (
 	// KEDAScalerFailed is for event when a scaler fails for a ScaledJob or a ScaledObject
 	KEDAScalerFailed = "KEDAScalerFailed"
 
-	// ScaleTargetActivated is for event when the scale target of ScaledObject was activated
+	// KEDAScaleTargetActivated is for event when the scale target of ScaledObject was activated
 	KEDAScaleTargetActivated = "KEDAScaleTargetActivated"
 
-	// ScaleTargetDeactivated is for event when the scale target for ScaledObject was deactivated
+	// KEDAScaleTargetDeactivated is for event when the scale target for ScaledObject was deactivated
 	KEDAScaleTargetDeactivated = "KEDAScaleTargetDeactivated"
 
-	// ScaleTargetActivationFailed is for event when the activation the scale target for ScaledObject fails
+	// KEDAScaleTargetActivationFailed is for event when the activation the scale target for ScaledObject fails
 	KEDAScaleTargetActivationFailed = "KEDAScaleTargetActivationFailed"
 
-	// ScaleTargetDeactivationFailed is for event when the deactivation of the scale target for ScaledObject fails
+	// KEDAScaleTargetDeactivationFailed is for event when the deactivation of the scale target for ScaledObject fails
 	KEDAScaleTargetDeactivationFailed = "KEDAScaleTargetDeactivationFailed"
 
-	// JobsCreated is for event when jobs for ScaledJob are created
+	// KEDAJobsCreated is for event when jobs for ScaledJob are created
 	KEDAJobsCreated = "KEDAJobsCreated"
 
 	// TriggerAuthenticationDeleted is for event when a TriggerAuthentication is deleted

--- a/pkg/scaling/executor/scale_executor.go
+++ b/pkg/scaling/executor/scale_executor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/client-go/tools/record"
+
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,15 +32,17 @@ type scaleExecutor struct {
 	scaleClient      *scale.ScalesGetter
 	reconcilerScheme *runtime.Scheme
 	logger           logr.Logger
+	recorder         record.EventRecorder
 }
 
 // NewScaleExecutor creates a ScaleExecutor object
-func NewScaleExecutor(client client.Client, scaleClient *scale.ScalesGetter, reconcilerScheme *runtime.Scheme) ScaleExecutor {
+func NewScaleExecutor(client client.Client, scaleClient *scale.ScalesGetter, reconcilerScheme *runtime.Scheme, recorder record.EventRecorder) ScaleExecutor {
 	return &scaleExecutor{
 		client:           client,
 		scaleClient:      scaleClient,
 		reconcilerScheme: reconcilerScheme,
 		logger:           logf.Log.WithName("scaleexecutor"),
+		recorder:         recorder,
 	}
 }
 

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -110,7 +110,7 @@ func (e *scaleExecutor) createJobs(logger logr.Logger, scaledJob *kedav1alpha1.S
 		}
 	}
 	logger.Info("Created jobs", "Number of jobs", scaleTo)
-	e.recorder.Eventf(scaledJob, corev1.EventTypeNormal, eventreason.JobsCreated, "Created %d jobs", scaleTo)
+	e.recorder.Eventf(scaledJob, corev1.EventTypeNormal, eventreason.KEDAJobsCreated, "Created %d jobs", scaleTo)
 }
 
 func (e *scaleExecutor) isJobFinished(j *batchv1.Job) bool {

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/kedacore/keda/v2/pkg/eventreason"
+
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -108,6 +110,7 @@ func (e *scaleExecutor) createJobs(logger logr.Logger, scaledJob *kedav1alpha1.S
 		}
 	}
 	logger.Info("Created jobs", "Number of jobs", scaleTo)
+	e.recorder.Eventf(scaledJob, corev1.EventTypeNormal, eventreason.JobsCreated, "Created %d jobs", scaleTo)
 }
 
 func (e *scaleExecutor) isJobFinished(j *batchv1.Job) bool {

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -127,13 +127,13 @@ func (e *scaleExecutor) scaleToZero(ctx context.Context, logger logr.Logger, sca
 		currentReplicas, err := e.updateScaleOnScaleTarget(ctx, scaledObject, scale, 0)
 		if err == nil {
 			logger.Info("Successfully scaled ScaleTarget to 0 replicas")
-			e.recorder.Eventf(scaledObject, corev1.EventTypeNormal, eventreason.ScaleTargetDeactivated, "Deactivated %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, 0)
+			e.recorder.Eventf(scaledObject, corev1.EventTypeNormal, eventreason.KEDAScaleTargetDeactivated, "Deactivated %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, 0)
 			if err := e.setActiveCondition(ctx, logger, scaledObject, metav1.ConditionFalse, "ScalerNotActive", "Scaling is not performed because triggers are not active"); err != nil {
 				logger.Error(err, "Error in setting active condition")
 				return
 			}
 		} else {
-			e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.ScaleTargetDeactivationFailed, "Failed to deactivated %s %s/%s", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, 0)
+			e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.KEDAScaleTargetDeactivationFailed, "Failed to deactivated %s %s/%s", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, 0)
 		}
 	} else {
 		logger.V(1).Info("ScaleTarget cooling down",
@@ -164,7 +164,7 @@ func (e *scaleExecutor) scaleFromZero(ctx context.Context, logger logr.Logger, s
 		logger.Info("Successfully updated ScaleTarget",
 			"Original Replicas Count", currentReplicas,
 			"New Replicas Count", replicas)
-		e.recorder.Eventf(scaledObject, corev1.EventTypeNormal, eventreason.ScaleTargetActivated, "Scaled %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
+		e.recorder.Eventf(scaledObject, corev1.EventTypeNormal, eventreason.KEDAScaleTargetActivated, "Scaled %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
 
 		// Scale was successful. Update lastScaleTime and lastActiveTime on the scaledObject
 		if err := e.updateLastActiveTime(ctx, logger, scaledObject); err != nil {
@@ -172,7 +172,7 @@ func (e *scaleExecutor) scaleFromZero(ctx context.Context, logger logr.Logger, s
 			return
 		}
 	} else {
-		e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.ScaleTargetActivationFailed, "Failed to scaled %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
+		e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.KEDAScaleTargetActivationFailed, "Failed to scaled %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
 	}
 }
 

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/kedacore/keda/v2/pkg/eventreason"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -121,13 +124,16 @@ func (e *scaleExecutor) scaleToZero(ctx context.Context, logger logr.Logger, sca
 	if scaledObject.Status.LastActiveTime == nil ||
 		scaledObject.Status.LastActiveTime.Add(cooldownPeriod).Before(time.Now()) {
 		// or last time a trigger was active was > cooldown period, so scale down.
-		_, err := e.updateScaleOnScaleTarget(ctx, scaledObject, scale, 0)
+		currentReplicas, err := e.updateScaleOnScaleTarget(ctx, scaledObject, scale, 0)
 		if err == nil {
 			logger.Info("Successfully scaled ScaleTarget to 0 replicas")
+			e.recorder.Eventf(scaledObject, corev1.EventTypeNormal, eventreason.ScaleTargetDeactivated, "Deactivated %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, 0)
 			if err := e.setActiveCondition(ctx, logger, scaledObject, metav1.ConditionFalse, "ScalerNotActive", "Scaling is not performed because triggers are not active"); err != nil {
 				logger.Error(err, "Error in setting active condition")
 				return
 			}
+		} else {
+			e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.ScaleTargetDeactivationFailed, "Failed to deactivated %s %s/%s", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, 0)
 		}
 	} else {
 		logger.V(1).Info("ScaleTarget cooling down",
@@ -158,12 +164,15 @@ func (e *scaleExecutor) scaleFromZero(ctx context.Context, logger logr.Logger, s
 		logger.Info("Successfully updated ScaleTarget",
 			"Original Replicas Count", currentReplicas,
 			"New Replicas Count", replicas)
+		e.recorder.Eventf(scaledObject, corev1.EventTypeNormal, eventreason.ScaleTargetActivated, "Scaled %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
 
 		// Scale was successful. Update lastScaleTime and lastActiveTime on the scaledObject
 		if err := e.updateLastActiveTime(ctx, logger, scaledObject); err != nil {
 			logger.Error(err, "Error in Updating lastScaleTime and lastActiveTime on the scaledObject")
 			return
 		}
+	} else {
+		e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.ScaleTargetActivationFailed, "Failed to scaled %s %s/%s from %d to %d", scaledObject.Spec.ScaleTargetRef.Kind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

This PR adds the following events:

For both `ScaledObjects` and `ScaledJobs`:

- `Ready`
- `CheckFailed`
- `Deleted`
- `ScalersStarted`
- `ScalersRestarted`
- `ScalersStopped`

For `ScaledObjects`:

- `ScaleTargetActivated`
- `ScaleTargetDeactivated`
- `ScaleTargetActivationFailed`
- `ScaleTargetDeactivationFailed`

For `ScaledJobs`:

- `JobsCreated`

If this list looks okay, I'll open a docs PR to list them in there. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Changelog has been updated

Fixes #530
