### PR TITLE
Add github action to run e2e command "on-demand"

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -78,8 +78,12 @@ jobs:
           IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
         run: |
           MESSAGE="${{ github.event.comment.body }}"
-          REGEX=${MESSAGE#"/e2e "}
-          export e2eTestRegex=$REGEX
+          REGEX='/e2e (.+)'
+          if [[ "$MESSAGE" =~ $REGEX ]]
+          then
+            export e2eTestRegex="${BASH_REMATCH[1]}"
+          fi
+          echo "${{ steps.checkout.outputs.pr_num }}"
           make e2e-test
 
       - name: React to comment

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: React to comment
         uses: dkershner6/reaction-action@v1
-        if: steps.test.conclusion == "success"
+        if: steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: React to comment
         uses: dkershner6/reaction-action@v1
-        if: !(steps.test.conclusion == "success")
+        if: steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -1,0 +1,91 @@
+name: pr-e2e-tests
+concurrency: e2e-tests
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: khan/pull-request-comment-trigger@master
+        id: check-comment
+        with:
+          trigger: 'e2e'
+          reaction: rocket
+          prefix_only: true
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Check user permission
+        id: check-permission
+        uses: scherermichael-oss/action-has-permission@master
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout Pull Request
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: checkout
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_NUM=${PR_URL##*/}
+          echo "Checking out from PR #$PR_NUM based on URL: $PR_URL"
+          hub pr checkout $PR_NUM
+          echo "::set-output name=pr_num::$PR_NUM"
+      
+      - name: Login to GitHub Container Registry
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
+        uses: docker/login-action@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_AUTH_PAT }}
+          registry: ghcr.io
+
+      - name: Publish on GitHub Container Registry
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
+        run: make publish VERSION=pr-${{ steps.checkout.outputs.pr_num }}
+        
+      - name: Run end to end tests
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
+        id: test
+        env:
+          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
+          AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
+          AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
+          TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
+          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
+          OPENSTACK_USER_ID: ${{ secrets.OPENSTACK_USER_ID }}
+          OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD }}
+          OPENSTACK_PROJECT_ID: ${{ secrets.OPENSTACK_PROJECT_ID }}
+          OPENSTACK_AUTH_URL: ${{ secrets.OPENSTACK_AUTH_URL }}
+          AZURE_DEVOPS_BUILD_DEFINITON_ID: ${{ secrets.AZURE_DEVOPS_BUILD_DEFINITON_ID }}
+          AZURE_DEVOPS_ORGANIZATION_URL: ${{ secrets.AZURE_DEVOPS_ORGANIZATION_URL }}
+          AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+          AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
+          AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
+        run: make e2e-test VERSION=pr-${{ steps.checkout.outputs.pr_num }}
+
+      - name: React to comment
+        uses: dkershner6/reaction-action@v1
+        if: steps.test.conclusion == "success"
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commentId: ${{ github.event.comment.id }}
+          reaction: "+1"
+      
+      - name: React to comment
+        uses: dkershner6/reaction-action@v1
+        if: steps.test.conclusion != "success"
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commentId: ${{ github.event.comment.id }}
+          reaction: "-1"

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -86,6 +86,12 @@ jobs:
           echo "${{ steps.checkout.outputs.pr_num }}"
           make e2e-test
 
+      - name: Publish on GitHub Container Registry
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
+        run: make docker-delete
+        env:
+          IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1
         if: steps.test.outcome == 'success'

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -53,7 +53,7 @@ jobs:
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         run: make publish
         env:
-          IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+          E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
 
       - name: Run end to end tests
         continue-on-error: true
@@ -76,7 +76,7 @@ jobs:
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
-          IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+          E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
         run: |
           MESSAGE="${{ github.event.comment.body }}"
           REGEX='/e2e (.+)'
@@ -87,11 +87,21 @@ jobs:
           echo "${{ steps.checkout.outputs.pr_num }}"
           make e2e-test
 
-      - name: Delete e2e test image
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
-        run: make docker-delete
-        env:
-          IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+      - name: Delete operator tag
+        uses: bots-house/ghcr-delete-image-action@v1.0.1
+        with:
+          owner: kedacore
+          name: keda
+          token: ${{ secrets.GHCR_AUTH_PAT }}
+          tag: "pr-${{ steps.checkout.outputs.pr_num }}"
+
+      - name: Delete metrics server tag
+        uses: bots-house/ghcr-delete-image-action@v1.0.1
+        with:
+          owner: kedacore
+          name: keda-metrics-apiserver
+          token: ${{ secrets.GHCR_AUTH_PAT }}
+          tag: "pr-${{ steps.checkout.outputs.pr_num }}"
 
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -81,7 +81,7 @@ jobs:
           REGEX='/e2e (.+)'
           if [[ "$MESSAGE" =~ $REGEX ]]
           then
-            export e2eTestRegex="${BASH_REMATCH[1]}"
+            export E2E_TEST_REGEX="${BASH_REMATCH[1]}"
           fi
           echo "${{ steps.checkout.outputs.pr_num }}"
           make e2e-test

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -56,6 +56,7 @@ jobs:
           IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
 
       - name: Run end to end tests
+        continue-on-error: true
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         id: test
         env:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -93,7 +93,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}
           reaction: "+1"
-      
+
       - name: React to comment
         uses: dkershner6/reaction-action@v1
         if: steps.test.conclusion != "success"

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -87,22 +87,6 @@ jobs:
           echo "${{ steps.checkout.outputs.pr_num }}"
           make e2e-test
 
-      - name: Delete operator tag
-        uses: bots-house/ghcr-delete-image-action@v1.0.1
-        with:
-          owner: kedacore
-          name: keda-test
-          token: ${{ secrets.GHCR_AUTH_PAT }}
-          tag: "pr-${{ steps.checkout.outputs.pr_num }}"
-
-      - name: Delete metrics server tag
-        uses: bots-house/ghcr-delete-image-action@v1.0.1
-        with:
-          owner: kedacore
-          name: keda-metrics-apiserver-test
-          token: ${{ secrets.GHCR_AUTH_PAT }}
-          tag: "pr-${{ steps.checkout.outputs.pr_num }}"
-
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1
         if: steps.test.outcome == 'success'

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: React to comment
         uses: dkershner6/reaction-action@v1
-        if: steps.test.conclusion != "success"
+        if: !(steps.test.conclusion == "success")
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -39,7 +39,7 @@ jobs:
           echo "Checking out from PR #$PR_NUM based on URL: $PR_URL"
           hub pr checkout $PR_NUM
           echo "::set-output name=pr_num::$PR_NUM"
-      
+
       - name: Login to GitHub Container Registry
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         uses: docker/login-action@v1
@@ -51,7 +51,7 @@ jobs:
       - name: Publish on GitHub Container Registry
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         run: make publish VERSION=pr-${{ steps.checkout.outputs.pr_num }}
-        
+
       - name: Run end to end tests
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         id: test

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -14,13 +14,14 @@ jobs:
       - uses: khan/pull-request-comment-trigger@master
         id: check-comment
         with:
-          trigger: 'e2e'
+          trigger: '/e2e'
           reaction: rocket
           prefix_only: true
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Check user permission
+        if: steps.check-comment.outputs.triggered == 'true'
         id: check-permission
         uses: scherermichael-oss/action-has-permission@master
         with:
@@ -50,7 +51,9 @@ jobs:
 
       - name: Publish on GitHub Container Registry
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
-        run: make publish VERSION=pr-${{ steps.checkout.outputs.pr_num }}
+        run: make publish
+        env:
+          IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
 
       - name: Run end to end tests
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
@@ -72,7 +75,12 @@ jobs:
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
-        run: make e2e-test VERSION=pr-${{ steps.checkout.outputs.pr_num }}
+          IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+        run: |
+          MESSAGE="${{ github.event.comment.body }}"
+          REGEX=${MESSAGE#"/e2e "}
+          export e2eTestRegex=$REGEX
+          make e2e-test
 
       - name: React to comment
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: khan/pull-request-comment-trigger@master
         id: check-comment
         with:
-          trigger: '/e2e'
+          trigger: '/run-e2e'
           reaction: rocket
           prefix_only: true
         env:
@@ -79,7 +79,7 @@ jobs:
           E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
         run: |
           MESSAGE="${{ github.event.comment.body }}"
-          REGEX='/e2e (.+)'
+          REGEX='/run-e2e (.+)'
           if [[ "$MESSAGE" =~ $REGEX ]]
           then
             export E2E_TEST_REGEX="${BASH_REMATCH[1]}"

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    container: ghcr.io/kedacore/build-tools:main
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -87,7 +87,7 @@ jobs:
           echo "${{ steps.checkout.outputs.pr_num }}"
           make e2e-test
 
-      - name: Publish on GitHub Container Registry
+      - name: Delete e2e test image
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         run: make docker-delete
         env:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -91,7 +91,7 @@ jobs:
         uses: bots-house/ghcr-delete-image-action@v1.0.1
         with:
           owner: kedacore
-          name: keda
+          name: keda-test
           token: ${{ secrets.GHCR_AUTH_PAT }}
           tag: "pr-${{ steps.checkout.outputs.pr_num }}"
 
@@ -99,7 +99,7 @@ jobs:
         uses: bots-house/ghcr-delete-image-action@v1.0.1
         with:
           owner: kedacore
-          name: keda-metrics-apiserver
+          name: keda-metrics-apiserver-test
           token: ${{ secrets.GHCR_AUTH_PAT }}
           tag: "pr-${{ steps.checkout.outputs.pr_num }}"
 

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -45,9 +45,9 @@ jobs:
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         uses: docker/login-action@v1
         with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_AUTH_PAT }}
           registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish on GitHub Container Registry
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -86,7 +86,7 @@ jobs:
           echo "${{ steps.checkout.outputs.pr_num }}"
           make e2e-test
 
-      - name: React to comment
+      - name: React to comment with success
         uses: dkershner6/reaction-action@v1
         if: steps.test.outcome == 'success'
         with:
@@ -94,7 +94,7 @@ jobs:
           commentId: ${{ github.event.comment.id }}
           reaction: "+1"
 
-      - name: React to comment
+      - name: React to comment with failure
         uses: dkershner6/reaction-action@v1
         if: steps.test.outcome != 'success'
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Prometheus scaler: omit `serverAddress` from generated metric name ([#2099](https://github.com/kedacore/keda/pull/2099))
 - Add Makefile mockgen targets ([#2090](https://github.com/kedacore/keda/issues/2090)|[#2184](https://github.com/kedacore/keda/pull/2184))
 - Drop support to `ValueMetricType` using cpu_memory_scaler ([#2218](https://github.com/kedacore/keda/issues/2218))
+- Add github action to run e2e command "on-demand" ([#2241](https://github.com/kedacore/keda/issues/2241))
 
 ## v2.4.0
 

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,10 @@ publish-dockerhub: ## Mirror images on Docker Hub.
 	docker push docker.io/$(IMAGE_REPO)/keda:$(VERSION)
 	docker push docker.io/$(IMAGE_REPO)/keda-metrics-apiserver:$(VERSION)
 
+docker-delete: ## Delete images from Container Registry (default: ghcr.io).
+	docker image rm $(IMAGE_CONTROLLER)
+	docker image rm $(IMAGE_ADAPTER)
+
 release: manifests kustomize set-version ## Produce new KEDA release in keda-$(VERSION).yaml file.
 	cd config/manager && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda=${IMAGE_CONTROLLER}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL           = /bin/bash
 # If E2E_IMAGE_TAG is defined, we are on pr e2e test and we have to use the new tag and append -test to the repository
 ifeq '${E2E_IMAGE_TAG}' ''
 VERSION = main
-# SUFIX here is intentional empty to not append nothing the the repository
+# SUFIX here is intentional empty to not append nothing to the repository
 SUFFIX =
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ SHELL           = /bin/bash
 # If E2E_IMAGE_TAG is defined, we are on pr e2e test and we have to use the new tag and append -test to the repository
 ifeq '${E2E_IMAGE_TAG}' ''
 VERSION = main
-SUFFIX = 
+# SUFIX here is intentional empty to not append nothing the the repository
+SUFFIX =
 endif
 
 ifneq '${E2E_IMAGE_TAG}' ''

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 ##################################################
 SHELL           = /bin/bash
 
-# VERSION is the image tag that will be used. It could be provided using environment variable IMAGE_TAG
-VERSION = ${IMAGE_TAG}
+# VERSION is the image tag that will be used. It could be provided using environment variable E2E_IMAGE_TAG
+VERSION = ${E2E_IMAGE_TAG}
 ifeq '$(VERSION)' ''
 VERSION = main
 endif
@@ -173,10 +173,6 @@ publish-dockerhub: ## Mirror images on Docker Hub.
 	docker tag $(IMAGE_ADAPTER) docker.io/$(IMAGE_REPO)/keda-metrics-apiserver:$(VERSION)
 	docker push docker.io/$(IMAGE_REPO)/keda:$(VERSION)
 	docker push docker.io/$(IMAGE_REPO)/keda-metrics-apiserver:$(VERSION)
-
-docker-delete: ## Delete images from Container Registry (default: ghcr.io).
-	docker image rm $(IMAGE_CONTROLLER)
-	docker image rm $(IMAGE_ADAPTER)
 
 release: manifests kustomize set-version ## Produce new KEDA release in keda-$(VERSION).yaml file.
 	cd config/manager && \

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 ##################################################
 SHELL           = /bin/bash
 
-# VERSION is the image tag that will be used. It could be provided using environment variable imageTag
-VERSION = ${imageTag}
+# VERSION is the image tag that will be used. It could be provided using environment variable IMAGE_TAG
+VERSION = ${IMAGE_TAG}
 ifeq '$(VERSION)' ''
 VERSION = main
 endif

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@
 # Variables                                      #
 ##################################################
 SHELL           = /bin/bash
-VERSION        ?= main
+
+# VERSION is the image tag that will be used. It could be provided using environment variable imageTag
+VERSION = ${imageTag}
+ifeq '$(VERSION)' ''
+VERSION = main
+endif
+
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore
 

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,22 @@
 ##################################################
 SHELL           = /bin/bash
 
-# VERSION is the image tag that will be used. It could be provided using environment variable E2E_IMAGE_TAG
-VERSION = ${E2E_IMAGE_TAG}
-ifeq '$(VERSION)' ''
+# If E2E_IMAGE_TAG is defined, we are on pr e2e test and we have to use the new tag and append -test to the repository
+ifeq '${E2E_IMAGE_TAG}' ''
 VERSION = main
+SUFFIX = ''
+endif
+
+ifneq '${E2E_IMAGE_TAG}' ''
+VERSION = ${E2E_IMAGE_TAG}
+SUFFIX = -test
 endif
 
 IMAGE_REGISTRY ?= ghcr.io
 IMAGE_REPO     ?= kedacore
 
-IMAGE_CONTROLLER = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda:$(VERSION)
-IMAGE_ADAPTER    = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda-metrics-apiserver:$(VERSION)
+IMAGE_CONTROLLER = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda$(SUFFIX):$(VERSION)
+IMAGE_ADAPTER    = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda-metrics-apiserver$(SUFFIX):$(VERSION)
 
 IMAGE_BUILD_TOOLS = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/build-tools:main
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL           = /bin/bash
 # If E2E_IMAGE_TAG is defined, we are on pr e2e test and we have to use the new tag and append -test to the repository
 ifeq '${E2E_IMAGE_TAG}' ''
 VERSION = main
-SUFFIX = ''
+SUFFIX = 
 endif
 
 ifneq '${E2E_IMAGE_TAG}' ''

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 set -eu
 
+e2eRegex=${e2eTestRegex:-*.test.ts}
+
 DIR=$(dirname "$0")
 cd $DIR
 
@@ -18,7 +20,7 @@ function run_setup {
 function run_tests {
     counter=0
     # randomize tests order using shuf
-    for test_case in $(find scalers -name "*.test.ts" | shuf)
+    for test_case in $(find scalers -name "$e2eRegex" | shuf)
     do
         counter=$((counter+1))
         ./node_modules/.bin/ava $test_case > "${test_case}.log" 2>&1 &

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -eu
 
-e2eRegex=${e2eTestRegex:-*.test.ts}
+E2E_REGEX=${E2E_TEST_REGEX:-*.test.ts}
 
 DIR=$(dirname "$0")
 cd $DIR
@@ -20,7 +20,7 @@ function run_setup {
 function run_tests {
     counter=0
     # randomize tests order using shuf
-    for test_case in $(find scalers -name "$e2eRegex" | shuf)
+    for test_case in $(find scalers -name "$E2E_REGEX" | shuf)
     do
         counter=$((counter+1))
         ./node_modules/.bin/ava $test_case > "${test_case}.log" 2>&1 &

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -1,14 +1,17 @@
 FROM ubuntu:18.04
 
 # Install prerequisite
-RUN apt-get update && \
-    apt-get install -y wget curl build-essential git
+RUN apt update && \
+    apt-get install software-properties-common -y
+RUN apt-add-repository ppa:git-core/ppa && \ 
+    apt update && \
+    apt install -y wget curl build-essential git
 
 # Use Bash instead of Dash
 RUN ln -sf bash /bin/sh
 
 # Install azure-cli
-RUN apt-get install apt-transport-https lsb-release software-properties-common dirmngr -y && \
+RUN apt-get install apt-transport-https lsb-release dirmngr -y && \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | \
         tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
     AZ_REPO=$(lsb_release -cs) && \
@@ -64,3 +67,8 @@ ENV PATH=${PATH}:/usr/local/go/bin \
 
 # Install FOSSA tooling
 RUN curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+
+# Install hub
+RUN curl -LJO https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz && \
+    tar zxvf hub-linux-amd64-2.14.2.tgz
+ENV PATH="/hub-linux-amd64-2.14.2/bin:${PATH}"

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 # Install prerequisite
 RUN apt update && \
     apt-get install software-properties-common -y
-RUN apt-add-repository ppa:git-core/ppa && \ 
+RUN apt-add-repository ppa:git-core/ppa && \
     apt update && \
     apt install -y wget curl build-essential git
 


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

We have been discussing how to run e2e test in PRs before merge them when anyone with writing permissions requests it.
There are several options to achieve this behavior, in this PR I propose to use several actions in a row to allow it.

When someone with writing permissions comment the PR with the message `/e2e`, automatically this action will be executed reacting the comment with 🚀  to refer that the pipeline is in process, and also with 👍 / 👎  to notify if the e2e tests have passed or not.

Also, the trigger supports setting the e2e test discovery regex using if you want, using this format `/e2e REGEX`, ex:
- `/run-e2e *.test.ts`
- `/run-e2e cron*`

**Note**: To use this feature, we should build and push this image `ghcr.io/kedacore/build-tools:main` because a few extra packages are needed like up-to-dated git, or hub pr
**Note2**: [Because of this](https://github.com/bots-house/ghcr-delete-image-action/issues/29), a PAT with delete permissions in the packages should be added also in order to be able to drop the e2e-test-tag from ghcr. GITHUB_TOKEN is not enough. The expected secret name is `GHCR_AUTH_PAT`

Achievements:
- [x] Execute e2e test on demand using a command
- [x] Allow providing the regex to select a subset of the tests
- [x] Execute the process to ensure that it works


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/discussions/2224
