### PR TITLE
Update cron scaler to parse the cron with parser instead of searching for '-'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Improvements
 
 - Improve validation in Cron scaler in case start & end input is same.([#2032](https://github.com/kedacore/keda/pull/2032))
+- Improve the cron validation in Cron Scaler ([#2038](https://github.com/kedacore/keda/pull/2038))
 
 ### Breaking Changes
 

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -73,17 +73,20 @@ func parseCronMetadata(config *ScalerConfig) (*cronMetadata, error) {
 	} else {
 		return nil, fmt.Errorf("no timezone specified. %s", config.TriggerMetadata)
 	}
+	parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 	if val, ok := config.TriggerMetadata["start"]; ok && val != "" {
-		if strings.Contains(val, "-") {
-			return nil, fmt.Errorf("error parsing start schedule. %s: range or hyphenated inputs are not allowed", config.TriggerMetadata)
+		_, err := parser.Parse(val)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing start schedule: %s", err)
 		}
 		meta.start = val
 	} else {
 		return nil, fmt.Errorf("no start schedule specified. %s", config.TriggerMetadata)
 	}
 	if val, ok := config.TriggerMetadata["end"]; ok && val != "" {
-		if strings.Contains(val, "-") {
-			return nil, fmt.Errorf("error parsing end schedule. %s: range or hyphenated inputs are not allowed", config.TriggerMetadata)
+		_, err := parser.Parse(val)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing end schedule: %s", err)
 		}
 		meta.end = val
 	} else {

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -73,7 +73,7 @@ func parseCronMetadata(config *ScalerConfig) (*cronMetadata, error) {
 	} else {
 		return nil, fmt.Errorf("no timezone specified. %s", config.TriggerMetadata)
 	}
-	parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 	if val, ok := config.TriggerMetadata["start"]; ok && val != "" {
 		_, err := parser.Parse(val)
 		if err != nil {

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -26,13 +26,22 @@ var validCronMetadata = map[string]string{
 	"desiredReplicas": "10",
 }
 
+// A complete valid metadata example which is enabled every even hours
+var validCronMetadata2 = map[string]string{
+	"timezone":        "Etc/UTC",
+	"start":           "0 */2 * * *",    //Every 2 hours (even)
+	"end":             "0 1-23/2 * * *", //Every 2 hours starting at 1 (odd)
+	"desiredReplicas": "10",
+}
+
 var testCronMetadata = []parseCronMetadataTestData{
 	{map[string]string{}, true},
 	{validCronMetadata, false},
+	{validCronMetadata2, false},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45 * * * *"}, true},
 	{map[string]string{"start": "30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
-	{map[string]string{"timezone": "Asia/Kolkata", "start": "30-33 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
-	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45-50 * * * *", "desiredReplicas": "10"}, true},
+	{map[string]string{"timezone": "Asia/Kolkata", "start": "30-33 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, false},
+	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45-50 * * * *", "desiredReplicas": "10"}, false},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "-30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "-50 * * * *", "desiredReplicas": "10"}, true},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "50 * * -3 *", "desiredReplicas": "10"}, true},
@@ -41,10 +50,12 @@ var testCronMetadata = []parseCronMetadataTestData{
 
 var cronMetricIdentifiers = []cronMetricIdentifier{
 	{&testCronMetadata[1], "cron-Etc-UTC-00xxThu-5923xxThu"},
+	{&testCronMetadata[2], "cron-Etc-UTC-0xSl2xxx-01-23Sl2xxx"},
 }
 
-var tz, _ = time.LoadLocation(validCronMetadata["timezone"])
+var tz, _ = time.LoadLocation(validCronMetadata2["timezone"])
 var currentDay = time.Now().In(tz).Weekday().String()
+var currentHour = time.Now().In(tz).Hour()
 
 func TestCronParseMetadata(t *testing.T) {
 	for _, testData := range testCronMetadata {
@@ -68,11 +79,32 @@ func TestIsActive(t *testing.T) {
 	}
 }
 
+func TestIsActiveRange(t *testing.T) {
+	scaler, _ := NewCronScaler(&ScalerConfig{TriggerMetadata: validCronMetadata2})
+	isActive, _ := scaler.IsActive(context.TODO())
+	if currentHour%2 == 0 {
+		assert.Equal(t, isActive, true)
+	} else {
+		assert.Equal(t, isActive, false)
+	}
+}
+
 func TestGetMetrics(t *testing.T) {
 	scaler, _ := NewCronScaler(&ScalerConfig{TriggerMetadata: validCronMetadata})
 	metrics, _ := scaler.GetMetrics(context.TODO(), "ReplicaCount", nil)
 	assert.Equal(t, metrics[0].MetricName, "ReplicaCount")
 	if currentDay == "Thursday" {
+		assert.Equal(t, metrics[0].Value.Value(), int64(10))
+	} else {
+		assert.Equal(t, metrics[0].Value.Value(), int64(1))
+	}
+}
+
+func TestGetMetricsRange(t *testing.T) {
+	scaler, _ := NewCronScaler(&ScalerConfig{TriggerMetadata: validCronMetadata2})
+	metrics, _ := scaler.GetMetrics(context.TODO(), "ReplicaCount", nil)
+	assert.Equal(t, metrics[0].MetricName, "ReplicaCount")
+	if currentHour%2 == 0 {
 		assert.Equal(t, metrics[0].Value.Value(), int64(10))
 	} else {
 		assert.Equal(t, metrics[0].Value.Value(), int64(1))

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -29,8 +29,8 @@ var validCronMetadata = map[string]string{
 // A complete valid metadata example which is enabled every even hours
 var validCronMetadata2 = map[string]string{
 	"timezone":        "Etc/UTC",
-	"start":           "0 */2 * * *",    //Every 2 hours (even)
-	"end":             "0 1-23/2 * * *", //Every 2 hours starting at 1 (odd)
+	"start":           "0 */2 * * *",    // Every 2 hours (even)
+	"end":             "0 1-23/2 * * *", // Every 2 hours starting at 1 (odd)
 	"desiredReplicas": "10",
 }
 


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

This PR changes the method to validate the cron. Now the package parser is used to detect invalid expressions instead a custom method.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* https://github.com/kedacore/keda-docs/pull/514
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2034
