### PR TITLE
Add global http timeout for manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Improvements
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- Add `KEDA_HTTP_DEFAULT_TIMEOUT` support in operator ([#1548](https://github.com/kedacore/keda/issues/1548))
 
 ### Breaking Changes
 

--- a/controllers/scaledjob_controller.go
+++ b/controllers/scaledjob_controller.go
@@ -28,13 +28,13 @@ type ScaledJobReconciler struct {
 	client.Client
 	Log               logr.Logger
 	Scheme            *runtime.Scheme
+	GlobalHTTPTimeout time.Duration
 	scaleHandler      scaling.ScaleHandler
-	globalHTTPTimeout time.Duration
 }
 
 // SetupWithManager initializes the ScaledJobReconciler instance and starts a new controller managed by the passed Manager instance.
 func (r *ScaledJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.scaleHandler = scaling.NewScaleHandler(mgr.GetClient(), nil, mgr.GetScheme(), r.globalHTTPTimeout)
+	r.scaleHandler = scaling.NewScaleHandler(mgr.GetClient(), nil, mgr.GetScheme(), r.GlobalHTTPTimeout)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		// Ignore updates to ScaledJob Status (in this case metadata.Generation does not change)

--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -42,17 +42,16 @@ import (
 
 // ScaledObjectReconciler reconciles a ScaledObject object
 type ScaledObjectReconciler struct {
-	Log    logr.Logger
-	Client client.Client
-	Scheme *runtime.Scheme
+	Log               logr.Logger
+	Client            client.Client
+	Scheme            *runtime.Scheme
+	GlobalHTTPTimeout time.Duration
 
 	scaleClient              *scale.ScalesGetter
 	restMapper               meta.RESTMapper
 	scaledObjectsGenerations *sync.Map
 	scaleHandler             scaling.ScaleHandler
 	kubeVersion              kedautil.K8sVersion
-
-	globalHTTPTimeout time.Duration
 }
 
 // A cache mapping "resource.group" to true or false if we know if this resource is scalable.
@@ -92,7 +91,7 @@ func (r *ScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Init the rest of ScaledObjectReconciler
 	r.restMapper = mgr.GetRESTMapper()
 	r.scaledObjectsGenerations = &sync.Map{}
-	r.scaleHandler = scaling.NewScaleHandler(mgr.GetClient(), r.scaleClient, mgr.GetScheme(), r.globalHTTPTimeout)
+	r.scaleHandler = scaling.NewScaleHandler(mgr.GetClient(), r.scaleClient, mgr.GetScheme(), r.GlobalHTTPTimeout)
 
 	// Start controller
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
This was already done in adapter but was missed in manager. Since manager
calls scaler.IsActive() with 0 timeout, it is erring out with "context
deadline exceeded" errors when connection latency is high (like prometheus
scaler trying to contact a prometheus server running in different region)

Signed-off-by: Suresh Kumar Ponnusamy <suresh.ponnusamy@freshworks.com>

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Changelog has been updated

