### PR TITLE
updating stan scaler with correct error message

### DIFF
--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -63,7 +63,7 @@ var stanLog = logf.Log.WithName("stan_scaler")
 func NewStanScaler(config *ScalerConfig) (Scaler, error) {
 	stanMetadata, err := parseStanMetadata(config)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing kafka metadata: %s", err)
+		return nil, fmt.Errorf("error parsing stan metadata: %s", err)
 	}
 
 	return &stanScaler{


### PR DESCRIPTION
Signed-off-by: Ritikaa96 <ritika@india.nec.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Stan Scaler shows error message with Kafka in text instead of nats. 
The error message is:
```
"error": "error parsing kafka metadata: no queue group given."

```
It should be 

```
 "error": "error parsing stan metadata: no queue group given."
```
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes #1781 
