### PR TITLE
Fix timing in azure-queue and redis-cluster-streams tests

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+concurrency: e2e-tests
 jobs:
   validate:
     name: Validate

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -2,6 +2,7 @@ name: nightly-e2e-test
 on:
   schedule:
     - cron: "0 0 * * *"
+concurrency: e2e-tests
 jobs:
   test:
     name: Test

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,6 @@ name: CI
 on:
   - push
   - pull_request
-
 jobs:
   validate:
     name: Validate PR

--- a/tests/scalers/azure-queue.test.ts
+++ b/tests/scalers/azure-queue.test.ts
@@ -46,7 +46,7 @@ test.serial.cb(
         (n, cb) => queueSvc.createMessage('queue-name', `test ${n}`, cb),
         () => {
           let replicaCount = '0'
-          for (let i = 0; i < 10 && replicaCount !== '4'; i++) {
+          for (let i = 0; i < 30 && replicaCount !== '4'; i++) {
             replicaCount = sh.exec(
               `kubectl get deployment.apps/test-deployment --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`
             ).stdout
@@ -55,7 +55,7 @@ test.serial.cb(
             }
           }
 
-          t.is('4', replicaCount, 'Replica count should be 4 after 10 seconds')
+          t.is('4', replicaCount, 'Replica count should be 4 after 30 seconds')
 
           for (let i = 0; i < 50 && replicaCount !== '0'; i++) {
             replicaCount = sh.exec(

--- a/tests/scalers/helpers.ts
+++ b/tests/scalers/helpers.ts
@@ -1,0 +1,5 @@
+import * as sh from "shelljs";
+
+export function waitForRollout(type: 'deployment' | 'statefulset', name: string, namespace: string): number {
+    return sh.exec(`kubectl rollout status ${type}/${name} -n ${namespace}`).code
+}


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

- `azure-queue` tests had an issue where it would fail if it took the deployment more than 10 seconds to scale. increasing it seems to make the test pretty reliable. However, we might wanna take a future work item to see what's the effective wait time of `pollingInterval`. 
- `redis-cluster-streams` had an issue with running the producer jobs before redis finished installing and that would cause them to fail to connect most of the time. To fix it I added a wait until redis statefulset rollout is complete.
- `influxdb` tests had a similar issue to `redis-cluster-streams` but with influxdb server. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes #
