### PR TITLE
Don't panic when HashiCorp Vault path doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Improvements
 
 - Fix READY and ACTIVE fields of ScaledJob to show status when we run `kubectl get sj` ([#1855](https://github.com/kedacore/keda/pull/1855))
+- Don't panic when HashiCorp Vault path doesn't exist ([#1864](https://github.com/kedacore/keda/pull/1864))
 
 ### Breaking Changes
 

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -93,10 +93,15 @@ func ResolveAuthRef(client client.Client, logger logr.Logger, triggerAuthRef *ke
 						if err != nil {
 							logger.Error(err, "Error trying to read secret from Vault", "triggerAuthRef.Name", triggerAuthRef.Name,
 								"secret.path", e.Path)
-							continue
+						} else {
+							if secret == nil {
+								// sometimes there is no error, but `vault.Read(e.Path)` is not being able to parse the secret and returns nil
+								logger.Error(fmt.Errorf("unable to parse secret, is the provided path correct?"), "Error trying to read secret from Vault",
+									"triggerAuthRef.Name", triggerAuthRef.Name, "secret.path", e.Path)
+							} else {
+								result[e.Parameter] = resolveVaultSecret(logger, secret.Data, e.Key)
+							}
 						}
-
-						result[e.Parameter] = resolveVaultSecret(logger, secret.Data, e.Key)
 					}
 
 					vault.Stop()


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

If HashiCorp Vault is being used and the input path is non existent, the library for reading the secret doesn't return error. In this case we need to handle this case and return error, instead of panic caused by accessing non existent secret.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

Fixes #1864
