### PR TITLE
Add support for Trigger Authentication for InfluxDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 - Fix READY and ACTIVE fields of ScaledJob to show status when we run `kubectl get sj` ([#1855](https://github.com/kedacore/keda/pull/1855))
 - Don't panic when HashiCorp Vault path doesn't exist ([#1864](https://github.com/kedacore/keda/pull/1864))
-
+- Allow influxdb `authToken`, `serverURL`, and `organizationName` to be sourced from `(Cluster)TriggerAuthentication` ([#1904](https://github.com/kedacore/keda/pull/1904))
 ### Breaking Changes
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -67,6 +67,8 @@ func parseInfluxDBMetadata(config *ScalerConfig) (*influxDBMetadata, error) {
 		} else {
 			return nil, fmt.Errorf("no auth token given")
 		}
+	case config.AuthParams["authToken"] != "":
+		authToken = config.AuthParams["authToken"]
 	default:
 		return nil, fmt.Errorf("no auth token given")
 	}
@@ -81,6 +83,8 @@ func parseInfluxDBMetadata(config *ScalerConfig) (*influxDBMetadata, error) {
 		} else {
 			return nil, fmt.Errorf("no organization name given")
 		}
+	case config.AuthParams["organizationName"] != "":
+		organizationName = config.AuthParams["organizationName"]
 	default:
 		return nil, fmt.Errorf("no organization name given")
 	}
@@ -92,6 +96,8 @@ func parseInfluxDBMetadata(config *ScalerConfig) (*influxDBMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["serverURL"]; ok {
+		serverURL = val
+	} else if val, ok := config.AuthParams["serverURL"]; ok {
 		serverURL = val
 	} else {
 		return nil, fmt.Errorf("no server url given")


### PR DESCRIPTION
This allows `authToken`, `serverURL`, and `organizationName` to be sourced from `TriggerAuthentication` and `ClusterTriggerAuthentication` by the influxdb scaler.

Relates to https://github.com/kedacore/keda/issues/1905
Relates to https://github.com/kedacore/keda/discussions/1892

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [n/a] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated


