### PR TITLE
set timeout on deployment rollout

### DIFF
--- a/tests/scalers/helpers.ts
+++ b/tests/scalers/helpers.ts
@@ -1,7 +1,7 @@
 import * as sh from "shelljs";
 
-export function waitForRollout(type: 'deployment' | 'statefulset', name: string, namespace: string): number {
-    return sh.exec(`kubectl rollout status ${type}/${name} -n ${namespace}`).code
+export function waitForRollout(type: 'deployment' | 'statefulset', name: string, namespace: string, timeoutSeconds = 180): number {
+    return sh.exec(`kubectl rollout status ${type}/${name} -n ${namespace} --timeout ${timeoutSeconds}s`).code
 }
 
 export function sleep(duration: number) {


### PR DESCRIPTION
@zroubalik I'm not sure why the redis-cluster test never finished rolling out. I have seen that test case be a bit inconsistent due to the time it takes azure to mount the persistentVolumnClaim redis-cluster is requiring. I'm not sure if this was an instance of that or not. I added a timeout to the command so it doesn't get stuck for hours.

For the stability of the test itself, I can make it always try to rerun it or restart the redis cluster if it's stuck


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [N/A] Changelog has been updated

