### PR TITLE
Reverting #2261

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -2,7 +2,6 @@ name: pr-e2e-tests
 on:
   issue_comment:
     types: [created]
-concurrency: e2e-tests
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Reverting #2261 because `concurrency` has been already set on the second job in the worklflow: https://github.com/kedacore/keda/blob/5d035404e73aa6b25e5af21d150c99c9e0752bde/.github/workflows/pr-e2e.yml#L43

Setting it once again on the workflow level causes problems like: https://github.com/kedacore/keda/actions/runs/1439326562

```

Execute e2e tests
Canceling since a higher priority waiting request for 'e2e-tests' exists

```


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

