### PR TITLE
Add custom http timeout in RabbitMQ Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add Bearer auth for Metrics API scaler ([#2028](https://github.com/kedacore/keda/pull/2028))
 - Anonymize the host in case of HTTP failure (RabbitMQ Scaler) ([#2041](https://github.com/kedacore/keda/pull/2041))
 - Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string (bug fix) ([#2055](https://github.com/kedacore/keda/pull/2055))
+- Add custom http timeout in RabbitMQ Scaler ([#2086](https://github.com/kedacore/keda/pull/2086))
 
 ### Breaking Changes
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -69,7 +69,7 @@ type rabbitMQMetadata struct {
 	useRegex   bool          // specify if the queueName contains a rexeg
 	operation  string        // specify the operation to apply in case of multiples queues
 	metricName string        // custom metric name for trigger
-	timeout    time.Duration // custom http timeout for a specifyc trigger
+	timeout    time.Duration // custom http timeout for a specific trigger
 }
 
 type queueInfo struct {

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/streadway/amqp"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
@@ -60,14 +61,15 @@ type rabbitMQScaler struct {
 
 type rabbitMQMetadata struct {
 	queueName  string
-	mode       string  // QueueLength or MessageRate
-	value      int     // trigger value (queue length or publish/sec. rate)
-	host       string  // connection string for either HTTP or AMQP protocol
-	protocol   string  // either http or amqp protocol
-	vhostName  *string // override the vhost from the connection info
-	useRegex   bool    // specify if the queueName contains a rexeg
-	operation  string  // specify the operation to apply in case of multiples queues
-	metricName string  // Custom metric name for trigger
+	mode       string        // QueueLength or MessageRate
+	value      int           // trigger value (queue length or publish/sec. rate)
+	host       string        // connection string for either HTTP or AMQP protocol
+	protocol   string        // either http or amqp protocol
+	vhostName  *string       // override the vhost from the connection info
+	useRegex   bool          // specify if the queueName contains a rexeg
+	operation  string        // specify the operation to apply in case of multiples queues
+	metricName string        // custom metric name for trigger
+	timeout    time.Duration // custom http timeout for a specifyc trigger
 }
 
 type queueInfo struct {
@@ -93,11 +95,11 @@ var rabbitmqLog = logf.Log.WithName("rabbitmq_scaler")
 
 // NewRabbitMQScaler creates a new rabbitMQ scaler
 func NewRabbitMQScaler(config *ScalerConfig) (Scaler, error) {
-	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout)
 	meta, err := parseRabbitMQMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing rabbitmq metadata: %s", err)
 	}
+	httpClient := kedautil.CreateHTTPClient(meta.timeout)
 
 	if meta.protocol == httpProtocol {
 		return &rabbitMQScaler{
@@ -218,6 +220,23 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 		} else {
 			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq-rate", url.QueryEscape(meta.queueName)))
 		}
+	}
+
+	// Resolve timeout
+	if val, ok := config.TriggerMetadata["timeout"]; ok {
+		timeoutMS, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse timeout: %s", err)
+		}
+		if meta.protocol == amqpProtocol {
+			return nil, fmt.Errorf("amqp protocol doesn't support custom timeouts: %s", err)
+		}
+		if timeoutMS <= 0 {
+			return nil, fmt.Errorf("timeout must be greater than 0: %s", err)
+		}
+		meta.timeout = time.Duration(timeoutMS) * time.Millisecond
+	} else {
+		meta.timeout = config.GlobalHTTPTimeout
 	}
 
 	return &meta, nil

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -96,6 +96,14 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "http://", "useRegex": "true"}, false, map[string]string{}},
 	// custom metric name
 	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "http://", "useRegex": "true", "metricName": "host1-sample"}, false, map[string]string{}},
+	// http valid timeout
+	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "http://", "timeout": "1000"}, false, map[string]string{}},
+	// http invalid timeout
+	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "http://", "timeout": "-10"}, true, map[string]string{}},
+	// http wrong timeout
+	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "http://", "timeout": "error"}, true, map[string]string{}},
+	// amqp timeout
+	{map[string]string{"mode": "QueueLength", "value": "1000", "queueName": "sample", "host": "amqp://", "timeout": "10"}, true, map[string]string{}},
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PT adds the support to specify a specific timeout to use for each trigger when you are using RabbitMQ Scaler.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* (https://github.com/kedacore/keda-docs/pull/523)
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2053
