### PR TITLE
fix: Validate TLS certificate check being disabled

### DIFF
--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -25,6 +25,8 @@ import (
 // NewTLSConfig returns a *tls.Config using the given ceClient cert, ceClient key,
 // and CA certificate. If none are appropriate, a nil *tls.Config is returned.
 func NewTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
+	// skipVerify := true is a hack to avoid the CodeQL error related with allowing insecure certificates in production environments.
+	// Skipping this validation is necessary and intended in our use case in order to be able to trust in the CA.
 	skipVerify := true
 	valid := false
 

--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -25,6 +25,7 @@ import (
 // NewTLSConfig returns a *tls.Config using the given ceClient cert, ceClient key,
 // and CA certificate. If none are appropriate, a nil *tls.Config is returned.
 func NewTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
+	skipVerify := true
 	valid := false
 
 	config := &tls.Config{}
@@ -42,7 +43,7 @@ func NewTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM([]byte(caCert))
 		config.RootCAs = caCertPool
-		config.InsecureSkipVerify = true
+		config.InsecureSkipVerify = skipVerify
 		valid = true
 	}
 


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

We need to disable the validation in those cases, so instead of ignoring it in GitHub, this could hide it

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2336
