### PR TITLE
WIP - Improve metric name creation to be unique using scaler index

### DIFF
--- a/controllers/keda/hpa.go
+++ b/controllers/keda/hpa.go
@@ -166,15 +166,17 @@ func (r *ScaledObjectReconciler) getScaledObjectMetricSpecs(logger logr.Logger, 
 		return nil, err
 	}
 
-	for _, scaler := range scalers {
+	for scalerIndex, scaler := range scalers {
 		metricSpecs := scaler.GetMetricSpecForScaling()
-
 		for _, metricSpec := range metricSpecs {
 			if metricSpec.Resource != nil {
 				resourceMetricNames = append(resourceMetricNames, string(metricSpec.Resource.Name))
 			}
 
 			if metricSpec.External != nil {
+				// Add the scaler index prefix
+				metricSpec.External.Metric.Name = fmt.Sprintf("s%d-%s", scalerIndex, metricSpec.External.Metric.Name)
+
 				externalMetricName := metricSpec.External.Metric.Name
 				if kedacontrollerutil.Contains(externalMetricNames, externalMetricName) {
 					return nil, fmt.Errorf("metricName %s defined multiple times in ScaledObject %s, please refer the documentation how to define metricName manually", externalMetricName, scaledObject.Name)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -108,6 +108,10 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 			if metricSpec.External == nil {
 				continue
 			}
+
+			// Add the scaler index prefix
+			metricSpec.External.Metric.Name = fmt.Sprintf("s%d-%s", scalerIndex, metricSpec.External.Metric.Name)
+
 			// Filter only the desired metric
 			if strings.EqualFold(metricSpec.External.Metric.Name, info.Metric) {
 				metrics, err := p.getMetricsWithFallback(scaler, info.Metric, metricSelector, scaledObject, metricSpec)

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -239,7 +239,7 @@ func (h *scaleHandler) checkScalers(ctx context.Context, scalableObject interfac
 func (h *scaleHandler) isScaledObjectActive(ctx context.Context, scalers []scalers.Scaler, scaledObject *kedav1alpha1.ScaledObject) (bool, bool) {
 	isActive := false
 	isError := false
-	for i, scaler := range scalers {
+	for scalerIndex, scaler := range scalers {
 		isTriggerActive, err := scaler.IsActive(ctx)
 		scaler.Close()
 
@@ -251,12 +251,12 @@ func (h *scaleHandler) isScaledObjectActive(ctx context.Context, scalers []scale
 		} else if isTriggerActive {
 			isActive = true
 			if externalMetricsSpec := scaler.GetMetricSpecForScaling()[0].External; externalMetricsSpec != nil {
-				h.logger.V(1).Info("Scaler for scaledObject is active", "Metrics Name", externalMetricsSpec.Metric.Name)
+				h.logger.V(1).Info("Scaler for scaledObject is active", "Metrics Name", fmt.Sprintf("s%d-%s", scalerIndex, externalMetricsSpec))
 			}
 			if resourceMetricsSpec := scaler.GetMetricSpecForScaling()[0].Resource; resourceMetricsSpec != nil {
 				h.logger.V(1).Info("Scaler for scaledObject is active", "Metrics Name", resourceMetricsSpec.Name)
 			}
-			closeScalers(scalers[i+1:])
+			closeScalers(scalers[scalerIndex+1:])
 			break
 		}
 	}


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This draft shows the approach of using the scaler index as a prefix to ensure all metric names are unique in the ScaledObject. All the metric names will be composed using the pattern `sX-currentMetricName` where `x` is the index.

I have just tried the changes executing PostgreSQL and MongoDB e2e tests and it works really fine. 
I tried to do above the scalers in order to avoid a lot of changes.
@tomkerkhove @zroubalik @ahmelsayed 
Could you share your thoughts?

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2123
