### PR TITLE
Renovate: ignore other deps then GH actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,13 @@
   "labels":["dependencies"],
   "packageRules": [
     {
+      "packagePatterns": ["*"],
+      "enabled": false
+    },
+    {
       "packagePatterns": ["^actions/"],
-      "groupName": "GitHub Actions"
+      "groupName": "GitHub Actions",
+      "enabled": true
     }
   ],
   "commitBodyTable": true,


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Seems like https://github.com/kedacore/keda/pull/1947 doesn't work as expected :(

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
