### PR TITLE
Add execution url in the pr-e2e triggering comment and fix problem related with not starting with

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -26,14 +26,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: React to comment with rocket
-        uses: dkershner6/reaction-action@v1
-        if: steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commentId: ${{ github.event.comment.id }}
-          reaction: "rocket"
-
   run-test:
     needs: check
     runs-on: ubuntu-latest
@@ -43,6 +35,14 @@ jobs:
     if: needs.check.outputs.run-e2e == '1'
     steps:
       - uses: actions/checkout@v2
+
+      - name: Update comment with the execution url
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            **Update:** You can check the progres [here](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
+          reactions: rocket
 
       - name: Checkout Pull Request
         env:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -7,18 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Comment evaluate
     outputs:
-      run-e2e: ${{ steps.check-comment.outputs.triggered == 'true' && steps.check-permission.outputs.has-permission }}
+      run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.check-permission.outputs.has-permission }}
     steps:
-      - uses: khan/pull-request-comment-trigger@master
-        id: check-comment
-        with:
-          trigger: '/run-e2e'
-          prefix_only: true
-        env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-
       - name: Check user permission
-        if: steps.check-comment.outputs.triggered == 'true'
+        if: startsWith(github.event.comment.body,'/run-e2e')
         id: check-permission
         uses: scherermichael-oss/action-has-permission@master
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Add Makefile mockgen targets ([#2090](https://github.com/kedacore/keda/issues/2090)|[#2184](https://github.com/kedacore/keda/pull/2184))
 - Drop support to `ValueMetricType` using cpu_memory_scaler ([#2218](https://github.com/kedacore/keda/issues/2218))
 - Add github action to run e2e command "on-demand" ([#2241](https://github.com/kedacore/keda/issues/2241))
+- Add execution url in the pr-e2e triggering comment ([#2306](https://github.com/kedacore/keda/issues/2306))
 
 ## v2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 - Add Makefile mockgen targets ([#2090](https://github.com/kedacore/keda/issues/2090)|[#2184](https://github.com/kedacore/keda/pull/2184))
 - Drop support to `ValueMetricType` using cpu_memory_scaler ([#2218](https://github.com/kedacore/keda/issues/2218))
 - Add github action to run e2e command "on-demand" ([#2241](https://github.com/kedacore/keda/issues/2241))
-- Add execution url in the pr-e2e triggering comment ([#2306](https://github.com/kedacore/keda/issues/2306))
+- Add execution url in the pr-e2e triggering comment and fix problem related with not starting with ([#2306](https://github.com/kedacore/keda/issues/2306))
 
 ## v2.4.0
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Using the on-demand e2e test feature, we discovered that getting the execution url is useful to check what happened in case of failure. This PR modifies the workflow in order to update the trigger comment with a link to the execution.

~~**EDIT**: I converted it to draw again because I'd like to solve the problem with the replies also in this PR~~

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/discussions/2224#discussioncomment-1604768
