### PR TITLE
Use `scaled[object/job].keda.sh/` prefix for KEDA related labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 ### Other
 
-- TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
+- Use `scaled[object/job].keda.sh/` prefix for KEDA related labels ([#2008](https://github.com/kedacore/keda/pull/2008))
 
 ## v2.3.0
 

--- a/controllers/hpa.go
+++ b/controllers/hpa.go
@@ -164,9 +164,9 @@ func (r *ScaledObjectReconciler) getScaledObjectMetricSpecs(logger logr.Logger, 
 					return nil, fmt.Errorf("metricName %s defined multiple times in ScaledObject %s, please refer the documentation how to define metricName manually", externalMetricName, scaledObject.Name)
 				}
 
-				// add the scaledObjectName label. This is how the MetricsAdapter will know which scaledobject a metric is for when the HPA queries it.
+				// add the scaledobject.keda.sh/name label. This is how the MetricsAdapter will know which scaledobject a metric is for when the HPA queries it.
 				metricSpec.External.Metric.Selector = &metav1.LabelSelector{MatchLabels: make(map[string]string)}
-				metricSpec.External.Metric.Selector.MatchLabels["scaledObjectName"] = scaledObject.Name
+				metricSpec.External.Metric.Selector.MatchLabels["scaledobject.keda.sh/name"] = scaledObject.Name
 				externalMetricNames = append(externalMetricNames, externalMetricName)
 			}
 		}

--- a/controllers/scaledjob_controller.go
+++ b/controllers/scaledjob_controller.go
@@ -145,7 +145,7 @@ func (r *ScaledJobReconciler) reconcileScaledJob(logger logr.Logger, scaledJob *
 func (r *ScaledJobReconciler) deletePreviousVersionScaleJobs(logger logr.Logger, scaledJob *kedav1alpha1.ScaledJob) (string, error) {
 	opts := []client.ListOption{
 		client.InNamespace(scaledJob.GetNamespace()),
-		client.MatchingLabels(map[string]string{"scaledJob": scaledJob.GetName()}),
+		client.MatchingLabels(map[string]string{"scaledjob.keda.sh/name": scaledJob.GetName()}),
 	}
 	jobs := &batchv1.JobList{}
 	err := r.Client.List(context.TODO(), jobs, opts...)

--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -231,10 +231,10 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(logger logr.Logger, scale
 	return "ScaledObject is defined correctly and is ready for scaling", nil
 }
 
-// ensureScaledObjectLabel ensures that scaledObjectName=<scaledObject.Name> label exist in the ScaledObject
+// ensureScaledObjectLabel ensures that scaledobject.keda.sh/name=<scaledObject.Name> label exist in the ScaledObject
 // This is how the MetricsAdapter will know which ScaledObject a metric is for when the HPA queries it.
 func (r *ScaledObjectReconciler) ensureScaledObjectLabel(logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) error {
-	const labelScaledObjectName = "scaledObjectName"
+	const labelScaledObjectName = "scaledobject.keda.sh/name"
 
 	if scaledObject.Labels == nil {
 		scaledObject.Labels = map[string]string{labelScaledObjectName: scaledObject.Name}
@@ -246,7 +246,7 @@ func (r *ScaledObjectReconciler) ensureScaledObjectLabel(logger logr.Logger, sca
 		scaledObject.Labels[labelScaledObjectName] = scaledObject.Name
 	}
 
-	logger.V(1).Info("Adding scaledObjectName label on ScaledObject", "value", scaledObject.Name)
+	logger.V(1).Info("Adding \"scaledobject.keda.sh/name\" label on ScaledObject", "value", scaledObject.Name)
 	return r.Client.Update(context.TODO(), scaledObject)
 }
 

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -76,7 +76,7 @@ func (e *scaleExecutor) createJobs(logger logr.Logger, scaledJob *kedav1alpha1.S
 	if scaledJob.Spec.JobTargetRef.Template.Labels == nil {
 		scaledJob.Spec.JobTargetRef.Template.Labels = map[string]string{}
 	}
-	scaledJob.Spec.JobTargetRef.Template.Labels["scaledjob"] = scaledJob.GetName()
+	scaledJob.Spec.JobTargetRef.Template.Labels["scaledjob.keda.sh/name"] = scaledJob.GetName()
 
 	logger.Info("Creating jobs", "Effective number of max jobs", maxScale)
 
@@ -90,7 +90,7 @@ func (e *scaleExecutor) createJobs(logger logr.Logger, scaledJob *kedav1alpha1.S
 		"app.kubernetes.io/version":    version.Version,
 		"app.kubernetes.io/part-of":    scaledJob.GetName(),
 		"app.kubernetes.io/managed-by": "keda-operator",
-		"scaledjob":                    scaledJob.GetName(),
+		"scaledjob.keda.sh/name":       scaledJob.GetName(),
 	}
 	for key, value := range scaledJob.ObjectMeta.Labels {
 		labels[key] = value
@@ -142,7 +142,7 @@ func (e *scaleExecutor) getRunningJobCount(scaledJob *kedav1alpha1.ScaledJob) in
 
 	opts := []client.ListOption{
 		client.InNamespace(scaledJob.GetNamespace()),
-		client.MatchingLabels(map[string]string{"scaledjob": scaledJob.GetName()}),
+		client.MatchingLabels(map[string]string{"scaledjob.keda.sh/name": scaledJob.GetName()}),
 	}
 
 	jobs := &batchv1.JobList{}
@@ -216,7 +216,7 @@ func (e *scaleExecutor) getPendingJobCount(scaledJob *kedav1alpha1.ScaledJob) in
 
 	opts := []client.ListOption{
 		client.InNamespace(scaledJob.GetNamespace()),
-		client.MatchingLabels(map[string]string{"scaledjob": scaledJob.GetName()}),
+		client.MatchingLabels(map[string]string{"scaledjob.keda.sh/name": scaledJob.GetName()}),
 	}
 
 	jobs := &batchv1.JobList{}
@@ -251,7 +251,7 @@ func (e *scaleExecutor) cleanUp(scaledJob *kedav1alpha1.ScaledJob) error {
 
 	opts := []client.ListOption{
 		client.InNamespace(scaledJob.GetNamespace()),
-		client.MatchingLabels(map[string]string{"scaledjob": scaledJob.GetName()}),
+		client.MatchingLabels(map[string]string{"scaledjob.keda.sh/name": scaledJob.GetName()}),
 	}
 
 	jobs := &batchv1.JobList{}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

KEDA defines and uses labels in order to do scaling, there are certain recommendations for labels naming, ie. use some prefix and keep non prefixed for user defined labels. 

https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
> If the prefix is omitted, the label Key is presumed to be private to the user. Automated system components (e.g. kube-scheduler, kube-controller-manager, kube-apiserver, kubectl, or other third-party automation) which add labels to end-user objects must specify a prefix.

Also:
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

---
So this PR intoduces a change in labels (It shouldn't bring any problems to users as KEDA Operator automatically sets these):

ScaledObject: `scaledObjectName` -> `scaledobject.keda.sh/name`
ScaleJob: `scaledJob` -> `scaledjob.keda.sh/name`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

