### PR TITLE
fix typo in isScalableCache

### DIFF
--- a/controllers/scaledobject_controller.go
+++ b/controllers/scaledobject_controller.go
@@ -64,8 +64,8 @@ var isScalableCache map[string]bool
 func init() {
 	// Prefill the cache with some known values for core resources in case of future parallelism to avoid stampeding herd on startup.
 	isScalableCache = map[string]bool{
-		"deployments.apps": true,
-		"statefusets.apps": true,
+		"deployments.apps":  true,
+		"statefulsets.apps": true,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

There was a typo in `isScalableCache`, StatefulSets weren't properly specified there, it is not a big deal, since this map is properly populated with first StatefulSet `/scale` call.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

