### PR TITLE
Add RabbitMQ `publishRate` trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - KEDA should make sure generate correct labels for HPA ([#1630](https://github.com/kedacore/keda/issues/1630))
 - Fix memory leak by checking triggers uniqueness properly ([#1640](https://github.com/kedacore/keda/pull/1640))
 - Print correct ScaleTarget Kind in Events ([#1641](https://github.com/kedacore/keda/pull/1641))
+- Add `publishRate` trigger to RabbitMQ scaler ([#1653](https://github.com/kedacore/keda/pull/1653))
 
 ### Breaking Changes
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -164,6 +164,15 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 		meta.vhostName = &val
 	}
 
+	_, err := parseTrigger(&meta, config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse trigger: %s", err)
+	}
+
+	return &meta, nil
+}
+
+func parseTrigger(meta *rabbitMQMetadata, config *ScalerConfig) (*rabbitMQMetadata, error) {
 	deprecatedQueueLengthValue, deprecatedQueueLengthPresent := config.TriggerMetadata[rabbitQueueLengthMetricName]
 	mode, modePresent := config.TriggerMetadata[rabbitModeTriggerConfigName]
 	value, valuePresent := config.TriggerMetadata[rabbitValueTriggerConfigName]
@@ -174,7 +183,7 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 
 	// If nothing is specified for the trigger then return the default
 	if !deprecatedQueueLengthPresent && !modePresent && !valuePresent {
-		return &meta, nil
+		return meta, nil
 	}
 
 	// Only allow one of `queueLength` or `mode`/`value`
@@ -191,7 +200,7 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 		meta.mode = rabbitModeQueueLength
 		meta.value = queueLength
 
-		return &meta, nil
+		return meta, nil
 	}
 
 	if !modePresent {
@@ -220,7 +229,7 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 		return nil, fmt.Errorf("protocol %s not supported; must be http to use mode %s", meta.protocol, rabbitModeMessageRate)
 	}
 
-	return &meta, nil
+	return meta, nil
 }
 
 func getConnectionAndChannel(host string) (*amqp.Connection, *amqp.Channel, error) {


### PR DESCRIPTION
Signed-off-by: Ryan Karg <rwkarg@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added an additional trigger for RabbitMQ scaling on `publishRate`.

This allows for higher throughput workloads to scale based on the incoming message rate. This is useful because the message backlog does not often correlate with the desired instance count.

Both `publishRate` and `queueLength` triggers can be specified on a single ScaledObject. I would imagine the normal case would be to use both of these triggers.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] Tests have been added
~~[ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~~
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
  - https://github.com/kedacore/keda-docs/pull/388
- [X] Changelog has been updated

Fixes #1643
