### PR TITLE
Changed Azure Service Bus scaler `metricName` to include Azure Service Bus Namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Improvements
 
-- Azure Service Bus Scaler: Fixed `metricname` uniqueness on instances with multiple queues with the same name ([#1755](https://github.com/kedacore/keda/issues/1755))
+- Azure Service Bus Scaler: Namespace from `connectionString` parameter is added to `metricName` due to uniqueness violation for clusters having more than one queue with the same name  ([#1755](https://github.com/kedacore/keda/issues/1755))
 - Remove app.kubernetes.io/version label from label selectors ([#1696](https://github.com/kedacore/keda/pull/1696))
 - Apache Kafka Scaler: Add `allowIdleConsumers` to the list of trigger parameters ([#1684](https://github.com/kedacore/keda/pull/1684))
 - Fixed goroutine leaks in usage of timers ([#1704](https://github.com/kedacore/keda/pull/1704) | [#1739](https://github.com/kedacore/keda/pull/1739))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Improvements
 
+- Azure Service Bus Scaler: Fixed `metricname` uniqueness on instances with multiple queues with the same name ([#1755](https://github.com/kedacore/keda/issues/1755))
 - Remove app.kubernetes.io/version label from label selectors ([#1696](https://github.com/kedacore/keda/pull/1696))
 - Apache Kafka Scaler: Add `allowIdleConsumers` to the list of trigger parameters ([#1684](https://github.com/kedacore/keda/pull/1684))
 - Fixed goroutine leaks in usage of timers ([#1704](https://github.com/kedacore/keda/pull/1704) | [#1739](https://github.com/kedacore/keda/pull/1739))

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -151,7 +151,7 @@ func (s *azureServiceBusScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetLengthQty := resource.NewQuantity(int64(s.metadata.targetLength), resource.DecimalSI)
 	namespace, err := s.getServiceBusNamespace()
 	if err != nil {
-		fmt.Errorf("error parsing azure service bus metadata: %s", err)
+		azureServiceBusLog.Error(err, "error parsing azure service bus metadata", "namespace")
 		return nil
 	}
 

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -40,6 +40,7 @@ type azureServiceBusScaler struct {
 
 type azureServiceBusMetadata struct {
 	targetLength     int
+	clusterNamespace string
 	queueName        string
 	topicName        string
 	subscriptionName string
@@ -67,6 +68,7 @@ func parseAzureServiceBusMetadata(config *ScalerConfig) (*azureServiceBusMetadat
 	meta := azureServiceBusMetadata{}
 	meta.entityType = none
 	meta.targetLength = defaultTargetMessageCount
+	meta.clusterNamespace = config.Namespace
 
 	// get target metric value
 	if val, ok := config.TriggerMetadata[messageCountMetricName]; ok {
@@ -151,9 +153,9 @@ func (s *azureServiceBusScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetLengthQty := resource.NewQuantity(int64(s.metadata.targetLength), resource.DecimalSI)
 	metricName := "azure-servicebus"
 	if s.metadata.entityType == queue {
-		metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", metricName, s.metadata.queueName))
+		metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", metricName, s.metadata.clusterNamespace, s.metadata.queueName))
 	} else {
-		metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", metricName, s.metadata.topicName, s.metadata.subscriptionName))
+		metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", metricName, s.metadata.clusterNamespace, s.metadata.topicName, s.metadata.subscriptionName))
 	}
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -37,6 +37,11 @@ var sampleResolvedEnv = map[string]string{
 	connectionSetting: "none",
 }
 
+// namespace example for setting up metric name
+var connectionResolvedEnv = map[string]string{
+	connectionSetting: "Endpoint=sb://namespacename.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=c29tZXJlYWxseWltcG9ydGFudGtleQ==",
+}
+
 var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 	{map[string]string{}, true, none, map[string]string{}, ""},
 	// properly formed queue
@@ -66,8 +71,8 @@ var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 }
 
 var azServiceBusMetricIdentifiers = []azServiceBusMetricIdentifier{
-	{&parseServiceBusMetadataDataset[1], "azure-servicebus-testqueue"},
-	{&parseServiceBusMetadataDataset[3], "azure-servicebus-testtopic-testsubscription"},
+	{&parseServiceBusMetadataDataset[1], "azure-servicebus-namespacename-testqueue"},
+	{&parseServiceBusMetadataDataset[3], "azure-servicebus-namespacename-testtopic-testsubscription"},
 }
 
 var commonHTTPClient = &http.Client{
@@ -151,7 +156,7 @@ func TestGetServiceBusLength(t *testing.T) {
 
 func TestAzServiceBusGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azServiceBusMetricIdentifiers {
-		meta, err := parseAzureServiceBusMetadata(&ScalerConfig{ResolvedEnv: sampleResolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, PodIdentity: testData.metadataTestData.podIdentity})
+		meta, err := parseAzureServiceBusMetadata(&ScalerConfig{ResolvedEnv: connectionResolvedEnv, TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, PodIdentity: testData.metadataTestData.podIdentity})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}


### PR DESCRIPTION
Signed-off-by: Damian Trojanowski <trojan.dg@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Changed Azure Service Bus scaler `metricName` to include Azure Service Bus Namespace, provided either from metric trigger parameter or from connection string. Thanks to this we can have more than one metric with the same `queueName` parameter.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] Documentation update not required
- [x] Changelog has been updated

Fixes #1755
