### PR TITLE
Fix regression brought by using time.NewTimer() in scale loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ## Unreleased
 
 - Add OpenStack Metrics Scaler ([#1382](https://github.com/kedacore/keda/issues/1382))
-- Fixed goroutine leaks in usage of timers ([#1704](https://github.com/kedacore/keda/pull/1704))
+- Fixed goroutine leaks in usage of timers ([#1704](https://github.com/kedacore/keda/pull/1704) | [#1739](https://github.com/kedacore/keda/pull/1739))
 
 ### New
 

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -140,8 +140,9 @@ func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1a
 	pollingInterval := getPollingInterval(withTriggers)
 	logger.V(1).Info("Watching with pollingInterval", "PollingInterval", pollingInterval)
 
-	tmr := time.NewTimer(pollingInterval)
 	for {
+		tmr := time.NewTimer(pollingInterval)
+
 		select {
 		case <-tmr.C:
 			h.checkScalers(ctx, scalableObject, scalingMutex)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

https://github.com/kedacore/keda/pull/1704 changed the way how is the timer in scale loop calculated, but we have missed a bug. The timer was initialized only once (at the start), causing the scale loop not perform any checks :)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

