### PR TITLE
use Patch to set FallbackCondition on ScaledObject.Status

### DIFF
--- a/pkg/provider/fallback.go
+++ b/pkg/provider/fallback.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
-	"github.com/kedacore/keda/v2/pkg/scalers"
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/api/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/scalers"
 )
 
 func isFallbackEnabled(scaledObject *kedav1alpha1.ScaledObject, metricSpec v2beta2.MetricSpec) bool {
@@ -18,7 +20,9 @@ func isFallbackEnabled(scaledObject *kedav1alpha1.ScaledObject, metricSpec v2bet
 }
 
 func (p *KedaProvider) getMetricsWithFallback(scaler scalers.Scaler, metricName string, metricSelector labels.Selector, scaledObject *kedav1alpha1.ScaledObject, metricSpec v2beta2.MetricSpec) ([]external_metrics.ExternalMetricValue, error) {
-	initHealthStatus(scaledObject)
+	status := scaledObject.Status.DeepCopy()
+
+	initHealthStatus(status)
 	metrics, err := scaler.GetMetrics(context.TODO(), metricName, metricSelector)
 	healthStatus := getHealthStatus(scaledObject, metricName)
 
@@ -26,17 +30,17 @@ func (p *KedaProvider) getMetricsWithFallback(scaler scalers.Scaler, metricName 
 		zero := int32(0)
 		healthStatus.NumberOfFailures = &zero
 		healthStatus.Status = kedav1alpha1.HealthStatusHappy
-		scaledObject.Status.Health[metricName] = *healthStatus
+		status.Health[metricName] = *healthStatus
 
-		p.updateStatus(scaledObject, metricSpec)
+		p.updateStatus(scaledObject, status, metricSpec)
 		return metrics, nil
 	}
 
 	healthStatus.Status = kedav1alpha1.HealthStatusFailing
 	*healthStatus.NumberOfFailures++
-	scaledObject.Status.Health[metricName] = *healthStatus
+	status.Health[metricName] = *healthStatus
 
-	p.updateStatus(scaledObject, metricSpec)
+	p.updateStatus(scaledObject, status, metricSpec)
 
 	switch {
 	case !isFallbackEnabled(scaledObject, metricSpec):
@@ -84,16 +88,19 @@ func doFallback(scaledObject *kedav1alpha1.ScaledObject, metricSpec v2beta2.Metr
 	return fallbackMetrics
 }
 
-func (p *KedaProvider) updateStatus(scaledObject *kedav1alpha1.ScaledObject, metricSpec v2beta2.MetricSpec) {
+func (p *KedaProvider) updateStatus(scaledObject *kedav1alpha1.ScaledObject, status *kedav1alpha1.ScaledObjectStatus, metricSpec v2beta2.MetricSpec) {
+	patch := runtimeclient.MergeFrom(scaledObject.DeepCopy())
+
 	if fallbackExistsInScaledObject(scaledObject, metricSpec) {
-		scaledObject.Status.Conditions.SetFallbackCondition(metav1.ConditionTrue, "FallbackExists", "At least one trigger is falling back on this scaled object")
+		status.Conditions.SetFallbackCondition(metav1.ConditionTrue, "FallbackExists", "At least one trigger is falling back on this scaled object")
 	} else {
-		scaledObject.Status.Conditions.SetFallbackCondition(metav1.ConditionFalse, "NoFallbackFound", "No fallbacks are active on this scaled object")
+		status.Conditions.SetFallbackCondition(metav1.ConditionFalse, "NoFallbackFound", "No fallbacks are active on this scaled object")
 	}
 
-	err := p.client.Status().Update(context.TODO(), scaledObject)
+	scaledObject.Status = *status
+	err := p.client.Status().Patch(context.TODO(), scaledObject, patch)
 	if err != nil {
-		logger.Error(err, "Error updating ScaledObject status", "Error")
+		logger.Error(err, "Failed to patch ScaledObjects Status")
 	}
 }
 
@@ -112,9 +119,9 @@ func getHealthStatus(scaledObject *kedav1alpha1.ScaledObject, metricName string)
 	return &healthStatus
 }
 
-func initHealthStatus(scaledObject *kedav1alpha1.ScaledObject) {
+func initHealthStatus(status *kedav1alpha1.ScaledObjectStatus) {
 	// Init health status if missing
-	if scaledObject.Status.Health == nil {
-		scaledObject.Status.Health = make(map[string]kedav1alpha1.HealthStatus)
+	if status.Health == nil {
+		status.Health = make(map[string]kedav1alpha1.HealthStatus)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The recent Fallback feature #1910 has brought a problem in ScaledObject Status update: `the object has been modified; please apply your changes to the latest version and try again`.
Using `Patch()` to mitigate this problem.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Changelog has been updated

Fixes #2035
