### PR TITLE
Added new scaler for selenium grid and test cases.

### DIFF
--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -1,0 +1,201 @@
+package scalers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+	v2beta2 "k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+)
+
+type seleniumGridScaler struct {
+	metadata *seleniumGridScalerMetadata
+	client   *http.Client
+}
+
+type seleniumGridScalerMetadata struct {
+	url         string
+	browserName string
+	targetValue int64
+}
+
+type seleniumResponse struct {
+	Data data `json:"data"`
+}
+
+type data struct {
+	SessionsInfo sessionsInfo `json:"sessionsInfo"`
+}
+
+type sessionsInfo struct {
+	SessionQueueRequests []string          `json:"sessionQueueRequests"`
+	Sessions             []seleniumSession `json:"sessions"`
+}
+
+type seleniumSession struct {
+	Id           string `json:"id"`
+	Capabilities string `json:"capabilities"`
+	NodeId       string `json:"nodeId"`
+}
+
+type capability struct {
+	BrowserName string `json:"browserName"`
+}
+
+func NewSeleniumGridScaler(config *ScalerConfig) (Scaler, error) {
+	meta, err := parseSeleniumGridScalerMetadata(config)
+
+	if err != nil {
+		return nil, fmt.Errorf("error parsing selenium grid metadata: %s", err)
+	}
+
+	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout)
+
+	return &seleniumGridScaler{
+		metadata: meta,
+		client:   httpClient,
+	}, nil
+}
+
+func parseSeleniumGridScalerMetadata(config *ScalerConfig) (*seleniumGridScalerMetadata, error) {
+	meta := seleniumGridScalerMetadata{
+		targetValue: 1,
+	}
+
+	if val, ok := config.TriggerMetadata["url"]; ok {
+		meta.url = val
+	} else {
+		return nil, fmt.Errorf("no selenium grid url given in metadata")
+	}
+
+	if val, ok := config.TriggerMetadata["browserName"]; ok {
+		meta.browserName = val
+	} else {
+		return nil, fmt.Errorf("no browser name given in metadata")
+	}
+
+	return &meta, nil
+}
+
+// No cleanup required for selenium grid scaler
+func (s *seleniumGridScaler) Close() error {
+	return nil
+}
+
+func (s *seleniumGridScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
+	v, err := s.getSessionsCount()
+	if err != nil {
+		return []external_metrics.ExternalMetricValue{}, fmt.Errorf("error requesting selenium grid endpoint: %s", err)
+	}
+
+	metric := external_metrics.ExternalMetricValue{
+		MetricName: metricName,
+		Value:      *v,
+		Timestamp:  metav1.Now(),
+	}
+
+	return append([]external_metrics.ExternalMetricValue{}, metric), nil
+}
+
+func (s *seleniumGridScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetValue := resource.NewQuantity(s.metadata.targetValue, resource.DecimalSI)
+	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s", "seleniumgrid", s.metadata.browserName))
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: metricName,
+		},
+		Target: v2beta2.MetricTarget{
+			Type:         v2beta2.AverageValueMetricType,
+			AverageValue: targetValue,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{
+		External: externalMetric, Type: externalMetricType,
+	}
+	return []v2beta2.MetricSpec{metricSpec}
+}
+
+func (s *seleniumGridScaler) IsActive(ctx context.Context) (bool, error) {
+	v, err := s.getSessionsCount()
+	if err != nil {
+		return false, err
+	}
+
+	return v.AsApproximateFloat64() > 0.0, nil
+}
+
+func (s *seleniumGridScaler) getSessionsCount() (*resource.Quantity, error) {
+	body, err := json.Marshal(map[string]string{
+		"query": "{ sessionsInfo { sessionQueueRequests, sessions { id, capabilities, nodeId } } }",
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", s.metadata.url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		msg := fmt.Sprintf("selenium grid returned %d", res.StatusCode)
+		return nil, errors.New(msg)
+	}
+
+	defer res.Body.Close()
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	v, err := getCountFromSeleniumResponse(b, s.metadata.browserName)
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func getCountFromSeleniumResponse(b []byte, browserName string) (*resource.Quantity, error) {
+	var count int64 = 0
+	var seleniumResponse seleniumResponse = seleniumResponse{}
+
+	if err := json.Unmarshal(b, &seleniumResponse); err != nil {
+		return nil, err
+	}
+
+	var sessionQueueRequests = seleniumResponse.Data.SessionsInfo.SessionQueueRequests
+	for _, sessionQueueRequest := range sessionQueueRequests {
+		var capability = capability{}
+		if err := json.Unmarshal([]byte(sessionQueueRequest), &capability); err == nil {
+			if capability.BrowserName == browserName {
+				count = count + 1
+			}
+		}
+	}
+
+	var sessions = seleniumResponse.Data.SessionsInfo.Sessions
+	for _, session := range sessions {
+		var capability = capability{}
+		if err := json.Unmarshal([]byte(session.Capabilities), &capability); err == nil {
+			if capability.BrowserName == browserName {
+				count = count + 1
+			}
+		}
+	}
+
+	return resource.NewQuantity(count, resource.DecimalSI), nil
+}

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -1,0 +1,190 @@
+package scalers
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func Test_getCountFromSeleniumResponse(t *testing.T) {
+	type args struct {
+		b           []byte
+		browserName string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *resource.Quantity
+		wantErr bool
+	}{
+		{
+			name: "nil response body should through error",
+			args: args{
+				b:           []byte(nil),
+				browserName: "",
+			},
+			// want:    resource.NewQuantity(0, resource.DecimalSI),
+			wantErr: true,
+		},
+		{
+			name: "empty response body should through error",
+			args: args{
+				b:           []byte(""),
+				browserName: "",
+			},
+			// want:    resource.NewQuantity(0, resource.DecimalSI),
+			wantErr: true,
+		},
+		{
+			name: "no active sessions should return count as 0",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"sessionsInfo": {
+							"sessionQueueRequests": [],
+							"sessions": []
+						}
+					}
+				}`),
+				browserName: "",
+			},
+			want:    resource.NewQuantity(0, resource.DecimalSI),
+			wantErr: false,
+		},
+		{
+			name: "active sessions with no matching browsername should return count as 0",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"sessionsInfo": {
+							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
+							"sessions": [
+								{
+									"id": "0f9c5a941aa4d755a54b84be1f6535b1",
+									"capabilities": "{\n  \"acceptInsecureCerts\": false,\n  \"browserName\": \"chrome\",\n  \"browserVersion\": \"91.0.4472.114\",\n  \"chrome\": {\n    \"chromedriverVersion\": \"91.0.4472.101 (af52a90bf87030dd1523486a1cd3ae25c5d76c9b-refs\\u002fbranch-heads\\u002f4472@{#1462})\",\n    \"userDataDir\": \"\\u002ftmp\\u002f.com.google.Chrome.DMqx9m\"\n  },\n  \"goog:chromeOptions\": {\n    \"debuggerAddress\": \"localhost:35839\"\n  },\n  \"networkConnectionEnabled\": false,\n  \"pageLoadStrategy\": \"normal\",\n  \"platformName\": \"linux\",\n  \"proxy\": {\n  },\n  \"se:cdp\": \"http:\\u002f\\u002flocalhost:35839\",\n  \"se:cdpVersion\": \"91.0.4472.114\",\n  \"se:vncEnabled\": true,\n  \"se:vncLocalAddress\": \"ws:\\u002f\\u002flocalhost:7900\\u002fwebsockify\",\n  \"setWindowRect\": true,\n  \"strictFileInteractability\": false,\n  \"timeouts\": {\n    \"implicit\": 0,\n    \"pageLoad\": 300000,\n    \"script\": 30000\n  },\n  \"unhandledPromptBehavior\": \"dismiss and notify\",\n  \"webauthn:extension:largeBlob\": true,\n  \"webauthn:virtualAuthenticators\": true\n}",
+									"nodeId": "d44dcbc5-0b2c-4d5e-abf4-6f6aa5e0983c"
+								}
+							]
+						}
+					}
+				}`),
+				browserName: "",
+			},
+			want:    resource.NewQuantity(0, resource.DecimalSI),
+			wantErr: false,
+		},
+		{
+			name: "active sessions with matching browsername should return count as 2",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"sessionsInfo": {
+							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
+							"sessions": []
+						}
+					}
+				}`),
+				browserName: "chrome",
+			},
+			want:    resource.NewQuantity(2, resource.DecimalSI),
+			wantErr: false,
+		},
+		{
+			name: "active sessions with matching browsername should return count as 3",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"sessionsInfo": {
+							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
+							"sessions": [
+								{
+									"id": "0f9c5a941aa4d755a54b84be1f6535b1",
+									"capabilities": "{\n  \"acceptInsecureCerts\": false,\n  \"browserName\": \"chrome\",\n  \"browserVersion\": \"91.0.4472.114\",\n  \"chrome\": {\n    \"chromedriverVersion\": \"91.0.4472.101 (af52a90bf87030dd1523486a1cd3ae25c5d76c9b-refs\\u002fbranch-heads\\u002f4472@{#1462})\",\n    \"userDataDir\": \"\\u002ftmp\\u002f.com.google.Chrome.DMqx9m\"\n  },\n  \"goog:chromeOptions\": {\n    \"debuggerAddress\": \"localhost:35839\"\n  },\n  \"networkConnectionEnabled\": false,\n  \"pageLoadStrategy\": \"normal\",\n  \"platformName\": \"linux\",\n  \"proxy\": {\n  },\n  \"se:cdp\": \"http:\\u002f\\u002flocalhost:35839\",\n  \"se:cdpVersion\": \"91.0.4472.114\",\n  \"se:vncEnabled\": true,\n  \"se:vncLocalAddress\": \"ws:\\u002f\\u002flocalhost:7900\\u002fwebsockify\",\n  \"setWindowRect\": true,\n  \"strictFileInteractability\": false,\n  \"timeouts\": {\n    \"implicit\": 0,\n    \"pageLoad\": 300000,\n    \"script\": 30000\n  },\n  \"unhandledPromptBehavior\": \"dismiss and notify\",\n  \"webauthn:extension:largeBlob\": true,\n  \"webauthn:virtualAuthenticators\": true\n}",
+									"nodeId": "d44dcbc5-0b2c-4d5e-abf4-6f6aa5e0983c"
+								}
+							]
+						}
+					}
+				}`),
+				browserName: "chrome",
+			},
+			want:    resource.NewQuantity(3, resource.DecimalSI),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getCountFromSeleniumResponse(tt.args.b, tt.args.browserName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getCountFromSeleniumResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getCountFromSeleniumResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
+	type args struct {
+		config *ScalerConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *seleniumGridScalerMetadata
+		wantErr bool
+	}{
+		{
+			name: "invalid url string should throw error",
+			args: args{
+				config: &ScalerConfig{
+					TriggerMetadata: map[string]string{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid browsername string should throw error",
+			args: args{
+				config: &ScalerConfig{
+					TriggerMetadata: map[string]string{
+						"url": "",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid url and browsername should return metadata",
+			args: args{
+				config: &ScalerConfig{
+					TriggerMetadata: map[string]string{
+						"url":         "http://selenium-hub:4444/graphql",
+						"browserName": "chrome",
+					},
+				},
+			},
+			wantErr: false,
+			want: &seleniumGridScalerMetadata{
+				url:         "http://selenium-hub:4444/graphql",
+				browserName: "chrome",
+				targetValue: 1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSeleniumGridScalerMetadata(tt.args.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSeleniumGridScalerMetadata() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseSeleniumGridScalerMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -449,6 +449,8 @@ func buildScaler(triggerType string, config *scalers.ScalerConfig) (scalers.Scal
 		return scalers.NewRedisStreamsScaler(true, config)
 	case "redis-streams":
 		return scalers.NewRedisStreamsScaler(false, config)
+	case "selenium-grid":
+		return scalers.NewSeleniumGridScaler(config)
 	case "solace-event-queue":
 		return scalers.NewSolaceScaler(config)
 	case "stan":


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added a new scaler to scale selenium grid browser nodes based on the requests pending in queue. This will query the selenium grid based on the url that user provides and determine the metric based on the provided browser name.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes #
