### PR TITLE
WIP - Improve metric name creation to be unique

### DIFF
--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -222,7 +222,6 @@ var _ = Describe("ScaledObjectController", func() {
 								"start":           "0 * * * *",
 								"end":             "1 * * * *",
 								"desiredReplicas": "1",
-								"metricName":      "trigger-1",
 							},
 						},
 						{
@@ -232,7 +231,7 @@ var _ = Describe("ScaledObjectController", func() {
 								"start":           "2 * * * *",
 								"end":             "3 * * * *",
 								"desiredReplicas": "2",
-								"metricName":      "trigger-2",
+								"metricName":      "custom-name",
 							},
 						},
 					},
@@ -247,8 +246,8 @@ var _ = Describe("ScaledObjectController", func() {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-clean-up-test", Namespace: "default"}, hpa)
 			}).ShouldNot(HaveOccurred())
 			Expect(hpa.Spec.Metrics).To(HaveLen(2))
-			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-trigger-1"))
-			Expect(hpa.Spec.Metrics[1].External.Metric.Name).To(Equal("cron-trigger-2"))
+			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-3ca863839b90fc71b32f1482f651d93ae71e87fe9e5f3fac273870c36f769ee6"))
+			Expect(hpa.Spec.Metrics[1].External.Metric.Name).To(Equal("cron-custom-name"))
 
 			// Remove the second trigger.
 			Eventually(func() error {
@@ -265,7 +264,7 @@ var _ = Describe("ScaledObjectController", func() {
 				return len(hpa.Spec.Metrics)
 			}).Should(Equal(1))
 			// And it should only be the first one left.
-			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-trigger-1"))
+			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-3ca863839b90fc71b32f1482f651d93ae71e87fe9e5f3fac273870c36f769ee6"))
 		})
 
 		It("deploys ScaledObject and creates HPA, when IdleReplicaCount, MinReplicaCount and MaxReplicaCount is defined", func() {

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -222,6 +222,7 @@ var _ = Describe("ScaledObjectController", func() {
 								"start":           "0 * * * *",
 								"end":             "1 * * * *",
 								"desiredReplicas": "1",
+								"metricName":      "trigger-1",
 							},
 						},
 						{
@@ -231,6 +232,7 @@ var _ = Describe("ScaledObjectController", func() {
 								"start":           "2 * * * *",
 								"end":             "3 * * * *",
 								"desiredReplicas": "2",
+								"metricName":      "trigger-2",
 							},
 						},
 					},
@@ -245,8 +247,8 @@ var _ = Describe("ScaledObjectController", func() {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-clean-up-test", Namespace: "default"}, hpa)
 			}).ShouldNot(HaveOccurred())
 			Expect(hpa.Spec.Metrics).To(HaveLen(2))
-			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-UTC-0xxxx-1xxxx"))
-			Expect(hpa.Spec.Metrics[1].External.Metric.Name).To(Equal("cron-UTC-2xxxx-3xxxx"))
+			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-trigger-1"))
+			Expect(hpa.Spec.Metrics[1].External.Metric.Name).To(Equal("cron-trigger-2"))
 
 			// Remove the second trigger.
 			Eventually(func() error {
@@ -263,7 +265,7 @@ var _ = Describe("ScaledObjectController", func() {
 				return len(hpa.Spec.Metrics)
 			}).Should(Equal(1))
 			// And it should only be the first one left.
-			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-UTC-0xxxx-1xxxx"))
+			Expect(hpa.Spec.Metrics[0].External.Metric.Name).To(Equal("cron-trigger-1"))
 		})
 
 		It("deploys ScaledObject and creates HPA, when IdleReplicaCount, MinReplicaCount and MaxReplicaCount is defined", func() {

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -35,6 +35,7 @@ type artemisMetadata struct {
 	restAPITemplate    string
 	queueLength        int
 	corsHeader         string
+	metricName         string
 }
 
 //revive:enable:var-naming
@@ -149,6 +150,9 @@ func parseArtemisMetadata(config *ScalerConfig) (*artemisMetadata, error) {
 	if meta.password == "" {
 		return nil, fmt.Errorf("password cannot be empty")
 	}
+
+	meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "artemis", config.TriggerMetadata[scalerMetricName]))
+
 	return &meta, nil
 }
 
@@ -214,7 +218,7 @@ func (s *artemisScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "artemis", s.metadata.brokerName, s.metadata.queueName)),
+			Name: s.metadata.metricName,
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/artemis_scaler_test.go
+++ b/pkg/scalers/artemis_scaler_test.go
@@ -52,7 +52,7 @@ var testArtemisMetadata = []parseArtemisMetadataTestData{
 	{map[string]string{"managementEndpoint": "localhost:8161", "queueName": "queue1", "brokerName": "broker-activemq", "brokerAddress": "test", "username": "", "password": "myPassword"}, true},
 	// Missing password, should fail
 	{map[string]string{"managementEndpoint": "localhost:8161", "queueName": "queue1", "brokerName": "broker-activemq", "brokerAddress": "test", "username": "myUserName", "password": ""}, true},
-	{map[string]string{"managementEndpoint": "localhost:8161", "queueName": "queue1", "brokerName": "broker-activemq", "brokerAddress": "test", "username": "myUserName", "password": "myPassword"}, false},
+	{map[string]string{"managementEndpoint": "localhost:8161", "queueName": "queue1", "brokerName": "broker-activemq", "brokerAddress": "test", "username": "myUserName", "password": "myPassword", "metricName": "broker-activemq-queue1"}, false},
 }
 
 var artemisMetricIdentifiers = []artemisMetricIdentifier{

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -143,14 +142,6 @@ func (s *cronScaler) IsActive(ctx context.Context) (bool, error) {
 
 func (s *cronScaler) Close() error {
 	return nil
-}
-
-func parseCronTimeFormat(s string) string {
-	s = strings.ReplaceAll(s, " ", "")
-	s = strings.ReplaceAll(s, "*", "x")
-	s = strings.ReplaceAll(s, "/", "Sl")
-	s = strings.ReplaceAll(s, "?", "Qm")
-	return s
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -24,6 +24,7 @@ var validCronMetadata = map[string]string{
 	"start":           "0 0 * * Thu",
 	"end":             "59 23 * * Thu",
 	"desiredReplicas": "10",
+	"metricName":      "cron1",
 }
 
 // A complete valid metadata example which is enabled every even hours
@@ -32,6 +33,7 @@ var validCronMetadata2 = map[string]string{
 	"start":           "0 */2 * * *",    // Every 2 hours (even)
 	"end":             "0 1-23/2 * * *", // Every 2 hours starting at 1 (odd)
 	"desiredReplicas": "10",
+	"metricName":      "cron2",
 }
 
 var testCronMetadata = []parseCronMetadataTestData{
@@ -49,8 +51,8 @@ var testCronMetadata = []parseCronMetadataTestData{
 }
 
 var cronMetricIdentifiers = []cronMetricIdentifier{
-	{&testCronMetadata[1], "cron-Etc-UTC-00xxThu-5923xxThu"},
-	{&testCronMetadata[2], "cron-Etc-UTC-0xSl2xxx-01-23Sl2xxx"},
+	{&testCronMetadata[1], "cron-cron1"},
+	{&testCronMetadata[2], "cron-cron2"},
 }
 
 var tz, _ = time.LoadLocation(validCronMetadata2["timezone"])

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -2,7 +2,6 @@ package scalers
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -139,25 +138,7 @@ func parseMSSQLMetadata(config *ScalerConfig) (*mssqlMetadata, error) {
 		}
 	}
 
-	// get the metricName, which can be explicit or from the (masked) connection string
-	if val, ok := config.TriggerMetadata["metricName"]; ok {
-		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mssql-%s", val))
-	} else {
-		switch {
-		case meta.database != "":
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mssql-%s", meta.database))
-		case meta.host != "":
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mssql-%s", meta.host))
-		case meta.connectionString != "":
-			// The mssql provider supports of a variety of connection string formats. Instead of trying to parse
-			// the connection string and mask out sensitive data, play it safe and just hash the whole thing.
-			connectionStringHash := sha256.Sum256([]byte(meta.connectionString))
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mssql-%x", connectionStringHash))
-		default:
-			meta.metricName = "mssql"
-		}
-	}
-
+	meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "mssql", config.TriggerMetadata[scalerMetricName]))
 	return &meta, nil
 }
 

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -43,7 +43,7 @@ var testInputs = []mssqlTestData{
 	},
 	// connection string generated from minimal required metadata
 	{
-		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "127.0.0.1"},
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "127.0.0.1", "metricName": "127-0-0-1"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{},
 		expectedMetricName:       "mssql-127-0-0-1",
@@ -57,17 +57,17 @@ var testInputs = []mssqlTestData{
 		expectedMetricName:       "mssql-myMetric1",
 		expectedConnectionString: "sqlserver://user1:Password%231@example.database.windows.net:1433?database=AdventureWorks",
 	},
-	// variation of previous: no port, password from authParams, metricName from database name
+	// variation of previous: no port, password from authParams
 	{
-		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks"},
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks", "metricName": "AdventureWorks"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#2"},
 		expectedMetricName:       "mssql-AdventureWorks",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net?database=AdventureWorks",
 	},
-	// variation of previous: no database name, metricName from host
+	// variation of previous: no database name
 	{
-		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3"},
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3", "metricName": "example-database-windows-net"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#3"},
 		expectedMetricName:       "mssql-example-database-windows-net",

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -68,7 +68,7 @@ type rabbitMQMetadata struct {
 	vhostName  *string       // override the vhost from the connection info
 	useRegex   bool          // specify if the queueName contains a rexeg
 	operation  string        // specify the operation to apply in case of multiples queues
-	metricName string        // custom metric name for trigger
+	metricName string        // metric name for trigger
 	timeout    time.Duration // custom http timeout for a specific trigger
 }
 
@@ -212,16 +212,7 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 		return nil, fmt.Errorf("unable to parse trigger: %s", err)
 	}
 
-	// Resolve metricName
-	if val, ok := config.TriggerMetadata["metricName"]; ok {
-		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq", url.QueryEscape(val)))
-	} else {
-		if meta.mode == rabbitModeQueueLength {
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq", url.QueryEscape(meta.queueName)))
-		} else {
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq-rate", url.QueryEscape(meta.queueName)))
-		}
-	}
+	meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq", config.TriggerMetadata[scalerMetricName]))
 
 	// Resolve timeout
 	if val, ok := config.TriggerMetadata["timeout"]; ok {

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -35,7 +35,7 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	// nothing passed
 	{map[string]string{}, true, map[string]string{}},
 	// properly formed metadata
-	{map[string]string{"queueLength": "10", "queueName": "sample", "hostFromEnv": host}, false, map[string]string{}},
+	{map[string]string{"queueLength": "10", "queueName": "sample", "hostFromEnv": host, "metricName": "metric1"}, false, map[string]string{}},
 	// malformed queueLength
 	{map[string]string{"queueLength": "AA", "queueName": "sample", "hostFromEnv": host}, true, map[string]string{}},
 	// missing host
@@ -47,7 +47,7 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	// properly formed metadata with http protocol
 	{map[string]string{"queueLength": "10", "queueName": "sample", "host": host, "protocol": "http"}, false, map[string]string{}},
 	// queue name with slashes
-	{map[string]string{"queueLength": "10", "queueName": "namespace/name", "hostFromEnv": host}, false, map[string]string{}},
+	{map[string]string{"queueLength": "10", "queueName": "namespace/name", "hostFromEnv": host, "metricName": "metric2"}, false, map[string]string{}},
 	// vhost passed
 	{map[string]string{"vhostName": "myVhost", "queueName": "namespace/name", "hostFromEnv": host}, false, map[string]string{}},
 	// vhost passed but empty
@@ -107,9 +107,8 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{
-	{&testRabbitMQMetadata[1], "rabbitmq-sample"},
-	{&testRabbitMQMetadata[7], "rabbitmq-namespace-2Fname"},
-	{&testRabbitMQMetadata[31], "rabbitmq-host1-sample"},
+	{&testRabbitMQMetadata[1], "rabbitmq-metric1"},
+	{&testRabbitMQMetadata[7], "rabbitmq-metric2"},
 }
 
 func TestRabbitMQParseMetadata(t *testing.T) {

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -28,6 +28,10 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 )
 
+const (
+	scalerMetricName = "metricName"
+)
+
 func init() {
 	// Disable metrics for kafka client (sarama)
 	// https://github.com/Shopify/sarama/issues/1321

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -18,7 +18,7 @@ package scaling
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -451,7 +451,7 @@ func generateMetricName(config *scalers.ScalerConfig) error {
 	if err != nil {
 		return err
 	}
-	metricName := md5.Sum(byteMetadata)
+	metricName := sha256.Sum256(byteMetadata)
 	config.TriggerMetadata[scalerMetricName] = fmt.Sprintf("%x", metricName)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This draft shows the approach that I propose to generate unique metric names in base of the trigger values. All the scalers will contain an option in trigger named `metricName` which supports setting specific metric name instead generate if from hashing result. All the metric names will be composed using the pattern `scalerType-metricName`

I have just tried the change passing mssql e2e tests and it works really fine.  Of course, this PR needs a lot of effort yet because all the scalers should be updated, but I'd like to get your opinion about the approach before update all the scalers. 
@tomkerkhove @zroubalik 
Could you share your thoughts?


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Updated scalers:
- [x] ActiveMQ Artemis
- [ ] Apache Kafka
- [ ] AWS CloudWatch
- [ ] AWS Kinesis Stream
- [ ] AWS SQS Queue
- [ ] Azure Blob Storage
- [ ] Azure Event Hubs
- [ ] Azure Log Analytics
- [ ] Azure Monitor
- [ ] Azure Pipelines
- [ ] Azure Service Bus
- [ ] Azure Storage Queue
- [ ] CPU
- [x] Cron
- [ ] External
- [ ] External Push
- [ ] Google Cloud Platform‎ Pub/Sub
- [ ] Huawei Cloudeye
- [ ] IBM MQ
- [ ] InfluxDB
- [ ] Kubernetes Workload
- [ ] Liiklus Topic
- [ ] Memory
- [ ] Metrics API
- [ ] MongoDB
- [x] MSSQL
- [ ] MySQL
- [ ] NATS Streaming
- [ ] OpenStack Metric
- [ ] OpenStack Swift
- [ ] PostgreSQL
- [ ] Prometheus
- [x] RabbitMQ Queue
- [ ] Redis Lists
- [ ] Redis Lists (supports Redis Cluster)
- [ ] Redis Streams
- [ ] Redis Streams (supports Redis Cluster)
- [ ] Selenium Grid Scaler
- [ ] Solace PubSub+ Event Broker

Fixes https://github.com/kedacore/keda/issues/2123
