### PR TITLE
cron: adding validation for range or hyphenated inputs for start and end

### DIFF
--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -74,11 +74,17 @@ func parseCronMetadata(config *ScalerConfig) (*cronMetadata, error) {
 		return nil, fmt.Errorf("no timezone specified. %s", config.TriggerMetadata)
 	}
 	if val, ok := config.TriggerMetadata["start"]; ok && val != "" {
+		if strings.Contains(val, "-") {
+			return nil, fmt.Errorf("error parsing start schedule. %s: range or hyphenated inputs are not allowed", config.TriggerMetadata)
+		}
 		meta.start = val
 	} else {
 		return nil, fmt.Errorf("no start schedule specified. %s", config.TriggerMetadata)
 	}
 	if val, ok := config.TriggerMetadata["end"]; ok && val != "" {
+		if strings.Contains(val, "-") {
+			return nil, fmt.Errorf("error parsing end schedule. %s: range or hyphenated inputs are not allowed", config.TriggerMetadata)
+		}
 		meta.end = val
 	} else {
 		return nil, fmt.Errorf("no end schedule specified. %s", config.TriggerMetadata)

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -31,11 +31,11 @@ var testCronMetadata = []parseCronMetadataTestData{
 	{validCronMetadata, false},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45 * * * *"}, true},
 	{map[string]string{"start": "30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
-	{map[string]string{"timezone": "Asia/Kolkata","start": "30-33 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
-	{map[string]string{"timezone": "Asia/Kolkata","start": "30 * * * *", "end": "45-50 * * * *", "desiredReplicas": "10"}, true},
-	{map[string]string{"timezone": "Asia/Kolkata","start": "-30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
-	{map[string]string{"timezone": "Asia/Kolkata","start": "30 * * * *", "end": "-50 * * * *", "desiredReplicas": "10"}, true},
-	{map[string]string{"timezone": "Asia/Kolkata","start": "30 * * * *", "end": "50 * * -3 *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata", "start": "30-33 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45-50 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata", "start": "-30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "-50 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "50 * * -3 *", "desiredReplicas": "10"}, true},
 }
 
 var cronMetricIdentifiers = []cronMetricIdentifier{

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -31,6 +31,8 @@ var testCronMetadata = []parseCronMetadataTestData{
 	{validCronMetadata, false},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45 * * * *"}, true},
 	{map[string]string{"start": "30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata","start": "30-33 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata","start": "30 * * * *", "end": "45-50 * * * *", "desiredReplicas": "10"}, true},
 }
 
 var cronMetricIdentifiers = []cronMetricIdentifier{

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -33,6 +33,9 @@ var testCronMetadata = []parseCronMetadataTestData{
 	{map[string]string{"start": "30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
 	{map[string]string{"timezone": "Asia/Kolkata","start": "30-33 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
 	{map[string]string{"timezone": "Asia/Kolkata","start": "30 * * * *", "end": "45-50 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata","start": "-30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata","start": "30 * * * *", "end": "-50 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata","start": "30 * * * *", "end": "50 * * -3 *", "desiredReplicas": "10"}, true},
 }
 
 var cronMetricIdentifiers = []cronMetricIdentifier{


### PR DESCRIPTION
Signed-off-by: Ritikaa96 <ritika@india.nec.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Adding validation to check start and end for range values such as : 

> start: "30-39 * * * *" 

or negative values such as 

> start: "-39 * * * *"

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added


Fixes #1809 
