### PR TITLE
Add GOCACHE to github action cache

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,13 +15,22 @@ jobs:
         with:
           fetch-depth: 1
 
+      - id: go-paths
+        run: |
+          echo ::set-output name=mod_cache::$(go env GOMODCACHE)
+          echo ::set-output name=build_cache::$(go env GOCACHE)
+
       - name: Go modules cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
-          path: /go/pkg
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ${{ steps.go-paths.outputs.mod_cache }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Go build cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-paths.outputs.build_cache }}
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
       - name: Go modules sync
         run: go mod tidy

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,13 +15,22 @@ jobs:
         with:
           fetch-depth: 1
 
+      - id: go-paths
+        run: |
+          echo ::set-output name=mod_cache::$(go env GOMODCACHE)
+          echo ::set-output name=build_cache::$(go env GOCACHE)
+
       - name: Go modules cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
-          path: /go/pkg
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ${{ steps.go-paths.outputs.mod_cache }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Go build cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-paths.outputs.build_cache }}
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
       - name: Go modules sync
         run: go mod tidy

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,13 +15,22 @@ jobs:
         with:
           fetch-depth: 1
 
+      - id: go-paths
+        run: |
+          echo ::set-output name=mod_cache::$(go env GOMODCACHE)
+          echo ::set-output name=build_cache::$(go env GOCACHE)
+
       - name: Go modules cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
-          path: /go/pkg
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ${{ steps.go-paths.outputs.mod_cache }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Go build cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-paths.outputs.build_cache }}
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
       - name: Go modules sync
         run: go mod tidy


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

Adds the CI's go build cache to the static cache

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [N/A] Changelog has been updated

Fixes #
