### PR TITLE
`beta.kubernetes.io/os` nodeSelector is deprecated

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,4 +61,4 @@ spec:
               value: ""
       terminationGracePeriodSeconds: 10
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           - mountPath: /tmp
             name: temp-vol
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       volumes:
       - name: temp-vol
         emptyDir: {}

--- a/tests/scalers/azure-blob.test.ts
+++ b/tests/scalers/azure-blob.test.ts
@@ -122,7 +122,7 @@ spec:
               name: test-secrets
               key: AzureWebJobsStorage
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
```
Warning: spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

