### PR TITLE
Add triggering condition to failure reaction for on-demand command

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1
-        if: steps.test.outcome == 'success'
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission && steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}
@@ -97,7 +97,7 @@ jobs:
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1
-        if:  steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission && steps.test.outcome != 'success'
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission && steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1
-        if: steps.test.outcome != 'success'
+        if:  steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission && steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

After merged, the new workflow,  all the comment on PRs are reacted with 👎 always that e2e are not successfully passed, even if they should not be executed. 
[This is an example](https://github.com/kedacore/keda/pull/2241#issuecomment-962034017)

The workflow only should react to authorized comments

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated
