### PR TITLE
chore: Use @kedacore/keda-maintainers for code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-*       @ahmelsayed @zroubalik
+*       @kedacore/keda-maintainers


### PR DESCRIPTION
Use @kedacore/keda-maintainers for code ownership which includes @JorTurFer 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Closes https://github.com/kedacore/governance/issues/42
