### PR TITLE
Improve redis cluster e2e tests stability

### DIFF
--- a/tests/scalers/redis-cluster-lists.test.ts
+++ b/tests/scalers/redis-cluster-lists.test.ts
@@ -28,9 +28,18 @@ test.before(t => {
     // Deploy Redis cluster.
     sh.exec(`kubectl create namespace ${redisNamespace}`)
     sh.exec(`helm repo add bitnami https://charts.bitnami.com/bitnami`)
+
+    let clusterStatus = 1
+    for (let i = 0; i < 3; i++) {
+        clusterStatus = sh.exec(`helm install ${redisClusterName} --namespace ${redisNamespace} --set "global.redis.password=${redisPassword}" bitnami/redis-cluster`).code
+        if (clusterStatus == 0) {
+          break
+        }
+        sh.exec('sleep 5s')
+    }
     t.is(0,
-      sh.exec(`helm install ${redisClusterName} --namespace ${redisNamespace} --set "global.redis.password=${redisPassword}" bitnami/redis-cluster`).code,
-      'creating a Redis cluster should work.'
+        clusterStatus,
+        'creating a Redis cluster should work.'
     )
 
     // Wait for Redis cluster to be ready.

--- a/tests/scalers/redis-cluster-streams.test.ts
+++ b/tests/scalers/redis-cluster-streams.test.ts
@@ -16,9 +16,18 @@ test.before(t => {
     // Deploy Redis cluster.
     sh.exec(`kubectl create namespace ${redisNamespace}`)
     sh.exec(`helm repo add bitnami https://charts.bitnami.com/bitnami`)
+
+    let clusterStatus = 1
+    for (let i = 0; i < 3; i++) {
+        clusterStatus = sh.exec(`helm install ${redisClusterName} --namespace ${redisNamespace} --set "global.redis.password=${redisPassword}" bitnami/redis-cluster`).code
+        if (clusterStatus == 0) {
+          break
+        }
+        sh.exec('sleep 5s')
+    }
     t.is(0,
-      sh.exec(`helm install ${redisClusterName} --namespace ${redisNamespace} --set "global.redis.password=${redisPassword}" bitnami/redis-cluster`).code,
-      'creating a Redis cluster should work.'
+        clusterStatus,
+        'creating a Redis cluster should work.'
     )
 
     // Wait for Redis cluster to be ready.
@@ -158,7 +167,7 @@ spec:
     spec:
       containers:
         - name: redis-streams-consumer
-          image: goku321/redis-cluster-streams:v2.2
+          image: goku321/redis-cluster-streams:v2.3
           command: ["./main"]
           args: ["consumer"]
           imagePullPolicy: Always
@@ -209,7 +218,7 @@ spec:
     spec:
       containers:
       - name: producer
-        image: goku321/redis-cluster-streams:v2.2
+        image: goku321/redis-cluster-streams:v2.3
         command: ["./main"]
         args: ["producer"]
         imagePullPolicy: Always


### PR DESCRIPTION

Signed-off-by: Deepak <sah.sslpu@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

This adds a delay in redis cluster streams consumer to allow pods to scale. Also, adds a retry loop in case
redis cluster creation fails.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [N/A] Tests have been added
- [N/A] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [N/A] Changelog has been updated

Fixes #1491 
