### PR TITLE
scale handler: minor chores

### DIFF
--- a/api/v1alpha1/withtriggers_types.go
+++ b/api/v1alpha1/withtriggers_types.go
@@ -1,11 +1,19 @@
 package v1alpha1
 
 import (
+	"fmt"
+	"time"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	// Default polling interval for a ScaledObject triggers if no pollingInterval is defined.
+	defaultPollingInterval = 30
 )
 
 // +kubebuilder:object:root=true
@@ -54,4 +62,18 @@ type WithTriggersList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
 	Items           []WithTriggers `json:"items"`
+}
+
+// GetPollingInterval returns defined polling interval, if not set default is being returned
+func (t *WithTriggers) GetPollingInterval() time.Duration {
+	if t.Spec.PollingInterval != nil {
+		return time.Second * time.Duration(*t.Spec.PollingInterval)
+	}
+
+	return time.Second * time.Duration(defaultPollingInterval)
+}
+
+// GenerateIdenitifier returns identifier for the object in for "kind.namespace.name"
+func (t *WithTriggers) GenerateIdenitifier() string {
+	return fmt.Sprintf("%s.%s.%s", t.Kind, t.Namespace, t.Name)
 }

--- a/pkg/scaling/resolver/scale_resolvers_test.go
+++ b/pkg/scaling/resolver/scale_resolvers_test.go
@@ -312,7 +312,7 @@ func TestResolveAuthRef(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			clusterObjectNamespaceCache = &clusterNamespace // Inject test cluster namespace.
-			gotMap, gotPodIdentity := ResolveAuthRef(fake.NewFakeClientWithScheme(scheme.Scheme, test.existing...), logf.Log.WithName("test"), test.soar, test.podSpec, namespace)
+			gotMap, gotPodIdentity := resolveAuthRef(fake.NewFakeClientWithScheme(scheme.Scheme, test.existing...), logf.Log.WithName("test"), test.soar, test.podSpec, namespace)
 			if diff := cmp.Diff(gotMap, test.expected); diff != "" {
 				t.Errorf("Returned authParams are different: %s", diff)
 			}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

No changes to the functionality.

Minor chores and code refactoring/cleanup in scaler handler:
- moved `scalehandler.getPods()` -> `resolver.ResolveScaleTargetPodSpec()`
- extracted the relevant code from `scalehandler.buildScalers() `-> `resolver.ResolveAuthRefAndPodIdentity()`
- moved functions relevant to `WithTriggers` close to the `WithTriggers` source code
- some renaming

The code relevant to `ScaledJob` in scale_handler.go needs some love as well, but should be done in a separate PR.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

