### PR TITLE
Add publishRate config for RabbitMQ Scaler

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -325,7 +325,7 @@ func (s *rabbitMQScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq", s.metadata.queueName)),
+			Name: kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq-rate", s.metadata.queueName)),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -52,10 +52,14 @@ type rabbitMQMetadata struct {
 }
 
 type queueInfo struct {
-	Messages               int           `json:"messages"`
-	MessagesUnacknowledged int           `json:"messages_unacknowledged"`
-	PublishDetail          publishDetail `json:"publish_details"`
-	Name                   string        `json:"name"`
+	Messages               int         `json:"messages"`
+	MessagesUnacknowledged int         `json:"messages_unacknowledged"`
+	MessageStat            messageStat `json:"message_stats"`
+	Name                   string      `json:"name"`
+}
+
+type messageStat struct {
+	PublishDetail publishDetail `json:"publish_details"`
 }
 
 type publishDetail struct {
@@ -242,7 +246,7 @@ func (s *rabbitMQScaler) getQueueStatus() (int, float64, error) {
 		}
 
 		// messages count includes count of ready and unack-ed
-		return info.Messages, info.PublishDetail.Rate, nil
+		return info.Messages, info.MessageStat.PublishDetail.Rate, nil
 	}
 
 	items, err := s.channel.QueueInspect(s.metadata.queueName)

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -58,6 +58,18 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	{map[string]string{"queueName": "sample", "host": "http://"}, false, map[string]string{}},
 	// auto protocol and an HTTPS URL
 	{map[string]string{"queueName": "sample", "host": "https://"}, false, map[string]string{}},
+	// publishRate number
+	{map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueName": "sample", "host": "https://"}, false, map[string]string{}},
+	// publishRate not number
+	{map[string]string{rabbitPublishedPerSecondMetricName: "AA", "queueName": "sample", "host": "https://"}, true, map[string]string{}},
+	// publishRate http
+	{map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueName": "sample", "host": "http://"}, false, map[string]string{}},
+	// publishRate amqp
+	{map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueName": "sample", "host": "amqp://"}, true, map[string]string{}},
+	// publishRate amqps
+	{map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueName": "sample", "host": "amqps://"}, true, map[string]string{}},
+	// publishRate and queueLength
+	{map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "10", "queueName": "sample", "host": "https://"}, true, map[string]string{}},
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
@@ -82,6 +94,8 @@ var testDefaultQueueLength = []parseRabbitMQMetadataTestData{
 	{map[string]string{"queueName": "sample", "hostFromEnv": host}, false, map[string]string{}},
 	// use default queueLength with includeUnacked
 	{map[string]string{"queueName": "sample", "hostFromEnv": host, "protocol": "http"}, false, map[string]string{}},
+	// use default queueLength with includeUnacked
+	{map[string]string{"queueName": "sample", rabbitPublishedPerSecondMetricName: "100", "hostFromEnv": host, "protocol": "http"}, false, map[string]string{}},
 }
 
 func TestParseDefaultQueueLength(t *testing.T) {
@@ -92,7 +106,9 @@ func TestParseDefaultQueueLength(t *testing.T) {
 			t.Error("Expected success but got error", err)
 		case testData.isError && err == nil:
 			t.Error("Expected error but got success")
-		case metadata.queueLength != defaultRabbitMQQueueLength:
+		case metadata.publishRate > 0 && metadata.queueLength != 0:
+			t.Error("Expected default queueLength = 0 when publishRate is specified")
+		case metadata.publishRate == 0 && metadata.queueLength != defaultRabbitMQQueueLength:
 			t.Error("Expected default queueLength =", defaultRabbitMQQueueLength, "but got", metadata.queueLength)
 		}
 	}
@@ -107,19 +123,33 @@ type getQueueInfoTestData struct {
 }
 
 var testQueueInfoTestData = []getQueueInfoTestData{
-	{`{"messages": 4, "messages_unacknowledged": 1, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 1, "messages_unacknowledged": 1, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 1, "messages_unacknowledged": 0, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 0, "messages_unacknowledged": 0, "name": "evaluate_trials"}`, http.StatusOK, false, nil, ""},
+	// queueLength
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 0, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, false, nil, ""},
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 0, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, false, nil, ""},
+	// publishRate
+	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, false, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, false, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	// error response
 	{`Password is incorrect`, http.StatusUnauthorized, false, nil, ""},
 }
 
 var vhostPathes = []string{"/myhost", "", "/", "//", "/%2F"}
 
 var testQueueInfoTestDataSingleVhost = []getQueueInfoTestData{
-	{`{"messages": 4, "messages_unacknowledged": 1, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
 }
 
 func TestGetQueueInfo(t *testing.T) {

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -124,19 +124,19 @@ type getQueueInfoTestData struct {
 
 var testQueueInfoTestData = []getQueueInfoTestData{
 	// queueLength
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 1, "messages_unacknowledged": 0, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, false, nil, ""},
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 1, "messages_unacknowledged": 0, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
-	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, false, nil, ""},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 0, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, false, nil, ""},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 1, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, nil, ""},
+	{`{"messages": 0, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, false, nil, ""},
 	// publishRate
-	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
-	{`{"messages": 0, "messages_unacknowledged": 0, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, false, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
-	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
-	{`{"messages": 1, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, false, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	{`{"messages": 0, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	{`{"messages": 0, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, false, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
+	{`{"messages": 1, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, false, map[string]string{rabbitPublishedPerSecondMetricName: "100", "queueLength": "0"}, ""},
 	// error response
 	{`Password is incorrect`, http.StatusUnauthorized, false, nil, ""},
 }
@@ -144,12 +144,12 @@ var testQueueInfoTestData = []getQueueInfoTestData{
 var vhostPathes = []string{"/myhost", "", "/", "//", "/%2F"}
 
 var testQueueInfoTestDataSingleVhost = []getQueueInfoTestData{
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":1743.2}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "publish_details":{"rate":0}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
 }
 
 func TestGetQueueInfo(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Adding `publishRate` config for RabbitMQ scaler. This is mutually exclusive with the existing `queueLength` config.
The use is for scaling higher throughput scenarios where there is little queue length backlog or the queue length doesn't adequately correlate to the number of instances required to match the workload.

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] Tests have been added
- [-] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes #
