### PR TITLE
linter: update & use revive instead of golint

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update \
         github.com/mgechev/revive \
         github.com/derekparker/delve/cmd/dlv 2>&1 \
     # Install golangci-lint
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0 \
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1 \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           go-version: 1.15.6
       - name: Get golangci
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.39.0
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
       - uses: pre-commit/action@v2.0.3
 
   codeScanning:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - nolintlint
     - rowserrcheck
     - gofmt
-    - golint
+    - revive
     - goimports
     - misspell
     - bodyclose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ For more installation options visit the [pre-commits](https://pre-commit.com).
 
 Before running pre-commit, you must install the [golangci-lint](https://golangci-lint.run/) tool as a static check tool for golang code (contains a series of linter)
 ```shell script
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
 # or
 brew install golangci/tap/golangci-lint
 ```

--- a/controllers/scaledjob_controller.go
+++ b/controllers/scaledjob_controller.go
@@ -170,15 +170,11 @@ func (r *ScaledJobReconciler) deletePreviousVersionScaleJobs(logger logr.Logger,
 // requestScaleLoop request ScaleLoop handler for the respective ScaledJob
 func (r *ScaledJobReconciler) requestScaleLoop(logger logr.Logger, scaledJob *kedav1alpha1.ScaledJob) error {
 	logger.V(1).Info("Starting a new ScaleLoop")
-
 	return r.scaleHandler.HandleScalableObject(scaledJob)
 }
 
 // stopScaleLoop stops ScaleLoop handler for the respective ScaledJob
-func (r *ScaledJobReconciler) stopScaleLoop(scaledJob *kedav1alpha1.ScaledJob) error {
-	if err := r.scaleHandler.DeleteScalableObject(scaledJob); err != nil {
-		return err
-	}
-
-	return nil
+func (r *ScaledJobReconciler) stopScaleLoop(logger logr.Logger, scaledJob *kedav1alpha1.ScaledJob) error {
+	logger.V(1).Info("Stopping a ScaleLoop")
+	return r.scaleHandler.DeleteScalableObject(scaledJob)
 }

--- a/controllers/scaledjob_finalizer.go
+++ b/controllers/scaledjob_finalizer.go
@@ -22,7 +22,7 @@ func (r *ScaledJobReconciler) finalizeScaledJob(logger logr.Logger, scaledJob *k
 		// Run finalization logic for scaledJobFinalizer. If the
 		// finalization logic fails, don't remove the finalizer so
 		// that we can retry during the next reconciliation.
-		if err := r.stopScaleLoop(scaledJob); err != nil {
+		if err := r.stopScaleLoop(logger, scaledJob); err != nil {
 			return err
 		}
 

--- a/controllers/scaledobject_controller_test.go
+++ b/controllers/scaledobject_controller_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ScaledObjectController", func() {
 			mockStatusWriter         *mock_client.MockStatusWriter
 		)
 
-		var triggerMeta []map[string]string = []map[string]string{
+		var triggerMeta = []map[string]string{
 			{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "disableScaleToZero": "true"},
 			{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total2", "threshold": "100", "query": "up"},
 		}

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -145,7 +145,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 		return -1, err
 	}
 
-	var count int = 0
+	var count = 0
 	jobs, ok := result["value"].([]interface{})
 
 	if !ok {

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -113,7 +113,7 @@ func parseInfluxDBMetadata(config *ScalerConfig) (*influxDBMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["thresholdValue"]; ok {
-		value, err := strconv.ParseFloat(val, 10)
+		value, err := strconv.ParseFloat(val, 64)
 		if err != nil {
 			return nil, fmt.Errorf("thresholdValue: failed to parse thresholdValue length %s", err.Error())
 		}

--- a/pkg/scalers/openstack_metrics_scaler.go
+++ b/pkg/scalers/openstack_metrics_scaler.go
@@ -247,7 +247,7 @@ func (a *openstackMetricScaler) Close() error {
 
 // Gets measureament from API as float64, converts it to int and return the value.
 func (a *openstackMetricScaler) readOpenstackMetrics() (float64, error) {
-	var metricURL string = a.metadata.metricsURL
+	var metricURL = a.metadata.metricsURL
 
 	isValid, validationError := a.metricClient.IsTokenValid()
 

--- a/pkg/scalers/openstack_swift_scaler.go
+++ b/pkg/scalers/openstack_swift_scaler.go
@@ -124,7 +124,7 @@ func (s *openstackSwiftScaler) getOpenstackSwiftContainerObjectCount() (int, err
 
 		// If onlyFiles is set to "true", return the total amount of files (excluding empty objects/folders)
 		if s.metadata.onlyFiles {
-			var count int = 0
+			var count = 0
 			for i := 0; i < len(objectsList); i++ {
 				if !strings.HasSuffix(objectsList[i], "/") {
 					count++


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Update golint to 1.41.1 and minor related fixes

```
level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."


controllers/scaledjob_controller.go:179:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
        if err := r.scaleHandler.DeleteScalableObject(scaledJob); err != nil {
                return err
        }
controllers/scaledobject_controller_test.go:46:19: ST1023: should omit type []map[string]string from declaration; it will be inferred from the right-hand side (stylecheck)
		var triggerMeta []map[string]string = []map[string]string{
		                ^
pkg/scalers/influxdb_scaler.go:116:41: SA1030: 'bitSize' argument is invalid, must be either 32 or 64 (staticcheck)
		value, err := strconv.ParseFloat(val, 10)
		                                      ^
pkg/scalers/azure_pipelines_scaler.go:148:12: ST1023: should omit type int from declaration; it will be inferred from the right-hand side (stylecheck)
	var count int = 0
	          ^
pkg/scalers/openstack_metrics_scaler.go:250:16: ST1023: should omit type string from declaration; it will be inferred from the right-hand side (stylecheck)
	var metricURL string = a.metadata.metricsURL
	              ^
pkg/scalers/openstack_swift_scaler.go:127:14: ST1023: should omit type int from declaration; it will be inferred from the right-hand side (stylecheck)
			var count int = 0
			          ^
```

Fixes: #1868