### PR TITLE
Adds e2e test for PostgreSQL scaler

### DIFF
--- a/tests/scalers/postgresql.test.ts
+++ b/tests/scalers/postgresql.test.ts
@@ -15,7 +15,7 @@ test.before(t => {
     // install postgresql
     sh.exec(`kubectl create namespace ${postgreSQLNamespace}`)
     const postgreSQLTmpFile = tmp.fileSync()
-    fs.writeFileSync(postgreSQLTmpFile.name, postgresqlDeploymentYaml.replace('{{POSTGRES_USER}}', postgreSQLUsername)        
+    fs.writeFileSync(postgreSQLTmpFile.name, postgresqlDeploymentYaml.replace('{{POSTGRES_USER}}', postgreSQLUsername)
         .replace('{{POSTGRES_PASSWORD}}', postgreSQLPassword)
         .replace('{{POSTGRES_DB}}', postgreSQLDatabase)
         .replace('{{POSTGRES_DB}}', postgreSQLDatabase))
@@ -36,7 +36,7 @@ test.before(t => {
     t.not(postgresqlPod, '')
     const createTableSQL = `CREATE TABLE task_instance (id serial PRIMARY KEY,state VARCHAR(10));`
     sh.exec( `kubectl exec -n ${postgreSQLNamespace} ${postgresqlPod} -- psql -U ${postgreSQLUsername} -d ${postgreSQLDatabase} -c "${createTableSQL}"`)
-    
+
     sh.config.silent = true
     sh.exec(`kubectl create namespace ${testNamespace}`)
     // deploy streams consumer app, scaled object etc.

--- a/tests/scalers/postgresql.test.ts
+++ b/tests/scalers/postgresql.test.ts
@@ -131,7 +131,7 @@ spec:
         app: postgresql-update-worker
     spec:
       containers:
-      - image: docker.io/jorturfer/e2e-postgre
+      - image: ghcr.io/kedacore/tests-postgresql
         imagePullPolicy: Always
         name: postgresql-processor-test
         command:
@@ -188,7 +188,7 @@ kind: Job
 metadata:
   labels:
     app: postgresql-insert-job
-  name: mpostgresqlysql-insert-job
+  name: postgresql-insert-job
 spec:
   template:
     metadata:
@@ -196,7 +196,7 @@ spec:
         app: postgresql-insert-job
     spec:
       containers:
-      - image: docker.io/jorturfer/e2e-postgre
+      - image: ghcr.io/kedacore/tests-postgresql
         imagePullPolicy: Always
         name: postgresql-processor-test
         command:

--- a/tests/scalers/postgresql.test.ts
+++ b/tests/scalers/postgresql.test.ts
@@ -1,0 +1,261 @@
+import * as async from 'async'
+import * as fs from 'fs'
+import * as sh from 'shelljs'
+import * as tmp from 'tmp'
+import test from 'ava'
+
+const testNamespace = 'postgresql-test'
+const postgreSQLNamespace = 'postgresql'
+const postgreSQLUsername = 'test-user'
+const postgreSQLPassword = 'test-password'
+const postgreSQLDatabase = 'test_db'
+const deploymentName = 'worker'
+
+test.before(t => {
+    // install postgresql
+    sh.exec(`kubectl create namespace ${postgreSQLNamespace}`)
+    const postgreSQLTmpFile = tmp.fileSync()
+    fs.writeFileSync(postgreSQLTmpFile.name, postgresqlDeploymentYaml.replace('{{POSTGRES_USER}}', postgreSQLUsername)        
+        .replace('{{POSTGRES_PASSWORD}}', postgreSQLPassword)
+        .replace('{{POSTGRES_DB}}', postgreSQLDatabase)
+        .replace('{{POSTGRES_DB}}', postgreSQLDatabase))
+
+    t.is(0, sh.exec(`kubectl apply --namespace ${postgreSQLNamespace} -f ${postgreSQLTmpFile.name}`).code, 'creating a POSTGRES deployment should work.')
+    // wait for postgresql to load
+    let postgresqlReadyReplicaCount = '0'
+    for (let i = 0; i < 30; i++) {
+      postgresqlReadyReplicaCount = sh.exec(`kubectl get deploy/postgresql -n ${postgreSQLNamespace} -o jsonpath='{.status.readyReplicas}'`).stdout
+        if (postgresqlReadyReplicaCount != '1') {
+            sh.exec('sleep 2s')
+        }
+    }
+    t.is('1', postgresqlReadyReplicaCount, 'Postgresql is not in a ready state')
+
+    // create table that used by the job and the worker
+    const postgresqlPod = sh.exec(`kubectl get po -n ${postgreSQLNamespace} -o jsonpath='{.items[0].metadata.name}'`).stdout
+    t.not(postgresqlPod, '')
+    const createTableSQL = `CREATE TABLE task_instance (id serial PRIMARY KEY,state VARCHAR(10));`
+    sh.exec( `kubectl exec -n ${postgreSQLNamespace} ${postgresqlPod} -- psql -U ${postgreSQLUsername} -d ${postgreSQLDatabase} -c "${createTableSQL}"`)
+    
+    sh.config.silent = true
+    sh.exec(`kubectl create namespace ${testNamespace}`)
+    // deploy streams consumer app, scaled object etc.
+    const tmpFile = tmp.fileSync()
+    const base64ConnectionString = Buffer.from(`postgresql://${postgreSQLUsername}:${postgreSQLPassword}@postgresql.${postgreSQLNamespace}.svc.cluster.local:5432/${postgreSQLDatabase}?sslmode=disable`).toString('base64')
+    fs.writeFileSync(tmpFile.name, deployYaml.replace('{{POSTGRES_CONNECTION_STRING}}', base64ConnectionString).replace('{{DEPLOYMENT_NAME}}', deploymentName))
+    t.is(
+        0,
+        sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
+        'creating a deployment should work..'
+    )
+})
+
+test.serial('Deployment should have 0 replicas on start', t => {
+    const replicaCount = sh.exec(
+        `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+    ).stdout
+    t.is(replicaCount, '0', 'replica count should start out as 0')
+})
+
+test.serial(`Deployment should scale to 5 (the max) then back to 0`, t => {
+    const tmpFile = tmp.fileSync()
+    fs.writeFileSync(tmpFile.name, insertRecordsJobYaml)
+    t.is(
+        0,
+        sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
+        'creating job should work.'
+    )
+
+    let replicaCount = '0'
+
+    const maxReplicaCount = '5'
+
+    for (let i = 0; i < 30 && replicaCount !== maxReplicaCount; i++) {
+        replicaCount = sh.exec(
+            `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+        ).stdout
+        if (replicaCount !== maxReplicaCount) {
+            sh.exec('sleep 2s')
+        }
+    }
+
+    t.is(maxReplicaCount, replicaCount, `Replica count should be ${maxReplicaCount} after 60 seconds`)
+
+    for (let i = 0; i < 36 && replicaCount !== '0'; i++) {
+      replicaCount = sh.exec(
+        `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+      ).stdout
+      if (replicaCount !== '0') {
+        sh.exec('sleep 5s')
+      }
+    }
+
+    t.is('0', replicaCount, 'Replica count should be 0 after 3 minutes')
+})
+
+test.after.always.cb('clean up postgresql deployment', t => {
+    const resources = [
+        'scaledobject.keda.sh/postgresql-scaledobject',
+        'triggerauthentication.keda.sh/keda-trigger-auth-postgresql-secret',
+        `deployment.apps/${deploymentName}`,
+        'secret/postgresql-secrets',
+        'job/postgresql-insert-job',
+    ]
+
+    for (const resource of resources) {
+        sh.exec(`kubectl delete ${resource} --namespace ${testNamespace}`)
+    }
+    sh.exec(`kubectl delete namespace ${testNamespace}`)
+
+    // uninstall postgresql
+    sh.exec(`kubectl delete --namespace ${postgreSQLNamespace} deploy/postgresql`)
+    sh.exec(`kubectl delete namespace ${postgreSQLNamespace}`)
+
+    t.end()
+})
+
+const deployYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: postgresql-update-worker
+  name: {{DEPLOYMENT_NAME}}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: postgresql-update-worker
+  template:
+    metadata:
+      labels:
+        app: postgresql-update-worker
+    spec:
+      containers:
+      - image: docker.io/jorturfer/e2e-postgre
+        imagePullPolicy: Always
+        name: postgresql-processor-test
+        command:
+          - /app
+          - update
+        env:
+          - name: TASK_INSTANCES_COUNT
+            value: "10000"
+          - name: CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: postgresql-secrets
+                key: postgresql_conn_str
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-secrets
+type: Opaque
+data:
+  postgresql_conn_str: {{POSTGRES_CONNECTION_STRING}}
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-postgresql-secret
+spec:
+  secretTargetRef:
+  - parameter: connection
+    name: postgresql-secrets
+    key: postgresql_conn_str
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: postgresql-scaledobject
+spec:
+  scaleTargetRef:
+    name: worker
+  pollingInterval: 5
+  cooldownPeriod:  10
+  minReplicaCount: 0
+  maxReplicaCount: 5
+  triggers:
+  - type: postgresql
+    metadata:
+      targetQueryValue: "4"
+      query: "SELECT CEIL(COUNT(*) / 5) FROM task_instance WHERE state='running' OR state='queued'"
+    authenticationRef:
+      name: keda-trigger-auth-postgresql-secret`
+
+const insertRecordsJobYaml = `apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: postgresql-insert-job
+  name: mpostgresqlysql-insert-job
+spec:
+  template:
+    metadata:
+      labels:
+        app: postgresql-insert-job
+    spec:
+      containers:
+      - image: docker.io/jorturfer/e2e-postgre
+        imagePullPolicy: Always
+        name: postgresql-processor-test
+        command:
+          - /app
+          - insert
+        env:
+          - name: TASK_INSTANCES_COUNT
+            value: "20000"
+          - name: CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: postgresql-secrets
+                key: postgresql_conn_str
+      restartPolicy: Never
+  backoffLimit: 4`
+
+
+const postgresqlDeploymentYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: postgresql
+  name: postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+      - image: postgres:10.5
+        name: postgresql
+        env:
+          - name: POSTGRES_USER
+            value: {{POSTGRES_USER}}
+          - name: POSTGRES_PASSWORD
+            value: {{POSTGRES_PASSWORD}}
+          - name: POSTGRES_DB
+            value: {{POSTGRES_DB}}
+        ports:
+          - name: postgresql
+            protocol: TCP
+            containerPort: 5432
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postgresql
+  name: postgresql
+spec:
+  ports:
+  - port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: postgresql
+  type: ClusterIP`

--- a/tests/scalers/postgresql.test.ts
+++ b/tests/scalers/postgresql.test.ts
@@ -204,7 +204,7 @@ spec:
           - insert
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "20000"
+            value: "10000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
This PR adds e2e test for Postgres scaler. It's a draft until this other PR is merged ~~https://github.com/kedacore/test-tools/pull/18~~ https://github.com/kedacore/test-tools/pull/20  (I need it to use the PostgreSQL docker image here :) )
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added

