### PR TITLE
Add support to get connection data from Trigger Authorization in MSSQL Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string (bug fix) ([#2055](https://github.com/kedacore/keda/pull/2055))
 - TriggerAuthentication/Vault: add support for HashiCorp Vault namespace (Vault Enterprise) ([#2085](https://github.com/kedacore/keda/pull/2085))
 - Add custom http timeout in RabbitMQ Scaler ([#2086](https://github.com/kedacore/keda/pull/2086))
+- Add support to getthe connection data from Trigger Authorization in MSSQL Scaler ([#2112](https://github.com/kedacore/keda/pull/2112))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string (bug fix) ([#2055](https://github.com/kedacore/keda/pull/2055))
 - TriggerAuthentication/Vault: add support for HashiCorp Vault namespace (Vault Enterprise) ([#2085](https://github.com/kedacore/keda/pull/2085))
 - Add custom http timeout in RabbitMQ Scaler ([#2086](https://github.com/kedacore/keda/pull/2086))
-- Add support to getthe connection data from Trigger Authorization in MSSQL Scaler ([#2112](https://github.com/kedacore/keda/pull/2112))
+- Add support to get connection data from Trigger Authorization in MSSQL Scaler ([#2112](https://github.com/kedacore/keda/pull/2112))
 
 ### Breaking Changes
 

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -108,28 +108,41 @@ func parseMSSQLMetadata(config *ScalerConfig) (*mssqlMetadata, error) {
 		meta.connectionString = config.ResolvedEnv[config.TriggerMetadata["connectionStringFromEnv"]]
 	default:
 		meta.connectionString = ""
-		if val, ok := config.TriggerMetadata["host"]; ok {
-			meta.host = val
-		} else {
+
+		if config.AuthParams["host"] != "" {
+			meta.host = config.AuthParams["host"]
+		} else if config.TriggerMetadata["host"] != "" {
+			meta.host = config.TriggerMetadata["host"]
+		}
+		if meta.host == "" {
 			return nil, fmt.Errorf("no host given")
 		}
 
-		if val, ok := config.TriggerMetadata["port"]; ok {
-			port, err := strconv.Atoi(val)
+		var paramPort string
+		if config.AuthParams["port"] != "" {
+			paramPort = config.AuthParams["port"]
+		} else if config.TriggerMetadata["port"] != "" {
+			paramPort = config.TriggerMetadata["port"]
+		}
+		if paramPort != "" {
+			port, err := strconv.Atoi(paramPort)
 			if err != nil {
 				return nil, fmt.Errorf("port parsing error %s", err.Error())
 			}
-
 			meta.port = port
 		}
 
-		if val, ok := config.TriggerMetadata["username"]; ok {
-			meta.username = val
+		if config.AuthParams["username"] != "" {
+			meta.username = config.AuthParams["username"]
+		} else if config.TriggerMetadata["username"] != "" {
+			meta.username = config.TriggerMetadata["username"]
 		}
 
 		// database is optional in SQL s
-		if val, ok := config.TriggerMetadata["database"]; ok {
-			meta.database = val
+		if config.AuthParams["database"] != "" {
+			meta.database = config.AuthParams["database"]
+		} else if config.TriggerMetadata["database"] != "" {
+			meta.database = config.TriggerMetadata["database"]
 		}
 
 		if config.AuthParams["password"] != "" {

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -65,6 +65,14 @@ var testInputs = []mssqlTestData{
 		expectedMetricName:       "mssql-AdventureWorks",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net?database=AdventureWorks",
 	},
+	// connection string generated from full authParams
+	{
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1"},
+		resolvedEnv:              map[string]string{},
+		authParams:               map[string]string{"password": "Password#2", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks", "port": "1433"},
+		expectedMetricName:       "mssql-AdventureWorks",
+		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net:1433?database=AdventureWorks",
+	},
 	// variation of previous: no database name, metricName from host
 	{
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3"},


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Adds support to getthe connection data from Trigger Authorization in MSSQL Scaler

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* https://github.com/kedacore/keda-docs/pull/537
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2108
