### PR TITLE
Enable Authentication Parameters to configure as triggers metadata

### DIFF
--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -250,6 +250,18 @@ func TestKafkaCombinedMetadataConfig(t *testing.T) {
 		if err == nil && meta.password != testData.password {
 			t.Errorf("Expected password %s but got %s\n", testData.password, meta.password)
 		}
+		if meta.enableTLS != testData.enableTLS {
+			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
+		}
+		if err == nil && meta.cert != testData.cert {
+			t.Errorf("Expected cert %s but got %s\n", testData.cert, meta.cert)
+		}
+		if err == nil && meta.key != testData.key {
+			t.Errorf("Expected key %s but got %s\n", testData.key, meta.key)
+		}
+		if err == nil && meta.ca != testData.ca {
+			t.Errorf("Expected ca %s but got %s\n", testData.ca, meta.ca)
+		}
 	}
 }
 


### PR DESCRIPTION
We wanted to configure kafka scaler's Authentication Parameters as Triggers metadata. The purpose is, We use KEDA heavily and wanted to generate ScaledObject automatically. Through this process, this feature is required. I wrote the code that won't affect existing feature. 

This PR is, if the customer can write Authentication Parameters like this.  `FromEnv` notation is also supported. 

```yaml 
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: kafka-scaledobject
  namespace: default
spec:
  scaleTargetRef:
    name: azure-functions-deployment
  pollingInterval: 30
  triggers:
  - type: kafka
    metadata:
      bootstrapServers: localhost:9092
      consumerGroup: my-group       # Make sure that this consumer group name is the same one as the one that is consuming topics
      topic: test-topic
      # Optional
      lagThreshold: "50"
      offsetResetPolicy: latest
      sasl: "plaintext"
      username: "admin"
      password: "admin"
```

Since we don't discuss on an issue, once, this PR's proposal is accepted, I'd happy to write documentation and update the Changelog

CC @pragnagopa @ahmelsayed 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

