### PR TITLE
docs: Add step in release process for next release

### DIFF
--- a/RELEASE-PROCESS.MD
+++ b/RELEASE-PROCESS.MD
@@ -83,4 +83,4 @@ Create Helm release on GitHub with changelog of what changed to our Helm chart.
 
 ## 7. Prepare next release
 
-Prepare next release by creating a new GitHub milestone with a target date in 3 months as per our [release governance](https://github.com/kedacore/governance/blob/main/RELEASES.md).
+Prepare next release by creating a [new GitHub milestone](https://github.com/kedacore/keda/milestones/new) called `v{upcoming-semver-version}` with a target date in 3 months as per our [release governance](https://github.com/kedacore/governance/blob/main/RELEASES.md).


### PR DESCRIPTION
Add step in release process for next release to create a new GitHub milestone.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Relates to https://github.com/kedacore/governance/issues/24
