### PR TITLE
chore: use @kedacore/keda-core-contributors for code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-*       @ahmelsayed @zroubalik @JorTurFer
+*       @kedacore/keda-core-contributors


### PR DESCRIPTION
Use @kedacore/keda-core-contributors for code ownership to see if this works, thanks to @JorTurFer for repo access tip.

Let's see if this works, if not then just revert the PR.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
