### PR TITLE
hardcode os and arch in kubebuilder installer

### DIFF
--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -56,10 +56,8 @@ RUN RELEASE_VERSION=v1.0.1 && \
     rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 
 # Install kubebuilder tools
-RUN os=$(go env GOOS) && \
-    arch=$(go env GOARCH) && \
-    curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/ && \
-    mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+RUN curl -L https://go.kubebuilder.io/dl/2.3.1/linux/amd64 | tar -xz -C /tmp/ && \
+    mv /tmp/kubebuilder_2.3.1_linux_amd64 /usr/local/kubebuilder
 
 ENV PATH=${PATH}:/usr/local/go/bin \
     GOROOT=/usr/local/go \


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
go is not installed in the image

Fixes: 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

