### PR TITLE
change (azure_pipelines): typo and logging improve

### DIFF
--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -139,7 +139,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	r.Body.Close()
 
 	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
-		return -1, fmt.Errorf("azure Devops REST api returned error. status: %d response: %s", r.StatusCode, string(b))
+		return -1, fmt.Errorf("Azure Devops REST API (%s) returned error. StatusCode: %d Response: %s", url, r.StatusCode, string(b))
 	}
 
 	var result map[string]interface{}


### PR DESCRIPTION
We were trying to use this scaler in our use case, and standardizing this error helped us. Because in some cases we thought that the URL was being created wrong, what do you think?

Signed-off-by: Enderson M Candido <endersonster@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

- typo from few words
- logging improve with url output

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))