### PR TITLE
Fix mongdb e2e tests

### DIFF
--- a/pkg/scalers/mongo_scaler.go
+++ b/pkg/scalers/mongo_scaler.go
@@ -98,6 +98,7 @@ func NewMongoDBScaler(config *ScalerConfig) (Scaler, error) {
 
 func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error) {
 	var connStr string
+	var err error
 	// setting default metadata
 	meta := mongoDBMetadata{}
 
@@ -124,6 +125,11 @@ func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error
 		return nil, "", fmt.Errorf("no queryValue given")
 	}
 
+	meta.dbName, err = GetFromAuthOrMeta(config, "dbName")
+	if err != nil {
+		return nil, "", err
+	}
+
 	// Resolve connectionString
 	switch {
 	case config.AuthParams["connectionString"] != "":
@@ -132,13 +138,7 @@ func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error
 		meta.connectionString = config.ResolvedEnv[config.TriggerMetadata["connectionStringFromEnv"]]
 	default:
 		meta.connectionString = ""
-		var err error
 		meta.host, err = GetFromAuthOrMeta(config, "host")
-		if err != nil {
-			return nil, "", err
-		}
-
-		meta.dbName, err = GetFromAuthOrMeta(config, "dbName")
 		if err != nil {
 			return nil, "", err
 		}


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

In the context of this [PR](https://github.com/kedacore/keda/pull/2115)  I introduced an error which has broken the e2e test. This PR solves it.
Thanks a lot @zroubalik detecting it

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated