### PR TITLE
WIP - Cleanup metric names inside scalers

### DIFF
--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -254,7 +254,7 @@ func (s *artemisScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.M
 	targetMetricValue := resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "artemis", s.metadata.brokerName, s.metadata.queueName))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("artemis-%s", s.metadata.queueName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/artemis_scaler_test.go
+++ b/pkg/scalers/artemis_scaler_test.go
@@ -61,8 +61,8 @@ var testArtemisMetadata = []parseArtemisMetadataTestData{
 }
 
 var artemisMetricIdentifiers = []artemisMetricIdentifier{
-	{&testArtemisMetadata[7], 0, "s0-artemis-broker-activemq-queue1"},
-	{&testArtemisMetadata[7], 1, "s1-artemis-broker-activemq-queue1"},
+	{&testArtemisMetadata[7], 0, "s0-artemis-queue1"},
+	{&testArtemisMetadata[7], 1, "s1-artemis-queue1"},
 }
 
 var testArtemisMetadataWithEmptyAuthParams = []parseArtemisMetadataTestData{

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -292,7 +292,7 @@ func (c *awsCloudwatchScaler) GetMetricSpecForScaling(context.Context) []v2beta2
 	targetMetricValue := resource.NewQuantity(int64(c.metadata.targetMetricValue), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(c.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", "aws-cloudwatch", c.metadata.namespace, c.metadata.dimensionName[0], c.metadata.dimensionValue[0]))),
+			Name: GenerateMetricNameWithIndex(c.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-cloudwatch-%s", c.metadata.dimensionName[0]))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/aws_cloudwatch_test.go
+++ b/pkg/scalers/aws_cloudwatch_test.go
@@ -321,8 +321,8 @@ var testAWSCloudwatchMetadata = []parseAWSCloudwatchMetadataTestData{
 }
 
 var awsCloudwatchMetricIdentifiers = []awsCloudwatchMetricIdentifier{
-	{&testAWSCloudwatchMetadata[1], 0, "s0-aws-cloudwatch-AWS-SQS-QueueName-keda"},
-	{&testAWSCloudwatchMetadata[1], 3, "s3-aws-cloudwatch-AWS-SQS-QueueName-keda"},
+	{&testAWSCloudwatchMetadata[1], 0, "s0-aws-cloudwatch-QueueName"},
+	{&testAWSCloudwatchMetadata[1], 3, "s3-aws-cloudwatch-QueueName"},
 }
 
 var awsCloudwatchGetMetricTestData = []awsCloudwatchMetadata{

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -136,7 +136,7 @@ func (s *awsKinesisStreamScaler) GetMetricSpecForScaling(context.Context) []v2be
 	targetShardCountQty := resource.NewQuantity(int64(s.metadata.targetShardCount), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s", "AWS-Kinesis-Stream", s.metadata.streamName))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-kinesis-%s", s.metadata.streamName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/aws_kinesis_stream_test.go
+++ b/pkg/scalers/aws_kinesis_stream_test.go
@@ -220,8 +220,8 @@ var testAWSKinesisMetadata = []parseAWSKinesisMetadataTestData{
 }
 
 var awsKinesisMetricIdentifiers = []awsKinesisMetricIdentifier{
-	{&testAWSKinesisMetadata[1], 0, "s0-AWS-Kinesis-Stream-test"},
-	{&testAWSKinesisMetadata[1], 1, "s1-AWS-Kinesis-Stream-test"},
+	{&testAWSKinesisMetadata[1], 0, "s0-aws-kinesis-test"},
+	{&testAWSKinesisMetadata[1], 1, "s1-aws-kinesis-test"},
 }
 
 var awsKinesisGetMetricTestData = []*awsKinesisStreamMetadata{

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -158,7 +158,7 @@ func (s *awsSqsQueueScaler) GetMetricSpecForScaling(context.Context) []v2beta2.M
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s", "AWS-SQS-Queue", s.metadata.queueName))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-sqs-%s", s.metadata.queueName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/aws_sqs_queue_test.go
+++ b/pkg/scalers/aws_sqs_queue_test.go
@@ -168,8 +168,8 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 }
 
 var awsSQSMetricIdentifiers = []awsSQSMetricIdentifier{
-	{&testAWSSQSMetadata[1], 0, "s0-AWS-SQS-Queue-DeleteArtifactQ"},
-	{&testAWSSQSMetadata[1], 1, "s1-AWS-SQS-Queue-DeleteArtifactQ"},
+	{&testAWSSQSMetadata[1], 0, "s0-aws-sqs-DeleteArtifactQ"},
+	{&testAWSSQSMetadata[1], 1, "s1-aws-sqs-DeleteArtifactQ"},
 }
 
 var awsSQSGetMetricTestData = []*awsSqsQueueMetadata{

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -118,13 +118,9 @@ func parseAzureBlobMetadata(config *ScalerConfig) (*azureBlobMetadata, kedav1alp
 	}
 
 	if val, ok := config.TriggerMetadata["metricName"]; ok {
-		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "azure-blob", val))
+		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("azure-blob-%s", val))
 	} else {
-		if meta.blobPrefix != "" {
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "azure-blob", meta.blobContainerName, meta.blobPrefix))
-		} else {
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "azure-blob", meta.blobContainerName))
-		}
+		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("azure-blob-%s", meta.blobContainerName))
 	}
 
 	// If the Use AAD Pod Identity is not present, or set to "none"

--- a/pkg/scalers/azure_blob_scaler_test.go
+++ b/pkg/scalers/azure_blob_scaler_test.go
@@ -74,7 +74,7 @@ var testAzBlobMetadata = []parseAzBlobMetadataTestData{
 }
 
 var azBlobMetricIdentifiers = []azBlobMetricIdentifier{
-	{&testAzBlobMetadata[1], 0, "s0-azure-blob-sample-blobsubpath-"},
+	{&testAzBlobMetadata[1], 0, "s0-azure-blob-sample"},
 	{&testAzBlobMetadata[2], 1, "s1-azure-blob-customname"},
 	{&testAzBlobMetadata[5], 2, "s2-azure-blob-sample_container"},
 }

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -255,7 +255,7 @@ func (scaler *azureEventHubScaler) GetMetricSpecForScaling(context.Context) []v2
 	targetMetricVal := resource.NewQuantity(scaler.metadata.threshold, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(scaler.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "azure-eventhub", scaler.metadata.eventHubInfo.EventHubConnection, scaler.metadata.eventHubInfo.EventHubConsumerGroup))),
+			Name: GenerateMetricNameWithIndex(scaler.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-eventhub-%s", scaler.metadata.eventHubInfo.EventHubConnection))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -66,8 +66,8 @@ var parseEventHubMetadataDatasetWithPodIdentity = []parseEventHubMetadataTestDat
 }
 
 var eventHubMetricIdentifiers = []eventHubMetricIdentifier{
-	{&parseEventHubMetadataDataset[1], 0, "s0-azure-eventhub-none-testEventHubConsumerGroup"},
-	{&parseEventHubMetadataDataset[1], 1, "s1-azure-eventhub-none-testEventHubConsumerGroup"},
+	{&parseEventHubMetadataDataset[1], 0, "s0-azure-eventhub-none"},
+	{&parseEventHubMetadataDataset[1], 1, "s1-azure-eventhub-none"},
 }
 
 var testEventHubScaler = azureEventHubScaler{

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -194,7 +194,7 @@ func (s *azureMonitorScaler) GetMetricSpecForScaling(context.Context) []v2beta2.
 	targetMetricVal := resource.NewQuantity(int64(s.metadata.targetValue), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", "azure-monitor", s.metadata.azureMonitorInfo.ResourceURI, s.metadata.azureMonitorInfo.ResourceGroupName, s.metadata.azureMonitorInfo.Name))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-monitor-%s", s.metadata.azureMonitorInfo.Name))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_monitor_scaler_test.go
+++ b/pkg/scalers/azure_monitor_scaler_test.go
@@ -82,8 +82,8 @@ var testParseAzMonitorMetadata = []parseAzMonitorMetadataTestData{
 }
 
 var azMonitorMetricIdentifiers = []azMonitorMetricIdentifier{
-	{&testParseAzMonitorMetadata[1], 0, "s0-azure-monitor-test-resource-uri-test-metric"},
-	{&testParseAzMonitorMetadata[1], 1, "s1-azure-monitor-test-resource-uri-test-metric"},
+	{&testParseAzMonitorMetadata[1], 0, "s0-azure-monitor-metric"},
+	{&testParseAzMonitorMetadata[1], 1, "s1-azure-monitor-metric"},
 }
 
 func TestAzMonitorParseMetadata(t *testing.T) {

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -169,7 +169,7 @@ func (s *azurePipelinesScaler) GetMetricSpecForScaling(context.Context) []v2beta
 	targetPipelinesQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetPipelinesQueueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "azure-pipelines-queue", s.metadata.organizationName, s.metadata.poolID))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-pipelines-%s", s.metadata.poolID))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_pipelines_scaler_test.go
+++ b/pkg/scalers/azure_pipelines_scaler_test.go
@@ -40,8 +40,8 @@ var testAzurePipelinesMetadata = []parseAzurePipelinesMetadataTestData{
 }
 
 var azurePipelinesMetricIdentifiers = []azurePipelinesMetricIdentifier{
-	{&testAzurePipelinesMetadata[1], 0, "s0-azure-pipelines-queue-sample-1"},
-	{&testAzurePipelinesMetadata[1], 1, "s1-azure-pipelines-queue-sample-1"},
+	{&testAzurePipelinesMetadata[1], 0, "s0-azure-pipelines-1"},
+	{&testAzurePipelinesMetadata[1], 1, "s1-azure-pipelines-1"},
 }
 
 func TestParseAzurePipelinesMetadata(t *testing.T) {

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -166,7 +166,7 @@ func (s *azureQueueScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Me
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueLength), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s", "azure-queue", s.metadata.queueName))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-queue-%s", s.metadata.queueName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -100,8 +100,8 @@ var parseServiceBusMetadataDataset = []parseServiceBusMetadataTestData{
 }
 
 var azServiceBusMetricIdentifiers = []azServiceBusMetricIdentifier{
-	{&parseServiceBusMetadataDataset[1], 0, "s0-azure-servicebus-namespacename-testqueue"},
-	{&parseServiceBusMetadataDataset[3], 1, "s1-azure-servicebus-namespacename-testtopic-testsubscription"},
+	{&parseServiceBusMetadataDataset[1], 0, "s0-azure-servicebus-testqueue"},
+	{&parseServiceBusMetadataDataset[3], 1, "s1-azure-servicebus-testtopic"},
 }
 
 var commonHTTPClient = &http.Client{

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -157,7 +157,7 @@ func (s *cronScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSp
 	targetMetricValue := resource.NewQuantity(int64(specReplicas), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", "cron", s.metadata.timezone, parseCronTimeFormat(s.metadata.start), parseCronTimeFormat(s.metadata.end)))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("cron-%s-%s-%s", s.metadata.timezone, parseCronTimeFormat(s.metadata.start), parseCronTimeFormat(s.metadata.end)))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/gcp_pub_sub_scaler.go
+++ b/pkg/scalers/gcp_pub_sub_scaler.go
@@ -116,7 +116,7 @@ func (s *pubsubScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Metric
 
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s", "gcp", s.metadata.subscriptionName))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("gcp-%s", s.metadata.subscriptionName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/graphite_scaler.go
+++ b/pkg/scalers/graphite_scaler.go
@@ -145,10 +145,9 @@ func (s *graphiteScaler) Close(context.Context) error {
 
 func (s *graphiteScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(s.metadata.threshold), resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s", "graphite", s.metadata.metricName))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("graphite-%s", s.metadata.metricName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/huawei_cloudeye_scaler.go
+++ b/pkg/scalers/huawei_cloudeye_scaler.go
@@ -245,10 +245,7 @@ func (h *huaweiCloudeyeScaler) GetMetricSpecForScaling(context.Context) []v2beta
 	targetMetricValue := resource.NewQuantity(int64(h.metadata.targetMetricValue), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(h.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s-%s", "huawei-cloudeye",
-				h.metadata.namespace,
-				h.metadata.metricsName,
-				h.metadata.dimensionName, h.metadata.dimensionValue))),
+			Name: GenerateMetricNameWithIndex(h.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("huawei-cloudeye-%s", h.metadata.metricsName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/huawei_cloudeye_test.go
+++ b/pkg/scalers/huawei_cloudeye_test.go
@@ -142,8 +142,8 @@ var testHuaweiCloudeyeMetadata = []parseHuaweiCloudeyeMetadataTestData{
 }
 
 var huaweiCloudeyeMetricIdentifiers = []huaweiCloudeyeMetricIdentifier{
-	{&testHuaweiCloudeyeMetadata[0], 0, "s0-huawei-cloudeye-SYS-ELB-mb_l7_qps-lbaas_instance_id-5e052238-0346-xxb0-86ea-92d9f33e29d2"},
-	{&testHuaweiCloudeyeMetadata[0], 1, "s1-huawei-cloudeye-SYS-ELB-mb_l7_qps-lbaas_instance_id-5e052238-0346-xxb0-86ea-92d9f33e29d2"},
+	{&testHuaweiCloudeyeMetadata[0], 0, "s0-huawei-cloudeye-mb_l7_qps"},
+	{&testHuaweiCloudeyeMetadata[0], 1, "s1-huawei-cloudeye-mb_l7_qps"},
 }
 
 func TestHuaweiCloudeyeParseMetadata(t *testing.T) {

--- a/pkg/scalers/ibmmq_scaler.go
+++ b/pkg/scalers/ibmmq_scaler.go
@@ -205,7 +205,7 @@ func (s *IBMMQScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricS
 	targetQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetQueueDepth), resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "IBMMQ", s.metadata.queueManager, s.metadata.queueName))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("ibmmq-%s", s.metadata.queueName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/ibmmq_scaler_test.go
+++ b/pkg/scalers/ibmmq_scaler_test.go
@@ -34,8 +34,8 @@ type IBMMQMetricIdentifier struct {
 
 // Setting metric identifier mock name
 var IBMMQMetricIdentifiers = []IBMMQMetricIdentifier{
-	{&testIBMMQMetadata[1], 0, "s0-IBMMQ-testQueueManager-testQueue"},
-	{&testIBMMQMetadata[1], 1, "s1-IBMMQ-testQueueManager-testQueue"},
+	{&testIBMMQMetadata[1], 0, "s0-ibmmq-testQueue"},
+	{&testIBMMQMetadata[1], 1, "s1-ibmmq-testQueue"},
 }
 
 // Test cases for TestIBMMQParseMetadata test

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"net/url"
 	"strconv"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
@@ -116,16 +115,7 @@ func parseInfluxDBMetadata(config *ScalerConfig) (*influxDBMetadata, error) {
 	if val, ok := config.TriggerMetadata["metricName"]; ok {
 		metricName = kedautil.NormalizeString(fmt.Sprintf("influxdb-%s", val))
 	} else {
-		parsedURL, err := url.Parse(serverURL)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse server url")
-		}
-
-		maskedURL, err := kedautil.MaskPartOfURL(parsedURL.String(), kedautil.Hostname)
-		if err != nil {
-			return nil, fmt.Errorf("failure masking part of url")
-		}
-		metricName = kedautil.NormalizeString(fmt.Sprintf("influxdb-%s-%s", maskedURL, organizationName))
+		metricName = kedautil.NormalizeString(fmt.Sprintf("influxdb-%s", organizationName))
 	}
 
 	if val, ok := config.TriggerMetadata["thresholdValue"]; ok {

--- a/pkg/scalers/influxdb_scaler_test.go
+++ b/pkg/scalers/influxdb_scaler_test.go
@@ -49,7 +49,7 @@ var testInfluxDBMetadata = []parseInfluxDBMetadataTestData{
 
 var influxDBMetricIdentifiers = []influxDBMetricIdentifier{
 	{&testInfluxDBMetadata[1], 0, "s0-influxdb-influx_metric"},
-	{&testInfluxDBMetadata[2], 1, "s1-influxdb-https---xxx-influx_org"},
+	{&testInfluxDBMetadata[2], 1, "s1-influxdb-influx_org"},
 }
 
 func TestInfluxDBParseMetadata(t *testing.T) {

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -353,7 +353,7 @@ func (s *kafkaScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricS
 	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "kafka", s.metadata.topic, s.metadata.group))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("kafka-%s", s.metadata.topic))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -116,8 +116,8 @@ var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 }
 
 var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
-	{&parseKafkaMetadataTestDataset[4], 0, "s0-kafka-my-topic-my-group"},
-	{&parseKafkaMetadataTestDataset[4], 1, "s1-kafka-my-topic-my-group"},
+	{&parseKafkaMetadataTestDataset[4], 0, "s0-kafka-my-topic"},
+	{&parseKafkaMetadataTestDataset[4], 1, "s1-kafka-my-topic"},
 }
 
 func TestGetBrokers(t *testing.T) {

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -85,7 +85,7 @@ func (s *kubernetesWorkloadScaler) GetMetricSpecForScaling(context.Context) []v2
 	targetMetricValue := resource.NewQuantity(s.metadata.value, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "workload", s.metadata.namespace, normalizeSelectorString(s.metadata.podSelector)))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("workload-%s", s.metadata.namespace))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/kubernetes_workload_scaler_test.go
+++ b/pkg/scalers/kubernetes_workload_scaler_test.go
@@ -92,13 +92,13 @@ type workloadGetMetricSpecForScalingTestData struct {
 
 var getMetricSpecForScalingTestDataset = []workloadGetMetricSpecForScalingTestData{
 	// "podSelector": "app=demo", "namespace": "test"
-	{parseWorkloadMetadataTestDataset[0].metadata, parseWorkloadMetadataTestDataset[0].namespace, 0, "s0-workload-test-app=demo"},
+	{parseWorkloadMetadataTestDataset[0].metadata, parseWorkloadMetadataTestDataset[0].namespace, 0, "s0-workload-test"},
 	// "podSelector": "app=demo", "namespace": "default"
-	{parseWorkloadMetadataTestDataset[1].metadata, parseWorkloadMetadataTestDataset[1].namespace, 1, "s1-workload-default-app=demo"},
+	{parseWorkloadMetadataTestDataset[1].metadata, parseWorkloadMetadataTestDataset[1].namespace, 1, "s1-workload-default"},
 	// "podSelector": "app in (demo1, demo2)", "namespace": "test"
-	{parseWorkloadMetadataTestDataset[2].metadata, parseWorkloadMetadataTestDataset[2].namespace, 2, "s2-workload-test-appin-demo1-demo2-"},
+	{parseWorkloadMetadataTestDataset[2].metadata, parseWorkloadMetadataTestDataset[2].namespace, 2, "s2-workload-test"},
 	// "podSelector": "app in (demo1, demo2),deploy in (deploy1, deploy2)", "namespace": "test"
-	{parseWorkloadMetadataTestDataset[3].metadata, parseWorkloadMetadataTestDataset[3].namespace, 3, "s3-workload-test-appin-demo1-demo2--deployin-deploy1-deploy2-"},
+	{parseWorkloadMetadataTestDataset[3].metadata, parseWorkloadMetadataTestDataset[3].namespace, 3, "s3-workload-test"},
 }
 
 func TestWorkloadGetMetricSpecForScaling(t *testing.T) {

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -86,7 +86,7 @@ func (s *liiklusScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Metri
 	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "liiklus", s.metadata.topic, s.metadata.group))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("liiklus-%s", s.metadata.topic))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/liiklus_scaler_test.go
+++ b/pkg/scalers/liiklus_scaler_test.go
@@ -34,8 +34,8 @@ var parseLiiklusMetadataTestDataset = []parseLiiklusMetadataTestData{
 }
 
 var liiklusMetricIdentifiers = []liiklusMetricIdentifier{
-	{&parseLiiklusMetadataTestDataset[4], 0, "s0-liiklus-foo-mygroup"},
-	{&parseLiiklusMetadataTestDataset[4], 1, "s1-liiklus-foo-mygroup"},
+	{&parseLiiklusMetadataTestDataset[4], 0, "s0-liiklus-foo"},
+	{&parseLiiklusMetadataTestDataset[4], 1, "s1-liiklus-foo"},
 }
 
 func TestLiiklusParseMetadata(t *testing.T) {

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -247,10 +247,9 @@ func (s *metricsAPIScaler) IsActive(ctx context.Context) (bool, error) {
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
 func (s *metricsAPIScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetValue := resource.NewQuantity(int64(s.metadata.targetValue), resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "http", s.metadata.url, s.metadata.valueLocation))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("http-%s", s.metadata.valueLocation))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/mongo_scaler.go
+++ b/pkg/scalers/mongo_scaler.go
@@ -179,11 +179,7 @@ func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error
 	if val, ok := config.TriggerMetadata["metricName"]; ok {
 		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mongodb-%s", val))
 	} else {
-		maskedURL, err := kedautil.MaskPartOfURL(connStr, kedautil.Hostname)
-		if err != nil {
-			return nil, "", fmt.Errorf("failure masking part of url")
-		}
-		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mongodb-%s-%s", maskedURL, meta.collection))
+		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mongodb-%s", meta.collection))
 	}
 	meta.scalerIndex = config.ScalerIndex
 	return &meta, connStr, nil

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -2,7 +2,6 @@ package scalers
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"net/url"
@@ -149,11 +148,6 @@ func parseMSSQLMetadata(config *ScalerConfig) (*mssqlMetadata, error) {
 			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mssql-%s", meta.database))
 		case meta.host != "":
 			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mssql-%s", meta.host))
-		case meta.connectionString != "":
-			// The mssql provider supports of a variety of connection string formats. Instead of trying to parse
-			// the connection string and mask out sensitive data, play it safe and just hash the whole thing.
-			connectionStringHash := sha256.Sum256([]byte(meta.connectionString))
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("mssql-%x", connectionStringHash))
 		default:
 			meta.metricName = "mssql"
 		}

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -2,7 +2,6 @@ package scalers
 
 import (
 	"errors"
-	"strings"
 	"testing"
 )
 
@@ -59,26 +58,26 @@ var testInputs = []mssqlTestData{
 	},
 	// variation of previous: no port, password from authParams, metricName from database name
 	{
-		metadata:    map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks"},
-		resolvedEnv: map[string]string{},
-		authParams:  map[string]string{"password": "Password#2"},
-		// expectedMetricName:       "mssql-AdventureWorks",
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks"},
+		resolvedEnv:              map[string]string{},
+		authParams:               map[string]string{"password": "Password#2"},
+		expectedMetricName:       "mssql-AdventureWorks",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net?database=AdventureWorks",
 	},
 	// connection string generated from full authParams
 	{
-		metadata:    map[string]string{"query": "SELECT 1", "targetValue": "1"},
-		resolvedEnv: map[string]string{},
-		authParams:  map[string]string{"password": "Password#2", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks", "port": "1433"},
-		// expectedMetricName:       "mssql-AdventureWorks",
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1"},
+		resolvedEnv:              map[string]string{},
+		authParams:               map[string]string{"password": "Password#2", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks", "port": "1433"},
+		expectedMetricName:       "mssql-AdventureWorks",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net:1433?database=AdventureWorks",
 	},
 	// variation of previous: no database name, metricName from host
 	{
-		metadata:    map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3"},
-		resolvedEnv: map[string]string{},
-		authParams:  map[string]string{"password": "Password#3"},
-		// expectedMetricName:       "mssql-example-database-windows-net",
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3"},
+		resolvedEnv:              map[string]string{},
+		authParams:               map[string]string{"password": "Password#3"},
+		expectedMetricName:       "mssql-example-database-windows-net",
 		expectedConnectionString: "sqlserver://user3:Password%233@example.database.windows.net",
 	},
 	// Error: missing query
@@ -136,10 +135,6 @@ func TestMSSQLMetadataParsing(t *testing.T) {
 		outputConnectionString := getMSSQLConnectionString(outputMetadata)
 		if testData.expectedConnectionString != outputConnectionString {
 			t.Errorf("Wrong connection string. Expected '%s' but got '%s'", testData.expectedConnectionString, outputConnectionString)
-		}
-
-		if !strings.HasPrefix(outputMetadata.metricName, "mssql-") {
-			t.Errorf("Metric name '%s' was expected to start with 'mssql-' but got '%s'", outputMetadata.metricName, testData.expectedMetricName)
 		}
 
 		if testData.expectedMetricName != "" && testData.expectedMetricName != outputMetadata.metricName {

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -59,26 +59,26 @@ var testInputs = []mssqlTestData{
 	},
 	// variation of previous: no port, password from authParams, metricName from database name
 	{
-		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks"},
-		resolvedEnv:              map[string]string{},
-		authParams:               map[string]string{"password": "Password#2"},
-		expectedMetricName:       "mssql-AdventureWorks",
+		metadata:    map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks"},
+		resolvedEnv: map[string]string{},
+		authParams:  map[string]string{"password": "Password#2"},
+		// expectedMetricName:       "mssql-AdventureWorks",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net?database=AdventureWorks",
 	},
 	// connection string generated from full authParams
 	{
-		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1"},
-		resolvedEnv:              map[string]string{},
-		authParams:               map[string]string{"password": "Password#2", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks", "port": "1433"},
-		expectedMetricName:       "mssql-AdventureWorks",
+		metadata:    map[string]string{"query": "SELECT 1", "targetValue": "1"},
+		resolvedEnv: map[string]string{},
+		authParams:  map[string]string{"password": "Password#2", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks", "port": "1433"},
+		// expectedMetricName:       "mssql-AdventureWorks",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net:1433?database=AdventureWorks",
 	},
 	// variation of previous: no database name, metricName from host
 	{
-		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3"},
-		resolvedEnv:              map[string]string{},
-		authParams:               map[string]string{"password": "Password#3"},
-		expectedMetricName:       "mssql-example-database-windows-net",
+		metadata:    map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3"},
+		resolvedEnv: map[string]string{},
+		authParams:  map[string]string{"password": "Password#3"},
+		// expectedMetricName:       "mssql-example-database-windows-net",
 		expectedConnectionString: "sqlserver://user3:Password%233@example.database.windows.net",
 	},
 	// Error: missing query

--- a/pkg/scalers/openstack_metrics_scaler.go
+++ b/pkg/scalers/openstack_metrics_scaler.go
@@ -197,7 +197,7 @@ func parseOpenstackMetricAuthenticationMetadata(config *ScalerConfig) (openstack
 
 func (a *openstackMetricScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetMetricVal := resource.NewQuantity(int64(a.metadata.threshold), resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("openstack-metric-%s-%s-%s", a.metadata.metricID, strconv.FormatFloat(a.metadata.threshold, 'f', 0, 32), a.metadata.aggregationMethod))
+	metricName := kedautil.NormalizeString(fmt.Sprintf("openstack-metric-%s", a.metadata.metricID))
 
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{

--- a/pkg/scalers/openstack_metrics_scaler_test.go
+++ b/pkg/scalers/openstack_metrics_scaler_test.go
@@ -90,14 +90,14 @@ var invalidOpenstackMetricAuthMetadataTestData = []parseOpenstackMetricAuthMetad
 func TestOpenstackMetricsGetMetricsForSpecScaling(t *testing.T) {
 	// first, test cases with authentication based on password
 	testCases := []openstackMetricScalerMetricIdentifier{
-		{nil, &opentsackMetricMetadataTestData[0], &openstackMetricAuthMetadataTestData[0], 0, "s0-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-mean"},
-		{nil, &opentsackMetricMetadataTestData[1], &openstackMetricAuthMetadataTestData[0], 1, "s1-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-sum"},
-		{nil, &opentsackMetricMetadataTestData[2], &openstackMetricAuthMetadataTestData[0], 2, "s2-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-max"},
-		{nil, &opentsackMetricMetadataTestData[3], &openstackMetricAuthMetadataTestData[0], 3, "s3-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-mean"},
-		{nil, &opentsackMetricMetadataTestData[0], &openstackMetricAuthMetadataTestData[1], 4, "s4-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-mean"},
-		{nil, &opentsackMetricMetadataTestData[1], &openstackMetricAuthMetadataTestData[1], 5, "s5-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-sum"},
-		{nil, &opentsackMetricMetadataTestData[2], &openstackMetricAuthMetadataTestData[1], 6, "s6-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-max"},
-		{nil, &opentsackMetricMetadataTestData[3], &openstackMetricAuthMetadataTestData[1], 7, "s7-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de-1250-mean"},
+		{nil, &opentsackMetricMetadataTestData[0], &openstackMetricAuthMetadataTestData[0], 0, "s0-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
+		{nil, &opentsackMetricMetadataTestData[1], &openstackMetricAuthMetadataTestData[0], 1, "s1-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
+		{nil, &opentsackMetricMetadataTestData[2], &openstackMetricAuthMetadataTestData[0], 2, "s2-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
+		{nil, &opentsackMetricMetadataTestData[3], &openstackMetricAuthMetadataTestData[0], 3, "s3-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
+		{nil, &opentsackMetricMetadataTestData[0], &openstackMetricAuthMetadataTestData[1], 4, "s4-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
+		{nil, &opentsackMetricMetadataTestData[1], &openstackMetricAuthMetadataTestData[1], 5, "s5-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
+		{nil, &opentsackMetricMetadataTestData[2], &openstackMetricAuthMetadataTestData[1], 6, "s6-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
+		{nil, &opentsackMetricMetadataTestData[3], &openstackMetricAuthMetadataTestData[1], 7, "s7-openstack-metric-003bb589-166d-439d-8c31-cbf098d863de"},
 	}
 
 	for _, testData := range testCases {

--- a/pkg/scalers/openstack_swift_scaler.go
+++ b/pkg/scalers/openstack_swift_scaler.go
@@ -392,7 +392,7 @@ func (s *openstackSwiftScaler) GetMetricSpecForScaling(context.Context) []v2beta
 		metricName = s.metadata.containerName
 	}
 
-	metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "openstack-swift", metricName))
+	metricName = kedautil.NormalizeString(fmt.Sprintf("openstack-swift-%s", metricName))
 
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -118,16 +118,7 @@ func parsePostgreSQLMetadata(config *ScalerConfig) (*postgreSQLMetadata, error) 
 	if val, ok := config.TriggerMetadata["metricName"]; ok {
 		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("postgresql-%s", val))
 	} else {
-		if meta.connection != "" {
-			maskedConnectionString, err := kedautil.MaskPartOfURL(meta.connection, kedautil.Password)
-			if err != nil {
-				return nil, fmt.Errorf("url parsing error %s", err.Error())
-			}
-
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("postgresql-%s", maskedConnectionString))
-		} else {
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("postgresql-%s", meta.dbName))
-		}
+		meta.metricName = kedautil.NormalizeString("postgresql")
 	}
 	meta.scalerIndex = config.ScalerIndex
 	return &meta, nil

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -33,11 +33,11 @@ var testPostgreSQLMetdata = []parsePostgreSQLMetadataTestData{
 }
 
 var postgreSQLMetricIdentifiers = []postgreSQLMetricIdentifier{
-	{&testPostgreSQLMetdata[0], map[string]string{"test_connection_string": "postgresql://localhost:5432"}, nil, 0, "s0-postgresql-postgresql---localhost-5432"},
-	{&testPostgreSQLMetdata[1], map[string]string{"test_connection_string2": "postgresql://test@localhost"}, nil, 1, "s1-postgresql-postgresql---test@localhost"},
-	{&testPostgreSQLMetdata[2], nil, map[string]string{"connection": "postgresql://user:password@localhost:5432/dbname"}, 2, "s2-postgresql-postgresql---user-xxx@localhost-5432-dbname"},
+	{&testPostgreSQLMetdata[0], map[string]string{"test_connection_string": "postgresql://localhost:5432"}, nil, 0, "s0-postgresql"},
+	{&testPostgreSQLMetdata[1], map[string]string{"test_connection_string2": "postgresql://test@localhost"}, nil, 1, "s1-postgresql"},
+	{&testPostgreSQLMetdata[2], nil, map[string]string{"connection": "postgresql://user:password@localhost:5432/dbname"}, 2, "s2-postgresql"},
 	{&testPostgreSQLMetdata[3], nil, map[string]string{"connection": "postgresql://Username123:secret@localhost"}, 3, "s3-postgresql-scaler_sql_data2"},
-	{&testPostgreSQLMetdata[4], nil, map[string]string{"connection": "postgresql://user:password@localhost:5432/dbname?app_name=test"}, 4, "s4-postgresql-postgresql---user-xxx@localhost-5432-dbname?app_name=test"},
+	{&testPostgreSQLMetdata[4], nil, map[string]string{"connection": "postgresql://user:password@localhost:5432/dbname?app_name=test"}, 4, "s4-postgresql"},
 	{&testPostgreSQLMetdata[5], nil, map[string]string{"connection": "postgresql://Username123:secret@localhost"}, 5, "s5-postgresql-scaler_sql_data"},
 }
 

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -202,7 +202,7 @@ func (s *prometheusScaler) Close(context.Context) error {
 
 func (s *prometheusScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(int64(s.metadata.threshold), resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s", "prometheus", s.metadata.metricName))
+	metricName := kedautil.NormalizeString(fmt.Sprintf("prometheus-%s", s.metadata.metricName))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -230,13 +230,9 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 
 	// Resolve metricName
 	if val, ok := config.TriggerMetadata["metricName"]; ok {
-		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq", url.QueryEscape(val)))
+		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("rabbitmq-%s", url.QueryEscape(val)))
 	} else {
-		if meta.mode == rabbitModeQueueLength {
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq", url.QueryEscape(meta.queueName)))
-		} else {
-			meta.metricName = kedautil.NormalizeString(fmt.Sprintf("%s-%s", "rabbitmq-rate", url.QueryEscape(meta.queueName)))
-		}
+		meta.metricName = kedautil.NormalizeString(fmt.Sprintf("rabbitmq-%s", url.QueryEscape(meta.queueName)))
 	}
 
 	// Resolve timeout

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -235,7 +235,7 @@ func (s *redisScaler) Close(context.Context) error {
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *redisScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetListLengthQty := resource.NewQuantity(int64(s.metadata.targetListLength), resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s", "redis", s.metadata.listName))
+	metricName := kedautil.NormalizeString(fmt.Sprintf("redis-%s", s.metadata.listName))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),

--- a/pkg/scalers/redis_streams_scaler.go
+++ b/pkg/scalers/redis_streams_scaler.go
@@ -219,10 +219,9 @@ func (s *redisStreamsScaler) Close(context.Context) error {
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *redisStreamsScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetPendingEntriesCount := resource.NewQuantity(int64(s.metadata.targetPendingEntriesCount), resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "redis-streams", s.metadata.streamName, s.metadata.consumerGroupName))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("redis-streams-%s", s.metadata.streamName))),
 		},
 		Target: v2beta2.MetricTarget{
 			Type:         v2beta2.AverageValueMetricType,

--- a/pkg/scalers/redis_streams_scaler_test.go
+++ b/pkg/scalers/redis_streams_scaler_test.go
@@ -134,8 +134,8 @@ func TestRedisStreamsGetMetricSpecForScaling(t *testing.T) {
 	}
 
 	var redisStreamMetricIdentifiers = []redisStreamsMetricIdentifier{
-		{&redisStreamsTestData[0], 0, "s0-redis-streams-my-stream-my-stream-consumer-group"},
-		{&redisStreamsTestData[0], 1, "s1-redis-streams-my-stream-my-stream-consumer-group"},
+		{&redisStreamsTestData[0], 0, "s0-redis-streams-my-stream"},
+		{&redisStreamsTestData[0], 1, "s1-redis-streams-my-stream"},
 	}
 
 	for _, testData := range redisStreamMetricIdentifiers {

--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -127,7 +127,7 @@ func (s *seleniumGridScaler) GetMetrics(ctx context.Context, metricName string, 
 
 func (s *seleniumGridScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetValue := resource.NewQuantity(s.metadata.targetValue, resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", "seleniumgrid", s.metadata.url, s.metadata.browserName, s.metadata.browserVersion))
+	metricName := kedautil.NormalizeString(fmt.Sprintf("seleniumgrid-%s", s.metadata.browserName))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),

--- a/pkg/scalers/solace_scaler.go
+++ b/pkg/scalers/solace_scaler.go
@@ -241,10 +241,10 @@ func getSolaceSempCredentials(config *ScalerConfig) (u string, p string, err err
 //	e.g. solace-myvpn-QUEUE1-msgCount
 func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	var metricSpecList []v2beta2.MetricSpec
+	metricName := kedautil.NormalizeString(fmt.Sprintf("solace-%s", s.metadata.queueName))
 	// Message Count Target Spec
 	if s.metadata.msgCountTarget > 0 {
 		targetMetricValue := resource.NewQuantity(int64(s.metadata.msgCountTarget), resource.DecimalSI)
-		metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", solaceScalerID, s.metadata.messageVpn, s.metadata.queueName, solaceTriggermsgcount))
 		externalMetric := &v2beta2.ExternalMetricSource{
 			Metric: v2beta2.MetricIdentifier{
 				Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
@@ -260,7 +260,6 @@ func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Metric
 	// Message Spool Usage Target Spec
 	if s.metadata.msgSpoolUsageTarget > 0 {
 		targetMetricValue := resource.NewQuantity(int64(s.metadata.msgSpoolUsageTarget), resource.DecimalSI)
-		metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", solaceScalerID, s.metadata.messageVpn, s.metadata.queueName, solaceTriggermsgspoolusage))
 		externalMetric := &v2beta2.ExternalMetricSource{
 			Metric: v2beta2.MetricIdentifier{
 				Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),

--- a/pkg/scalers/solace_scaler_test.go
+++ b/pkg/scalers/solace_scaler_test.go
@@ -368,8 +368,8 @@ var testSolaceGetMetricSpecData = []testSolaceMetadata{
 }
 
 var testSolaceExpectedMetricNames = map[string]string{
-	"s1-" + solaceScalerID + "-" + soltestValidVpn + "-" + soltestValidQueueName + "-" + solaceTriggermsgcount:      "",
-	"s1-" + solaceScalerID + "-" + soltestValidVpn + "-" + soltestValidQueueName + "-" + solaceTriggermsgspoolusage: "",
+	"s1-" + solaceScalerID + "-" + soltestValidQueueName: "",
+	"s1-" + solaceScalerID + "-" + soltestValidQueueName: "",
 }
 
 func TestSolaceParseSolaceMetadata(t *testing.T) {

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -198,7 +198,7 @@ func (s *stanScaler) hasPendingMessage() bool {
 
 func (s *stanScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	targetMetricValue := resource.NewQuantity(s.metadata.lagThreshold, resource.DecimalSI)
-	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s-%s", "stan", s.metadata.queueGroup, s.metadata.durableName, s.metadata.subject))
+	metricName := kedautil.NormalizeString(fmt.Sprintf("stan-%s", s.metadata.subject))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, metricName),
@@ -247,3 +247,4 @@ func (s *stanScaler) GetMetrics(ctx context.Context, metricName string, metricSe
 func (s *stanScaler) Close(context.Context) error {
 	return nil
 }
+

--- a/pkg/scalers/stan_scaler_test.go
+++ b/pkg/scalers/stan_scaler_test.go
@@ -36,8 +36,8 @@ var testStanMetadata = []parseStanMetadataTestData{
 }
 
 var stanMetricIdentifiers = []stanMetricIdentifier{
-	{&testStanMetadata[4], 0, "s0-stan-grp1-ImDurable-mySubject"},
-	{&testStanMetadata[4], 1, "s1-stan-grp1-ImDurable-mySubject"},
+	{&testStanMetadata[4], 0, "s0-stan-mySubject"},
+	{&testStanMetadata[4], 1, "s1-stan-mySubject"},
 }
 
 func TestStanParseMetadata(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

> After #2123, we can ensure that metric names are unique inside ScaledObject. Before it, we used several mechanism inside scalers to avoid conflicts in metric names (like adding part of masked connectionString) those are not needed right now.
IMHO, we should review all scalers and remove those mechanisms. This will clear the code, unify how we are calculating metric names, and reduce risks related with exposing secrets

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2191
