### PR TITLE
Removed MIN field for scaledjob.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Improvements
 
 - Add `KEDA_HTTP_DEFAULT_TIMEOUT` support in operator ([#1548](https://github.com/kedacore/keda/issues/1548))
+- Removed `MIN field` for scaledjob.([#1553](https://github.com/kedacore/keda/pull/1553))
 
 ### Breaking Changes
 

--- a/api/v1alpha1/scaledjob_types.go
+++ b/api/v1alpha1/scaledjob_types.go
@@ -9,7 +9,6 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=scaledjobs,scope=Namespaced,shortName=sj
-// +kubebuilder:printcolumn:name="Min",type="integer",JSONPath=".spec.minReplicaCount"
 // +kubebuilder:printcolumn:name="Max",type="integer",JSONPath=".spec.maxReplicaCount"
 // +kubebuilder:printcolumn:name="Triggers",type="string",JSONPath=".spec.triggers[*].type"
 // +kubebuilder:printcolumn:name="Authentication",type="string",JSONPath=".spec.triggers[*].authenticationRef.name"

--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -19,9 +19,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.minReplicaCount
-      name: Min
-      type: integer
     - jsonPath: .spec.maxReplicaCount
       name: Max
       type: integer


### PR DESCRIPTION
Signed-off-by: Shubham Kuchhal <shubham.kuchhal@india.nec.com>

Removed **MIN** field from `kubectl get scaledjob`or` kubectl get sj`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Tests have been added
- [ ] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs
- [x] Changelog has been updated

Fixes #1552
