### PR TITLE
Fix nil pointer panic

### DIFF
--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -75,7 +75,8 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 		_, err := e.updateScaleOnScaleTarget(ctx, scaledObject, currentScale, *scaledObject.Spec.MinReplicaCount)
 		if err == nil {
 			logger.Info("Successfully set ScaleTarget replicas count to ScaledObject minReplicaCount",
-				"ScaleTarget.Replicas", currentScale.Spec.Replicas)
+				"Original Replicas Count", currentReplicas,
+				"New Replicas Count", *scaledObject.Spec.MinReplicaCount)
 		}
 	case isActive:
 		// triggers are active, but we didn't need to scale (replica count > 0)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [N/A] Changelog has been updated



I found keda-operator crash when my scaleTarget's replicas count is less than minReplicaCount and operater try to reset the replicas to minReplicaCount. Here is the panic logs.

```
2021-02-04T09:32:06.887Z	INFO	controllers.ScaledObject	Updated HPA according to ScaledObject	{"ScaledObject.Namespace": "default", "ScaledObject.Name": "nginx-deployment", "HPA.Namespace": "default", "HPA.Name": "keda-hpa-nginx-deployment"}
2021-02-04T09:32:06.887Z	INFO	controllers.ScaledObject	Initializing Scaling logic according to ScaledObject Specification	{"ScaledObject.Namespace": "default", "ScaledObject.Name": "nginx-deployment"}
2021-02-04T09:32:06.892Z	INFO	controllers.ScaledObject	Reconciling ScaledObject	{"ScaledObject.Namespace": "default", "ScaledObject.Name": "nginx-deployment"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x118 pc=0x1fb1eaf]

goroutine 26318 [running]:
github.com/kedacore/keda/v2/pkg/scaling/executor.(*scaleExecutor).RequestScale(0xc0008a83f0, 0x2a098a0, 0xc0007a9380, 0xc00000a960, 0x0)
	/workspace/pkg/scaling/executor/scale_scaledobjects.go:78 +0x7cf
github.com/kedacore/keda/v2/pkg/scaling.(*scaleHandler).checkScalers(0xc0005db100, 0x2a098a0, 0xc0007a9380, 0x2560280, 0xc00000a960, 0x29d4f20, 0xc0007ebaa0)
	/workspace/pkg/scaling/scale_handler.go:195 +0x372
github.com/kedacore/keda/v2/pkg/scaling.(*scaleHandler).startScaleLoop(0xc0005db100, 0x2a098a0, 0xc0007a9380, 0xc0007f4dc0, 0x2560280, 0xc00000a960, 0x29d4f20, 0xc0007ebaa0)
	/workspace/pkg/scaling/scale_handler.go:130 +0x205
created by github.com/kedacore/keda/v2/pkg/scaling.(*scaleHandler).HandleScalableObject
	/workspace/pkg/scaling/scale_handler.go:98 +0x385
```

Then I found out that `currentScale` is always `nil` in `scaleExecutor.RequestScale` method  when scaleTarget is Deployment or StatufulSet. So `currentScale` referenced by the logger in L78 could be `nil`.

I fix that log and it works fine for me.