### PR TITLE
Anonymize the host in case of HTTP failure (RabbitMQ Scaler)

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 
 	"github.com/streadway/amqp"
@@ -302,7 +303,7 @@ func (s *rabbitMQScaler) Close() error {
 func (s *rabbitMQScaler) IsActive(ctx context.Context) (bool, error) {
 	messages, publishRate, err := s.getQueueStatus()
 	if err != nil {
-		return false, fmt.Errorf("error inspecting rabbitMQ: %s", err)
+		return false, s.anonimizeRabbitMQError(err)
 	}
 
 	if s.metadata.mode == rabbitModeQueueLength {
@@ -417,7 +418,7 @@ func (s *rabbitMQScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 func (s *rabbitMQScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	messages, publishRate, err := s.getQueueStatus()
 	if err != nil {
-		return []external_metrics.ExternalMetricValue{}, fmt.Errorf("error inspecting rabbitMQ: %s", err)
+		return []external_metrics.ExternalMetricValue{}, s.anonimizeRabbitMQError(err)
 	}
 
 	var metricValue resource.Quantity
@@ -493,4 +494,11 @@ func getMaximum(q []queueInfo) (int, float64) {
 		}
 	}
 	return maxMessages, maxRate
+}
+
+// Mask host for log porpouses
+func (s *rabbitMQScaler) anonimizeRabbitMQError(err error) error {
+	errorMessage := fmt.Sprintf("error inspecting rabbitMQ: %s", err)
+	m1 := regexp.MustCompile(`([^ \/:]+):([^\/:]+)\@`)
+	return fmt.Errorf(m1.ReplaceAllString(errorMessage, "user:password@"))
 }

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -386,5 +388,38 @@ func TestRabbitMQGetMetricSpecForScaling(t *testing.T) {
 		if metricName != testData.name {
 			t.Error("Wrong External metric source name:", metricName, "wanted:", testData.name)
 		}
+	}
+}
+
+type rabbitMQErrorTestData struct {
+	err     error
+	message string
+}
+
+var anonimizeRabbitMQErrorTestData = []rabbitMQErrorTestData{
+	{fmt.Errorf("https://user1:password1@domain.com"), "error inspecting rabbitMQ: https://user:password@domain.com"},
+	{fmt.Errorf("https://fdasr345_-:password1@domain.com"), "error inspecting rabbitMQ: https://user:password@domain.com"},
+	{fmt.Errorf("https://user1:fdasr345_-@domain.com"), "error inspecting rabbitMQ: https://user:password@domain.com"},
+	{fmt.Errorf("https://fdakls_dsa:password1@domain.com"), "error inspecting rabbitMQ: https://user:password@domain.com"},
+	{fmt.Errorf("fdasr345_-:password1@domain.com"), "error inspecting rabbitMQ: user:password@domain.com"},
+	{fmt.Errorf("this user1:password1@domain.com fails"), "error inspecting rabbitMQ: this user:password@domain.com fails"},
+	{fmt.Errorf("this https://user1:password1@domain.com fails also"), "error inspecting rabbitMQ: this https://user:password@domain.com fails also"},
+}
+
+func TestRabbitMQAnonimizeRabbitMQError(t *testing.T) {
+	metadata := map[string]string{
+		"queueName":   "evaluate_trials",
+		"hostFromEnv": host,
+		"protocol":    "http",
+	}
+	meta, _ := parseRabbitMQMetadata(&ScalerConfig{ResolvedEnv: sampleRabbitMqResolvedEnv, TriggerMetadata: metadata, AuthParams: nil})
+
+	s := &rabbitMQScaler{
+		metadata:   meta,
+		httpClient: nil,
+	}
+	for _, testData := range anonimizeRabbitMQErrorTestData {
+		err := s.anonimizeRabbitMQError(testData.err)
+		assert.Equal(t, fmt.Sprint(err), testData.message)
 	}
 }


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
This PR replaces the user and the password before log the host in case of failure (RabbitMQ Scaler) in KEDA metrics server

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes #
