### PR TITLE
Cache metric names provided by KEDA Metrics Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Improve Redis Scaler, upgrade library, add username and Sentinel support ([#2181](https://github.com/kedacore/keda/pull/2181))
 - Add GCP identity authentication when using Pubsub Scaler ([#2225](https://github.com/kedacore/keda/pull/2225))
 - Add ScalersCache to reuse scalers unless they need changing ([#2187](https://github.com/kedacore/keda/pull/2187))
-- Cache metrics provided by KEDA Metrics Server ([#2279](https://github.com/kedacore/keda/pull/2279))
+- Cache metric names provided by KEDA Metrics Server ([#2279](https://github.com/kedacore/keda/pull/2279))
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Improve Redis Scaler, upgrade library, add username and Sentinel support ([#2181](https://github.com/kedacore/keda/pull/2181))
 - Add GCP identity authentication when using Pubsub Scaler ([#2225](https://github.com/kedacore/keda/pull/2225))
 - Add ScalersCache to reuse scalers unless they need changing ([#2187](https://github.com/kedacore/keda/pull/2187))
+- Cache metrics provided by KEDA Metrics Server ([#2279](https://github.com/kedacore/keda/pull/2279))
 
 ### Improvements
 

--- a/controllers/keda/metrics_adapter_controller.go
+++ b/controllers/keda/metrics_adapter_controller.go
@@ -18,20 +18,68 @@ package keda
 
 import (
 	"context"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scaling"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 type MetricsScaledObjectReconciler struct {
-	ScaleHandler scaling.ScaleHandler
+	Client                  client.Client
+	ScaleHandler            scaling.ScaleHandler
+	ExternalMetricsInfo     *[]provider.ExternalMetricInfo
+	ExternalMetricsInfoLock *sync.RWMutex
 }
 
+var (
+	scaledObjectsMetrics     = map[string][]string{}
+	scaledObjectsMetricsLock = &sync.Mutex{}
+)
+
 func (r *MetricsScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	reqLogger := log.FromContext(ctx)
+
+	// Fetch the ScaledObject instance
+	scaledObject := &kedav1alpha1.ScaledObject{}
+	err := r.Client.Get(ctx, req.NamespacedName, scaledObject)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+
+			r.removeFromCache(req.NamespacedName.String())
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		reqLogger.Error(err, "Failed to get ScaledObject")
+		return ctrl.Result{}, err
+	}
+
+	// Check if the ScaledObject instance is marked to be deleted, which is
+	// indicated by the deletion timestamp being set.
+	if scaledObject.GetDeletionTimestamp() != nil {
+		r.removeFromCache(req.NamespacedName.String())
+		return ctrl.Result{}, nil
+	}
+
+	reqLogger.V(1).Info("Reconciling ScaledObject", "externalMetricNames", scaledObject.Status.ExternalMetricNames)
+
+	// The ScaledObject hasn't yet been properly initialized and ExternalMetricsNames list popoluted => requeue
+	if scaledObject.Status.ExternalMetricNames == nil || len(scaledObject.Status.ExternalMetricNames) < 1 {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	r.addToMetricsCache(req.NamespacedName.String(), scaledObject.Status.ExternalMetricNames)
 	r.ScaleHandler.ClearScalersCache(ctx, req.Name, req.Namespace)
 	return ctrl.Result{}, nil
 }
@@ -42,4 +90,48 @@ func (r *MetricsScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager, optio
 		Owns(&kedav1alpha1.ScaledObject{}).
 		WithOptions(options).
 		Complete(r)
+}
+
+func (r *MetricsScaledObjectReconciler) addToMetricsCache(namespacedName string, metrics []string) {
+	scaledObjectsMetricsLock.Lock()
+	defer scaledObjectsMetricsLock.Unlock()
+	scaledObjectsMetrics[namespacedName] = metrics
+	extMetrics := populateExternalMetrics(scaledObjectsMetrics)
+
+	r.ExternalMetricsInfoLock.Lock()
+	(*r.ExternalMetricsInfo) = extMetrics
+	r.ExternalMetricsInfoLock.Unlock()
+}
+
+func (r *MetricsScaledObjectReconciler) removeFromCache(namespacedName string) {
+	scaledObjectsMetricsLock.Lock()
+	defer scaledObjectsMetricsLock.Unlock()
+	delete(scaledObjectsMetrics, namespacedName)
+	extMetrics := populateExternalMetrics(scaledObjectsMetrics)
+
+	// the metric could have been already removed by the previous call
+	// in this case we don't have to rewrite r.ExternalMetricsInfo
+	changed := false
+	r.ExternalMetricsInfoLock.RLock()
+	if len(*r.ExternalMetricsInfo) != len(extMetrics) {
+		changed = true
+	}
+	r.ExternalMetricsInfoLock.RUnlock()
+
+	if changed {
+		r.ExternalMetricsInfoLock.Lock()
+		(*r.ExternalMetricsInfo) = extMetrics
+		r.ExternalMetricsInfoLock.Unlock()
+	}
+}
+
+func populateExternalMetrics(scaledObjectsMetrics map[string][]string) []provider.ExternalMetricInfo {
+	externalMetrics := []provider.ExternalMetricInfo{}
+	for _, metrics := range scaledObjectsMetrics {
+		for _, m := range metrics {
+			externalMetrics = append(externalMetrics, provider.ExternalMetricInfo{Metric: m})
+		}
+	}
+
+	return externalMetrics
 }

--- a/controllers/keda/metrics_adapter_controller.go
+++ b/controllers/keda/metrics_adapter_controller.go
@@ -121,8 +121,8 @@ func (r *MetricsScaledObjectReconciler) removeFromCache(namespacedName string) {
 
 	if changed {
 		r.ExternalMetricsInfoLock.Lock()
+		defer r.ExternalMetricsInfoLock.Unlock()
 		(*r.ExternalMetricsInfo) = extMetrics
-		r.ExternalMetricsInfoLock.Unlock()
 	}
 }
 

--- a/controllers/keda/metrics_adapter_controller.go
+++ b/controllers/keda/metrics_adapter_controller.go
@@ -67,6 +67,7 @@ func (r *MetricsScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	// Check if the ScaledObject instance is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.
+	// This depends on the preexisting finalizer setup in ScaledObjectController.
 	if scaledObject.GetDeletionTimestamp() != nil {
 		r.removeFromCache(req.NamespacedName.String())
 		return ctrl.Result{}, nil
@@ -99,8 +100,8 @@ func (r *MetricsScaledObjectReconciler) addToMetricsCache(namespacedName string,
 	extMetrics := populateExternalMetrics(scaledObjectsMetrics)
 
 	r.ExternalMetricsInfoLock.Lock()
+	defer r.ExternalMetricsInfoLock.Unlock()
 	(*r.ExternalMetricsInfo) = extMetrics
-	r.ExternalMetricsInfoLock.Unlock()
 }
 
 func (r *MetricsScaledObjectReconciler) removeFromCache(namespacedName string) {

--- a/pkg/provider/fallback_test.go
+++ b/pkg/provider/fallback_test.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
@@ -64,8 +63,6 @@ var _ = Describe("fallback", func() {
 		scaleHandler = mock_scaling.NewMockScaleHandler(ctrl)
 		client = mock_client.NewMockClient(ctrl)
 		providerUnderTest = &KedaProvider{
-			values:           make(map[provider.CustomMetricInfo]int64),
-			externalMetrics:  make([]externalMetric, 2, 10),
 			client:           client,
 			scaleHandler:     scaleHandler,
 			watchedNamespace: "",

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -148,8 +148,8 @@ func (p *KedaProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {
 	logger.V(1).Info("KEDA Metrics Server received request for list fo all provided external metrics names")
 
 	p.externalMetricsInfoLock.RLock()
+	defer p.externalMetricsInfoLock.RUnlock()
 	externalMetricsInfo := *p.externalMetricsInfo
-	p.externalMetricsInfoLock.RUnlock()
 
 	return externalMetricsInfo
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -145,7 +145,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 
 // ListAllExternalMetrics returns the supported external metrics for this provider
 func (p *KedaProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {
-	logger.V(1).Info("KEDA Metrics Server received request for list fo all provided external metrics names")
+	logger.V(1).Info("KEDA Metrics Server received request for list of all provided external metrics names")
 
 	p.externalMetricsInfoLock.RLock()
 	defer p.externalMetricsInfoLock.RUnlock()


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Cache metrics provided by KEDA Metrics Server instead of requesting list of all ScaledObjects in the cluster, this should reduce the load on k8s server and Metrics Server should respond much faster.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

Fixes #2156

Potential fix for: https://github.com/kedacore/keda/issues/1937
