### PR TITLE
Raises an error when RabbitMQ regex matches more than 1 page

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -80,7 +80,10 @@ type queueInfo struct {
 }
 
 type regexQueueInfo struct {
-	Queues []queueInfo `json:"items"`
+	Queues         []queueInfo `json:"items"`
+	FilteredQueues int         `json:"filtered_count"`
+	CurrentPage    int         `json:"page"`
+	TotalPages     int         `json:"page_count"`
 }
 
 type messageStat struct {
@@ -374,6 +377,9 @@ func getJSON(s *rabbitMQScaler, url string) (queueInfo, error) {
 			err = json.NewDecoder(r.Body).Decode(&queues)
 			if err != nil {
 				return queueInfo{}, err
+			}
+			if queues.FilteredQueues > len(queues.Queues) {
+				return queueInfo{}, fmt.Errorf("regex matches more queues than can be recover at once")
 			}
 			result, err := getComposedQueue(s, queues.Queues)
 			return result, err

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -80,10 +80,8 @@ type queueInfo struct {
 }
 
 type regexQueueInfo struct {
-	Queues         []queueInfo `json:"items"`
-	FilteredQueues int         `json:"filtered_count"`
-	CurrentPage    int         `json:"page"`
-	TotalPages     int         `json:"page_count"`
+	Queues     []queueInfo `json:"items"`
+	TotalPages int         `json:"page_count"`
 }
 
 type messageStat struct {
@@ -378,8 +376,8 @@ func getJSON(s *rabbitMQScaler, url string) (queueInfo, error) {
 			if err != nil {
 				return queueInfo{}, err
 			}
-			if queues.FilteredQueues > len(queues.Queues) {
-				return queueInfo{}, fmt.Errorf("regex matches more queues than can be recover at once")
+			if queues.TotalPages > 1 {
+				return queueInfo{}, fmt.Errorf("regex matches more queues than can be recovered at once")
 			}
 			result, err := getComposedQueue(s, queues.Queues)
 			return result, err


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

As we were talking during the last meeting, this PR modifies the behavior of RabbitMQ Scaler to raise an error in case of the provided regex matches with more queues those are returned in a single page. At least with this PR, the user get information about why the scaler doesn't reflect the current status of the queues (if they need 2 or more pages)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2068
