### PR TITLE
Fix issue of ScaledJob scaling and introduce MultiScalersOption

### DIFF
--- a/api/v1alpha1/scaledjob_types.go
+++ b/api/v1alpha1/scaledjob_types.go
@@ -71,6 +71,8 @@ type ScalingStrategy struct {
 	CustomScalingRunningJobPercentage string `json:"customScalingRunningJobPercentage,omitempty"`
 	// +optional
 	PendingPodConditions []string `json:"pendingPodConditions,omitempty"`
+	// +optional
+	MultipleScalersOption string `json:"multipleScalersOption,omitempty"`
 }
 
 func init() {

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -41,6 +41,12 @@ type scaleHandler struct {
 	recorder          record.EventRecorder
 }
 
+type scalerMetrics struct {
+	queueLength int64
+	maxValue    int64
+	isActive    bool
+}
+
 // NewScaleHandler creates a ScaleHandler object
 func NewScaleHandler(client client.Client, scaleClient scale.ScalesGetter, reconcilerScheme *runtime.Scheme, globalHTTPTimeout time.Duration, recorder record.EventRecorder) ScaleHandler {
 	return &scaleHandler{
@@ -250,13 +256,68 @@ func (h *scaleHandler) isScaledObjectActive(ctx context.Context, scalers []scale
 
 func (h *scaleHandler) isScaledJobActive(ctx context.Context, scalers []scalers.Scaler, scaledJob *kedav1alpha1.ScaledJob) (bool, int64, int64) {
 	var queueLength int64
-	var targetAverageValue int64
 	var maxValue int64
 	isActive := false
+
+	scalersMetrics := h.getScalersMetrics(ctx, scalers, scaledJob)
+	switch scaledJob.Spec.ScalingStrategy.MultipleScalersOption {
+	case "min":
+		for _, metrics := range scalersMetrics {
+			if (queueLength == 0 || metrics.queueLength < queueLength) && metrics.isActive {
+				queueLength = metrics.queueLength
+				maxValue = metrics.maxValue
+				isActive = metrics.isActive
+			}
+		}
+	case "avg":
+		queueLengthSum := int64(0)
+		maxValueSum := int64(0)
+		length := 0
+		for _, metrics := range scalersMetrics {
+			if metrics.isActive {
+				queueLengthSum += metrics.queueLength
+				maxValueSum += metrics.maxValue
+				isActive = metrics.isActive
+				length++
+			}
+		}
+		if length != 0 {
+			queueLength = divideWithCeil(queueLengthSum, int64(length))
+			maxValue = divideWithCeil(maxValueSum, int64(length))
+		}
+	case "sum":
+		for _, metrics := range scalersMetrics {
+			if metrics.isActive {
+				queueLength += metrics.queueLength
+				maxValue += metrics.maxValue
+				isActive = metrics.isActive
+			}
+		}
+	default: // max
+		for _, metrics := range scalersMetrics {
+			if metrics.queueLength > queueLength && metrics.isActive {
+				queueLength = metrics.queueLength
+				maxValue = metrics.maxValue
+				isActive = metrics.isActive
+			}
+		}
+	}
+	maxValue = min(scaledJob.MaxReplicaCount(), maxValue)
+	h.logger.Info("Scaler maxValue", "maxValue", maxValue)
+	return isActive, queueLength, maxValue
+}
+
+func (h *scaleHandler) getScalersMetrics(ctx context.Context, scalers []scalers.Scaler, scaledJob *kedav1alpha1.ScaledJob) []scalerMetrics {
+	scalersMetrics := []scalerMetrics{}
 
 	// TODO refactor this, do chores, reduce the verbosity ie: V(1) and frequency of logs
 	// move relevant funcs getTargetAverageValue(), min() and divideWithCeil() out of scaler_handler.go
 	for _, scaler := range scalers {
+		var queueLength int64
+		var targetAverageValue int64
+		isActive := false
+		maxValue := int64(0)
+
 		scalerLogger := h.logger.WithValues("Scaler", scaler)
 
 		metricSpecs := scaler.GetMetricSpecForScaling()
@@ -296,12 +357,17 @@ func (h *scaleHandler) isScaledJobActive(ctx context.Context, scalers []scalers.
 			isActive = true
 			scalerLogger.Info("Scaler is active")
 		}
+
+		if targetAverageValue != 0 {
+			maxValue = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
+		}
+		scalersMetrics = append(scalersMetrics, scalerMetrics{
+			queueLength: queueLength,
+			maxValue:    maxValue,
+			isActive:    isActive,
+		})
 	}
-	if targetAverageValue != 0 {
-		maxValue = min(scaledJob.MaxReplicaCount(), divideWithCeil(queueLength, targetAverageValue))
-	}
-	h.logger.Info("Scaler maxValue", "maxValue", maxValue)
-	return isActive, queueLength, maxValue
+	return scalersMetrics
 }
 
 func getTargetAverageValue(metricSpecs []v2beta2.MetricSpec) int64 {


### PR DESCRIPTION
This PR fix issue of multi scalers on Scaled Job. And introduce a new option. 
The current login assume only one scaler is active and available. 
The most of the cases, it is ok for that. That is why we don't get any issues about it. 

However @zroubalik  pointed out this issue, I come up with the fix and do some refactoring to make it clear. 

I'm not writing documentation yet, before that, I'd like to confirm this logic if fine for you guys. 
Once It looks, ok, I'll go ahead full testing and write the documentation and make this PR as not draft. 

# Spec

Introduce a new option `MultipleScalersOption` on ScaledJob.  

```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledJob
metadata:
  name: {scaled-job-name}
spec:
  jobTargetRef:
         :
  scalingStrategy:
    strategy: "custom"                        # Optional. Default: default. Which Scaling Strategy to use. 
    customScalingQueueLengthDeduction: 1      # Optional. A parameter to optimize custom ScalingStrategy.
    customScalingRunningJobPercentage: "0.5"  # Optional. A parameter to optimize custom ScalingStrategy.
    pendingPodConditions:                     # Optional. A parameter to calculate pending job count per the specified pod conditions
      - "Ready"
      - "PodScheduled"
      - "AnyOtherCustomPodCondition"
    MultipleScalersOption: "max" # Optional. Default: max. If multiple scaler is exists, how to calculate the queueLength and maxValue (that is the expected number of pods that will be created)
  triggers:
```

## Available Options
The option is how keda calculate `queueLength` and `maxValue` that is the number of pod will be created. 

`max` : default, pick a scaler that has the max number of `queueLength`. 
`min`: pick a scaler that has the min number of `queueLength`.
`avg`: sum up all the active scalers metrics and devided by the number of the active scalers.
`sum`: sum up all the active scalers metrics 

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes #
