### PR TITLE
Adding HTTP timeout to the IBM MQ Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add Azure Pipelines Scaler ([#1706](https://github.com/kedacore/keda/pull/1706))
 - Add OpenStack Metrics Scaler ([#1382](https://github.com/kedacore/keda/issues/1382))
 - Fixed goroutine leaks in usage of timers ([#1704](https://github.com/kedacore/keda/pull/1704) | [#1739](https://github.com/kedacore/keda/pull/1739))
+- Setting timeouts in the HTTP client used by the IBM MQ scaler ([#1758](https://github.com/kedacore/keda/pull/1758))
 
 ### New
 

--- a/pkg/scalers/ibmmq_scaler_test.go
+++ b/pkg/scalers/ibmmq_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 // Test host URLs for validation
@@ -98,11 +99,15 @@ func TestParseDefaultQueueDepth(t *testing.T) {
 func TestIBMMQGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range IBMMQMetricIdentifiers {
 		metadata, err := parseIBMMQMetadata(&ScalerConfig{ResolvedEnv: sampleIBMMQResolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams})
+		httpTimeout := 100 * time.Millisecond
 
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockIBMMQScaler := IBMMQScaler{metadata}
+		mockIBMMQScaler := IBMMQScaler{
+			metadata:           metadata,
+			defaultHTTPTimeout: httpTimeout,
+		}
 		metricSpec := mockIBMMQScaler.GetMetricSpecForScaling()
 		metricName := metricSpec[0].External.Metric.Name
 


### PR DESCRIPTION
Following https://github.com/kedacore/keda/issues/1133 and the related PR https://github.com/kedacore/keda/pull/1251, this PR adds a timeout to the HTTP client used by the IBM MQ scaler

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- ~A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~ N/A
- ~A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*~ N/A
- [x] Changelog has been updated


