### PR TITLE
Increase timeout for redis cluster in e2e tests

### DIFF
--- a/tests/scalers/redis-cluster-streams.test.ts
+++ b/tests/scalers/redis-cluster-streams.test.ts
@@ -17,14 +17,7 @@ test.before(t => {
     sh.exec(`kubectl create namespace ${redisNamespace}`)
     sh.exec(`helm repo add bitnami https://charts.bitnami.com/bitnami`)
 
-    let clusterStatus = 1
-    for (let i = 0; i < 3; i++) {
-        clusterStatus = sh.exec(`helm install ${redisClusterName} --namespace ${redisNamespace} --set "global.redis.password=${redisPassword}" bitnami/redis-cluster`).code
-        if (clusterStatus == 0) {
-          break
-        }
-        sh.exec('sleep 5s')
-    }
+    let clusterStatus = sh.exec(`helm install --timeout 600s ${redisClusterName} --namespace ${redisNamespace} --set "global.redis.password=${redisPassword}" bitnami/redis-cluster`).code
     t.is(0,
         clusterStatus,
         'creating a Redis cluster should work.'
@@ -167,7 +160,7 @@ spec:
     spec:
       containers:
         - name: redis-streams-consumer
-          image: goku321/redis-cluster-streams:v2.3
+          image: goku321/redis-cluster-streams:v2.5
           command: ["./main"]
           args: ["consumer"]
           imagePullPolicy: Always
@@ -218,7 +211,7 @@ spec:
     spec:
       containers:
       - name: producer
-        image: goku321/redis-cluster-streams:v2.3
+        image: goku321/redis-cluster-streams:v2.5
         command: ["./main"]
         args: ["producer"]
         imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: Deepak <sah.sslpu@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Increase timeout for redis cluster to start up properly during e2e tests.

This also introduces some increased delay while reading/writing redis lists during e2e tests.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [N/A] Changelog has been updated

Fixes #1491 
