### PR TITLE
fix memory leak by setting logger for controller-runtime in keda-adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Print correct ScaleTarget Kind in Events ([#1641](https://github.com/kedacore/keda/pull/1641))
 - Fixed keda clusterroles to give permissions for clustertriggerauthentications ([#1645](https://github.com/kedacore/keda/pull/1645))
 - Make `swiftURL` parameter optional for the OpenStack Swift scaler ([#1652](https://github.com/kedacore/keda/pull/1652))
+- Fix memory leak of `keda-metrics-apiserver` by setting a controller-runtime logger properly ([#1654](https://github.com/kedacore/keda/pull/1654))
 
 ### Breaking Changes
 

--- a/adapter/main.go
+++ b/adapter/main.go
@@ -134,7 +134,7 @@ func main() {
 	}
 
 	ctrl.SetLogger(logger)
-	
+
 	globalHTTPTimeoutStr := os.Getenv("KEDA_HTTP_DEFAULT_TIMEOUT")
 	if globalHTTPTimeoutStr == "" {
 		// default to 3 seconds if they don't pass the env var

--- a/adapter/main.go
+++ b/adapter/main.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -132,6 +133,8 @@ func main() {
 		return
 	}
 
+	ctrl.SetLogger(logger)
+	
 	globalHTTPTimeoutStr := os.Getenv("KEDA_HTTP_DEFAULT_TIMEOUT")
 	if globalHTTPTimeoutStr == "" {
 		// default to 3 seconds if they don't pass the env var


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Set logger for controller-runtime in keda-adapter

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #1639

- memory leak of keda-adapter

![image](https://user-images.githubusercontent.com/17028350/109954973-e6d1d680-7d1c-11eb-8022-d46b6be905c3.png)

## Related issue

- https://github.com/kedacore/keda/issues/1639
- https://github.com/kubernetes-sigs/controller-runtime/issues/1122
- https://github.com/kubernetes-sigs/controller-runtime/pull/1309


