### PR TITLE
Add support to get connection data from Trigger Authorization in MySQL Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string (bug fix) ([#2055](https://github.com/kedacore/keda/pull/2055))
 - TriggerAuthentication/Vault: add support for HashiCorp Vault namespace (Vault Enterprise) ([#2085](https://github.com/kedacore/keda/pull/2085))
 - Add custom http timeout in RabbitMQ Scaler ([#2086](https://github.com/kedacore/keda/pull/2086))
-- Add support to get connection data from Trigger Authorization in M;ySQL Scaler ([#2113](https://github.com/kedacore/keda/pull/2113))
+- Add support to get connection data from Trigger Authorization in MySQL Scaler ([#2113](https://github.com/kedacore/keda/pull/2113))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Escape `queueName` and `vhostName` in RabbitMQ Scaler before use them in query string (bug fix) ([#2055](https://github.com/kedacore/keda/pull/2055))
 - TriggerAuthentication/Vault: add support for HashiCorp Vault namespace (Vault Enterprise) ([#2085](https://github.com/kedacore/keda/pull/2085))
 - Add custom http timeout in RabbitMQ Scaler ([#2086](https://github.com/kedacore/keda/pull/2086))
+- Add support to get connection data from Trigger Authorization in M;ySQL Scaler ([#2113](https://github.com/kedacore/keda/pull/2113))
 
 ### Breaking Changes
 

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -78,26 +78,25 @@ func parseMySQLMetadata(config *ScalerConfig) (*mySQLMetadata, error) {
 		meta.connectionString = config.ResolvedEnv[config.TriggerMetadata["connectionStringFromEnv"]]
 	default:
 		meta.connectionString = ""
-		if val, ok := config.TriggerMetadata["host"]; ok {
-			meta.host = val
-		} else {
-			return nil, fmt.Errorf("no host given")
-		}
-		if val, ok := config.TriggerMetadata["port"]; ok {
-			meta.port = val
-		} else {
-			return nil, fmt.Errorf("no port given")
+		var err error
+		meta.host, err = getFromAuthOrMeta(config, "host")
+		if err != nil {
+			return nil, err
 		}
 
-		if val, ok := config.TriggerMetadata["username"]; ok {
-			meta.username = val
-		} else {
-			return nil, fmt.Errorf("no username given")
+		meta.port, err = getFromAuthOrMeta(config, "port")
+		if err != nil {
+			return nil, err
 		}
-		if val, ok := config.TriggerMetadata["dbName"]; ok {
-			meta.dbName = val
-		} else {
-			return nil, fmt.Errorf("no dbName given")
+
+		meta.username, err = getFromAuthOrMeta(config, "username")
+		if err != nil {
+			return nil, err
+		}
+
+		meta.dbName, err = getFromAuthOrMeta(config, "dbName")
+		if err != nil {
+			return nil, err
 		}
 
 		if config.AuthParams["password"] != "" {
@@ -218,4 +217,18 @@ func (s *mySQLScaler) GetMetrics(ctx context.Context, metricName string, metricS
 	}
 
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
+}
+
+func getFromAuthOrMeta(config *ScalerConfig, field string) (string, error) {
+	var result string
+	var err error
+	if config.AuthParams[field] != "" {
+		result = config.AuthParams[field]
+	} else if config.TriggerMetadata[field] != "" {
+		result = config.TriggerMetadata[field]
+	}
+	if result == "" {
+		err = fmt.Errorf("no %s given", field)
+	}
+	return result, err
 }


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add support to get connection data from Trigger Authorization in MySQL Scaler

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*https://github.com/kedacore/keda-docs/pull/536
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2109
