### PR TITLE
Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,5 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/kedacore/keda
-  newName: ghcr.io/kedacore/keda
+  newName: docker.io/jorturfer/keda
   newTag: main

--- a/config/metrics-server/kustomization.yaml
+++ b/config/metrics-server/kustomization.yaml
@@ -10,5 +10,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ghcr.io/kedacore/keda-metrics-apiserver
-  newName: ghcr.io/kedacore/keda-metrics-apiserver
+  newName: docker.io/jorturfer/keda-metrics-apiserver
   newTag: main

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -378,9 +378,9 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 	parsedURL.Path = ""
 	var getQueueInfoManagementURI string
 	if s.metadata.useRegex {
-		getQueueInfoManagementURI = fmt.Sprintf("%s/%s%s", parsedURL.String(), "api/queues?use_regex=true&pagination=false&name=", s.metadata.queueName)
+		getQueueInfoManagementURI = fmt.Sprintf("%s/%s%s", parsedURL.String(), "api/queues?page=1&use_regex=true&pagination=false&name=", url.QueryEscape(s.metadata.queueName))
 	} else {
-		getQueueInfoManagementURI = fmt.Sprintf("%s/%s%s/%s", parsedURL.String(), "api/queues", vhost, s.metadata.queueName)
+		getQueueInfoManagementURI = fmt.Sprintf("%s/%s%s/%s", parsedURL.String(), "api/queues", url.QueryEscape(vhost), url.QueryEscape(s.metadata.queueName))
 	}
 
 	var info queueInfo

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -368,7 +368,7 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 
 	// Override vhost if requested.
 	if s.metadata.vhostName != nil {
-		vhost = "/" + *s.metadata.vhostName
+		vhost = "/" + url.QueryEscape(*s.metadata.vhostName)
 	}
 
 	if vhost == "" || vhost == "/" || vhost == "//" {
@@ -380,7 +380,7 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 	if s.metadata.useRegex {
 		getQueueInfoManagementURI = fmt.Sprintf("%s/%s%s", parsedURL.String(), "api/queues?page=1&use_regex=true&pagination=false&name=", url.QueryEscape(s.metadata.queueName))
 	} else {
-		getQueueInfoManagementURI = fmt.Sprintf("%s/%s%s/%s", parsedURL.String(), "api/queues", url.QueryEscape(vhost), url.QueryEscape(s.metadata.queueName))
+		getQueueInfoManagementURI = fmt.Sprintf("%s/%s%s/%s", parsedURL.String(), "api/queues", vhost, url.QueryEscape(s.metadata.queueName))
 	}
 
 	var info queueInfo

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -311,7 +311,7 @@ var testRegexQueueInfoTestData = []getQueueInfoTestData{
 func TestGetQueueInfoWithRegex(t *testing.T) {
 	for _, testData := range testRegexQueueInfoTestData {
 		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedPath := "/api/queues?use_regex=true&pagination=false&name=evaluate_trials"
+			expectedPath := "/api/queues?page=1&use_regex=true&pagination=false&name=%5Eevaluate_trials%24"
 			if r.RequestURI != expectedPath {
 				t.Error("Expect request path to =", expectedPath, "but it is", r.RequestURI)
 			}
@@ -326,7 +326,7 @@ func TestGetQueueInfoWithRegex(t *testing.T) {
 		resolvedEnv := map[string]string{host: fmt.Sprintf("%s%s", apiStub.URL, testData.vhostPath), "plainHost": apiStub.URL}
 
 		metadata := map[string]string{
-			"queueName":   "evaluate_trials",
+			"queueName":   "^evaluate_trials$",
 			"hostFromEnv": host,
 			"protocol":    "http",
 		}

--- a/tests/scalers/rabbitmq-helpers.ts
+++ b/tests/scalers/rabbitmq-helpers.ts
@@ -35,11 +35,14 @@ export class RabbitMQHelper {
         )
     }
 
-    static publishMessages(t, namespace: string, connectionString: string, messageCount: number) {
+    static publishMessages(t, namespace: string, connectionString: string, messageCount: number, queueName: string) {
         // publish messages
         const tmpFile = tmp.fileSync()
         fs.writeFileSync(tmpFile.name, publishYaml.replace('{{CONNECTION_STRING}}', connectionString)
-            .replace('{{MESSAGE_COUNT}}', messageCount.toString()))
+        .replace('{{MESSAGE_COUNT}}', messageCount.toString())
+        .replace('{{QUEUE_NAME}}',  queueName)
+        .replace('{{QUEUE_NAME}}',  queueName))
+
         t.is(
             0,
             sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${namespace}`).code,
@@ -52,15 +55,15 @@ export class RabbitMQHelper {
 const publishYaml = `apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rabbitmq-publish
+  name: rabbitmq-publish-{{QUEUE_NAME}}
 spec:
   template:
     spec:
       containers:
       - name: rabbitmq-client
-        image: jeffhollan/rabbitmq-client:dev
+        image: jorturfer/tests-rabbitmq
         imagePullPolicy: Always
-        command: ["send",  "{{CONNECTION_STRING}}", "{{MESSAGE_COUNT}}"]
+        command: ["send",  "{{CONNECTION_STRING}}", "{{MESSAGE_COUNT}}", "{{QUEUE_NAME}}"]
       restartPolicy: Never`
 
 const rabbitmqDeployYaml = `apiVersion: v1

--- a/tests/scalers/rabbitmq-queue-amqp.test.ts
+++ b/tests/scalers/rabbitmq-queue-amqp.test.ts
@@ -31,7 +31,7 @@ test.serial('Deployment should have 0 replicas on start', t => {
 })
 
 test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, async t => {
-  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount)
+  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount, queueName)
 
   // with messages published, the consumer deployment should start receiving the messages
   t.true(await waitForDeploymentReplicaCount(4, 'test-deployment', testNamespace, 20, 5000), 'Replica count should be 4 after 10 seconds')
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq-consumer
-        image: jeffhollan/rabbitmq-client:dev
+        image: jorturfer/tests-rabbitmq
         imagePullPolicy: Always
         command:
           - receive

--- a/tests/scalers/rabbitmq-queue-http-regex.test.ts
+++ b/tests/scalers/rabbitmq-queue-http-regex.test.ts
@@ -109,7 +109,7 @@ spec:
   triggers:
   - type: rabbitmq
     metadata:
-      queueName: {{QUEUE_NAME}}
+      queueName: "^hell.{1}$"
       hostFromEnv: RabbitApiHost
       protocol: http
       useRegex: 'true'

--- a/tests/scalers/rabbitmq-queue-http-regex.test.ts
+++ b/tests/scalers/rabbitmq-queue-http-regex.test.ts
@@ -9,6 +9,8 @@ import {waitForDeploymentReplicaCount} from "./helpers";
 const testNamespace = 'rabbitmq-queue-http-regex-test'
 const rabbitmqNamespace = 'rabbitmq-http-regex-test'
 const queueName = 'hello'
+const dummyQueueName1 = 'hello-1'
+const dummyQueueName2 = 'hellohellohello'
 const username = "test-user"
 const password = "test-password"
 const vhost = "test-vh-regex"
@@ -20,7 +22,7 @@ test.before(t => {
 
   sh.config.silent = true
   // create deployment
-  const httpConnectionString = `http://${username}:${password}@rabbitmq.${rabbitmqNamespace}.svc.cluster.local/${vhost}`
+  const httpConnectionString = `http://${username}:${password}@rabbitmq.${rabbitmqNamespace}.svc.cluster.local`
 
   RabbitMQHelper.createDeployment(t, testNamespace, deployYaml, connectionString, httpConnectionString, queueName)
 })
@@ -33,7 +35,9 @@ test.serial('Deployment should have 0 replicas on start', t => {
 })
 
 test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, async t => {
-  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount)
+  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount, dummyQueueName1)
+  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount, dummyQueueName2)
+  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount, queueName)
 
   // with messages published, the consumer deployment should start receiving the messages
   t.true(await waitForDeploymentReplicaCount(4, 'test-deployment', testNamespace, 20, 5000), 'Replica count should be 4 after 10 seconds')
@@ -81,7 +85,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq-consumer
-        image: jeffhollan/rabbitmq-client:dev
+        image: jorturfer/tests-rabbitmq
         imagePullPolicy: Always
         command:
           - receive

--- a/tests/scalers/rabbitmq-queue-http.test.ts
+++ b/tests/scalers/rabbitmq-queue-http.test.ts
@@ -30,7 +30,7 @@ test.serial('Deployment should have 0 replicas on start', async t => {
 })
 
 test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, async t => {
-  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount)
+  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount, queueName)
 
   // with messages published, the consumer deployment should start receiving the messages
   t.true(await waitForDeploymentReplicaCount(4, 'test-deployment', testNamespace, 30, 5000))
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq-consumer
-        image: jeffhollan/rabbitmq-client:dev
+        image: jorturfer/tests-rabbitmq
         imagePullPolicy: Always
         command:
           - receive

--- a/tests/scalers/rabbitmq-queue-trigger-auth.test.ts
+++ b/tests/scalers/rabbitmq-queue-trigger-auth.test.ts
@@ -31,7 +31,7 @@ test.serial('Deployment should have 0 replicas on start', t => {
 })
 
 test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, t => {
-  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount)
+  RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount, queueName)
 
   // with messages published, the consumer deployment should start receiving the messages
   let replicaCount = '0'
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
       - name: rabbitmq-consumer
-        image: jeffhollan/rabbitmq-client:dev
+        image: jorturfer/tests-rabbitmq
         imagePullPolicy: Always
         command:
           - receive


### PR DESCRIPTION
This PR escapes the values introduced by the user before add them into a query string. These values are the `queueName` (main goal) and `vhostName`. This second one is because the virtual host can contain also escapable values: 
![image](https://user-images.githubusercontent.com/36899226/130688526-5ac6e2c8-d1a4-4942-95e8-d40b95f15ab0.png)

I update also the e2e test to ensure that it cover the regex use case

This PR is in WIP because I need to wait until this is merged https://github.com/kedacore/test-tools/pull/17

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated (not yet)

Fixes https://github.com/kedacore/keda/issues/2054
