### PR TITLE
MSSQL Scaler: Handle zero row query results

### DIFF
--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -253,7 +253,10 @@ func (s *mssqlScaler) GetMetrics(ctx context.Context, metricName string, metricS
 func (s *mssqlScaler) getQueryResult() (int, error) {
 	var value int
 	err := s.connection.QueryRow(s.metadata.query).Scan(&value)
-	if err != nil {
+	switch {
+	case err == sql.ErrNoRows:
+		value = 0
+	case err != nil:
 		mssqlLog.Error(err, fmt.Sprintf("Could not query mssql database: %s", err))
 		return 0, err
 	}


### PR DESCRIPTION
Signed-off-by: Chris Gillum <cgillum@microsoft.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The MSSQL scaler would raise an error if a query result returned zero rows. This PR changes the behavior to instead return a metric value of `0` if a query results in zero rows.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] ~~Tests have been added~~ N/A
- [x] ~~A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~~ N/A
- [x] ~~A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*~~ N/A
- [x] ~~Changelog has been updated~~ I assume this is N/A since the mssql scaler hasn't been released yet

