### PR TITLE
Add Bearer Auth for Metrics API scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### New
 
-- TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
+- Add JWT auth for Metrics API scaler ([#2028](https://github.com/kedacore/keda/pull/2028))
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@
 
 ### New
 
-- Add JWT auth for Metrics API scaler ([#2028](https://github.com/kedacore/keda/pull/2028))
+- TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 
 ### Improvements
 
-- TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
+- Add Bearer auth for Metrics API scaler ([#2028](https://github.com/kedacore/keda/pull/2028))
 
 ### Breaking Changes
 

--- a/pkg/scalers/authentication/authentication_types.go
+++ b/pkg/scalers/authentication/authentication_types.go
@@ -12,6 +12,4 @@ const (
 	TLSAuthType Type = "tls"
 	// BearerAuthType is a auth type using a bearer token
 	BearerAuthType Type = "bearer"
-	// JwtAuthType is a auth type using a jwt token
-	JwtAuthType Type = "jwt"
 )

--- a/pkg/scalers/authentication/authentication_types.go
+++ b/pkg/scalers/authentication/authentication_types.go
@@ -12,4 +12,6 @@ const (
 	TLSAuthType Type = "tls"
 	// BearerAuthType is a auth type using a bearer token
 	BearerAuthType Type = "bearer"
+	// JwtAuthType is a auth type using a jwt token
+	JwtAuthType Type = "jwt"
 )

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -52,9 +52,9 @@ type metricsAPIScalerMetadata struct {
 	key       string
 	ca        string
 
-	// jwt
-	enableJwtAuth bool
-	jwtToken      string
+	// bearer
+	enableBearerAuth bool
+	bearerToken      string
 }
 
 const (
@@ -163,13 +163,13 @@ func parseMetricsAPIMetadata(config *ScalerConfig) (*metricsAPIScalerMetadata, e
 
 		meta.key = config.AuthParams["key"]
 		meta.enableTLS = true
-	case authentication.JwtAuthType:
-		if len(config.AuthParams["jwtToken"]) == 0 {
-			return nil, errors.New("no jwtToken provided")
+	case authentication.BearerAuthType:
+		if len(config.AuthParams["token"]) == 0 {
+			return nil, errors.New("no token provided")
 		}
 
-		meta.jwtToken = config.AuthParams["jwtToken"]
-		meta.enableJwtAuth = true
+		meta.bearerToken = config.AuthParams["token"]
+		meta.enableBearerAuth = true
 	default:
 		return nil, fmt.Errorf("err incorrect value for authMode is given: %s", authMode)
 	}
@@ -317,12 +317,12 @@ func getMetricAPIServerRequest(meta *metricsAPIScalerMetadata) (*http.Request, e
 		}
 
 		req.SetBasicAuth(meta.username, meta.password)
-	case meta.enableJwtAuth:
+	case meta.enableBearerAuth:
 		req, err = http.NewRequest("GET", meta.url, nil)
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Add("Authorization", meta.jwtToken)
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", meta.bearerToken))
 	default:
 		req, err = http.NewRequest("GET", meta.url, nil)
 		if err != nil {

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -53,6 +53,10 @@ var testMetricsAPIAuthMetadata = []metricAPIAuthMetadataTestData{
 	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "authMode": "basic"}, map[string]string{"username": "user", "password": "pass"}, false},
 	// fail basicAuth with no username
 	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "authMode": "basic"}, map[string]string{}, true},
+	// success jwtAuth default
+	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "authMode": "jwt"}, map[string]string{"jwtToken": "token"}, false},
+	// fail jwtAuth with no api key
+	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "authMode": "jwt"}, map[string]string{}, true},
 }
 
 func TestParseMetricsAPIMetadata(t *testing.T) {
@@ -121,7 +125,8 @@ func TestMetricAPIScalerAuthParams(t *testing.T) {
 		if err == nil {
 			if (meta.enableAPIKeyAuth && !(testData.metadata["authMode"] == "apiKey")) ||
 				(meta.enableBaseAuth && !(testData.metadata["authMode"] == "basic")) ||
-				(meta.enableTLS && !(testData.metadata["authMode"] == "tls")) {
+				(meta.enableTLS && !(testData.metadata["authMode"] == "tls")) ||
+				(meta.enableJwtAuth && !(testData.metadata["authMode"] == "jwt")) {
 				t.Error("wrong auth mode detected")
 			}
 		}


### PR DESCRIPTION
Adds an authorization method named `bearer` for Metrics API scaler

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* https://github.com/kedacore/keda-docs/pull/513
- [x] Changelog has been updated

Relates to https://github.com/kedacore/keda/issues/1081
