### PR TITLE
ScaledJob: support metadata labels in Job template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Add `publishRate` trigger to RabbitMQ scaler ([#1653](https://github.com/kedacore/keda/pull/1653))
 - AWS SQS Scaler: Add Visible + NotVisible messages for scaling considerations ([#1664](https://github.com/kedacore/keda/pull/1664))
 - Fixing behavior on ScaledJob with incorrect External Scaler ([#1672](https://github.com/kedacore/keda/pull/1672))
+- ScaledJob: support metadata labels in Job template ([#1686](https://github.com/kedacore/keda/pull/1686))
 
 ### Breaking Changes
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,8 +8,7 @@ resources:
 - bases/keda.sh_clustertriggerauthentications.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-## ScaledJob CRD needs to be patched because of an issue with required properties
-## https://github.com/kedacore/keda/issues/927
+## ScaledJob CRD needs to be patched because for some usecases (details in the patch file)
 patchesJson6902:
 - target:
     version: v1

--- a/config/crd/patches/scaledjob_patch.yaml
+++ b/config/crd/patches/scaledjob_patch.yaml
@@ -1,4 +1,6 @@
 ---
+## needs to be patched because of an issue with required properties in order to be able to deploy on k8s 1.18+
+## https://github.com/kedacore/keda/issues/927
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/jobTargetRef/properties/template/properties/spec/properties/containers/items/properties/ports/items/required/-
   value: protocol
@@ -10,3 +12,9 @@
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/jobTargetRef/properties/template/properties/spec/properties/initContainers/items/properties/ports/items/required/-
   value: protocol
+
+## needs to be patched because of an issue with controller-gen, which is not including anything in metadata from nested contructs
+## https://github.com/kedacore/keda/issues/1311
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/jobTargetRef/properties/template/properties/metadata/x-kubernetes-preserve-unknown-fields
+  value: true


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add x-kubernetes-preserve-unknown-fields to ScaledJob CRD in order to support Labels in Job templates. Because there's a [bug](https://github.com/kubernetes-sigs/controller-tools/issues/448) in controller-gen, this field is not set during the generation. We need to patch during the "release of yaml" process via Kustomization.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #1311
