### PR TITLE
Extend Azure Monitor scaler to support custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### New
 
+- Extend Azure Monitor scaler to support custom metrics ([#1883](https://github.com/kedacore/keda/pull/1883))
 - Support non-public cloud environments in the Azure Storage Queue and Azure Storage Blob scalers ([#1863](https://github.com/kedacore/keda/pull/1863))
 - Show HashiCorp Vault Address when using `kubectl get ta` or `kubectl get cta` ([#1862](https://github.com/kedacore/keda/pull/1862))
 

--- a/pkg/scalers/azure/azure_monitor.go
+++ b/pkg/scalers/azure/azure_monitor.go
@@ -20,6 +20,7 @@ import (
 
 type azureExternalMetricRequest struct {
 	MetricName                string
+	MetricNamespace           string
 	SubscriptionID            string
 	ResourceName              string
 	ResourceProviderNamespace string
@@ -37,6 +38,7 @@ type MonitorInfo struct {
 	SubscriptionID      string
 	ResourceGroupName   string
 	Name                string
+	Namespace           string
 	Filter              string
 	AggregationInterval string
 	AggregationType     string
@@ -79,11 +81,12 @@ func createMetricsClient(info MonitorInfo, podIdentityEnabled bool) insights.Met
 
 func createMetricsRequest(info MonitorInfo) (*azureExternalMetricRequest, error) {
 	metricRequest := azureExternalMetricRequest{
-		MetricName:     info.Name,
-		SubscriptionID: info.SubscriptionID,
-		Aggregation:    info.AggregationType,
-		Filter:         info.Filter,
-		ResourceGroup:  info.ResourceGroupName,
+		MetricName:      info.Name,
+		MetricNamespace: info.Namespace,
+		SubscriptionID:  info.SubscriptionID,
+		Aggregation:     info.AggregationType,
+		Filter:          info.Filter,
+		ResourceGroup:   info.ResourceGroupName,
 	}
 
 	resourceInfo := strings.Split(info.ResourceURI, "/")
@@ -126,7 +129,7 @@ func getAzureMetric(ctx context.Context, client insights.MetricsClient, azMetric
 	metricResult, err := client.List(ctx, metricResourceURI,
 		azMetricRequest.Timespan, nil,
 		azMetricRequest.MetricName, azMetricRequest.Aggregation, nil,
-		"", azMetricRequest.Filter, "", "")
+		"", azMetricRequest.Filter, "", azMetricRequest.MetricNamespace)
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -119,6 +119,10 @@ func parseAzureMonitorMetadata(config *ScalerConfig) (*azureMonitorMetadata, err
 		return nil, fmt.Errorf("no tenantId given")
 	}
 
+	if val, ok := config.TriggerMetadata["metricNamespace"]; ok {
+		meta.azureMonitorInfo.Namespace = val
+	}
+
 	clientID, clientPassword, err := parseAzurePodIdentityParams(config)
 	if err != nil {
 		return nil, err

--- a/pkg/scalers/azure_monitor_scaler_test.go
+++ b/pkg/scalers/azure_monitor_scaler_test.go
@@ -28,7 +28,7 @@ var testParseAzMonitorMetadata = []parseAzMonitorMetadataTestData{
 	// nothing passed
 	{map[string]string{}, true, map[string]string{}, map[string]string{}, ""},
 	// properly formed
-	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5"}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace"}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
 	// no optional parameters
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5"}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
 	// incorrectly formatted resourceURI


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add `metricNamespace` parameter to the Azure Monitor scaler to allow scaling based on custom metrics.

When querying [Custom metrics in Azure Monitor](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-custom-overview), the metric namespace must be provided in the API request. Otherwise, only default metrics can be found. E.g. for Azure Key Vault, when trying to get a custom metric without specifying the namespace, we will get the following error from the metrics client:

keda_metrics_adapter/provider "msg"="error getting metric for scaler" "error"="error getting azure monitor metric QueueDepth: insights.MetricsClient#List: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code=\"BadRequest\" Message=\"**Failed to find metric configuration for provider: Microsoft.KeyVault, resource Type: vaults, metric: QueueDepth, Valid metrics: ServiceApiHit,ServiceApiLatency,ServiceApiResult,SaturationShoebox,Availability\"**"  "scaledObject.Name"="nginx-scaler" "scaledObject.Namespace"="keda" "scaler"={}

Documentation update PR: https://github.com/kedacore/keda-docs/pull/468

Partly fixes #1489 (I don't think it covers the Application Insights metrics)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs), [PR](https://github.com/kedacore/keda-docs/pull/468)) *(if applicable)*
- [x] Changelog has been updated

Signed-off-by: amirschw <24677563+amirschw@users.noreply.github.com>