### PR TITLE
Handle password value correctly; add tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Fix READY and ACTIVE fields of ScaledJob to show status when we run `kubectl get sj` ([#1855](https://github.com/kedacore/keda/pull/1855))
 - Don't panic when HashiCorp Vault path doesn't exist ([#1864](https://github.com/kedacore/keda/pull/1864))
 - Allow influxdb `authToken`, `serverURL`, and `organizationName` to be sourced from `(Cluster)TriggerAuthentication` ([#1904](https://github.com/kedacore/keda/pull/1904))
+- IBM MQ scaler password handling fix ([#1939](https://github.com/kedacore/keda/pull/1939))
+
 ### Breaking Changes
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))

--- a/pkg/scalers/ibmmq_scaler.go
+++ b/pkg/scalers/ibmmq_scaler.go
@@ -134,10 +134,10 @@ func parseIBMMQMetadata(config *ScalerConfig) (*IBMMQMetadata, error) {
 	default:
 		return nil, fmt.Errorf("no username given")
 	}
-	value, booleanValue := config.AuthParams["password"] // booleanValue reports whether the type assertion succeeded or not
+	pwdValue, booleanValue := config.AuthParams["password"] // booleanValue reports whether the type assertion succeeded or not
 	switch {
-	case booleanValue && value != "":
-		meta.password = val
+	case booleanValue && pwdValue != "":
+		meta.password = pwdValue
 	case config.TriggerMetadata["passwordFromEnv"] != "":
 		meta.password = config.ResolvedEnv[config.TriggerMetadata["passwordFromEnv"]]
 	default:

--- a/pkg/scalers/ibmmq_scaler_test.go
+++ b/pkg/scalers/ibmmq_scaler_test.go
@@ -61,9 +61,10 @@ var testIBMMQMetadata = []parseIBMMQMetadataTestData{
 
 // Test MQ Connection metadata is parsed correctly
 // should error on missing required field
+// and verify that the password field is handled correctly.
 func TestIBMMQParseMetadata(t *testing.T) {
 	for _, testData := range testIBMMQMetadata {
-		_, err := parseIBMMQMetadata(&ScalerConfig{ResolvedEnv: sampleIBMMQResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
+		metadata, err := parseIBMMQMetadata(&ScalerConfig{ResolvedEnv: sampleIBMMQResolvedEnv, TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 			fmt.Println(testData)
@@ -72,6 +73,11 @@ func TestIBMMQParseMetadata(t *testing.T) {
 			t.Error("Expected error but got success")
 			fmt.Println(testData)
 		}
+		if metadata != nil && metadata.password != "" && metadata.password != testData.authParams["password"] {
+			t.Error("Expected password from configuration but found something else: ", metadata.password)
+			fmt.Println(testData)
+		}
+
 	}
 }
 

--- a/pkg/scalers/ibmmq_scaler_test.go
+++ b/pkg/scalers/ibmmq_scaler_test.go
@@ -77,7 +77,6 @@ func TestIBMMQParseMetadata(t *testing.T) {
 			t.Error("Expected password from configuration but found something else: ", metadata.password)
 			fmt.Println(testData)
 		}
-
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Trevor Dolby <tdolby@uk.ibm.com>

Use passwords from secrets correctly.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #1938
