### PR TITLE
use Bash instead of Dash

### DIFF
--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -4,6 +4,9 @@ FROM ubuntu:18.04
 RUN apt-get update && \
     apt-get install -y wget curl build-essential git
 
+# Use Bash instead of Dash
+RUN ln -sf bash /bin/sh
+
 # Install azure-cli
 RUN apt-get install apt-transport-https lsb-release software-properties-common dirmngr -y && \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | \


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Build tool image - use Bash by default instead of limited Dash

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
