### PR TITLE
Support pod conditions for pending job count calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add Solace PubSub+ Event Broker Scaler ([#1945](https://github.com/kedacore/keda/pull/1945))
 - Add fallback functionality ([#1872](https://github.com/kedacore/keda/issues/1872))
 - Introduce Idle Replica Mode ([#1958](https://github.com/kedacore/keda/pull/1958))
+- Support pod conditions for pending job count calculation ([#1970](https://github.com/kedacore/keda/pull/1970))
 
 ### Improvements
 

--- a/api/v1alpha1/scaledjob_types.go
+++ b/api/v1alpha1/scaledjob_types.go
@@ -69,6 +69,8 @@ type ScalingStrategy struct {
 	CustomScalingQueueLengthDeduction *int32 `json:"customScalingQueueLengthDeduction,omitempty"`
 	// +optional
 	CustomScalingRunningJobPercentage string `json:"customScalingRunningJobPercentage,omitempty"`
+	// +optional
+	PendingPodConditions []string `json:"pendingPodConditions,omitempty"`
 }
 
 func init() {

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -192,7 +192,6 @@ func (e *scaleExecutor) areAllPendingPodConditionsFulfilled(j *batchv1.Job, pend
 
 	pods := &corev1.PodList{}
 	err := e.client.List(context.TODO(), pods, opts...)
-
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added the `pendingPodConditions` setting for which users can pass a list of [Pod Conditions](https://kubernetes.io/docs/concepts/workloads/pods/_print/#pod-conditions) which Keda will consider when calculating the pending job count.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* - https://github.com/kedacore/keda-docs/pull/496
- [x] Changelog has been updated

Resolves #1963 

Signed-off-by: Yaron Yarimi <yaron.yarimi@env0.com>