### PR TITLE
Fix sentinel streams e2e test

### DIFF
--- a/tests/scalers/redis-sentinel-streams.test.ts
+++ b/tests/scalers/redis-sentinel-streams.test.ts
@@ -181,7 +181,7 @@ spec:
       metadata:
         hostsFromEnv: REDIS_HOSTS
         portsFromEnv: REDIS_PORTS
-        sentinelPasswordFromEnv: REDIS_SENTINEL_MASTER
+        sentinelMasterFromEnv: REDIS_SENTINEL_MASTER
         stream: my-stream
         consumerGroup: consumer-group-1
         pendingEntriesCount: "10"


### PR DESCRIPTION
Signed-off-by: Jeroen Bobbeldijk <jeroen@klippa.com>

This fixes a minor mistake in the e2e test for Redis Sentinel Streams

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Relates to #2227
