### PR TITLE
chore: Don't send .git in docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Don't send .git context
+.git/
+
+# Binaries
+/bin/
+/keda
+
+# Dockerfiles
+Dockerfile
+Dockerfile.*
+
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Build the manager binary
 FROM golang:1.15.6 as builder
 
-ARG BUILD_VERSION
+ARG BUILD_VERSION=main
+ARG GIT_COMMIT=HEAD
+ARG GIT_VERSION=main
 
 WORKDIR /workspace
 
@@ -23,10 +25,8 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-COPY .git/ .git/
-
 # Build
-RUN VERSION=${BUILD_VERSION} make manager-dockerfile
+RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} make manager-dockerfile
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -1,7 +1,9 @@
 # Build the manager binary
 FROM golang:1.15.6 as builder
 
-ARG BUILD_VERSION
+ARG BUILD_VERSION=main
+ARG GIT_COMMIT=HEAD
+ARG GIT_VERSION=main
 
 WORKDIR /workspace
 
@@ -23,12 +25,10 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
-COPY .git/ .git/
-
 RUN mkdir -p /apiserver.local.config/certificates && chmod -R 777 /apiserver.local.config
 
 # Build
-RUN VERSION=${BUILD_VERSION} make adapter-dockerfile
+RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} make adapter-dockerfile
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ ARCH       ?=amd64
 CGO        ?=0
 TARGET_OS  ?=linux
 
-GIT_VERSION = $(shell git describe --always --abbrev=7)
-GIT_COMMIT  = $(shell git rev-list -1 HEAD)
+GIT_VERSION ?= $(shell git describe --always --abbrev=7)
+GIT_COMMIT  ?= $(shell git rev-list -1 HEAD)
 DATE        = $(shell date -u +"%Y.%m.%d.%H.%M.%S")
 
 TEST_CLUSTER_NAME ?= keda-nightly-run-2
@@ -143,8 +143,8 @@ build: manifests set-version manager adapter
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMAGE_CONTROLLER} --build-arg BUILD_VERSION=${VERSION}
-	docker build -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION}
+	docker build . -t ${IMAGE_CONTROLLER} --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+	docker build -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
 
 # Build KEDA Operator binary
 .PHONY: manager


### PR DESCRIPTION
- Context is lighter when running on remote docker server
- Image was not reproducible
- Azure ACR build ignore .git by default

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

Add parameters to `Makefile` and _build-arg_ to `Dockefile` to pass git commit and version (only things require `.git`).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
