### PR TITLE
feat: Add support custom metricName in RabbitMQ scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Introduce Idle Replica Mode ([#1958](https://github.com/kedacore/keda/pull/1958))
 - Add new scaler for Selenium Grid ([#1971](https://github.com/kedacore/keda/pull/1971))
 - Support using regex to select the queues in RabbitMQ Scaler ([#1957](https://github.com/kedacore/keda/pull/1957))
+- Support custom metric name in RabbitMQ Scaler ([#1976](https://github.com/kedacore/keda/pull/1976))
 
 ### Improvements
 

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -92,11 +92,14 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	{map[string]string{"mode": "MessageRate", "value": "1000", "queueName": "sample", "host": "http://", "useRegex": "true"}, false, map[string]string{}},
 	// queue length and useRegex
 	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "http://", "useRegex": "true"}, false, map[string]string{}},
+	// custom metric name
+	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "http://", "useRegex": "true", "metricName": "host1-sample"}, false, map[string]string{}},
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
 	{&testRabbitMQMetadata[1], "rabbitmq-sample"},
 	{&testRabbitMQMetadata[7], "rabbitmq-namespace-name"},
+	{&testRabbitMQMetadata[31], "rabbitmq-host1-sample"},
 }
 
 func TestRabbitMQParseMetadata(t *testing.T) {


### PR DESCRIPTION
This change adds support for parsing custom `metricName` in **RabbitMQ** scaler, and help to workaround use cases where there's reconcile error for a `ScaledObject` having duplicate auto generated `metricName`s, e.g., multiple trigger on the same queue, mode but from different RabbitMQ hosts.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- ~[ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~
- [x] A PR is opened to update the documentation on (https://github.com/kedacore/keda-docs/pull/499) *(if applicable)*
- [x] Changelog has been updated

Fixes #1975
