### PR TITLE
Metrics APIServer: Add ratelimiting parameters to override client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Don't panic when HashiCorp Vault path doesn't exist ([#1864](https://github.com/kedacore/keda/pull/1864))
 - Allow influxdb `authToken`, `serverURL`, and `organizationName` to be sourced from `(Cluster)TriggerAuthentication` ([#1904](https://github.com/kedacore/keda/pull/1904))
 - IBM MQ scaler password handling fix ([#1939](https://github.com/kedacore/keda/pull/1939))
+- Metrics APIServer: Add ratelimiting parameters to override client ([#1944](https://github.com/kedacore/keda/pull/1944))
 
 ### Breaking Changes
 


### PR DESCRIPTION
Add rate limiting parameters to the Keda metrics apiserver to allow override of client defaults

Signed-off-by: Chris Berry <bez625@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Adding flags to the metrics api server main so that we can override the default client QPS and burst. This allows us to enable higher throughput of requests when Kubernetes HPA sync rate is higher frequency than default client limits.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added - N/A no verification of input params present.
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)* - N/A as these are optional we did not feel we should change existing deployment templates.
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* - ~~we couldn't find an appropriate place to add these in the documentation. If you would like something to be added please let us know.~~ As suggested we have updated docs here https://github.com/kedacore/keda-docs/pull/485
- [x] Changelog has been updated 
