### PR TITLE
Fix Cassandra e2e test

### DIFF
--- a/tests/scalers/cassandra.test.ts
+++ b/tests/scalers/cassandra.test.ts
@@ -196,6 +196,25 @@ spec:
 `
 
 const nginxDeployYaml = `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cassandra-secrets
+type: Opaque
+data:
+  cassandra_password: Y2Fzc2FuZHJhCg==
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-cassandra-secret
+spec:
+  secretTargetRef:
+  - parameter: password
+    name: cassandra-secrets
+    key: cassandra_password
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -237,27 +256,10 @@ spec:
       consistency: "Quorum"
       protocolVersion: "4"
       port: "9042"
+      keyspace: "${cassandraKeyspace}"
       query: "SELECT COUNT(*) FROM ${cassandraKeyspace}.${cassandraTableName};"
       targetQueryValue: "1"
       metricName: "${cassandraKeyspace}"
     authenticationRef:
       name: keda-trigger-auth-cassandra-secret
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cassandra-secrets
-type: Opaque
-data:
-  cassandra_password: Y2Fzc2FuZHJhCg==
----
-apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-  name: keda-trigger-auth-cassandra-secret
-spec:
-  secretTargetRef:
-  - parameter: password
-    name: cassandra-secrets
-    key: cassandra_password
 `


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Problem:

```
2021-11-01T14:59:32.0823763Z 202***-***-0***T***4:48:25.590Z	INFO	controller.scaledobject	Reconciling ScaledObject	{"reconciler group": "keda.sh", "reconciler kind": "ScaledObject", "name": "cassandra-scaledobject", "namespace": "cassandra-test"}
2021-11-01T14:59:32.0826654Z 202***-***-0***T***4:48:25.590Z	INFO	controller.scaledobject	Adding Finalizer for the ScaledObject	{"reconciler group": "keda.sh", "reconciler kind": "ScaledObject", "name": "cassandra-scaledobject", "namespace": "cassandra-test"}
2021-11-01T14:59:32.0830282Z 202***-***-0***T***4:48:25.62***Z	INFO	controller.scaledobject	Detected resource targeted for scaling	{"reconciler group": "keda.sh", "reconciler kind": "ScaledObject", "name": "cassandra-scaledobject", "namespace": "cassandra-test", "resource": "apps/v***.Deployment", "name": "nginx-deployment"}
2021-11-01T14:59:32.0834414Z 202***-***-0***T***4:48:25.62***Z	INFO	controller.scaledobject	Creating a new HPA	{"reconciler group": "keda.sh", "reconciler kind": "ScaledObject", "name": "cassandra-scaledobject", "namespace": "cassandra-test", "HPA.Namespace": "cassandra-test", "HPA.Name": "keda-hpa-cassandra-scaledobject"}
2021-11-01T14:59:32.0839109Z 202***-***-0***T***4:48:25.62***Z	ERROR	scalehandler	Error getting triggerAuth	{"type": "ScaledObject", "namespace": "cassandra-test", "name": "cassandra-scaledobject", "triggerAuthRef.Name": "keda-trigger-auth-cassandra-secret", "error": "TriggerAuthentication.keda.sh \"keda-trigger-auth-cassandra-secret\" not found"}
...
2021-11-01T14:59:32.0878894Z 202***-***-0***T***4:48:25.622Z	ERROR	controller.scaledobject	Error getting scalers	{"reconciler group": "keda.sh", "reconciler kind": "ScaledObject", "name": "cassandra-scaledobject", "namespace": "cassandra-test", "error": "error getting scaler for trigger #0: error parsing cassandra metadata: no keyspace given"}
```


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to: https://github.com/kedacore/keda/issues/2227
