### PR TITLE
Provide additional configuration for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
     {
       "packagePatterns": ["^k8s.io/","^sigs.k8s.io/"],
       "groupName": "Kubernetes Dependencies"
+    },
+    {
+      "packagePatterns": ["^actions/"],
+      "groupName": "GitHub Actions"
     }
   ],
   "extends": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "default:disablePrControls"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
+  "branchPrefix":"renovate-",
+  "labels":["dependencies"],
   "extends": [
     "config:base",
     "default:disablePrControls"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,12 @@
 {
   "branchPrefix":"renovate-",
   "labels":["dependencies"],
+  "packageRules": [
+    {
+      "packagePatterns": ["^k8s.io/","^sigs.k8s.io/"],
+      "groupName": "Kubernetes Dependencies"
+    }
+  ],
   "extends": [
     "config:base",
     "default:disablePrControls"

--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,10 @@
       "groupName": "GitHub Actions"
     }
   ],
+  "commitBody": "",
   "extends": [
     "config:base",
-    "default:disablePrControls"
+    "default:disablePrControls",
+    ":gitSignOff"
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Provide additional configuration for Renovate:
- Disable PR control to pass the task list PR check
- Bundle Kubernetes updates into 1 PR
- Bundle GitHub Action updates into 1 PR
- Automatically add `dependencies` label to PR
- Define branch prefix name	
- Sign off commits for DCO

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
