### PR TITLE
Adds support for automatic navigation through the pages using regex in RabbitMQ Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add Bearer auth for Metrics API scaler ([#2028](https://github.com/kedacore/keda/pull/2028))
 - Anonymize the host in case of HTTP failure (RabbitMQ Scaler) ([#2041](https://github.com/kedacore/keda/pull/2041))
 - Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string (bug fix) ([#2055](https://github.com/kedacore/keda/pull/2055))
+- Adds support for automatic navigation through the pages using regex in RabbitMQ Scaler ([#2087](https://github.com/kedacore/keda/pull/2087))
 
 ### Breaking Changes
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -387,9 +387,8 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 func getQueueInfo(s *rabbitMQScaler, url string) (queueInfo, error) {
 	if s.metadata.useRegex {
 		return getQueueInfoUsingRegex(s, url)
-	} else {
-		return getQueueInfoFromSingleQueue(s, url)
 	}
+	return getQueueInfoFromSingleQueue(s, url)
 }
 
 func getQueueInfoFromSingleQueue(s *rabbitMQScaler, url string) (queueInfo, error) {
@@ -424,8 +423,8 @@ func getQueueInfoUsingRegex(s *rabbitMQScaler, url string) (queueInfo, error) {
 }
 
 func getQueuesPaginated(s *rabbitMQScaler, url string, page int) ([]queueInfo, error) {
-	pageUrl := fmt.Sprintf("%s&page=%d&page_size=%d", url, page, httpPageSize)
-	r, err := s.httpClient.Get(pageUrl)
+	pageURL := fmt.Sprintf("%s&page=%d&page_size=%d", url, page, httpPageSize)
+	r, err := s.httpClient.Get(pageURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -431,18 +431,14 @@ func TestRabbitMQAnonimizeRabbitMQError(t *testing.T) {
 }
 
 type getQueueInfoNavigationTestData struct {
-	responses      []string
-	responseStatus int
-	isActive       bool
-	extraMetadata  map[string]string
-	vhostPath      string
+	responses []string
 }
 
 var testRegexQueueInfoNavigationTestData = []getQueueInfoNavigationTestData{
 	// sum queue length
-	{[]string{`{"items":[], "filtered_count": 250, "page": 1, "page_count": 3}`, `{"items":[], "filtered_count": 250, "page": 2, "page_count": 3}`, `{"items":[], "filtered_count": 250, "page": 3, "page_count": 3}`}, http.StatusOK, true, map[string]string{"queueLength": "10", "useRegex": "true", "operation": "sum"}, ""},
-	{[]string{`{"items":[], "filtered_count": 250, "page": 1, "page_count": 2}`, `{"items":[], "filtered_count": 250, "page": 2, "page_count": 2}`}, http.StatusOK, true, map[string]string{"queueLength": "10", "useRegex": "true", "operation": "sum"}, ""},
-	{[]string{`{"items":[], "filtered_count": 250, "page": 1, "page_count": 1}`}, http.StatusOK, true, map[string]string{"queueLength": "10", "useRegex": "true", "operation": "sum"}, ""},
+	{[]string{`{"items":[], "filtered_count": 250, "page": 1, "page_count": 3}`, `{"items":[], "filtered_count": 250, "page": 2, "page_count": 3}`, `{"items":[], "filtered_count": 250, "page": 3, "page_count": 3}`}},
+	{[]string{`{"items":[], "filtered_count": 250, "page": 1, "page_count": 2}`, `{"items":[], "filtered_count": 250, "page": 2, "page_count": 2}`}},
+	{[]string{`{"items":[], "filtered_count": 250, "page": 1, "page_count": 1}`}},
 }
 
 func TestGetQueueInfoNavigation(t *testing.T) {
@@ -456,22 +452,20 @@ func TestGetQueueInfoNavigation(t *testing.T) {
 				t.Error("Expect request path to =", expectedPath, "but it is", r.RequestURI)
 			}
 
-			w.WriteHeader(testData.responseStatus)
+			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(response))
 			if err != nil {
 				t.Error("Expect request path to =", response, "but it is", err)
 			}
 		}))
 
-		resolvedEnv := map[string]string{host: fmt.Sprintf("%s%s", apiStub.URL, testData.vhostPath), "plainHost": apiStub.URL}
+		resolvedEnv := map[string]string{host: apiStub.URL, "plainHost": apiStub.URL}
 
 		metadata := map[string]string{
 			"queueName":   "evaluate_trials",
 			"hostFromEnv": host,
 			"protocol":    "http",
-		}
-		for k, v := range testData.extraMetadata {
-			metadata[k] = v
+			"useRegex":    "true",
 		}
 
 		s, err := NewRabbitMQScaler(


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR adds support for automatic navigation through the pages is scenarios when you are using regex with big amount of queues which match the  regex.
With this, the total amount of queues is not a limit because now KEDA can recover any amount of queues using pagination
In order to expose information about if it's an intensive process, the total amount of queues is printed to the log (only the regex and the total amount of matching queues)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2068
