### PR TITLE
don't overwrite kube-system namespace in Metrics Server rolebinding

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: keda
+#namespace: keda
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Via this global property, Kustomization replaced the namespace in RoleBinding `keda-auth-reader`, which is needed for Metrics Server, this RoleBinding should be applied to role in `kube-system` not `keda`.
Removing this global property doesn't have an effect on other resources.



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Fixes #1682
