### PR TITLE
improve (azure-pipelines): log url on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Cleanup metric names inside scalers ([#2260](https://github.com/kedacore/keda/pull/2260))
 - Validating values length in prometheus query response ([#2264](https://github.com/kedacore/keda/pull/2264))
 - Add `unsafeSsl` parameter in SeleniumGrid scaler ([#2157](https://github.com/kedacore/keda/pull/2157))
+- Improve logs of Azure Pipelines Scaler. ([#2297](https://github.com/kedacore/keda/pull/2297))
 
 ### Breaking Changes
 

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -139,7 +139,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	r.Body.Close()
 
 	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
-		return -1, fmt.Errorf("Azure DevOps REST api returned error. url: %s status: %d response: %s", string(url, r.StatusCode, string(b))
+		return -1, fmt.Errorf("Azure DevOps REST api returned error. url: %s status: %d response: %s", string(url), r.StatusCode, string(b))
 	}
 
 	var result map[string]interface{}

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -139,7 +139,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	r.Body.Close()
 
 	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
-		return -1, fmt.Errorf("Azure DevOps REST api returned error. url: %s status: %d response: %s", string(url), r.StatusCode, string(b))
+		return -1, fmt.Errorf("Azure DevOps REST api returned error. url: %s status: %d response: %s", url, r.StatusCode, string(b))
 	}
 
 	var result map[string]interface{}
@@ -152,7 +152,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	jobs, ok := result["value"].([]interface{})
 
 	if !ok {
-		return -1, fmt.Errorf("api (%s) result returned no value data", string(url))
+		return -1, fmt.Errorf("api (%s) result returned no value data", url)
 	}
 
 	for _, value := range jobs {

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -139,7 +139,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	r.Body.Close()
 
 	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
-		return -1, fmt.Errorf("azure Devops REST api returned error. status: %d response: %s", r.StatusCode, string(b))
+		return -1, fmt.Errorf("Azure DevOps REST api returned error. url: %s status: %d response: %s", string(url, r.StatusCode, string(b))
 	}
 
 	var result map[string]interface{}
@@ -152,7 +152,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	jobs, ok := result["value"].([]interface{})
 
 	if !ok {
-		return -1, fmt.Errorf("api result returned no value data")
+		return -1, fmt.Errorf("api (%s) result returned no value data", string(url))
 	}
 
 	for _, value := range jobs {

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -139,7 +139,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	r.Body.Close()
 
 	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
-		return -1, fmt.Errorf("api REST of Azure DevOps returned error. url: %s status: %d response: %s", url, r.StatusCode, string(b))
+		return -1, fmt.Errorf("the Azure DevOps REST API returned error. url: %s status: %d response: %s", url, r.StatusCode, string(b))
 	}
 
 	var result map[string]interface{}
@@ -152,7 +152,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	jobs, ok := result["value"].([]interface{})
 
 	if !ok {
-		return -1, fmt.Errorf("api (%s) result returned no value data", url)
+		return -1, fmt.Errorf("the Azure DevOps REST API result returned no value data. url: %s status: %d", url, r.StatusCode)
 	}
 
 	for _, value := range jobs {

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -139,7 +139,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 	r.Body.Close()
 
 	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
-		return -1, fmt.Errorf("Azure DevOps REST api returned error. url: %s status: %d response: %s", url, r.StatusCode, string(b))
+		return -1, fmt.Errorf("api REST of Azure DevOps returned error. url: %s status: %d response: %s", url, r.StatusCode, string(b))
 	}
 
 	var result map[string]interface{}


### PR DESCRIPTION
Signed-off-by: Enderson Menezes <endersonster@gmail.com>

Logging URL on Azure Pipelines Scaler Error!

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] Changelog has been updated

---

Hi, I'm new to Go and here at Keda we are running a POC within the company and this little addition helped us to better understand our mistake.

Does this change need to change CHANGELOG? Any other nonsense I've done let me know please!
