### PR TITLE
prepare testenv in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,6 @@ cover.out
 
 # GO debug binary
 cmd/manager/debug.test
+
+# testenv binary location
+testbin

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,12 @@ all: test build
 ##################################################
 # Tests                                          #
 ##################################################
+ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 .PHONY: test
-test: generate gofmt govet
-	go test ./... -covermode=atomic -coverprofile cover.out
+test: generate manifests gofmt govet
+	mkdir -p ${ENVTEST_ASSETS_DIR}
+	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.5/hack/setup-envtest.sh
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -covermode=atomic -coverprofile cover.out
 
 .PHONY: e2e-test
 e2e-test:
@@ -105,7 +108,7 @@ set-version:
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run
 run: generate
-	go run -ldflags $(GO_LDFLAGS) ./main.go $(ARGS)
+	WATCH_NAMESPACE="" go run -ldflags $(GO_LDFLAGS) ./main.go $(ARGS)
 
 # Install CRDs into a cluster
 .PHONY: install

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -55,10 +55,6 @@ RUN RELEASE_VERSION=v1.0.1 && \
     cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && \
     rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
 
-# Install kubebuilder tools
-RUN curl -L https://go.kubebuilder.io/dl/2.3.1/linux/amd64 | tar -xz -C /tmp/ && \
-    mv /tmp/kubebuilder_2.3.1_linux_amd64 /usr/local/kubebuilder
-
 ENV PATH=${PATH}:/usr/local/go/bin \
     GOROOT=/usr/local/go \
     GOPATH=/go


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Prepare testenv in Makefile as part of `test` target and don't rely on the keda-tools container with backed kubebuilder. This simplifies testin on local machine

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
