### PR TITLE
Improve and update E2E tests 

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,6 +1,5 @@
 name: CI
 on:
-  - push
   - pull_request
 jobs:
   validate:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GIT_VERSION ?= $(shell git describe --always --abbrev=7)
 GIT_COMMIT  ?= $(shell git rev-list -1 HEAD)
 DATE        = $(shell date -u +"%Y.%m.%d.%H.%M.%S")
 
-TEST_CLUSTER_NAME ?= keda-nightly-run-2
+TEST_CLUSTER_NAME ?= keda-nightly-run-3
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -6,20 +6,22 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-logr/logr"
-	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/eventreason"
-	"github.com/kedacore/keda/v2/pkg/scalers"
-	"github.com/kedacore/keda/v2/pkg/scaling/executor"
-	"github.com/kedacore/keda/v2/pkg/scaling/resolver"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/go-logr/logr"
 	"k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/scale"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/scalers"
+	"github.com/kedacore/keda/v2/pkg/scaling/executor"
+	"github.com/kedacore/keda/v2/pkg/scaling/resolver"
 )
 
 // ScaleHandler encapsulates the logic of calling the right scalers for

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -213,7 +213,7 @@ func (h *scaleHandler) checkScalers(ctx context.Context, scalableObject interfac
 	case *kedav1alpha1.ScaledJob:
 		err = h.client.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, obj)
 		if err != nil {
-			h.logger.Error(err, "Error getting scaledOJob", "object", scalableObject)
+			h.logger.Error(err, "Error getting scaledJob", "object", scalableObject)
 			return
 		}
 		isActive, scaleTo, maxScale := h.isScaledJobActive(ctx, scalers, obj)

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,7 +8,8 @@
     ],
     "require": [
       "ts-node/register"
-    ]
+    ],
+    "timeout": "10m"
   },
   "scripts": {
     "test": "ava"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -4,7 +4,7 @@ set -eu
 DIR=$(dirname "$0")
 cd $DIR
 
-concurrent_tests_limit=10
+concurrent_tests_limit=5
 pids=()
 lookup=()
 failed_count=0

--- a/tests/scalers/helpers.ts
+++ b/tests/scalers/helpers.ts
@@ -3,3 +3,22 @@ import * as sh from "shelljs";
 export function waitForRollout(type: 'deployment' | 'statefulset', name: string, namespace: string): number {
     return sh.exec(`kubectl rollout status ${type}/${name} -n ${namespace}`).code
 }
+
+export function sleep(duration: number) {
+    return new Promise(resolve => setTimeout(resolve, duration));
+}
+
+export async function waitForDeploymentReplicaCount(target: number, name: string, namespace: string, iterations = 10, interval = 3000): Promise<boolean> {
+    for (let i = 0; i < iterations; i++) {
+        let replicaCountStr = sh.exec(`kubectl get deployment.apps/${name} --namespace ${namespace} -o jsonpath="{.spec.replicas}"`).stdout
+        try {
+            const replicaCount = parseInt(replicaCountStr, 10)
+            if (replicaCount === target) {
+                return true
+            }
+        } catch { }
+
+        await sleep(interval)
+    }
+    return false
+}

--- a/tests/scalers/influxdb.test.ts
+++ b/tests/scalers/influxdb.test.ts
@@ -157,6 +157,11 @@ spec:
                 volumeMounts:
                   - mountPath: /root/.influxdbv2
                     name: data
+                readinessProbe:
+                  tcpSocket:
+                    port: 8086
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
     volumeClaimTemplates:
       - metadata:
             name: data

--- a/tests/scalers/prometheus-deployment.yaml
+++ b/tests/scalers/prometheus-deployment.yaml
@@ -344,6 +344,9 @@ subjects:
   - kind: ServiceAccount
     name: prometheus-server
     namespace: monitoring
+  - kind: ServiceAccount
+    name: prometheus-server
+    namespace: argo-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/scalers/prometheus.test.ts
+++ b/tests/scalers/prometheus.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import test from 'ava'
+import {waitForRollout} from "./helpers";
 
 const testNamespace = 'prometheus-test'
 const prometheusNamespace = 'monitoring'
@@ -13,14 +14,7 @@ test.before(t => {
   sh.exec(`kubectl create namespace ${prometheusNamespace}`)
   t.is(0, sh.exec(`kubectl apply --namespace ${prometheusNamespace} -f ${prometheusDeploymentFile}`).code, 'creating a Prometheus deployment should work.')
   // wait for prometheus to load
-  let prometheusReadyReplicaCount = '0'
-  for (let i = 0; i < 30; i++) {
-    prometheusReadyReplicaCount = sh.exec(`kubectl get deploy/prometheus-server -n ${prometheusNamespace} -o jsonpath='{.status.readyReplicas}'`).stdout
-    if (prometheusReadyReplicaCount != '1') {
-      sh.exec('sleep 2s')
-    }
-  }
-  t.is('1', prometheusReadyReplicaCount, 'Prometheus is not in a ready state')
+  t.is(0, waitForRollout('deployment', "prometheus-server", prometheusNamespace))
 
   sh.config.silent = true
   // create deployments - there are two deployments - both using the same image but one deployment

--- a/tests/scalers/rabbitmq-queue-amqp.test.ts
+++ b/tests/scalers/rabbitmq-queue-amqp.test.ts
@@ -4,6 +4,7 @@ import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import test from 'ava'
 import { RabbitMQHelper } from './rabbitmq-helpers'
+import {waitForDeploymentReplicaCount} from "./helpers";
 
 const testNamespace = 'rabbitmq-queue-amqp-test'
 const rabbitmqNamespace = 'rabbitmq-amqp-test'
@@ -29,33 +30,12 @@ test.serial('Deployment should have 0 replicas on start', t => {
   t.is(replicaCount, '0', 'replica count should start out as 0')
 })
 
-test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, t => {
+test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, async t => {
   RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount)
 
   // with messages published, the consumer deployment should start receiving the messages
-  let replicaCount = '0'
-  for (let i = 0; i < 10 && replicaCount !== '4'; i++) {
-    replicaCount = sh.exec(
-      `kubectl get deployment.apps/test-deployment --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-    ).stdout
-    t.log('replica count is:' + replicaCount)
-    if (replicaCount !== '4') {
-      sh.exec('sleep 5s')
-    }
-  }
-
-  t.is('4', replicaCount, 'Replica count should be 4 after 10 seconds')
-
-  for (let i = 0; i < 50 && replicaCount !== '0'; i++) {
-    replicaCount = sh.exec(
-      `kubectl get deployment.apps/test-deployment --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-    ).stdout
-    if (replicaCount !== '0') {
-      sh.exec('sleep 5s')
-    }
-  }
-
-  t.is('0', replicaCount, 'Replica count should be 0 after 3 minutes')
+  t.true(await waitForDeploymentReplicaCount(4, 'test-deployment', testNamespace, 20, 5000), 'Replica count should be 4 after 10 seconds')
+  t.true(await waitForDeploymentReplicaCount(0, 'test-deployment', testNamespace, 50, 5000), 'Replica count should be 0 after 3 minutes')
 })
 
 test.after.always.cb('clean up rabbitmq-queue deployment', t => {

--- a/tests/scalers/rabbitmq-queue-http-regex.test.ts
+++ b/tests/scalers/rabbitmq-queue-http-regex.test.ts
@@ -4,6 +4,7 @@ import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import test from 'ava'
 import { RabbitMQHelper } from './rabbitmq-helpers'
+import {waitForDeploymentReplicaCount} from "./helpers";
 
 const testNamespace = 'rabbitmq-queue-http-regex-test'
 const rabbitmqNamespace = 'rabbitmq-http-regex-test'
@@ -31,33 +32,12 @@ test.serial('Deployment should have 0 replicas on start', t => {
   t.is(replicaCount, '0', 'replica count should start out as 0')
 })
 
-test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, t => {
+test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, async t => {
   RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount)
 
   // with messages published, the consumer deployment should start receiving the messages
-  let replicaCount = '0'
-  for (let i = 0; i < 10 && replicaCount !== '4'; i++) {
-    replicaCount = sh.exec(
-      `kubectl get deployment.apps/test-deployment --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-    ).stdout
-    t.log('replica count is:' + replicaCount)
-    if (replicaCount !== '4') {
-      sh.exec('sleep 5s')
-    }
-  }
-
-  t.is('4', replicaCount, 'Replica count should be 4 after 10 seconds')
-
-  for (let i = 0; i < 50 && replicaCount !== '0'; i++) {
-    replicaCount = sh.exec(
-      `kubectl get deployment.apps/test-deployment --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-    ).stdout
-    if (replicaCount !== '0') {
-      sh.exec('sleep 5s')
-    }
-  }
-
-  t.is('0', replicaCount, 'Replica count should be 0 after 3 minutes')
+  t.true(await waitForDeploymentReplicaCount(4, 'test-deployment', testNamespace, 20, 5000), 'Replica count should be 4 after 10 seconds')
+  t.true(await waitForDeploymentReplicaCount(0, 'test-deployment', testNamespace, 50, 5000), 'Replica count should be 0 after 3 minutes')
 })
 
 test.after.always.cb('clean up rabbitmq-queue deployment', t => {

--- a/tests/scalers/redis-cluster-lists.test.ts
+++ b/tests/scalers/redis-cluster-lists.test.ts
@@ -2,6 +2,7 @@ import test from 'ava'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import * as fs from 'fs'
+import {waitForRollout} from "./helpers";
 
 const redisNamespace = 'redis-cluster'
 const redisService = 'redis-cluster'
@@ -36,14 +37,7 @@ test.before(t => {
     )
 
     // Wait for Redis cluster to be ready.
-    let redisReplicaCount = '0'
-    for (let i = 0; i < 30; i++) {
-        redisReplicaCount = sh.exec(`kubectl get statefulset/${redisStatefulSetName} -n ${redisNamespace} -o jsonpath='{.spec.replicas}'`).stdout
-        if (redisReplicaCount != '6') {
-            sh.exec('sleep 2s')
-        }
-    }
-    t.is('6', redisReplicaCount, 'Redis is not in a ready state')
+   t.is(0, waitForRollout('statefulset', redisStatefulSetName, redisNamespace))
 
     // Get Redis cluster address.
     redisHost = sh.exec(`kubectl get svc ${redisService} -n ${redisNamespace} -o jsonpath='{.spec.clusterIP}'`)

--- a/tests/scalers/stan-helpers.ts
+++ b/tests/scalers/stan-helpers.ts
@@ -1,6 +1,7 @@
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import * as fs from 'fs'
+import {waitForRollout} from "./helpers";
 
 export class StanHelper {
     static install(t, stanNamespace: string) {
@@ -14,7 +15,7 @@ export class StanHelper {
         )
         t.is(
             0,
-            sh.exec(`kubectl -n ${stanNamespace} wait --for=condition=Ready --timeout=600s po/stan-nats-ss-0`).code, 'Stan pod should be available.'
+            waitForRollout('statefulset', 'stan-nats-ss', stanNamespace), 'Stan pod should be available.'
         )
 
     }


### PR DESCRIPTION
This change:

- increases test timeout to ~5~ 10 minutes
- uses a different namespace for Prometheus for `argo-rollouts.test.ts` and `prometheus.test.ts` to avoid conflict if the tests run at the same time
- reduce `pollingInterval` and `cooldownPeriod` in `azure-pipelines.test.ts`
- add readiness probe on influxdb, and rabbitmq deployment
- use `rabbitmq.conf` and `enabled_plugins` files for configuring rabbitmq instead of env vars since they are [deprecated](https://github.com/docker-library/rabbitmq/pull/467) and cause an error on start up
- add some helper methods for common tasks. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [NA] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [N/A] Changelog has been updated


