### PR TITLE
refer to build-tools image hosted on ghcr.io

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: kedacore/build-tools:main
+    container: ghcr.io/kedacore/build-tools:main
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v2

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: kedacore/build-tools:main
+    container: ghcr.io/kedacore/build-tools:main
     steps:
       - name: Check out code
         uses: actions/checkout@v1

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -7,7 +7,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: kedacore/build-tools:main
+    container: ghcr.io/kedacore/build-tools:main
     steps:
       - name: Check out code
         uses: actions/checkout@v1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,7 +8,7 @@ jobs:
     name: Validate PR
     runs-on: ubuntu-latest
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: kedacore/build-tools:main
+    container: ghcr.io/kedacore/build-tools:main
     steps:
       - name: Check out code
         uses: actions/checkout@v1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Push Release
     runs-on: ubuntu-latest
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: kedacore/build-tools:main
+    container: ghcr.io/kedacore/build-tools:main
     steps:
       - name: Check out code
         uses: actions/checkout@v1


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

New version of this image are no longer push to Docker Hub, we need to refere to ghcr.io in order to consume the lastest one.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

