### PR TITLE
Remove app.kubernetes.io/version label from label selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### Improvements
 
-- TODO ([#XXX](https://github.com/kedacore/keda/pull/XXXX))
+- Remove app.kubernetes.io/version label from label selectors ([#1696](https://github.com/kedacore/keda/pull/1696))
 
 ### Breaking Changes
 

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ deploy: manifests kustomize
 	cd config/metrics-server && \
     $(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-metrics-apiserver=${IMAGE_ADAPTER}
 	# Need this workaround to mitigate a problem with inserting labels into selectors,
-	# until this issue is solved: https://github.com/kubernetes-sigs/kustomize/issues/1009	
+	# until this issue is solved: https://github.com/kubernetes-sigs/kustomize/issues/1009
 	@sed -i".out" -e 's@version:[ ].*@version: $(VERSION)@g' config/default/kustomize-config/metadataLabelTransformer.yaml
 	rm -rf config/default/kustomize-config/metadataLabelTransformer.yaml.out
 	$(KUSTOMIZE) build config/default | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ release: manifests kustomize set-version
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda=${IMAGE_CONTROLLER}
 	cd config/metrics-server && \
     $(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-metrics-apiserver=${IMAGE_ADAPTER}
+	# Need this workaround to mitigate a problem with inserting labels into selectors,
+	# until this issue is solved: https://github.com/kubernetes-sigs/kustomize/issues/1009
 	@sed -i".out" -e 's@version:[ ].*@version: $(VERSION)@g' config/default/kustomize-config/metadataLabelTransformer.yaml
 	rm -rf config/default/kustomize-config/metadataLabelTransformer.yaml.out
 	$(KUSTOMIZE) build config/default > keda-$(VERSION).yaml
@@ -122,6 +124,8 @@ deploy: manifests kustomize
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda=${IMAGE_CONTROLLER}
 	cd config/metrics-server && \
     $(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-metrics-apiserver=${IMAGE_ADAPTER}
+	# Need this workaround to mitigate a problem with inserting labels into selectors,
+	# until this issue is solved: https://github.com/kubernetes-sigs/kustomize/issues/1009	
 	@sed -i".out" -e 's@version:[ ].*@version: $(VERSION)@g' config/default/kustomize-config/metadataLabelTransformer.yaml
 	rm -rf config/default/kustomize-config/metadataLabelTransformer.yaml.out
 	$(KUSTOMIZE) build config/default | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ release: manifests kustomize set-version
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda=${IMAGE_CONTROLLER}
 	cd config/metrics-server && \
     $(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-metrics-apiserver=${IMAGE_ADAPTER}
-	cd config/default && \
-    $(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+	@sed -i".out" -e 's@version:[ ].*@version: $(VERSION)@g' config/default/kustomize-config/metadataLabelTransformer.yaml
+	rm -rf config/default/kustomize-config/metadataLabelTransformer.yaml.out
 	$(KUSTOMIZE) build config/default > keda-$(VERSION).yaml
 
 .PHONY: set-version
@@ -122,8 +122,8 @@ deploy: manifests kustomize
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda=${IMAGE_CONTROLLER}
 	cd config/metrics-server && \
     $(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-metrics-apiserver=${IMAGE_ADAPTER}
-	cd config/default && \
-    $(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+	@sed -i".out" -e 's@version:[ ].*@version: $(VERSION)@g' config/default/kustomize-config/metadataLabelTransformer.yaml
+	rm -rf config/default/kustomize-config/metadataLabelTransformer.yaml.out
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # Undeploy controller

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,6 +19,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
   app.kubernetes.io/part-of: keda-operator
+# Need this transformer to mitigate a problem with inserting labels into selectors,
+# until this issue is solved: https://github.com/kubernetes-sigs/kustomize/issues/1009
 transformers:
 - kustomize-config/metadataLabelTransformer.yaml
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,8 +19,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
   app.kubernetes.io/part-of: keda-operator
-  app.kubernetes.io/version: main
-
+transformers:
+- kustomize-config/metadataLabelTransformer.yaml
 
 resources:
 - ../crd

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,8 +17,6 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app.kubernetes.io/part-of: keda-operator
 # Need this transformer to mitigate a problem with inserting labels into selectors,
 # until this issue is solved: https://github.com/kubernetes-sigs/kustomize/issues/1009
 transformers:

--- a/config/default/kustomize-config/metadataLabelTransformer.yaml
+++ b/config/default/kustomize-config/metadataLabelTransformer.yaml
@@ -4,6 +4,7 @@ metadata:
   name: metadataLabelTransformer
 labels:
   app.kubernetes.io/version: main
+  app.kubernetes.io/part-of: keda-operator
 fieldSpecs:
 - path: metadata/labels
   create: true

--- a/config/default/kustomize-config/metadataLabelTransformer.yaml
+++ b/config/default/kustomize-config/metadataLabelTransformer.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: metadataLabelTransformer
+labels:
+  app.kubernetes.io/version: main
+fieldSpecs:
+- path: metadata/labels
+  create: true


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #1694 
