### PR TITLE
Fix Cassandra e2e tests part 2

### DIFF
--- a/tests/scalers/cassandra.test.ts
+++ b/tests/scalers/cassandra.test.ts
@@ -152,7 +152,7 @@ spec:
         app: cassandra-app
     spec:
       containers:
-      - image: cassandra:latest
+      - image: bitnami/cassandra:4.0.1
         imagePullPolicy: IfNotPresent
         name: cassandra
         ports:
@@ -190,7 +190,7 @@ spec:
         app: cassandra-client
     spec:
       containers:
-      - image: docker.io/bitnami/cassandra:4.0.1-debian-10-r0
+      - image: bitnami/cassandra:4.0.1
         imagePullPolicy: IfNotPresent
         name: cassandra-client
 `
@@ -203,7 +203,7 @@ metadata:
   name: cassandra-secrets
 type: Opaque
 data:
-  cassandra_password: Y2Fzc2FuZHJhCg==
+  cassandra_password: Y2Fzc2FuZHJh
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->


The Secret has encoded `cassandra\n` as the password instead of `cassandra`. Also changing cassandra images to bitnami/cassandra as they are non root.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Relates to: https://github.com/kedacore/keda/issues/2227
