### PR TITLE
feat: Add container port for Prometheus on operator YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 ### Improvements
 
 - Add `KEDA_HTTP_DEFAULT_TIMEOUT` support in operator ([#1548](https://github.com/kedacore/keda/issues/1548))
-- Removed `MIN field` for scaledjob.([#1553](https://github.com/kedacore/keda/pull/1553))
+- Removed `MIN field` for scaledjob ([#1553](https://github.com/kedacore/keda/pull/1553))
+- Add container port for Prometheus on operator YAML ([#1562](https://github.com/kedacore/keda/pull/1562))
 
 ### Breaking Changes
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,10 @@ spec:
               path: /readyz
               port: 8081
             initialDelaySeconds: 20
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
           env:
             - name: WATCH_NAMESPACE
               value: ""


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add container port for Prometheus on operator YAML exposed by operator SDK.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Relates to https://github.com/kedacore/charts/pull/118
