### PR TITLE
Publish KEDA images on GitHub Container Registry

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -16,11 +16,15 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Login to Docker Hub
-        env:
-          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          # Username used to log in to a Docker registry. If not set then no login will occur
+          username: ${{ github.repository_owner }}
+          # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
+          password: ${{ secrets.GHCR_AUTH_PAT }}
+          # Server address of Docker registry. If not set then will default to Docker Hub
+          registry: ghcr.io
 
       - name: Build and publish Tools image
         run: make publish-build-tools

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -29,14 +29,27 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          # Username used to log in to a Docker registry. If not set then no login will occur
+          username: ${{ github.repository_owner }}
+          # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
+          password: ${{ secrets.GHCR_AUTH_PAT }}
+          # Server address of Docker registry. If not set then will default to Docker Hub
+          registry: ghcr.io
+
       - name: Login to Docker Hub
         env:
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
 
-      - name: Publish
+      - name: Publish on GitHub Container Registry
         run: make publish
+
+      - name: Publish on Docker Hub
+        run: make publish-dockerhub
 
       - name: Run end to end tests
         env:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -26,6 +26,16 @@ jobs:
       - name: Go modules sync
         run: go mod tidy
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          # Username used to log in to a Docker registry. If not set then no login will occur
+          username: ${{ github.repository_owner }}
+          # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
+          password: ${{ secrets.GHCR_AUTH_PAT }}
+          # Server address of Docker registry. If not set then will default to Docker Hub
+          registry: ghcr.io
+
       - name: Login to Docker Hub
         env:
           DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -41,8 +51,13 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 
-      - name: Publish KEDA images to Docker Hub
+      - name: Publish KEDA images on GitHub Container Registry
         run: make publish
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+
+      - name: Publish KEDA images on Docker Hub
+        run: make publish-dockerhub
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -107,14 +107,14 @@ If you want to change KEDA's behaviour, or if you have created a new scaler (mor
 to deploy it as part of KEDA. Do the following:
 
 1. Make your change in the code.
-2. Build and publish on Docker Hub images with your changes, `IMAGE_REPO` should point to your repository
- (specifying `IMAGE_REGISTRY` as well allows you to use registry of your choice eg. quay.io).
+2. Build and publish images with your changes, `IMAGE_REPO` should point to your repository,
+`IMAGE_REGISTRY` allows you to use registry of your choice eg. quay.io, default is `ghcr.io`
    ```bash
-   IMAGE_REPO=johndoe make publish
+   IMAGE_REGISTRY=docker.io IMAGE_REPO=johndoe make publish
    ```
 3. Deploy KEDA with your custom images.
    ```bash
-   IMAGE_REPO=johndoe make deploy
+   IMAGE_REGISTRY=docker.io IMAGE_REPO=johndoe make deploy
    ```
 4. Once the KEDA pods are up, check the logs to verify everything running ok, eg:
     ```bash

--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -13,8 +13,8 @@ In order to develop a scaler, a developer should do the following:
 
 If you want to deploy locally
 1. Open the terminal and go to the root of the source code
-2. Run `IMAGE_REPO=johndoe make publish`, where `johndoe` is your Docker Hub repo, this will create and publish images with your build of KEDA into your repo. Please refer [the guide for local deployment](https://github.com/kedacore/keda/blob/main/BUILD.md#custom-keda-locally-outside-cluster) for more details.
-3. Run `IMAGE_REPO=johndoe make deploy`, this will deploy KEDA to your cluster.
+2. Run `IMAGE_REGISTRY=docker.io IMAGE_REPO=johndoe make publish`, where `johndoe` is your Docker Hub repo, this will create and publish images with your build of KEDA into your repo. Please refer [the guide for local deployment](https://github.com/kedacore/keda/blob/main/BUILD.md#custom-keda-locally-outside-cluster) for more details.
+3. Run `IMAGE_REGISTRY=docker.io IMAGE_REPO=johndoe make deploy`, this will deploy KEDA to your cluster.
 
 ## Scaler interface
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,6 +4,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: docker.io/kedacore/keda
-  newName: docker.io/kedacore/keda
+- name: ghcr.io/kedacore/keda
+  newName: ghcr.io/kedacore/keda
   newTag: main

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: keda-operator
       containers:
         - name: keda-operator
-          image: docker.io/kedacore/keda:latest
+          image: ghcr.io/kedacore/keda:latest
           command:
             - /keda
           args:

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: keda-operator
       containers:
         - name: keda-metrics-apiserver
-          image: docker.io/kedacore/keda-metrics-apiserver:latest
+          image: ghcr.io/kedacore/keda-metrics-apiserver:latest
           imagePullPolicy: Always
           resources:
             requests:

--- a/config/metrics-server/kustomization.yaml
+++ b/config/metrics-server/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: docker.io/kedacore/keda-metrics-apiserver
-  newName: docker.io/kedacore/keda-metrics-apiserver
+- name: ghcr.io/kedacore/keda-metrics-apiserver
+  newName: ghcr.io/kedacore/keda-metrics-apiserver
   newTag: main


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Publishing KEDA images on GitHub Container Registry, images are still mirrored to Docker Hub.

Fixes #1650
