### PR TITLE
TriggerAuthentication/Vault: add support for vault namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add Bearer auth for Metrics API scaler ([#2028](https://github.com/kedacore/keda/pull/2028))
 - Anonymize the host in case of HTTP failure (RabbitMQ Scaler) ([#2041](https://github.com/kedacore/keda/pull/2041))
 - Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string (bug fix) ([#2055](https://github.com/kedacore/keda/pull/2055))
+- TriggerAuthentication/Vault: add support for Vault namespace (Vault Enterprise) ([#2085](https://github.com/kedacore/keda/pull/2085))
 
 ### Breaking Changes
 

--- a/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -137,6 +137,9 @@ type HashiCorpVault struct {
 	Secrets        []VaultSecret       `json:"secrets"`
 
 	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
+	// +optional
 	Credential *Credential `json:"credential,omitempty"`
 
 	// +optional

--- a/pkg/scaling/resolver/hashicorpvault_handler.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler.go
@@ -54,6 +54,10 @@ func (vh *HashicorpVaultHandler) Initialize(logger logr.Logger) error {
 		return err
 	}
 
+	if len(vh.vault.Namespace) > 0 {
+		client.SetNamespace(vh.vault.Namespace)
+	}
+
 	token, err := vh.token(client)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Nicolas Chapurlat <nc@coorganix.com>

Related to this issue: [#2084](https://github.com/kedacore/keda/issues/2084)
Related to this discussion: [#2080](https://github.com/kedacore/keda/discussions/2080)

### Changes

- Add an optional "namespace" in Keda TriggerAuthentication spec: `spec.hashiCorpVault.namespace`
- Optionally configure the Vault namespace in the Vault client
- **REMOVED FROM THIS PR**: Make sure the VAULT_NAMESPACE env var never takes precedence (Vault client default behaviour)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added **no test yet in vault section (I performed a local integration test I could provide)**
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*  => **not applicable**
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*  => **Done: [https://github.com/kedacore/keda-docs/pull/522](https://github.com/kedacore/keda-docs/pull/522)**
- [x] Changelog has been updated

Relates to https://github.com/kedacore/keda/issues/2084
