### PR TITLE
Update Makefile to ensure that bash is used instead of sh or another

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ##################################################
 # Variables                                      #
 ##################################################
-SHELL 		   	= /bin/bash
+SHELL           = /bin/bash
 VERSION		   ?= main
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ##################################################
 # Variables                                      #
 ##################################################
+SHELL 		   = /bin/bash
 VERSION		   ?= main
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Variables                                      #
 ##################################################
 SHELL           = /bin/bash
-VERSION		   ?= main
+VERSION        ?= main
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ##################################################
 # Variables                                      #
 ##################################################
-SHELL 		   = /bin/bash
+SHELL 		   	= /bin/bash
 VERSION		   ?= main
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore


### PR DESCRIPTION
If you are using dev container to contribute to this repo, you could need run `make test` to ensure that all the tests working.
The default shell inside the container that is used with make is /bin/sh and it doesn't support `source`, so in order to maintain the same Makefile, the best approach could be specifying the `SHELL` variable to enforce the usage of bash.

This PR sets the variable inside the file

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated ---> is this needed in this case??
