### PR TITLE
Using time.Timers instead of time.After()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ## Unreleased
 
 - Add OpenStack Metrics Scaler ([#1382](https://github.com/kedacore/keda/issues/1382))
-- Fixed goroutine leaks in usage of timers
+- Fixed goroutine leaks in usage of timers ([#1704](https://github.com/kedacore/keda/pull/1704))
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ## Unreleased
 
 - Add OpenStack Metrics Scaler ([#1382](https://github.com/kedacore/keda/issues/1382))
+- Fixed goroutine leaks in usage of timers
 
 ### New
 

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -140,12 +140,15 @@ func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1a
 	pollingInterval := getPollingInterval(withTriggers)
 	logger.V(1).Info("Watching with pollingInterval", "PollingInterval", pollingInterval)
 
+	tmr := time.NewTimer(pollingInterval)
 	for {
 		select {
-		case <-time.After(pollingInterval):
+		case <-tmr.C:
 			h.checkScalers(ctx, scalableObject, scalingMutex)
+			tmr.Stop()
 		case <-ctx.Done():
 			logger.V(1).Info("Context canceled")
+			tmr.Stop()
 			return
 		}
 	}


### PR DESCRIPTION
As explained in the [docs for `time.After()`](https://pkg.go.dev/time#After), the `time.Timer` that underpins the call to `time.After` is not released and recovered by the GC. This PR fixes the resulting leak by creating and releasing `time.Timer`s instead of using `time.After()`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] (N/A) A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] (N/A) A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated
