### PR TITLE
Renovate: update only actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,6 @@
   "labels":["dependencies"],
   "packageRules": [
     {
-      "packagePatterns": ["*"],
-      "groupName": "All"
-    },
-    {
-      "packagePatterns": ["^k8s.io/","^sigs.k8s.io/"],
-      "groupName": "Kubernetes Dependencies"
-    },
-    {
       "packagePatterns": ["^actions/"],
       "groupName": "GitHub Actions"
     }


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

It is very hard to actually update dependencies automatically, because we have many conflicting dependencies in our project.
Let's use Renovate to update only GH Actions and get back to updating all dependencies later.
