### PR TITLE
fix: Use verbose code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-*       @keda-maintainers
+*       @ahmelsayed @zroubalik @JorTurFer


### PR DESCRIPTION
Use verbose code ownership given it's not working with groups.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))