### PR TITLE
chore: Change `feature` as allowed label for stale issues, instead of `feature-request`

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - cant-touch-this
-  - feature-request
+  - feature
   - security
 
 # Label to use when marking an issue as stale


### PR DESCRIPTION
Change `feature` as allowed label for stale issues, instead of `feature-request` as our intention was to mark issues as features if we want to keep them around.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Relates to https://github.com/kedacore/governance/issues/33
