### PR TITLE
use the `.` command to source setup-envtest.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate manifests gofmt govet
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.5/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -covermode=atomic -coverprofile cover.out
+	. ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -covermode=atomic -coverprofile cover.out
 
 .PHONY: e2e-test
 e2e-test:


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
Fixing `make test` target which was failing after merging https://github.com/kedacore/keda/pull/1960. There was used `source` command which is not supported on a shell that's has been used in Ubuntu (which we run the test against). Using the `.` command to source setup-envtest.sh will fix the problem.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

