### PR TITLE
Apache artemis origin header needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add Azure Pipelines Scaler ([#1706](https://github.com/kedacore/keda/pull/1706))
 - Add OpenStack Metrics Scaler ([#1382](https://github.com/kedacore/keda/issues/1382))
 - Added basic, tls and bearer authentication support to the Prometheus scaler [#1559](https://github.com/kedacore/keda/issues/1559)
+- Add header Origin to apache artemis scaler
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Add Azure Pipelines Scaler ([#1706](https://github.com/kedacore/keda/pull/1706))
 - Add OpenStack Metrics Scaler ([#1382](https://github.com/kedacore/keda/issues/1382))
 - Added basic, tls and bearer authentication support to the Prometheus scaler [#1559](https://github.com/kedacore/keda/issues/1559)
-- Add header Origin to apache artemis scaler
+- Add header Origin to Apache Artemis scaler [#1796](https://github.com/kedacore/keda/pull/1796)
 
 ### Improvements
 

--- a/pkg/scalers/artemis_scaler_test.go
+++ b/pkg/scalers/artemis_scaler_test.go
@@ -78,6 +78,30 @@ var testArtemisMetadataWithAuthParams = []parseArtemisMetadataTestData{
 	{map[string]string{"managementEndpoint": "localhost:8161", "queueName": "queue1", "brokerName": "broker-activemq", "brokerAddress": "test"}, false},
 }
 
+func TestArtemisDefaultCorsHeader(t *testing.T) {
+	metadata := map[string]string{"managementEndpoint": "localhost:8161", "queueName": "queue1", "brokerName": "broker-activemq", "brokerAddress": "test", "username": "myUserName", "password": "myPassword"}
+	meta, err := parseArtemisMetadata(&ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: metadata, AuthParams: nil})
+
+	if err != nil {
+		t.Error("Expected success but got error", err)
+	}
+	if !(meta.corsHeader == "http://localhost:8161") {
+		t.Errorf("Expected http://localhost:8161 but got %s", meta.corsHeader)
+	}
+}
+
+func TestArtemisCorsHeader(t *testing.T) {
+	metadata := map[string]string{"managementEndpoint": "localhost:8161", "queueName": "queue1", "brokerName": "broker-activemq", "brokerAddress": "test", "username": "myUserName", "password": "myPassword", "corsHeader": "test"}
+	meta, err := parseArtemisMetadata(&ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: metadata, AuthParams: nil})
+
+	if err != nil {
+		t.Error("Expected success but got error", err)
+	}
+	if !(meta.corsHeader == "test") {
+		t.Errorf("Expected test but got %s", meta.corsHeader)
+	}
+}
+
 func TestArtemisParseMetadata(t *testing.T) {
 	for _, testData := range testArtemisMetadata {
 		_, err := parseArtemisMetadata(&ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: nil})


### PR DESCRIPTION
Encounter a problem while using apache artemis (last version), it complains that the header Origin is null. It seems now, unless you remove cors protection there is a need to add this header.
Content of the patch:

- Adding the origin header
- making it configurable in the metadata

Signed-off-by: Bernard Chesnoy <bernard.chesnoy@gmail.com>
