### PR TITLE
Adds explicit the option of setting `KEDA_HTTP_DEFAULT_TIMEOUT`

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,6 +57,8 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: ""
+            - name: KEDA_HTTP_DEFAULT_TIMEOUT
+              value: ""
       terminationGracePeriodSeconds: 10
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: ""
+            - name: KEDA_HTTP_DEFAULT_TIMEOUT
+              value: ""
           args:
           - /usr/local/bin/keda-adapter
           - --secure-port=6443


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

As the same way as using helm, this PR adds the env `KEDA_HTTP_DEFAULT_TIMEOUT` to do explicit the option of setting it

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)* https://github.com/kedacore/charts/pull/181
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*

Fixes https://github.com/kedacore/charts/issues/180
