### PR TITLE
Disable sarama metrics and close scalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Add `KEDA_HTTP_DEFAULT_TIMEOUT` support in operator ([#1548](https://github.com/kedacore/keda/issues/1548))
 - Removed `MIN field` for scaledjob.([#1553](https://github.com/kedacore/keda/pull/1553))
+- Fix a memory leak in kafka client and close push scalers ([#1565](https://github.com/kedacore/keda/issues/1565))
 
 ### Breaking Changes
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/onsi/gomega v1.10.4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
+	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.6.1

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -9,7 +9,14 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
+	metrics "github.com/rcrowley/go-metrics"
 )
+
+func init() {
+	// Disable metrics for kafka client (sarama)
+	// https://github.com/Shopify/sarama/issues/1321
+	metrics.UseNilMetrics = true
+}
 
 // Scaler interface
 type Scaler interface {

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -154,12 +154,14 @@ func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav
 	for _, s := range ss {
 		scaler, ok := s.(scalers.PushScaler)
 		if !ok {
+			s.Close()
 			continue
 		}
 
 		go func() {
 			activeCh := make(chan bool)
 			go scaler.Run(ctx, activeCh)
+			defer scaler.Close()
 			for {
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

| before | after |
|--------|-------|
|![before](https://user-images.githubusercontent.com/645740/107080538-497b9500-67a6-11eb-8dd2-0a2851da8d46.png) | ![after](https://user-images.githubusercontent.com/645740/107080554-50a2a300-67a6-11eb-93ec-565d6380fb07.png) |

_after 500 reconciliations for a kafka ScaledObject_

This https://github.com/Shopify/sarama/issues/1321 was the main culprit, though tbh I'm not sure what turning off those metrics affects, I verified that the kafka tests still pass. I also noticed a place where some scalers weren't being closed. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #1565
