### PR TITLE
Fix memory leak by checking triggers uniqueness properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Fix a memory leak in kafka client and close push scalers ([#1565](https://github.com/kedacore/keda/issues/1565))
 - Add 'Metadata' header to AAD podIdentity request ([#1566](https://github.com/kedacore/keda/issues/1566))
 - KEDA should make sure generate correct labels for HPA ([#1630](https://github.com/kedacore/keda/issues/1630))
-- Close scalers after name check; fix memory leak ([#1636](https://github.com/kedacore/keda/issues/1636))
+- Fix memory leak by checking triggers uniqueness properly ([#1640](https://github.com/kedacore/keda/pull/1640))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix a memory leak in kafka client and close push scalers ([#1565](https://github.com/kedacore/keda/issues/1565))
 - Add 'Metadata' header to AAD podIdentity request ([#1566](https://github.com/kedacore/keda/issues/1566))
 - KEDA should make sure generate correct labels for HPA ([#1630](https://github.com/kedacore/keda/issues/1630))
+- Close scalers after name check; fix memory leak ([#1636](https://github.com/kedacore/keda/issues/1636))
 
 ### Breaking Changes
 

--- a/controllers/hpa.go
+++ b/controllers/hpa.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
-	"github.com/kedacore/keda/v2/controllers/util"
 	kedacontrollerutil "github.com/kedacore/keda/v2/controllers/util"
 )
 
@@ -160,7 +159,7 @@ func (r *ScaledObjectReconciler) getScaledObjectMetricSpecs(logger logr.Logger, 
 
 			if metricSpec.External != nil {
 				externalMetricName := metricSpec.External.Metric.Name
-				if util.Contains(externalMetricNames, externalMetricName) {
+				if kedacontrollerutil.Contains(externalMetricNames, externalMetricName) {
 					return nil, fmt.Errorf("metricName %s defined multiple times in ScaledObject %s, please refer the documentation how to define metricName manually", externalMetricName, scaledObject.Name)				}
 
 				// add the scaledObjectName label. This is how the MetricsAdapter will know which scaledobject a metric is for when the HPA queries it.

--- a/controllers/hpa.go
+++ b/controllers/hpa.go
@@ -161,8 +161,7 @@ func (r *ScaledObjectReconciler) getScaledObjectMetricSpecs(logger logr.Logger, 
 			if metricSpec.External != nil {
 				externalMetricName := metricSpec.External.Metric.Name
 				if util.Contains(externalMetricNames, externalMetricName) {
-					return nil, fmt.Errorf("metricName %s defined multiple times in ScaledObject %s, please refer the documentation how to define metircName manually", externalMetricName, scaledObject.Name)
-				}
+					return nil, fmt.Errorf("metricName %s defined multiple times in ScaledObject %s, please refer the documentation how to define metricName manually", externalMetricName, scaledObject.Name)				}
 
 				// add the scaledObjectName label. This is how the MetricsAdapter will know which scaledobject a metric is for when the HPA queries it.
 				metricSpec.External.Metric.Selector = &metav1.LabelSelector{MatchLabels: make(map[string]string)}

--- a/controllers/hpa.go
+++ b/controllers/hpa.go
@@ -160,7 +160,8 @@ func (r *ScaledObjectReconciler) getScaledObjectMetricSpecs(logger logr.Logger, 
 			if metricSpec.External != nil {
 				externalMetricName := metricSpec.External.Metric.Name
 				if kedacontrollerutil.Contains(externalMetricNames, externalMetricName) {
-					return nil, fmt.Errorf("metricName %s defined multiple times in ScaledObject %s, please refer the documentation how to define metricName manually", externalMetricName, scaledObject.Name)				}
+					return nil, fmt.Errorf("metricName %s defined multiple times in ScaledObject %s, please refer the documentation how to define metricName manually", externalMetricName, scaledObject.Name)
+				}
 
 				// add the scaledObjectName label. This is how the MetricsAdapter will know which scaledobject a metric is for when the HPA queries it.
 				metricSpec.External.Metric.Selector = &metav1.LabelSelector{MatchLabels: make(map[string]string)}

--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -201,12 +201,6 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(logger logr.Logger, scale
 		return "ScaledObject doesn't have correct scaleTargetRef specification", err
 	}
 
-	// Check for any duplicate names in scaledObject
-	err = r.validateMetricNameUniqueness(logger, scaledObject)
-	if err != nil {
-		return "Error checking metric name uniqueness", err
-	}
-
 	// Create a new HPA or update existing one according to ScaledObject
 	newHPACreated, err := r.ensureHPAForScaledObjectExists(logger, scaledObject, &gvkr)
 	if err != nil {
@@ -225,6 +219,12 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(logger logr.Logger, scale
 
 	// Notify ScaleHandler if a new HPA was created or if ScaledObject was updated
 	if newHPACreated || scaleObjectSpecChanged {
+		// Check for any duplicate names in scaledObject
+		err = r.validateMetricNameUniqueness(logger, scaledObject)
+		if err != nil {
+			return "Error checking metric name uniqueness", err
+		}
+
 		if r.requestScaleLoop(logger, scaledObject) != nil {
 			return "Failed to start a new scale loop with scaling logic", err
 		}

--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -201,6 +201,7 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(logger logr.Logger, scale
 		return "ScaledObject doesn't have correct scaleTargetRef specification", err
 	}
 
+	// Check for any duplicate names in scaledObject
 	err = r.validateMetricNameUniqueness(logger, scaledObject)
 	if err != nil {
 		return "Error checking metric name uniqueness", err
@@ -260,6 +261,8 @@ func (r *ScaledObjectReconciler) validateMetricNameUniqueness(logger logr.Logger
 
 	observedMetricNames := make(map[string]struct{})
 	for _, scaler := range scalers {
+		defer scaler.Close()
+
 		for _, metric := range scaler.GetMetricSpecForScaling() {
 			// Only validate external metricNames
 			if metric.External == nil {

--- a/controllers/scaledobject_controller_test.go
+++ b/controllers/scaledobject_controller_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
 	"github.com/kedacore/keda/v2/pkg/mock/mock_scaling"
 	"github.com/kedacore/keda/v2/pkg/scalers"
 	. "github.com/onsi/ginkgo"
@@ -31,6 +32,8 @@ var _ = Describe("ScaledObjectController", func() {
 		var (
 			metricNameTestReconciler ScaledObjectReconciler
 			mockScaleHandler         *mock_scaling.MockScaleHandler
+			mockClient               *mock_client.MockClient
+			mockStatusWriter         *mock_client.MockStatusWriter
 		)
 
 		var triggerMeta []map[string]string = []map[string]string{
@@ -39,18 +42,25 @@ var _ = Describe("ScaledObjectController", func() {
 		}
 
 		BeforeEach(func() {
-			mockScaleHandler = mock_scaling.NewMockScaleHandler(gomock.NewController(GinkgoTestReporter{}))
+			ctrl := gomock.NewController(GinkgoTestReporter{})
+			mockScaleHandler = mock_scaling.NewMockScaleHandler(ctrl)
+			mockClient = mock_client.NewMockClient(ctrl)
+			mockStatusWriter = mock_client.NewMockStatusWriter(ctrl)
 
 			metricNameTestReconciler = ScaledObjectReconciler{
 				scaleHandler: mockScaleHandler,
+				Client:       mockClient,
 			}
 		})
 
 		Context("With Unique Values", func() {
-			var uniqueNamedScaledObjectTrigger = &kedav1alpha1.ScaledObject{}
+			var uniquelyNamedScaledObject = &kedav1alpha1.ScaledObject{}
 
 			It("should pass metric name validation", func() {
+				// Generate test data
 				testScalers := make([]scalers.Scaler, 0)
+				expectedExternalMetricNames := make([]string, 0)
+
 				for i, tm := range triggerMeta {
 					config := &scalers.ScalerConfig{
 						Name:            fmt.Sprintf("test.%d", i),
@@ -66,14 +76,33 @@ var _ = Describe("ScaledObjectController", func() {
 					}
 
 					testScalers = append(testScalers, s)
+					for _, metricSpec := range s.GetMetricSpecForScaling() {
+						if metricSpec.External != nil {
+							expectedExternalMetricNames = append(expectedExternalMetricNames, metricSpec.External.Metric.Name)
+						}
+					}
 				}
 
-				mockScaleHandler.EXPECT().GetScalers(uniqueNamedScaledObjectTrigger).Return(testScalers, nil)
+				// Set up expectations
+				mockScaleHandler.EXPECT().GetScalers(uniquelyNamedScaledObject).Return(testScalers, nil)
+				mockClient.EXPECT().Status().Return(mockStatusWriter)
+				mockStatusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any())
 
-				Ω(metricNameTestReconciler.validateMetricNameUniqueness(testLogger, uniqueNamedScaledObjectTrigger)).Should(BeNil())
+				// Call function to be tested
+				metricSpecs, err := metricNameTestReconciler.getScaledObjectMetricSpecs(testLogger, uniquelyNamedScaledObject)
+
+				// Test that the status was updated with metric names
+				Ω(uniquelyNamedScaledObject.Status.ExternalMetricNames).Should(Equal(expectedExternalMetricNames))
+
+				// Test returned values
+				Ω(len(metricSpecs)).Should(Equal(len(testScalers)))
+				Ω(err).Should(BeNil())
 			})
 
 			It("should pass metric name validation with single value", func() {
+				// Generate test data
+				expectedExternalMetricNames := make([]string, 0)
+
 				config := &scalers.ScalerConfig{
 					Name:            "test",
 					Namespace:       "test",
@@ -86,17 +115,34 @@ var _ = Describe("ScaledObjectController", func() {
 				if err != nil {
 					Fail(err.Error())
 				}
+				for _, metricSpec := range s.GetMetricSpecForScaling() {
+					if metricSpec.External != nil {
+						expectedExternalMetricNames = append(expectedExternalMetricNames, metricSpec.External.Metric.Name)
+					}
+				}
 
-				mockScaleHandler.EXPECT().GetScalers(uniqueNamedScaledObjectTrigger).Return([]scalers.Scaler{s}, nil)
+				// Set up expectations
+				mockScaleHandler.EXPECT().GetScalers(uniquelyNamedScaledObject).Return([]scalers.Scaler{s}, nil)
+				mockClient.EXPECT().Status().Return(mockStatusWriter)
+				mockStatusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any())
 
-				Ω(metricNameTestReconciler.validateMetricNameUniqueness(testLogger, uniqueNamedScaledObjectTrigger)).Should(BeNil())
+				// Call function to be tested
+				metricSpecs, err := metricNameTestReconciler.getScaledObjectMetricSpecs(testLogger, uniquelyNamedScaledObject)
+
+				// Test that the status was updated
+				Ω(uniquelyNamedScaledObject.Status.ExternalMetricNames).Should(Equal(expectedExternalMetricNames))
+
+				// Test returned values
+				Ω(len(metricSpecs)).Should(Equal(1))
+				Ω(err).Should(BeNil())
 			})
 		})
 
 		Context("With Duplicate Values", func() {
-			var duplicateNamedScaledObjectTrigger = &kedav1alpha1.ScaledObject{}
+			var duplicateNamedScaledObject = &kedav1alpha1.ScaledObject{}
 
 			It("should pass metric name validation", func() {
+				// Generate test data
 				testScalers := make([]scalers.Scaler, 0)
 				for i := 0; i < 4; i++ {
 					config := &scalers.ScalerConfig{
@@ -115,9 +161,18 @@ var _ = Describe("ScaledObjectController", func() {
 					testScalers = append(testScalers, s)
 				}
 
-				mockScaleHandler.EXPECT().GetScalers(duplicateNamedScaledObjectTrigger).Return(testScalers, nil)
+				// Set up expectations
+				mockScaleHandler.EXPECT().GetScalers(duplicateNamedScaledObject).Return(testScalers, nil)
 
-				Ω(metricNameTestReconciler.validateMetricNameUniqueness(testLogger, duplicateNamedScaledObjectTrigger)).ShouldNot(BeNil())
+				// Call function tobe tested
+				metricSpecs, err := metricNameTestReconciler.getScaledObjectMetricSpecs(testLogger, duplicateNamedScaledObject)
+
+				// Test that the status was not updated
+				Ω(duplicateNamedScaledObject.Status.ExternalMetricNames).Should(BeNil())
+
+				// Test returned values
+				Ω(metricSpecs).Should(BeNil())
+				Ω(err).ShouldNot(BeNil())
 			})
 		})
 	})

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -43,7 +43,7 @@ func TestPosgresSQLGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range postgreSQLMetricIdentifiers {
 		meta, err := parsePostgreSQLMetadata(&ScalerConfig{ResolvedEnv: testData.resolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.authParam})
 		if err != nil {
-			t.Fatal("Could not parse n:", err)
+			t.Fatal("Could not parse metadata:", err)
 		}
 		mockPostgresSQLScaler := postgreSQLScaler{meta, nil}
 

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -43,7 +43,7 @@ func TestPosgresSQLGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range postgreSQLMetricIdentifiers {
 		meta, err := parsePostgreSQLMetadata(&ScalerConfig{ResolvedEnv: testData.resolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.authParam})
 		if err != nil {
-			t.Fatal("Could not parse metadata:", err)
+			t.Fatal("Could not parse n:", err)
 		}
 		mockPostgresSQLScaler := postgreSQLScaler{meta, nil}
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [ N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Changelog has been updated

Fixes #

Potential fix for #1636 

Scalers were not being closed properly after use.
