### PR TITLE
Azure Blob Scaler - Fix multiple scalers with the same blobContainerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Setting timeouts in the HTTP client used by the IBM MQ scaler ([#1758](https://github.com/kedacore/keda/pull/1758))
 - Fix cleanup of removed triggers ([#1768](https://github.com/kedacore/keda/pull/1768))
 - Eventhub Scaler: Add trigger parameter `checkpointStrategy` to support more language-specific checkpoints ([#1621](https://github.com/kedacore/keda/pull/1621))
+- Fix Azure Blob scaler when using multiple triggers with the same `blobContainerName` and added a optional `metricName` field ([#1816](https://github.com/kedacore/keda/pull/1816))
 
 ### Breaking Changes
 

--- a/pkg/scalers/azure_blob_scaler_test.go
+++ b/pkg/scalers/azure_blob_scaler_test.go
@@ -29,6 +29,8 @@ var testAzBlobMetadata = []parseAzBlobMetadataTestData{
 	{map[string]string{}, true, testAzBlobResolvedEnv, map[string]string{}, ""},
 	// properly formed
 	{map[string]string{"connectionFromEnv": "CONNECTION", "blobContainerName": "sample", "blobCount": "5", "blobDelimiter": "/", "blobPrefix": "blobsubpath"}, false, testAzBlobResolvedEnv, map[string]string{}, ""},
+	// properly formed with metricName
+	{map[string]string{"connectionFromEnv": "CONNECTION", "blobContainerName": "sample", "blobCount": "5", "blobDelimiter": "/", "blobPrefix": "blobsubpath", "metricName": "customname"}, false, testAzBlobResolvedEnv, map[string]string{}, ""},
 	// Empty blobcontainerName
 	{map[string]string{"connectionFromEnv": "CONNECTION", "blobContainerName": ""}, true, testAzBlobResolvedEnv, map[string]string{}, ""},
 	// improperly formed blobCount
@@ -44,8 +46,9 @@ var testAzBlobMetadata = []parseAzBlobMetadataTestData{
 }
 
 var azBlobMetricIdentifiers = []azBlobMetricIdentifier{
-	{&testAzBlobMetadata[1], "azure-blob-sample"},
-	{&testAzBlobMetadata[4], "azure-blob-sample_container"},
+	{&testAzBlobMetadata[1], "azure-blob-sample-blobsubpath-"},
+	{&testAzBlobMetadata[2], "azure-blob-customname"},
+	{&testAzBlobMetadata[5], "azure-blob-sample_container"},
 }
 
 func TestAzBlobParseMetadata(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Include blobPrefix in metricName and allow custom metricName for azure-blob scaler

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*: https://github.com/kedacore/keda-docs/pull/451
- [x] Changelog has been updated

Fixes #1815
