### PR TITLE
Support non-public cloud environments in the Azure Service Bus scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### New
 
 - Extend Azure Monitor scaler to support custom metrics ([#1883](https://github.com/kedacore/keda/pull/1883))
+- Support non-public cloud environments in the Azure Service Bus scaler ([#1907](https://github.com/kedacore/keda/pull/1907))
 - Support non-public cloud environments in the Azure Storage Queue and Azure Storage Blob scalers ([#1863](https://github.com/kedacore/keda/pull/1863))
 - Show HashiCorp Vault Address when using `kubectl get ta` or `kubectl get cta` ([#1862](https://github.com/kedacore/keda/pull/1862))
 - Add Solace PubSub+ Event Broker Scaler ([#1945](https://github.com/kedacore/keda/pull/1945))

--- a/pkg/scalers/azure/azure_cloud_environment.go
+++ b/pkg/scalers/azure/azure_cloud_environment.go
@@ -1,0 +1,33 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	az "github.com/Azure/go-autorest/autorest/azure"
+)
+
+// EnvironmentSuffixProvider for different types of Azure scalers
+type EnvironmentSuffixProvider func(env az.Environment) (string, error)
+
+// ParseEndpointSuffix parses cloud and endpointSuffix metadata and returns the resolved endpoint suffix
+func ParseEndpointSuffix(metadata map[string]string, suffixProvider EnvironmentSuffixProvider) (string, error) {
+	if val, ok := metadata["cloud"]; ok && val != "" {
+		if strings.EqualFold(val, PrivateCloud) {
+			if val, ok := metadata["endpointSuffix"]; ok && val != "" {
+				return val, nil
+			}
+			return "", fmt.Errorf("endpointSuffix must be provided for %s cloud type", PrivateCloud)
+		}
+
+		env, err := az.EnvironmentFromName(val)
+		if err != nil {
+			return "", fmt.Errorf("invalid cloud environment %s", val)
+		}
+
+		return suffixProvider(env)
+	}
+
+	// Use public cloud suffix if `cloud` isn't specified
+	return suffixProvider(az.PublicCloud)
+}

--- a/pkg/scalers/azure/azure_cloud_environment_test.go
+++ b/pkg/scalers/azure/azure_cloud_environment_test.go
@@ -1,0 +1,52 @@
+package azure
+
+import (
+	"fmt"
+	"testing"
+
+	az "github.com/Azure/go-autorest/autorest/azure"
+)
+
+type parseEndpointSuffixTestData struct {
+	metadata       map[string]string
+	endpointSuffix string
+	suffixProvider EnvironmentSuffixProvider
+	isError        bool
+}
+
+var testSuffixProvider EnvironmentSuffixProvider = func(env az.Environment) (string, error) {
+	if env == az.USGovernmentCloud {
+		return "", fmt.Errorf("test endpoint is not available in %s", env.Name)
+	}
+	return fmt.Sprintf("%s.suffix", env.Name), nil
+}
+
+var parseEndpointSuffixTestDataset = []parseEndpointSuffixTestData{
+	{map[string]string{}, "AzurePublicCloud.suffix", testSuffixProvider, false},
+	{map[string]string{"cloud": "Invalid"}, "", testSuffixProvider, true},
+	{map[string]string{"cloud": "AzureUSGovernmentCloud"}, "", testSuffixProvider, true},
+	{map[string]string{"cloud": "AzureGermanCloud"}, "AzureGermanCloud.suffix", testSuffixProvider, false},
+	{map[string]string{"cloud": "Private"}, "", testSuffixProvider, true},
+	{map[string]string{"cloud": "Private", "endpointSuffix": "suffix.private.cloud"}, "suffix.private.cloud", testSuffixProvider, false},
+	{map[string]string{"endpointSuffix": "ignored"}, "AzurePublicCloud.suffix", testSuffixProvider, false},
+}
+
+func TestParseEndpointSuffix(t *testing.T) {
+	for _, testData := range parseEndpointSuffixTestDataset {
+		endpointSuffix, err := ParseEndpointSuffix(testData.metadata, testData.suffixProvider)
+		if !testData.isError && err != nil {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+		if err == nil {
+			if endpointSuffix != testData.endpointSuffix {
+				t.Error(
+					"For", testData.metadata,
+					"expected endpointSuffix=", testData.endpointSuffix,
+					"but got", endpointSuffix)
+			}
+		}
+	}
+}

--- a/pkg/scalers/azure/azure_storage.go
+++ b/pkg/scalers/azure/azure_storage.go
@@ -53,23 +53,11 @@ func (e StorageEndpointType) GetEndpointSuffix(environment az.Environment) strin
 
 // ParseAzureStorageEndpointSuffix parses cloud and endpointSuffix metadata and returns endpoint suffix
 func ParseAzureStorageEndpointSuffix(metadata map[string]string, endpointType StorageEndpointType) (string, error) {
-	if val, ok := metadata["cloud"]; ok && val != "" {
-		if strings.EqualFold(val, PrivateCloud) {
-			if val, ok := metadata["endpointSuffix"]; ok && val != "" {
-				return val, nil
-			}
-			return "", fmt.Errorf("endpointSuffix must be provided for %s cloud type", PrivateCloud)
-		}
-
-		env, err := az.EnvironmentFromName(val)
-		if err != nil {
-			return "", fmt.Errorf("invalid cloud environment %s", val)
-		}
+	envSuffixProvider := func(env az.Environment) (string, error) {
 		return endpointType.GetEndpointSuffix(env), nil
 	}
 
-	// Use the default public cloud endpoint suffix if `cloud` isn't specified
-	return endpointType.GetEndpointSuffix(az.PublicCloud), nil
+	return ParseEndpointSuffix(metadata, envSuffixProvider)
 }
 
 // ParseAzureStorageQueueConnection parses queue connection string and returns credential and resource url

--- a/pkg/scalers/azure/azure_storage_test.go
+++ b/pkg/scalers/azure/azure_storage_test.go
@@ -61,14 +61,14 @@ func TestParseStorageConnectionString(t *testing.T) {
 	}
 }
 
-type parseEndpointSuffixTestData struct {
+type parseAzureStorageEndpointSuffixTestData struct {
 	metadata       map[string]string
 	endpointSuffix string
 	endpointType   StorageEndpointType
 	isError        bool
 }
 
-var parseEndpointSuffixTestDataset = []parseEndpointSuffixTestData{
+var parseAzureStorageEndpointSuffixTestDataset = []parseAzureStorageEndpointSuffixTestData{
 	{map[string]string{}, "queue.core.windows.net", QueueEndpoint, false},
 	{map[string]string{"cloud": "InvalidCloud"}, "", QueueEndpoint, true},
 	{map[string]string{"cloud": "AzureUSGovernmentCloud"}, "queue.core.usgovcloudapi.net", QueueEndpoint, false},
@@ -78,7 +78,7 @@ var parseEndpointSuffixTestDataset = []parseEndpointSuffixTestData{
 }
 
 func TestParseAzureStorageEndpointSuffix(t *testing.T) {
-	for _, testData := range parseEndpointSuffixTestDataset {
+	for _, testData := range parseAzureStorageEndpointSuffixTestDataset {
 		endpointSuffix, err := ParseAzureStorageEndpointSuffix(testData.metadata, testData.endpointType)
 		if !testData.isError && err != nil {
 			t.Error("Expected success but got error", err)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Similarly to #1863, added an optional `cloud` parameter to the Azure SB scaler to support non-public Azure clouds.

PR for updating the documentation: kedacore/keda-docs#473.

Fixes https://github.com/kedacore/keda/issues/1918

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs), [PR](https://github.com/kedacore/keda-docs/pull/473)) *(if applicable)*
- [x] Changelog has been updated

Signed-off-by: amirschw <24677563+amirschw@users.noreply.github.com>