### PR TITLE
Validate values length for prometheus scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Improve error message if `IdleReplicaCount` are equal to `MinReplicaCount` to be the same as the check ([#2212](https://github.com/kedacore/keda/pull/2212))
 - Improve Cloudwatch Scaler metric exporting logic ([#2243](https://github.com/kedacore/keda/pull/2243))
 - Refactor aws related scalers to reuse the aws clients instead of creating a new one for every GetMetrics call([#2255](https://github.com/kedacore/keda/pull/2255))
+- Validating values length in prometheus query response ([#2264](https://github.com/kedacore/keda/pull/2264))
 
 ### Breaking Changes
 

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -263,6 +263,13 @@ func (s *prometheusScaler) ExecutePromQuery(ctx context.Context) (float64, error
 		return -1, fmt.Errorf("prometheus query %s returned multiple elements", s.metadata.query)
 	}
 
+	valueLen := len(result.Data.Result[0].Value)
+	if valueLen == 0 {
+		return 0, nil
+	} else if valueLen < 2 {
+		return -1, fmt.Errorf("prometheus query %s didn't return enough values", s.metadata.query)
+	}
+
 	val := result.Data.Result[0].Value[1]
 	if val != nil {
 		s := val.(string)


### PR DESCRIPTION
Signed-off-by: Magdalena Andruszak <mandruszak@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Validating values length in prometheus query response. When there is no values returned `invalid array index` panic occurs. 

Solution:
- If there is no values in response return zero
- If single value received return error

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #
