### PR TITLE
feat(influxdb-scaler): add support for integer query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - IBM MQ scaler password handling fix ([#1939](https://github.com/kedacore/keda/pull/1939))
 - Metrics APIServer: Add ratelimiting parameters to override client ([#1944](https://github.com/kedacore/keda/pull/1944))
 - Optimize KafkaScaler by fetching all topic offsets using a single HTTP request ([#1956](https://github.com/kedacore/keda/pull/1956))
+- Adjusts InfluxDB scaler to support queries that return integers in addition to those that return floats ([#1977](https://github.com/kedacore/keda/pull/1977))
 
 ### Breaking Changes
 

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -170,17 +170,13 @@ func queryInfluxDB(queryAPI api.QueryAPI, query string) (float64, error) {
 		return 0, fmt.Errorf("no results found from query")
 	}
 
-	var val float64
-	switch valRaw := result.Record().Value(); valRaw.(type) {
+	switch valRaw := result.Record().Value().(type) {
 	case float64:
-		val = valRaw.(float64)
+		return valRaw, nil
 	case int64:
-		val = float64(valRaw.(int64))
+		return float64(valRaw), nil
 	default:
 		return 0, fmt.Errorf("value of type %T could not be converted into a float", valRaw)
-	}
-
-	return val, nil
 }
 
 // GetMetrics connects to influxdb via the client and returns a value based on the query

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -177,7 +177,7 @@ func queryInfluxDB(queryAPI api.QueryAPI, query string) (float64, error) {
 		return float64(valRaw), nil
 	default:
 		return 0, fmt.Errorf("value of type %T could not be converted into a float", valRaw)
-		}
+	}
 }
 
 // GetMetrics connects to influxdb via the client and returns a value based on the query

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -170,9 +170,14 @@ func queryInfluxDB(queryAPI api.QueryAPI, query string) (float64, error) {
 		return 0, fmt.Errorf("no results found from query")
 	}
 
-	val, ok := result.Record().Value().(float64)
-	if !ok {
-		return 0, fmt.Errorf("value could not be parsed into a float")
+	var val float64
+	switch valRaw := result.Record().Value(); valRaw.(type) {
+	case float64:
+		val = valRaw.(float64)
+	case int64:
+		val = float64(valRaw.(int64))
+	default:
+		return 0, fmt.Errorf("value of type %T could not be converted into a float", valRaw)
 	}
 
 	return val, nil

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -177,6 +177,7 @@ func queryInfluxDB(queryAPI api.QueryAPI, query string) (float64, error) {
 		return float64(valRaw), nil
 	default:
 		return 0, fmt.Errorf("value of type %T could not be converted into a float", valRaw)
+		}
 }
 
 // GetMetrics connects to influxdb via the client and returns a value based on the query

--- a/tests/scalers/influxdb.test.ts
+++ b/tests/scalers/influxdb.test.ts
@@ -69,7 +69,7 @@ test.before((t) => {
     t.is('true', influxdbStatus, 'Influxdb is not in a ready state')
 })
 
-test.serial('Should start off deployment with 0 replicas and scale to 2 replicas when scaled object is applied', (t) => {
+test.serial('Should start off deployment with 0 replicas and scale to 2 replicas when scaled object with float query is applied', (t) => {
     const { authToken, orgName } = runWriteJob(t)
     const basicDeploymentTmpFile = tmp.fileSync()
     fs.writeFileSync(basicDeploymentTmpFile.name, basicDeploymentYaml)
@@ -80,7 +80,7 @@ test.serial('Should start off deployment with 0 replicas and scale to 2 replicas
     t.is(numReplicasBefore, '0', 'Number of replicas should be 0 to start with')
 
     const scaledObjectTmpFile = tmp.fileSync()
-    fs.writeFileSync(scaledObjectTmpFile.name, scaledObjectYaml.replace('{{INFLUXDB_AUTH_TOKEN}}', authToken).replace('{{INFLUXDB_ORG_NAME}}', orgName))
+    fs.writeFileSync(scaledObjectTmpFile.name, scaledObjectYamlFloat.replace('{{INFLUXDB_AUTH_TOKEN}}', authToken).replace('{{INFLUXDB_ORG_NAME}}', orgName))
 
     t.is(0, sh.exec(`kubectl apply --namespace ${influxdbNamespaceName} -f ${scaledObjectTmpFile.name}`).code)
 
@@ -96,6 +96,35 @@ test.serial('Should start off deployment with 0 replicas and scale to 2 replicas
     }
 
     t.is(numReplicasAfter, '2', 'Number of replicas should have scaled to 2')
+})
+
+test.serial('Should start off deployment with 0 replicas and scale to 2 replicas when scaled object with int query is applied', (t) => {
+  const { authToken, orgName } = runWriteJob(t)
+  const basicDeploymentTmpFile = tmp.fileSync()
+  fs.writeFileSync(basicDeploymentTmpFile.name, basicDeploymentYaml)
+
+  t.is(0, sh.exec(`kubectl apply --namespace ${influxdbNamespaceName} -f ${basicDeploymentTmpFile.name}`).code)
+
+  const numReplicasBefore = sh.exec(`kubectl get deployment --namespace ${influxdbNamespaceName} ${nginxDeploymentName} -o jsonpath='{.spec.replicas}'`).stdout
+  t.is(numReplicasBefore, '0', 'Number of replicas should be 0 to start with')
+
+  const scaledObjectTmpFile = tmp.fileSync()
+  fs.writeFileSync(scaledObjectTmpFile.name, scaledObjectYamlInt.replace('{{INFLUXDB_AUTH_TOKEN}}', authToken).replace('{{INFLUXDB_ORG_NAME}}', orgName))
+
+  t.is(0, sh.exec(`kubectl apply --namespace ${influxdbNamespaceName} -f ${scaledObjectTmpFile.name}`).code)
+
+  // polling/waiting for deployment to scale to desired amount of replicas
+  let numReplicasAfter = '1'
+  for (let i = 0; i < 15; i++){
+      numReplicasAfter = sh.exec(`kubectl get deployment --namespace ${influxdbNamespaceName} ${nginxDeploymentName} -o jsonpath='{.spec.replicas}'`).stdout
+      if (numReplicasAfter !== '2') {
+          sh.exec('sleep 2s')
+      } else {
+          break
+      }
+  }
+
+  t.is(numReplicasAfter, '2', 'Number of replicas should have scaled to 2')
 })
 
 test.after.always((t) => {
@@ -162,7 +191,7 @@ spec:
     type: ClusterIP
 `
 
-const scaledObjectYaml = `
+const scaledObjectYamlFloat = `
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -183,6 +212,31 @@ spec:
         from(bucket:"bucket")
         |> range(start: -1h)
         |> filter(fn: (r) => r._measurement == "stat")
+        |> map(fn: (r) => ({r with _value: float(v: r._value)}))
+`
+
+const scaledObjectYamlInt = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: influxdb-scaler
+  namespace: influxdb
+spec:
+  scaleTargetRef:
+    name: nginx-deployment
+  maxReplicaCount: 2
+  triggers:
+  - type: influxdb
+    metadata:
+      authToken: {{INFLUXDB_AUTH_TOKEN}}
+      organizationName: {{INFLUXDB_ORG_NAME}}
+      serverURL: http://influxdb.influxdb.svc:8086
+      thresholdValue: "3"
+      query: |
+        from(bucket:"bucket")
+        |> range(start: -1h)
+        |> filter(fn: (r) => r._measurement == "stat")
+        |> map(fn: (r) => ({r with _value: int(v: r._value)}))
 `
 
 const influxdbWriteJobYaml = `


### PR DESCRIPTION
Signed-off-by: Adam Gardner <adam.gardner@magicmemories.com>

Adjusted the InfluxDB scaler so that it can successfully process queries that return integer results in addition to those that return float results.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #1973
