### PR TITLE
Fix link: Automatically determine the RabbitMQ protocol when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - Optimize Kafka scaler's `getLagForPartition` function ([#1464](https://github.com/kedacore/keda/pull/1464))
 - Reduce unnecessary /scale requests from ScaledObject controller ([#1453](https://github.com/kedacore/keda/pull/1453))
 - Add support for the `WATCH_NAMESPACE` environment variable to the operator ([#1474](https://github.com/kedacore/keda/pull/1474))
-- Automatically determine the RabbitMQ protocol when possible, and support setting the protocl via TriggerAuthentication ([#1459](https://github.com/kedacore/keda/pulls/1459), [#1483](https://github.com/kedacore/keda/pull/1483))
+- Automatically determine the RabbitMQ protocol when possible, and support setting the protocl via TriggerAuthentication ([#1459](https://github.com/kedacore/keda/pull/1459), [#1483](https://github.com/kedacore/keda/pull/1483))
 - Improve performance when fetching pod information ([#1457](https://github.com/kedacore/keda/pull/1457))
 - Improve performance when fetching current scaling information on Deployments ([#1458](https://github.com/kedacore/keda/pull/1458))
 - Improve error reporting in prometheus scaler ([#1497](https://github.com/kedacore/keda/pull/1497))


### PR DESCRIPTION
Signed-off-by: Shubham Kuchhal <shubham.kuchhal@india.nec.com>

_Provide a description of what has been changed_
Fixed the link for `Automatically determine the RabbitMQ protocol when possible` in CHANGELOG.md under unreleased. 
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [ ] Changelog has been updated