### PR TITLE
Add Kubernetes Workload scaler 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,9 @@ issues:
     - path: scale_resolvers_test.go
       linters:
         - staticcheck
+    - path: kubernetes_workload_scaler_test.go
+      linters:
+        - staticcheck
     # https://github.com/go-critic/go-critic/issues/926
     - linters:
         - gocritic

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,8 @@ issues:
     - path: scale_resolvers_test.go
       linters:
         - staticcheck
+  # Got "sigs.k8s.io/controller-runtime/pkg/client/fake is deprecated: please use pkg/envtest for testing"
+  # This might not be ideal, see: https://github.com/kubernetes-sigs/controller-runtime/issues/768
     - path: kubernetes_workload_scaler_test.go
       linters:
         - staticcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add new scaler for Selenium Grid ([#1971](https://github.com/kedacore/keda/pull/1971))
 - Support using regex to select the queues in RabbitMQ Scaler ([#1957](https://github.com/kedacore/keda/pull/1957))
 - Support custom metric name in RabbitMQ Scaler ([#1976](https://github.com/kedacore/keda/pull/1976))
+- Add new scaler for Kubernetes Workload ([#2010](https://github.com/kedacore/keda/pull/2010))
 
 ### Improvements
 

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -76,11 +76,7 @@ func (s *kubernetesWorkloadScaler) IsActive(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	if pods == 0 {
-		return false, fmt.Errorf("monitored pod count is 0")
-	}
-
-	return true, nil
+	return pods > 0, nil
 }
 
 // Close no need for kubernetes workload scaler
@@ -93,7 +89,7 @@ func (s *kubernetesWorkloadScaler) GetMetricSpecForScaling() []v2beta2.MetricSpe
 	targetMetricValue := resource.NewQuantity(s.metadata.value, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: kedautil.NormalizeString(fmt.Sprintf("%s-%s", "workload", normalizeSelectorString(s.metadata.podSelector))),
+			Name: kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "workload", s.metadata.namespace, normalizeSelectorString(s.metadata.podSelector))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -1,0 +1,90 @@
+package scalers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+	"go.etcd.io/etcd/client"
+	"k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+)
+
+type kubernetesWorkloadScaler struct {
+	metadata   *kubernetesWorkloadMetadata
+	kubeClient client.Client
+}
+
+const (
+	podSelectorKey       = "PodSelector"
+	namespaceSelectorKey = "NamespaceSelector"
+	valueKey             = "Value"
+)
+
+type kubernetesWorkloadMetadata struct {
+	podSelector labels.Selector
+	value       int64
+}
+
+// NewKubernetesWorkloadScaler creates a new kubernetesWorkloadScaler
+func NewKubernetesWorkloadScaler(kubeClient client.Client, config *ScalerConfig) (Scaler, error) {
+	meta, parseErr := parseWorkloadMetadata(config)
+	if parseErr != nil {
+		return nil, fmt.Errorf("error parsing kubernetes workload metadata: %s", parseErr)
+	}
+
+	return &kubernetesWorkloadScaler{
+		metadata:   meta,
+		kubeClient: kubeClient,
+	}, nil
+}
+
+func parseWorkloadMetadata(config *ScalerConfig) (*kubernetesWorkloadMetadata, error) {
+	meta := &kubernetesWorkloadMetadata{}
+	var err error
+	meta.podSelector, err = labels.Parse(config.TriggerMetadata[podSelectorKey])
+	if err != nil {
+		return nil, fmt.Errorf("invalid pod selector")
+	}
+	meta.value, err = strconv.ParseInt(config.TriggerMetadata[valueKey], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("value must be an integer")
+	}
+	return meta, nil
+}
+
+// IsActive determines if we need to scale from zero
+func (s *kubernetesWorkloadScaler) IsActive(ctx context.Context) (bool, error) {
+	//TODO
+	return true, nil
+}
+
+// Close no need for kubernetes workload scaler
+func (s *kubernetesWorkloadScaler) Close() error {
+	return nil
+}
+
+// GetMetricSpecForScaling returns the metric spec for the HPA
+func (s *kubernetesWorkloadScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
+	targetMetricValue := resource.NewQuantity(s.metadata.value, resource.DecimalSI)
+	externalMetric := &v2beta2.ExternalMetricSource{
+		Metric: v2beta2.MetricIdentifier{
+			Name: kedautil.NormalizeString(fmt.Sprintf("%s-%s", "workload", s.metadata.podSelector.String())),
+		},
+		Target: v2beta2.MetricTarget{
+			Type:  v2beta2.ValueMetricType,
+			Value: targetMetricValue,
+		},
+	}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: v2beta2.ResourceMetricSourceType}
+	return []v2beta2.MetricSpec{metricSpec}
+}
+
+// GetMetrics returns value for a supported metric
+func (s *kubernetesWorkloadScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
+	return nil, nil
+	// TODO
+}

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -31,7 +31,6 @@ const (
 
 type kubernetesWorkloadMetadata struct {
 	podSelector labels.Selector
-	name        string
 	value       int64
 }
 
@@ -59,7 +58,6 @@ func parseWorkloadMetadata(config *ScalerConfig) (*kubernetesWorkloadMetadata, e
 	if err != nil || meta.value == 0 {
 		return nil, fmt.Errorf("value must be an integer greater than 0")
 	}
-	meta.name = config.Name
 
 	return meta, nil
 }

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -6,11 +6,13 @@ import (
 	"strconv"
 
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
-	"go.etcd.io/etcd/client"
 	"k8s.io/api/autoscaling/v2beta2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
+
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type kubernetesWorkloadScaler struct {
@@ -19,9 +21,10 @@ type kubernetesWorkloadScaler struct {
 }
 
 const (
-	podSelectorKey       = "PodSelector"
-	namespaceSelectorKey = "NamespaceSelector"
-	valueKey             = "Value"
+	kubernetesWorkloadMetricType = "External"
+	podSelectorKey               = "podSelector"
+	namespaceSelectorKey         = "namespaceSelector"
+	valueKey                     = "value"
 )
 
 type kubernetesWorkloadMetadata struct {
@@ -46,19 +49,35 @@ func parseWorkloadMetadata(config *ScalerConfig) (*kubernetesWorkloadMetadata, e
 	meta := &kubernetesWorkloadMetadata{}
 	var err error
 	meta.podSelector, err = labels.Parse(config.TriggerMetadata[podSelectorKey])
-	if err != nil {
+	if err != nil || meta.podSelector.String() == "" {
 		return nil, fmt.Errorf("invalid pod selector")
 	}
 	meta.value, err = strconv.ParseInt(config.TriggerMetadata[valueKey], 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("value must be an integer")
+	if err != nil || meta.value == 0 {
+		return nil, fmt.Errorf("value must be an integer greater than 0")
 	}
 	return meta, nil
 }
 
 // IsActive determines if we need to scale from zero
 func (s *kubernetesWorkloadScaler) IsActive(ctx context.Context) (bool, error) {
-	//TODO
+	podList := &corev1.PodList{}
+	listOptions := client.ListOptions{}
+	opts := []client.ListOption{}
+
+	listOptions.LabelSelector = s.metadata.podSelector
+	//Could be wrong, review it
+	listOptions.ApplyOptions(opts)
+
+	err := s.kubeClient.List(ctx, podList, opts...)
+	if err != nil {
+		return false, err
+	}
+
+	if len(podList.Items) == 0 {
+		return false, nil
+	}
+
 	return true, nil
 }
 
@@ -79,7 +98,7 @@ func (s *kubernetesWorkloadScaler) GetMetricSpecForScaling() []v2beta2.MetricSpe
 			Value: targetMetricValue,
 		},
 	}
-	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: v2beta2.ResourceMetricSourceType}
+	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: kubernetesWorkloadMetricType}
 	return []v2beta2.MetricSpec{metricSpec}
 }
 

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	
+
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -25,7 +25,6 @@ type kubernetesWorkloadScaler struct {
 const (
 	kubernetesWorkloadMetricType = "External"
 	podSelectorKey               = "podSelector"
-	namespaceKey                 = "namespace"
 	valueKey                     = "value"
 )
 

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -51,6 +51,7 @@ func NewKubernetesWorkloadScaler(kubeClient client.Client, config *ScalerConfig)
 func parseWorkloadMetadata(config *ScalerConfig) (*kubernetesWorkloadMetadata, error) {
 	meta := &kubernetesWorkloadMetadata{}
 	var err error
+	meta.namespace = config.Namespace
 	meta.podSelector, err = labels.Parse(config.TriggerMetadata[podSelectorKey])
 	if err != nil || meta.podSelector.String() == "" {
 		return nil, fmt.Errorf("invalid pod selector")
@@ -59,12 +60,6 @@ func parseWorkloadMetadata(config *ScalerConfig) (*kubernetesWorkloadMetadata, e
 	if err != nil || meta.value == 0 {
 		return nil, fmt.Errorf("value must be an integer greater than 0")
 	}
-	if val, ok := config.TriggerMetadata[namespaceKey]; ok {
-		meta.namespace = val
-	} else {
-		meta.namespace = ""
-	}
-
 	return meta, nil
 }
 

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -6,15 +6,15 @@ import (
 	"strconv"
 	"strings"
 
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	"k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 type kubernetesWorkloadScaler struct {

--- a/pkg/scalers/kubernetes_workload_scaler_test.go
+++ b/pkg/scalers/kubernetes_workload_scaler_test.go
@@ -1,0 +1,42 @@
+package scalers
+
+import (
+	"testing"
+)
+
+type workloadMetadataTestData struct {
+	metadata map[string]string
+	isError  bool
+}
+
+var parseWorkloadMetadataTestDataset = []workloadMetadataTestData{
+	{map[string]string{"value": "1", "podSelector": "app=demo", "namespace": "test"}, false},
+	{map[string]string{"value": "1", "podSelector": "app=demo", "namespace": ""}, false},
+	{map[string]string{"value": "1", "podSelector": "app=demo"}, false},
+	{map[string]string{"value": "1", "podSelector": "app in (demo1, demo2)", "namespace": "test"}, false},
+	{map[string]string{"value": "1", "podSelector": "app in (demo1, demo2),deploy in (deploy1, deploy2)", "namespace": "test"}, false},
+	{map[string]string{"podSelector": "app=demo", "namespace": "test"}, true},
+	{map[string]string{"podSelector": "app=demo", "namespace": ""}, true},
+	{map[string]string{"podSelector": "app=demo"}, true},
+	{map[string]string{"value": "1", "namespace": "test"}, true},
+	{map[string]string{"value": "1", "namespace": ""}, true},
+	{map[string]string{"value": "1"}, true},
+	{map[string]string{"value": "a", "podSelector": "app=demo", "namespace": "test"}, true},
+	{map[string]string{"value": "a", "podSelector": "app=demo", "namespace": ""}, true},
+	{map[string]string{"value": "a", "podSelector": "app=demo"}, true},
+	{map[string]string{"value": "0", "podSelector": "app=demo", "namespace": "test"}, true},
+	{map[string]string{"value": "0", "podSelector": "app=demo", "namespace": ""}, true},
+	{map[string]string{"value": "0", "podSelector": "app=demo"}, true},
+}
+
+func TestParseWorkloadMetadata(t *testing.T) {
+	for _, testData := range parseWorkloadMetadataTestDataset {
+		_, err := parseWorkloadMetadata(&ScalerConfig{TriggerMetadata: testData.metadata})
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+	}
+}

--- a/pkg/scalers/kubernetes_workload_scaler_test.go
+++ b/pkg/scalers/kubernetes_workload_scaler_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -122,8 +121,8 @@ func TestWorkloadGetMetricSpecForScaling(t *testing.T) {
 	}
 }
 
-func createPodlist(count int) *corev1.PodList {
-	list := &corev1.PodList{}
+func createPodlist(count int) *v1.PodList {
+	list := &v1.PodList{}
 	for i := 0; i < count; i++ {
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scalers/kubernetes_workload_scaler_test.go
+++ b/pkg/scalers/kubernetes_workload_scaler_test.go
@@ -1,7 +1,15 @@
 package scalers
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type workloadMetadataTestData struct {
@@ -39,4 +47,95 @@ func TestParseWorkloadMetadata(t *testing.T) {
 			t.Error("Expected error but got success")
 		}
 	}
+}
+
+type workloadIsActiveTestData struct {
+	metadata map[string]string
+	podCount int
+	active   bool
+}
+
+var isActiveWorkloadTestDataset = []workloadIsActiveTestData{
+	// "podSelector": "app=demo", "namespace": "test"
+	{parseWorkloadMetadataTestDataset[0].metadata, 0, false},
+	{parseWorkloadMetadataTestDataset[0].metadata, 1, false},
+	{parseWorkloadMetadataTestDataset[0].metadata, 15, false},
+	// "podSelector": "app=demo"
+	{parseWorkloadMetadataTestDataset[1].metadata, 0, false},
+	{parseWorkloadMetadataTestDataset[1].metadata, 1, true},
+	{parseWorkloadMetadataTestDataset[1].metadata, 15, true},
+}
+
+func TestWorkloadIsActive(t *testing.T) {
+	for _, testData := range isActiveWorkloadTestDataset {
+		s, _ := NewKubernetesWorkloadScaler(
+			fake.NewFakeClient(createPodlist(testData.podCount)),
+			&ScalerConfig{
+				TriggerMetadata:   testData.metadata,
+				AuthParams:        map[string]string{},
+				GlobalHTTPTimeout: 1000 * time.Millisecond,
+			},
+		)
+		isActive, _ := s.IsActive(context.TODO())
+		if testData.active && !isActive {
+			t.Error("Expected active but got inactive")
+		}
+		if !testData.active && isActive {
+			t.Error("Expected inactive but got active")
+		}
+	}
+}
+
+type workloadGetMetricSpecForScalingTestData struct {
+	metadata map[string]string
+	name     string
+}
+
+var getMetricSpecForScalingTestDataset = []workloadGetMetricSpecForScalingTestData{
+	// "podSelector": "app=demo", "namespace": "test"
+	{parseWorkloadMetadataTestDataset[0].metadata, "workload-test-app=demo"},
+	// "podSelector": "app=demo", "namespace": ""
+	{parseWorkloadMetadataTestDataset[1].metadata, "workload--app=demo"},
+	// "podSelector": "app=demo"
+	{parseWorkloadMetadataTestDataset[2].metadata, "workload--app=demo"},
+	// "podSelector": "app=demo", "namespace": ""
+	{parseWorkloadMetadataTestDataset[3].metadata, "workload-test-appin-demo1-demo2-"},
+	// "podSelector": "app=demo"
+	{parseWorkloadMetadataTestDataset[4].metadata, "workload-test-appin-demo1-demo2--deployin-deploy1-deploy2-"},
+}
+
+func TestWorkloadGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range getMetricSpecForScalingTestDataset {
+		s, _ := NewKubernetesWorkloadScaler(
+			fake.NewFakeClient(),
+			&ScalerConfig{
+				TriggerMetadata:   testData.metadata,
+				AuthParams:        map[string]string{},
+				GlobalHTTPTimeout: 1000 * time.Millisecond,
+			},
+		)
+		metric := s.GetMetricSpecForScaling()
+
+		if metric[0].External.Metric.Name != testData.name {
+			t.Errorf("Expected '%s' as metric name and got '%s'", testData.name, metric[0].External.Metric.Name)
+		}
+	}
+}
+
+func createPodlist(count int) *corev1.PodList {
+	list := &corev1.PodList{}
+	for i := 0; i < count; i++ {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        fmt.Sprintf("demo-pod-v%d", i),
+				Namespace:   "default",
+				Annotations: map[string]string{},
+				Labels: map[string]string{
+					"app": "demo",
+				},
+			},
+		}
+		list.Items = append(list.Items, *pod)
+	}
+	return list
 }

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -363,7 +363,7 @@ func (h *scaleHandler) buildScalers(withTriggers *kedav1alpha1.WithTriggers, pod
 			return []scalers.Scaler{}, err
 		}
 
-		scaler, err := buildScaler(trigger.Type, config)
+		scaler, err := buildScaler(h.client, trigger.Type, config)
 		if err != nil {
 			closeScalers(scalersRes)
 			h.recorder.Event(withTriggers, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, err.Error())
@@ -376,7 +376,7 @@ func (h *scaleHandler) buildScalers(withTriggers *kedav1alpha1.WithTriggers, pod
 	return scalersRes, nil
 }
 
-func buildScaler(triggerType string, config *scalers.ScalerConfig) (scalers.Scaler, error) {
+func buildScaler(client client.Client, triggerType string, config *scalers.ScalerConfig) (scalers.Scaler, error) {
 	// TRIGGERS-START
 	switch triggerType {
 	case "artemis-queue":
@@ -419,6 +419,8 @@ func buildScaler(triggerType string, config *scalers.ScalerConfig) (scalers.Scal
 		return scalers.NewInfluxDBScaler(config)
 	case "kafka":
 		return scalers.NewKafkaScaler(config)
+	case "kubernetes-workload":
+		return scalers.NewKubernetesWorkloadScaler(client, config)
 	case "liiklus":
 		return scalers.NewLiiklusScaler(config)
 	case "memory":

--- a/tests/scalers/kubernetes-workload.test.ts
+++ b/tests/scalers/kubernetes-workload.test.ts
@@ -27,11 +27,11 @@ test.before(t => {
 	)
 })
 
-test.serial('Deployment should have 1 replicas on start', t => {
+test.serial('Deployment should have 0 replicas on start', t => {
   const replicaCount = sh.exec(
     `kubectl get deployment.apps/sut-deployment --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
   ).stdout
-  t.is(replicaCount, '1', 'replica count should start out as 1')
+  t.is(replicaCount, '0', 'replica count should start out as 0')
 })
 
 test.serial(`Deployment should scale to fit the amount of pods which match the selector`, async t => {
@@ -52,9 +52,9 @@ test.serial(`Deployment should scale to fit the amount of pods which match the s
   t.true(await waitForDeploymentReplicaCount(5, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 5 after 60 seconds')
 
   sh.exec(
-    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=1`
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=0`
   )
-  t.true(await waitForDeploymentReplicaCount(1, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 1 after 60 seconds')
+  t.true(await waitForDeploymentReplicaCount(0, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 0 after 60 seconds')
 })
 
 test.after.always.cb('clean up workload test related deployments', t => {
@@ -78,7 +78,7 @@ metadata:
   labels:
     deploy: workload-test
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       pod: workload-test
@@ -98,7 +98,7 @@ metadata:
   labels:
     deploy: workload-sut
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       pod: workload-sut
@@ -120,7 +120,7 @@ spec:
     name: sut-deployment
   pollingInterval: 5
   cooldownPeriod: 5
-  minReplicaCount: 1
+  minReplicaCount: 0
   maxReplicaCount: 10
   advanced:
     horizontalPodAutoscalerConfig:

--- a/tests/scalers/kubernetes-workload.test.ts
+++ b/tests/scalers/kubernetes-workload.test.ts
@@ -40,17 +40,17 @@ test.serial(`Deployment should scale to fit the amount of pods which match the s
     `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=5`
   )
   t.true(await waitForDeploymentReplicaCount(5, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 5 after 60 seconds')
-  
+
   sh.exec(
     `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=10`
   )
   t.true(await waitForDeploymentReplicaCount(10, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 10 after 60 seconds')
-  
+
   sh.exec(
     `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=5`
   )
   t.true(await waitForDeploymentReplicaCount(5, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 5 after 60 seconds')
-  
+
   sh.exec(
     `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=1`
   )
@@ -59,7 +59,7 @@ test.serial(`Deployment should scale to fit the amount of pods which match the s
 
 test.after.always.cb('clean up workload test related deployments', t => {
   const resources = [
-    'scaledobject.keda.sh/sut-scaledobject',    
+    'scaledobject.keda.sh/sut-scaledobject',
     'deployment.apps/sut-deployment',
     'deployment.apps/monitored-deployment',
   ]
@@ -67,7 +67,7 @@ test.after.always.cb('clean up workload test related deployments', t => {
   for (const resource of resources) {
     sh.exec(`kubectl delete ${resource} --namespace ${testNamespace}`)
   }
-  sh.exec(`kubectl delete namespace ${testNamespace}`)  
+  sh.exec(`kubectl delete namespace ${testNamespace}`)
   t.end()
 })
 
@@ -122,14 +122,14 @@ spec:
   cooldownPeriod: 5
   minReplicaCount: 1
   maxReplicaCount: 10
-  advanced:                        
-    horizontalPodAutoscalerConfig: 
-      behavior:                    
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
         scaleDown:
           stabilizationWindowSeconds: 15
   triggers:
   - type: kubernetes-workload
-    metadata:      
+    metadata:
       podSelector: 'pod=workload-test'
       namespace: ${testNamespace}
       value: '1'`

--- a/tests/scalers/kubernetes-workload.test.ts
+++ b/tests/scalers/kubernetes-workload.test.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs'
+import * as sh from 'shelljs'
+import * as tmp from 'tmp'
+import test from 'ava'
+import {waitForDeploymentReplicaCount} from "./helpers";
+
+const testNamespace = 'kubernetes-workload-test'
+const monitoredDeploymentFile = tmp.fileSync()
+const sutDeploymentFile = tmp.fileSync()
+
+test.before(t => {
+  sh.config.silent = true
+	sh.exec(`kubectl create namespace ${testNamespace}`)
+
+  fs.writeFileSync(monitoredDeploymentFile.name, monitoredDeploymentYaml)
+	t.is(
+		0,
+		sh.exec(`kubectl apply -f ${monitoredDeploymentFile.name} --namespace ${testNamespace}`).code,
+		'Deploying monitored deployment should work.'
+	)
+
+  fs.writeFileSync(sutDeploymentFile.name, sutDeploymentYaml)
+	t.is(
+		0,
+		sh.exec(`kubectl apply -f ${sutDeploymentFile.name} --namespace ${testNamespace}`).code,
+		'Deploying monitored deployment should work.'
+	)
+})
+
+test.serial('Deployment should have 1 replicas on start', t => {
+  const replicaCount = sh.exec(
+    `kubectl get deployment.apps/sut-deployment --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+  ).stdout
+  t.is(replicaCount, '1', 'replica count should start out as 1')
+})
+
+test.serial(`Deployment should scale to fit the amount of pods which match the selector`, async t => {
+
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=5`
+  )
+  t.true(await waitForDeploymentReplicaCount(5, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 5 after 60 seconds')
+  
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=10`
+  )
+  t.true(await waitForDeploymentReplicaCount(10, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 10 after 60 seconds')
+  
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=5`
+  )
+  t.true(await waitForDeploymentReplicaCount(5, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 5 after 60 seconds')
+  
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=1`
+  )
+  t.true(await waitForDeploymentReplicaCount(1, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 1 after 60 seconds')
+})
+
+test.after.always.cb('clean up workload test related deployments', t => {
+  const resources = [
+    'scaledobject.keda.sh/sut-scaledobject',    
+    'deployment.apps/sut-deployment',
+    'deployment.apps/monitored-deployment',
+  ]
+
+  for (const resource of resources) {
+    sh.exec(`kubectl delete ${resource} --namespace ${testNamespace}`)
+  }
+  sh.exec(`kubectl delete namespace ${testNamespace}`)  
+  t.end()
+})
+
+const monitoredDeploymentYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitored-deployment
+  labels:
+    deploy: workload-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      pod: workload-test
+  template:
+    metadata:
+      labels:
+        pod: workload-test
+    spec:
+      containers:
+        - name: nginx
+          image: 'nginx'`
+
+const sutDeploymentYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sut-deployment
+  labels:
+    deploy: workload-sut
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      pod: workload-sut
+  template:
+    metadata:
+      labels:
+        pod: workload-sut
+    spec:
+      containers:
+        - name: nginx
+          image: 'nginx'
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: sut-scaledobject
+spec:
+  scaleTargetRef:
+    name: sut-deployment
+  pollingInterval: 5
+  cooldownPeriod: 5
+  minReplicaCount: 1
+  maxReplicaCount: 10
+  advanced:                        
+    horizontalPodAutoscalerConfig: 
+      behavior:                    
+        scaleDown:
+          stabilizationWindowSeconds: 15
+  triggers:
+  - type: kubernetes-workload
+    metadata:      
+      podSelector: 'pod=workload-test'
+      namespace: ${testNamespace}
+      value: '1'`

--- a/tests/scalers/kubernetes-workload.test.ts
+++ b/tests/scalers/kubernetes-workload.test.ts
@@ -131,5 +131,4 @@ spec:
   - type: kubernetes-workload
     metadata:
       podSelector: 'pod=workload-test'
-      namespace: ${testNamespace}
       value: '1'`


### PR DESCRIPTION
Add a new scaler based on the amount of pods which match the selectors (allowing also to specify a specific namespace or all)

With this scaler, you can scale a workload according to another relater workload inside the cluster:
> For example - Workload A processes a queue and interacts with workload B. Workload A can autoscale based on queue depth and workload B on CPU. But in some scenarios, you want to add 1 instance for workload B for every 4 instances of workload A


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* https://github.com/kedacore/keda-docs/pull/501
- [x] Changelog has been updated 

Relates to #1735