### PR TITLE
Update OpenStack Swift scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix memory leak by checking triggers uniqueness properly ([#1640](https://github.com/kedacore/keda/pull/1640))
 - Print correct ScaleTarget Kind in Events ([#1641](https://github.com/kedacore/keda/pull/1641))
 - Fixed keda clusterroles to give permissions for clustertriggerauthentications ([#1645](https://github.com/kedacore/keda/pull/1645))
+- Make `swiftURL` parameter optional for the OpenStack Swift scaler ([#1652](https://github.com/kedacore/keda/pull/1652))
 
 ### Breaking Changes
 

--- a/pkg/scalers/openstack/utils/serviceTypes.go
+++ b/pkg/scalers/openstack/utils/serviceTypes.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+)
+
+const (
+	serviceTypesAuthorityEndpoint = "https://service-types.openstack.org/service-types.json"
+	defaultHTTPClientTimeout      = 30
+)
+
+type serviceTypesRequest struct {
+	AllTypesByServiceType   map[string][]string       `json:"all_types_by_service_type"`
+	Forward                 map[string][]string       `json:"forward"`
+	PrimaryServiceByProject map[string]serviceMapping `json:"primary_service_by_project"`
+	Reverse                 map[string]string         `json:"reverse"`
+	ServiceTypesByProject   map[string][]string       `json:"service_types_by_project"`
+	Services                []serviceMapping          `json:"services"`
+	SHA                     string                    `json:"sha"`
+	Version                 string                    `json:"version"`
+}
+
+type serviceMapping struct {
+	Aliases      []string `json:"aliases,omitempty"`
+	APIReference string   `json:"api_reference"`
+	Project      string   `json:"project"`
+	ServiceType  string   `json:"service_type"`
+}
+
+// GetServiceTypes retrieves all historical OpenStack Service Types for a given OpenStack project
+func GetServiceTypes(projectName string) ([]string, error) {
+	var serviceTypesRequest serviceTypesRequest
+
+	var httpClient = kedautil.CreateHTTPClient(defaultHTTPClientTimeout * time.Second)
+
+	var url = serviceTypesAuthorityEndpoint
+
+	getServiceTypes, err := http.NewRequest("GET", url, nil)
+
+	if err != nil {
+		return []string{}, err
+	}
+
+	resp, err := httpClient.Do(getServiceTypes)
+
+	if err != nil || resp.Status >= "300" {
+		return []string{}, nil
+	}
+
+	defer resp.Body.Close()
+
+	jsonErr := json.NewDecoder(resp.Body).Decode(&serviceTypesRequest)
+
+	if jsonErr != nil {
+		return []string{}, jsonErr
+	}
+
+	var serviceTypes = serviceTypesRequest.PrimaryServiceByProject[projectName].Aliases
+
+	if len(serviceTypes) == 0 {
+		var serviceType = serviceTypesRequest.PrimaryServiceByProject[projectName].ServiceType
+
+		if serviceType != "" {
+			return []string{serviceType}, nil
+		}
+
+		return []string{}, fmt.Errorf("project is not an official OpenStack project")
+	}
+
+	return serviceTypes, nil
+}

--- a/pkg/scalers/openstack_swift_scaler_test.go
+++ b/pkg/scalers/openstack_swift_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"testing"
 
+	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +24,7 @@ type openstackSwiftMetricIdentifier struct {
 
 var openstackSwiftMetadataTestData = []parseOpenstackSwiftMetadataTestData{
 	// Only required parameters
-	{metadata: map[string]string{"swiftURL": "http://localhost:8080/v1/my-account-id", "containerName": "my-container"}},
+	{metadata: map[string]string{"containerName": "my-container"}},
 	// Adding objectCount
 	{metadata: map[string]string{"swiftURL": "http://localhost:8080/v1/my-account-id", "containerName": "my-container", "objectCount": "5"}},
 	// Adding objectPrefix
@@ -44,8 +45,6 @@ var openstackSwiftAuthMetadataTestData = []parseOpenstackSwiftAuthMetadataTestDa
 }
 
 var invalidOpenstackSwiftMetadataTestData = []parseOpenstackSwiftMetadataTestData{
-	// Missing swiftURL
-	{metadata: map[string]string{"containerName": "my-container", "objectCount": "5"}},
 	// Missing containerName
 	{metadata: map[string]string{"swiftURL": "http://localhost:8080/v1/my-account-id", "objectCount": "5"}},
 	// objectCount is not an integer value
@@ -108,7 +107,7 @@ func TestOpenstackSwiftGetMetricSpecForScaling(t *testing.T) {
 			t.Fatal("Could not parse auth metadata:", err)
 		}
 
-		mockSwiftScaler := openstackSwiftScaler{meta, nil}
+		mockSwiftScaler := openstackSwiftScaler{meta, openstack.Client{}}
 
 		metricSpec := mockSwiftScaler.GetMetricSpecForScaling()
 
@@ -122,11 +121,10 @@ func TestOpenstackSwiftGetMetricSpecForScaling(t *testing.T) {
 
 func TestParseOpenstackSwiftMetadataForInvalidCases(t *testing.T) {
 	testCases := []openstackSwiftMetricIdentifier{
-		{nil, &invalidOpenstackSwiftMetadataTestData[0], &parseOpenstackSwiftAuthMetadataTestData{}, "missing swiftURL"},
-		{nil, &invalidOpenstackSwiftMetadataTestData[1], &parseOpenstackSwiftAuthMetadataTestData{}, "missing containerName"},
-		{nil, &invalidOpenstackSwiftMetadataTestData[2], &parseOpenstackSwiftAuthMetadataTestData{}, "objectCount is not an integer value"},
-		{nil, &invalidOpenstackSwiftMetadataTestData[3], &parseOpenstackSwiftAuthMetadataTestData{}, "onlyFiles is not a boolean value"},
-		{nil, &invalidOpenstackSwiftMetadataTestData[4], &parseOpenstackSwiftAuthMetadataTestData{}, "timeout is not an integer value"},
+		{nil, &invalidOpenstackSwiftMetadataTestData[0], &parseOpenstackSwiftAuthMetadataTestData{}, "missing containerName"},
+		{nil, &invalidOpenstackSwiftMetadataTestData[1], &parseOpenstackSwiftAuthMetadataTestData{}, "objectCount is not an integer value"},
+		{nil, &invalidOpenstackSwiftMetadataTestData[2], &parseOpenstackSwiftAuthMetadataTestData{}, "onlyFiles is not a boolean value"},
+		{nil, &invalidOpenstackSwiftMetadataTestData[3], &parseOpenstackSwiftAuthMetadataTestData{}, "timeout is not an integer value"},
 	}
 
 	for _, testData := range testCases {


### PR DESCRIPTION
Signed-off-by: Pedro Felipe Dominguite (<p.dominguite@sidi.org.br>)

### Changes

- The `swiftURL` is now an optional parameter since it can be retrieved from the catalog.
- The optional parameter `regionName` was added.
- Now, the Keystone module can retrieve the service URL dynamically for any OpenStack service, by searching into the OpenStack catalog within the given authorization scope.
- Add serviceTypes helper which retrieves all the service types historically used by an OpenStack project.
- Update OpenStack Swift scaler unit tests

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added
- [x] A PR is opened to update the documentation ([#386](https://github.com/kedacore/keda-docs/pull/386))
- [x] Changelog has been updated
