### PR TITLE
Use a different cluster for pr e2e runs

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -88,6 +88,7 @@ jobs:
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
           E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+          TEST_CLUSTER_NAME: keda-pr-run
         run: |
           MESSAGE="${{ github.event.comment.body }}"
           REGEX='/run-e2e (.+)'

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Execute e2e tests
     container: ghcr.io/kedacore/build-tools:main
-    concurrency: e2e-tests
+    concurrency: pr-e2e-tests
     if: needs.check.outputs.run-e2e == '1'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Ahmed ElSayed <ahmed@elsayed.io>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #
