### PR TITLE
Split the workflow to trigger e2e test in 2 different jobs

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -1,21 +1,19 @@
 name: pr-e2e-tests
-concurrency: e2e-tests
 on:
   issue_comment:
     types: [created]
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
-    container: ghcr.io/kedacore/build-tools:main
+    name: Comment evaluate
+    outputs:
+      run-e2e: ${{ steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission }}
     steps:
-      - uses: actions/checkout@v2
-
       - uses: khan/pull-request-comment-trigger@master
         id: check-comment
         with:
           trigger: '/run-e2e'
-          reaction: rocket
           prefix_only: true
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -28,9 +26,26 @@ jobs:
           required-permission: write
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: React to comment with rocket
+        uses: dkershner6/reaction-action@v1
+        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commentId: ${{ github.event.comment.id }}
+          reaction: "rocket"
+
+  run-test:
+    needs: check
+    runs-on: ubuntu-latest
+    name: Execute e2e tests
+    container: ghcr.io/kedacore/build-tools:main    
+    concurrency: e2e-tests
+    if: needs.check.outputs.run-e2e == '1'
+    steps:
+      - uses: actions/checkout@v2      
 
       - name: Checkout Pull Request
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: checkout
@@ -42,7 +57,6 @@ jobs:
           echo "::set-output name=pr_num::$PR_NUM"
 
       - name: Login to GitHub Container Registry
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -50,14 +64,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish on GitHub Container Registry
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         run: make publish
         env:
           E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
 
       - name: Run end to end tests
         continue-on-error: true
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
         id: test
         env:
           AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
@@ -89,7 +101,7 @@ jobs:
 
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission && steps.test.outcome == 'success'
+        if: steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}
@@ -97,7 +109,7 @@ jobs:
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission && steps.test.outcome != 'success'
+        if: steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -26,7 +26,7 @@ jobs:
           required-permission: write
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: React to comment with rocket
         uses: dkershner6/reaction-action@v1
         if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
@@ -39,11 +39,11 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     name: Execute e2e tests
-    container: ghcr.io/kedacore/build-tools:main    
+    container: ghcr.io/kedacore/build-tools:main
     concurrency: e2e-tests
     if: needs.check.outputs.run-e2e == '1'
     steps:
-      - uses: actions/checkout@v2      
+      - uses: actions/checkout@v2
 
       - name: Checkout Pull Request
         env:


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The new workflow to trigger e2e-test on demand runs in a single job with concurrency with other e2e processes. This could produce long queues of waiting comments until the e2e tests finish.

This is not necessary at all and can be handled splitting the workflow in 2 different jobs, one without concurrency to evaluate the comments and another one with concurrency to execute the tests. Another improvement using this second way is that the "e2e related steps" don't need a condition in each one because the condition is at job level.

This PR implements the second way to improve the process and also fix a minor problem that react with rocket always when the comment is on a PR 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated
