### PR TITLE
RabbitMQ: use int64 for `pageSize` to avoid conversion problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 - Add support to provide the metric name in Azure Log Analytics Scaler ([#2106](https://github.com/kedacore/keda/pull/2106))
 - MySQL Scaler: don't expose connection string in `metricName` ([#2171](https://github.com/kedacore/keda/pull/2171))
 - Provide support for configuring authentication through TriggerAuthentication for Stan scaler ([#2167](https://github.com/kedacore/keda/pull/2167))
-- Add `pageSize` (using regex) in RabbitMQ Scaler ([#2162](https://github.com/kedacore/keda/pull/2162))
+- Add `pageSize` (using regex) in RabbitMQ Scaler ([#2162](https://github.com/kedacore/keda/pull/2162)|[#2319](https://github.com/kedacore/keda/pull/2319))
 - Add `unsafeSsl` parameter in InfluxDB scaler ([#2157](https://github.com/kedacore/keda/pull/2157))
 - Improve metric name creation to be unique using scaler index inside the scaler ([#2161](https://github.com/kedacore/keda/pull/2161))
 - Improve error message if `IdleReplicaCount` are equal to `MinReplicaCount` to be the same as the check ([#2212](https://github.com/kedacore/keda/pull/2212))

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -67,7 +67,7 @@ type rabbitMQMetadata struct {
 	protocol    string        // either http or amqp protocol
 	vhostName   *string       // override the vhost from the connection info
 	useRegex    bool          // specify if the queueName contains a rexeg
-	pageSize    int           // specify the page size if useRegex is enabled
+	pageSize    int64         // specify the page size if useRegex is enabled
 	operation   string        // specify the operation to apply in case of multiples queues
 	metricName  string        // custom metric name for trigger
 	timeout     time.Duration // custom http timeout for a specific trigger
@@ -205,7 +205,7 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 		if err != nil {
 			return nil, fmt.Errorf("pageSize has invalid value")
 		}
-		meta.pageSize = int(pageSize)
+		meta.pageSize = pageSize
 		if meta.pageSize < 1 {
 			return nil, fmt.Errorf("pageSize should be 1 or greater than 1")
 		}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/2318
