### PR TITLE
Fix typo in log

### DIFF
--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -218,7 +218,7 @@ func resolveEnv(client client.Client, logger logr.Logger, container *corev1.Cont
 							namespace)
 					}
 				default:
-					logger.V(1).Info("cannot resolve env %s to a value. fieldRef and resourceFieldRef env are skipped", envVar.Name)
+					logger.V(1).Info("cannot resolve env to a value. fieldRef and resourceFieldRef env are skipped", "env-var-name", envVar.Name)
 					continue
 				}
 			}


### PR DESCRIPTION
logr expects key,value pairs.

Signed-off-by: Suresh Kumar Ponnusamy <suresh.ponnusamy@freshworks.com>

Fix a typo in the log printing, getting below kinds of errors when debug log mode is enabled:

```
2021-01-25T11:05:32.527Z        DEBUG   scalehandler    cannot resolve env %s to a value. fieldRef and resourceFieldRef env are skipped {"type": "ScaledObject", "namespace": "freshcaller", "name": "envoy-blue"}
2021-01-25T11:05:32.527Z        DPANIC  scalehandler    odd number of arguments passed as key-value pairs for logging   {"type": "ScaledObject", "namespace": "freshcaller", "name": "envoy-blue", "ignored key": "NODE_IP"}
github.com/go-logr/zapr.handleFields
        /go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:106
github.com/go-logr/zapr.(*infoLogger).Info
        /go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:70
github.com/kedacore/keda/pkg/scaling/resolver.resolveEnv
        /workspace/pkg/scaling/resolver/scale_resolvers.go:171
github.com/kedacore/keda/pkg/scaling/resolver.ResolveContainerEnv
        /workspace/pkg/scaling/resolver/scale_resolvers.go:47
github.com/kedacore/keda/pkg/scaling.(*scaleHandler).buildScalers
        /workspace/pkg/scaling/scale_handler.go:321
github.com/kedacore/keda/pkg/scaling.(*scaleHandler).GetScalers
        /workspace/pkg/scaling/scale_handler.go:68
github.com/kedacore/keda/controllers.(*ScaledObjectReconciler).getScaledObjectMetricSpecs
        /workspace/controllers/hpa.go:140
github.com/kedacore/keda/controllers.(*ScaledObjectReconciler).newHPAForScaledObject
        /workspace/controllers/hpa.go:44
github.com/kedacore/keda/controllers.(*ScaledObjectReconciler).updateHPAIfNeeded
        /workspace/controllers/hpa.go:102
github.com/kedacore/keda/controllers.(*ScaledObjectReconciler).ensureHPAForScaledObjectExists
        /workspace/controllers/scaledobject_controller.go:289
github.com/kedacore/keda/controllers.(*ScaledObjectReconciler).reconcileScaledObject
        /workspace/controllers/scaledobject_controller.go:173
github.com/kedacore/keda/controllers.(*ScaledObjectReconciler).Reconcile
        /workspace/controllers/scaledobject_controller.go:138
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:235
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
        /go/pkg/mod/k8s.io/apimachinery@v0.18.8/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
        /go/pkg/mod/k8s.io/apimachinery@v0.18.8/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
        /go/pkg/mod/k8s.io/apimachinery@v0.18.8/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
        /go/pkg/mod/k8s.io/apimachinery@v0.18.8/pkg/util/wait/wait.go:90
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated
