### PR TITLE
Set concurrency for pr-e2e action

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -2,7 +2,7 @@ name: pr-e2e-tests
 on:
   issue_comment:
     types: [created]
-
+concurrency: e2e-tests
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmels@microsoft.com>

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [N/A] Tests have been added
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [N/A] Changelog has been updated

the e2e env is shared, so all actions running e2e should wait on the same concurrency key. 