### PR TITLE
Add new Datadog scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Add New Relic Scaler ([#2387](https://github.com/kedacore/keda/pull/2387))
 - Add ActiveMQ Scaler ([#2305](https://github.com/kedacore/keda/pull/2305))
+- Add New Datadog Scaler ([#2354](https://github.com/kedacore/keda/pull/2354))
 
 ### Improvements
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/Azure/azure-storage-queue-go v0.0.0-20191125232315-636801874cdd
 	github.com/Azure/go-autorest/autorest v0.11.22
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.9
+	github.com/DataDog/datadog-api-client-go v1.6.0 // indirect
 	github.com/Huawei/gophercloud v1.0.21
 	github.com/Shopify/sarama v1.30.0
 	github.com/aws/aws-sdk-go v1.42.16

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/datadog-api-client-go v1.6.0 h1:ccMzM4vw37/8ww9VKKydWMrI+xEs0uE13O5mkG9Ny/8=
+github.com/DataDog/datadog-api-client-go v1.6.0/go.mod h1:QzaQF1cDO1/BIQG1fz14VrY+6RECUGkiwzDCtVbfP5c=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Huawei/gophercloud v1.0.21 h1:HhtzZzRGZiVmLypqHlXrGAcdC1TJW99FLewfPSVktpY=
 github.com/Huawei/gophercloud v1.0.21/go.mod h1:TUtAO2PE+Nj7/QdfUXbhi5Xu0uFKVccyukPA7UCxD9w=

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -139,7 +139,7 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 func newDatadogConnection(ctx context.Context, meta *datadogMetadata) (*datadog.APIClient, error) {
 
 	ctx = context.WithValue(
-		context.Background(),
+		ctx,
 		datadog.ContextAPIKeys,
 		map[string]datadog.APIKey{
 			"apiKeyAuth": {
@@ -177,7 +177,7 @@ func (s *datadogScaler) Close(context.Context) error {
 func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 
 	ctx = context.WithValue(
-		context.Background(),
+		ctx,
 		datadog.ContextAPIKeys,
 		map[string]datadog.APIKey{
 			"apiKeyAuth": {
@@ -220,7 +220,7 @@ func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
 
 	ctx = context.WithValue(
-		context.Background(),
+		ctx,
 		datadog.ContextAPIKeys,
 		map[string]datadog.APIKey{
 			"apiKeyAuth": {

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -119,15 +119,13 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 		return nil, fmt.Errorf("no app key given")
 	}
 
-	if val, ok := config.AuthParams["datadogSite"]; ok {
-		if val != "" {
-			meta.datadogSite = val
-		} else {
-			meta.datadogSite = "datadoghq.com"
-		}
-	} else {
-		meta.datadogSite = "datadoghq.com"
+	siteVal := "datadoghq.com"
+
+	if val, ok := config.AuthParams["datadogSite"]; ok && val != "" {
+		siteVal = val
 	}
+
+	meta.datadogSite = siteVal
 
 	metricName := meta.query[0:strings.Index(meta.query, "{")]
 	meta.metricName = GenerateMetricNameWithIndex(config.ScalerIndex, kedautil.NormalizeString(fmt.Sprintf("datadog-%s", metricName)))

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -247,7 +247,6 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
 	points := series[0].GetPointlist()
 
 	if len(points) == 0 || len(points[0]) < 2 {
-
 		return 0, fmt.Errorf("no Datadog metrics returned")
 	}
 
@@ -262,7 +261,6 @@ func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Metri
 	targetQueryValue := resource.NewQuantity(int64(s.metadata.queryValue), resource.DecimalSI)
 
 	switch s.metadata.vType {
-
 	case average:
 		externalMetric = &v2beta2.ExternalMetricSource{
 			Metric: v2beta2.MetricIdentifier{

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -107,12 +107,6 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 		meta.vType = average // Default to average between pods
 	}
 
-	if val, ok := config.TriggerMetadata["metricName"]; ok {
-		meta.metricName = GenerateMetricNameWithIndex(config.ScalerIndex, kedautil.NormalizeString(fmt.Sprintf("datadog-%s", val)))
-	} else {
-		return nil, fmt.Errorf("no metric name given")
-	}
-
 	if val, ok := config.AuthParams["apiKey"]; ok {
 		meta.apiKey = val
 	} else {
@@ -134,6 +128,9 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 	} else {
 		meta.datadogSite = "datadoghq.com"
 	}
+
+	metricName := meta.query[0:strings.Index(meta.query, "{")]
+	meta.metricName = GenerateMetricNameWithIndex(config.ScalerIndex, kedautil.NormalizeString(fmt.Sprintf("datadog-%s", metricName)))
 
 	return &meta, nil
 }

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -262,6 +262,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
 func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	var externalMetric *v2beta2.ExternalMetricSource
+	externalMetric = new(v2beta2.ExternalMetricSource)
 
 	targetQueryValue := resource.NewQuantity(int64(s.metadata.queryValue), resource.DecimalSI)
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -256,8 +256,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
 func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	var externalMetric *v2beta2.ExternalMetricSource
-	externalMetric = new(v2beta2.ExternalMetricSource)
+	externalMetric := new(v2beta2.ExternalMetricSource)
 
 	targetQueryValue := resource.NewQuantity(int64(s.metadata.queryValue), resource.DecimalSI)
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -50,7 +50,7 @@ func NewDatadogScaler(ctx context.Context, config *ScalerConfig) (Scaler, error)
 		return nil, fmt.Errorf("error parsing Datadog metadata: %s", err)
 	}
 
-	apiClient, err := newDatadogConnection(ctx, meta)
+	apiClient, err := newDatadogConnection(ctx, meta, config)
 	if err != nil {
 		return nil, fmt.Errorf("error establishing Datadog connection: %s", err)
 	}
@@ -134,7 +134,7 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 }
 
 // newDatddogConnection tests a connection to the Datadog API
-func newDatadogConnection(ctx context.Context, meta *datadogMetadata) (*datadog.APIClient, error) {
+func newDatadogConnection(ctx context.Context, meta *datadogMetadata, config *ScalerConfig) (*datadog.APIClient, error) {
 	ctx = context.WithValue(
 		ctx,
 		datadog.ContextAPIKeys,
@@ -155,6 +155,7 @@ func newDatadogConnection(ctx context.Context, meta *datadogMetadata) (*datadog.
 		})
 
 	configuration := datadog.NewConfiguration()
+	configuration.HTTPClient = kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
 	apiClient := datadog.NewAPIClient(configuration)
 
 	_, _, err := apiClient.AuthenticationApi.Validate(ctx)

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -91,7 +91,7 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 
 	// For all the points in a given window, we take the rollup to the window size
 	rollup := fmt.Sprintf(".rollup(avg, %d)", meta.age)
-	meta.query = meta.query + rollup
+	meta.query += rollup
 
 	if val, ok := config.TriggerMetadata["type"]; ok {
 		val = strings.ToLower(val)
@@ -135,7 +135,6 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 
 // newDatddogConnection tests a connection to the Datadog API
 func newDatadogConnection(ctx context.Context, meta *datadogMetadata) (*datadog.APIClient, error) {
-
 	ctx = context.WithValue(
 		ctx,
 		datadog.ContextAPIKeys,
@@ -173,7 +172,6 @@ func (s *datadogScaler) Close(context.Context) error {
 
 // IsActive returns true if we are able to get metrics from Datadog
 func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
-
 	ctx = context.WithValue(
 		ctx,
 		datadog.ContextAPIKeys,
@@ -216,7 +214,6 @@ func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 
 // getQueryResult returns result of the scaler query
 func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
-
 	ctx = context.WithValue(
 		ctx,
 		datadog.ContextAPIKeys,

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -31,14 +31,14 @@ const (
 )
 
 type datadogMetadata struct {
-	apiKey     string // Database connection string
-	appKey     string
-	ddSite     string
-	query      string
-	queryValue int
-	vType      valueType
-	metricName string
-	age        int
+	apiKey      string
+	appKey      string
+	datadogSite string
+	query       string
+	queryValue  int
+	vType       valueType
+	metricName  string
+	age         int
 }
 
 var datadogLog = logf.Log.WithName("datadog_scaler")
@@ -125,14 +125,14 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 		return nil, fmt.Errorf("no app key given")
 	}
 
-	if val, ok := config.AuthParams["ddSite"]; ok {
+	if val, ok := config.AuthParams["datadogSite"]; ok {
 		if val != "" {
-			meta.ddSite = val
+			meta.datadogSite = val
 		} else {
-			meta.ddSite = "datadoghq.com"
+			meta.datadogSite = "datadoghq.com"
 		}
 	} else {
-		meta.ddSite = "datadoghq.com"
+		meta.datadogSite = "datadoghq.com"
 	}
 
 	return &meta, nil
@@ -157,7 +157,7 @@ func newDatadogConnection(ctx context.Context, meta *datadogMetadata) (*datadog.
 	ctx = context.WithValue(ctx,
 		datadog.ContextServerVariables,
 		map[string]string{
-			"site": meta.ddSite,
+			"site": meta.datadogSite,
 		})
 
 	configuration := datadog.NewConfiguration()
@@ -195,7 +195,7 @@ func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 	ctx = context.WithValue(ctx,
 		datadog.ContextServerVariables,
 		map[string]string{
-			"site": s.metadata.ddSite,
+			"site": s.metadata.datadogSite,
 		})
 
 	resp, _, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)
@@ -238,7 +238,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
 	ctx = context.WithValue(ctx,
 		datadog.ContextServerVariables,
 		map[string]string{
-			"site": s.metadata.ddSite,
+			"site": s.metadata.datadogSite,
 		})
 
 	resp, _, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -1,0 +1,316 @@
+package scalers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/api/autoscaling/v2beta2"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	datadog "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+)
+
+type datadogScaler struct {
+	metadata  *datadogMetadata
+	apiClient *datadog.APIClient
+}
+
+type valueType int
+
+const (
+	average = iota
+	global
+)
+
+type datadogMetadata struct {
+	apiKey     string // Database connection string
+	appKey     string
+	ddSite     string
+	query      string
+	queryValue int
+	vType      valueType
+	metricName string
+	age        int
+}
+
+var datadogLog = logf.Log.WithName("datadog_scaler")
+
+// NewDatadogScaler creates a new Datadog scaler
+func NewDatadogScaler(ctx context.Context, config *ScalerConfig) (Scaler, error) {
+	meta, err := parseDatadogMetadata(config)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Datadog metadata: %s", err)
+	}
+
+	apiClient, err := newDatadogConnection(ctx, meta)
+	if err != nil {
+		return nil, fmt.Errorf("error establishing Datadog connection: %s", err)
+	}
+	return &datadogScaler{
+		metadata:  meta,
+		apiClient: apiClient,
+	}, nil
+}
+
+func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
+	meta := datadogMetadata{}
+
+	if val, ok := config.TriggerMetadata["query"]; ok {
+		meta.query = val
+	} else {
+		return nil, fmt.Errorf("no query given")
+	}
+
+	if val, ok := config.TriggerMetadata["queryValue"]; ok {
+		queryValue, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, fmt.Errorf("queryValue parsing error %s", err.Error())
+		}
+		meta.queryValue = queryValue
+	} else {
+		return nil, fmt.Errorf("no queryValue given")
+	}
+
+	if val, ok := config.TriggerMetadata["age"]; ok {
+		age, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, fmt.Errorf("age parsing error %s", err.Error())
+		}
+		meta.age = age
+	} else {
+		meta.age = 90 // Default window 90 seconds
+	}
+
+	// For all the points in a given window, we take the rollup to the window size
+	rollup := fmt.Sprintf(".rollup(avg, %d)", meta.age)
+	meta.query = meta.query + rollup
+
+	if val, ok := config.TriggerMetadata["type"]; ok {
+		val = strings.ToLower(val)
+		switch val {
+		case "average":
+			meta.vType = average
+		case "global":
+			meta.vType = global
+		default:
+			return nil, fmt.Errorf("type has to be global or average")
+		}
+	} else {
+		meta.vType = average // Default to average between pods
+	}
+
+	if val, ok := config.TriggerMetadata["metricName"]; ok {
+		meta.metricName = GenerateMetricNameWithIndex(config.ScalerIndex, kedautil.NormalizeString(fmt.Sprintf("datadog-%s", val)))
+	} else {
+		return nil, fmt.Errorf("no metric name given")
+	}
+
+	if val, ok := config.AuthParams["apiKey"]; ok {
+		meta.apiKey = val
+	} else {
+		return nil, fmt.Errorf("no api key given")
+	}
+
+	if val, ok := config.AuthParams["appKey"]; ok {
+		meta.appKey = val
+	} else {
+		return nil, fmt.Errorf("no app key given")
+	}
+
+	if val, ok := config.AuthParams["ddSite"]; ok {
+		if val != "" {
+			meta.ddSite = val
+		} else {
+			meta.ddSite = "datadoghq.com"
+		}
+	} else {
+		meta.ddSite = "datadoghq.com"
+	}
+
+	return &meta, nil
+}
+
+// newDatddogConnection tests a connection to the Datadog API
+func newDatadogConnection(ctx context.Context, meta *datadogMetadata) (*datadog.APIClient, error) {
+
+	ctx = context.WithValue(
+		context.Background(),
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{
+			"apiKeyAuth": {
+				Key: meta.apiKey,
+			},
+			"appKeyAuth": {
+				Key: meta.appKey,
+			},
+		},
+	)
+
+	ctx = context.WithValue(ctx,
+		datadog.ContextServerVariables,
+		map[string]string{
+			"site": meta.ddSite,
+		})
+
+	configuration := datadog.NewConfiguration()
+	apiClient := datadog.NewAPIClient(configuration)
+
+	_, _, err := apiClient.AuthenticationApi.Validate(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to Datadog API endpoint: %v", err)
+	}
+
+	return apiClient, nil
+}
+
+// No need to close connections
+func (s *datadogScaler) Close(context.Context) error {
+	return nil
+}
+
+// IsActive returns true if we are able to get metrics from Datadog
+func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
+
+	ctx = context.WithValue(
+		context.Background(),
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{
+			"apiKeyAuth": {
+				Key: s.metadata.apiKey,
+			},
+			"appKeyAuth": {
+				Key: s.metadata.appKey,
+			},
+		},
+	)
+
+	ctx = context.WithValue(ctx,
+		datadog.ContextServerVariables,
+		map[string]string{
+			"site": s.metadata.ddSite,
+		})
+
+	resp, _, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)
+
+	if err != nil {
+		return false, err
+	}
+
+	series := resp.GetSeries()
+
+	if len(series) == 0 {
+		return false, nil
+	}
+
+	points := series[0].GetPointlist()
+
+	if len(points) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// getQueryResult returns result of the scaler query
+func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
+
+	ctx = context.WithValue(
+		context.Background(),
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{
+			"apiKeyAuth": {
+				Key: s.metadata.apiKey,
+			},
+			"appKeyAuth": {
+				Key: s.metadata.appKey,
+			},
+		},
+	)
+
+	ctx = context.WithValue(ctx,
+		datadog.ContextServerVariables,
+		map[string]string{
+			"site": s.metadata.ddSite,
+		})
+
+	resp, _, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)
+	if err != nil {
+		return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", err)
+	}
+
+	series := resp.GetSeries()
+
+	if len(series) == 0 {
+		return 0, fmt.Errorf("no Datadog metrics returned")
+	}
+
+	points := series[0].GetPointlist()
+
+	if len(points) == 0 {
+		return 0, fmt.Errorf("no Datadog metrics returned")
+	}
+
+	var val int = int(*points[0][1])
+
+	return val, nil
+}
+
+// GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
+func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+	var externalMetric *v2beta2.ExternalMetricSource
+
+	targetQueryValue := resource.NewQuantity(int64(s.metadata.queryValue), resource.DecimalSI)
+
+	switch s.metadata.vType {
+
+	case average:
+		externalMetric = &v2beta2.ExternalMetricSource{
+			Metric: v2beta2.MetricIdentifier{
+				Name: s.metadata.metricName,
+			},
+			Target: v2beta2.MetricTarget{
+				Type:         v2beta2.AverageValueMetricType,
+				AverageValue: targetQueryValue,
+			},
+		}
+	case global:
+		externalMetric = &v2beta2.ExternalMetricSource{
+			Metric: v2beta2.MetricIdentifier{
+				Name: s.metadata.metricName,
+			},
+			Target: v2beta2.MetricTarget{
+				Type:  v2beta2.ValueMetricType,
+				Value: targetQueryValue,
+			},
+		}
+	}
+	metricSpec := v2beta2.MetricSpec{
+		External: externalMetric, Type: externalMetricType,
+	}
+	return []v2beta2.MetricSpec{metricSpec}
+}
+
+// GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
+func (s *datadogScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
+	num, err := s.getQueryResult(ctx)
+	if err != nil {
+		datadogLog.Error(err, "error getting metrics from Datadog")
+		return []external_metrics.ExternalMetricValue{}, fmt.Errorf("error getting metrics from Datadog: %s", err)
+	}
+
+	metric := external_metrics.ExternalMetricValue{
+		MetricName: s.metadata.metricName,
+		Value:      *resource.NewQuantity(int64(num), resource.DecimalSI),
+		Timestamp:  metav1.Now(),
+	}
+
+	return append([]external_metrics.ExternalMetricValue{}, metric), nil
+}

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -251,13 +251,12 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
 
 	points := series[0].GetPointlist()
 
-	if len(points) == 0 {
+	if len(points) == 0 || len(points[0]) < 2 {
+
 		return 0, fmt.Errorf("no Datadog metrics returned")
 	}
 
-	var val int = int(*points[0][1])
-
-	return val, nil
+	return int(*points[0][1]), nil
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -21,28 +21,26 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 	{map[string]string{}, map[string]string{}, true},
 
 	// all properly formed
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// default age
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// default type
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// missing query
-	{map[string]string{"queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
+	{map[string]string{"queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// missing queryValue
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
-	// missing metricName
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// wrong query value type
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "notanint", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "notanint", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 
 	// success api/app keys
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// default datadogSite
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey"}, false},
 	// missing apiKey
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"appKey": "appKey"}, true},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"appKey": "appKey"}, true},
 	// missing appKey
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey"}, true},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"apiKey": "apiKey"}, true},
 }
 
 func TestDatadogScalerAuthParams(t *testing.T) {
@@ -59,8 +57,8 @@ func TestDatadogScalerAuthParams(t *testing.T) {
 }
 
 var datadogMetricIdentifiers = []datadogMetricIdentifier{
-	{&testDatadogMetadata[1], 0, "s0-datadog-redis-hits"},
-	{&testDatadogMetadata[1], 1, "s1-datadog-redis-hits"},
+	{&testDatadogMetadata[1], 0, "s0-datadog-sum-trace-redis-command-hits"},
+	{&testDatadogMetadata[1], 1, "s1-datadog-sum-trace-redis-command-hits"},
 }
 
 func TestDatadogGetMetricSpecForScaling(t *testing.T) {

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -1,0 +1,83 @@
+package scalers
+
+import (
+	"context"
+	"testing"
+)
+
+type datadogMetricIdentifier struct {
+	metadataTestData *datadogAuthMetadataTestData
+	scalerIndex      int
+	name             string
+}
+
+type datadogAuthMetadataTestData struct {
+	metadata   map[string]string
+	authParams map[string]string
+	isError    bool
+}
+
+var testDatadogMetadata = []datadogAuthMetadataTestData{
+	{map[string]string{}, map[string]string{}, true},
+
+	// all properly formed
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
+	// default age
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
+	// default type
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
+	// missing query
+	{map[string]string{"queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+	// missing queryValue
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+	// missing metricName
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+	// wrong query value type
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "notanint", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+
+	// success api/app keys
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
+	// default ddSite
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey"}, false},
+	// missing apiKey
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"appKey": "appKey"}, true},
+	// missing appKey
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey"}, true},
+}
+
+func TestDatadogScalerAuthParams(t *testing.T) {
+	for _, testData := range testDatadogMetadata {
+		_, err := parseDatadogMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
+
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+	}
+}
+
+var datadogMetricIdentifiers = []datadogMetricIdentifier{
+	{&testDatadogMetadata[1], 0, "s0-datadog-redis-hits"},
+	{&testDatadogMetadata[1], 1, "s1-datadog-redis-hits"},
+}
+
+func TestDatadogGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range datadogMetricIdentifiers {
+		meta, err := parseDatadogMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, ScalerIndex: testData.scalerIndex})
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+		mockDatadogScaler := datadogScaler{
+			metadata:  meta,
+			apiClient: nil,
+		}
+
+		metricSpec := mockDatadogScaler.GetMetricSpecForScaling(context.Background())
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
+		}
+	}
+}

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -21,23 +21,23 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 	{map[string]string{}, map[string]string{}, true},
 
 	// all properly formed
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// default age
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "type": "average"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// default type
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// missing query
-	{map[string]string{"queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+	{map[string]string{"queryValue": "7", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// missing queryValue
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// missing metricName
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// wrong query value type
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "notanint", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, true},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "notanint", "metricName": "redis-hits", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 
 	// success api/app keys
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "ddSite": "ddSite"}, false},
-	// default ddSite
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
+	// default datadogSite
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey"}, false},
 	// missing apiKey
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricName": "redis-hits"}, map[string]string{"appKey": "appKey"}, true},

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -358,6 +358,8 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 		return scalers.NewCPUMemoryScaler(corev1.ResourceCPU, config)
 	case "cron":
 		return scalers.NewCronScaler(config)
+	case "datadog":
+		return scalers.NewDatadogScaler(ctx, config)
 	case "elasticsearch":
 		return scalers.NewElasticsearchScaler(config)
 	case "external":

--- a/tests/scalers/datadog.test.ts
+++ b/tests/scalers/datadog.test.ts
@@ -25,7 +25,7 @@ let datadogSite = process.env['DATADOG_SITE']
 const testNamespace = 'datadog-test'
 const datadogNamespace = 'datadog'
 const datadogHelmRepo = 'https://helm.datadoghq.com'
-const datadogHelmRelease = 'datadogkeda' 
+const datadogHelmRelease = 'datadogkeda'
 const kuberneteClusterName = 'keda-datadog-cluster'
 
 test.before(t => {
@@ -156,12 +156,12 @@ test.after.always.cb('clean up datadog resources', t => {
 })
 
 const generateRequestsYaml = `apiVersion: v1
-kind: Pod 
+kind: Pod
 metadata:
   name: fake-traffic
 spec:
   containers:
-  - image: busybox 
+  - image: busybox
     name: test
     command: ["/bin/sh"]
     args: ["-c", "while true; do wget -O /dev/null -o /dev/null http://nginx/; sleep 0.1; done"]`
@@ -212,12 +212,12 @@ spec:
         name: nginx
         ports:
         - containerPort: 80
-        - containerPort: 81 
+        - containerPort: 81
         volumeMounts:
-        - mountPath: /etc/nginx/conf.d/status.conf 
+        - mountPath: /etc/nginx/conf.d/status.conf
           subPath: status.conf
           readOnly: true
-          name: "config" 
+          name: "config"
       volumes:
       - name: "config"
         configMap:
@@ -237,7 +237,7 @@ spec:
     name: default
   - port: 81
     protocol: TCP
-    targetPort: 81 
+    targetPort: 81
     name: status
   selector:
     app: nginx
@@ -254,9 +254,9 @@ spec:
   - parameter: appKey
     name: datadog-secrets
     key: appKey
-  - parameter: datadogSite 
+  - parameter: datadogSite
     name: datadog-secrets
-    key: datadogSite 
+    key: datadogSite
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -264,11 +264,11 @@ metadata:
   name: datadog-scaledobject
 spec:
   scaleTargetRef:
-    name: nginx 
+    name: nginx
   minReplicaCount: 1
-  maxReplicaCount: 3 
+  maxReplicaCount: 3
   pollingInterval: 5
-  cooldownPeriod:  10
+  cooldownPeriod: 10
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:

--- a/tests/scalers/datadog.test.ts
+++ b/tests/scalers/datadog.test.ts
@@ -1,0 +1,286 @@
+/*
+To use this test you will need:
+* Datadog API Key
+* Datadog App Key
+* Datadog site
+
+You can get a free account on https://www.datadoghq.com/free-datadog-trial/
+
+once you have your Datadog account set up, you need to setup the following
+environment variables
+
+DATADOG_API_KEY
+DATADOG_APP_KEY
+DATADOG_SITE (optional, default datadoghq.com)
+
+*/
+import * as fs from 'fs'
+import * as sh from 'shelljs'
+import * as tmp from 'tmp'
+import test from 'ava'
+
+const datadogApiKey = process.env['DATADOG_API_KEY']
+const datadogAppKey = process.env['DATADOG_APP_KEY']
+let datadogSite = process.env['DATADOG_SITE']
+const testNamespace = 'datadog-test'
+const datadogNamespace = 'datadog'
+const datadogHelmRepo = 'https://helm.datadoghq.com'
+const datadogHelmRelease = 'datadogkeda' 
+const kuberneteClusterName = 'keda-datadog-cluster'
+
+test.before(t => {
+  if (!datadogApiKey) {
+    t.fail('DATADOG_API_KEY environment variable is required for Datadog tests')
+  }
+  if (!datadogAppKey) {
+    t.fail('DATADOG_APP_KEY environment variable is required for Datadog tests')
+  }
+  if (!datadogSite) {
+    datadogSite = 'datadoghq.com'
+  }
+
+  sh.exec(`helm repo add datadog ${datadogHelmRepo}`)
+  sh.exec(`helm repo update`)
+  let helmInstallStatus = sh.exec(`helm upgrade \
+  		--install \
+  		--set datadog.apiKey=${datadogApiKey} \
+  		--set datadog.appKey=${datadogAppKey} \
+		  --set datadog.site=${datadogSite} \
+		  --set datadog.clusterName=${kuberneteClusterName} \
+		  --set datadog.kubelet.tlsVerify=false \
+		  --create-namespace \
+		  --namespace ${datadogNamespace} \
+        ${datadogHelmRelease} datadog/datadog`).code
+  sh.echo(`${helmInstallStatus}`)
+  t.is(0,
+    helmInstallStatus,
+    'deploying the Datadog Helm chart should work.'
+  )
+
+//  sh.config.silent = true
+
+  // Let's wait until the Datadog agent is ready
+  let datadogDesired = sh.exec(`kubectl get daemonset ${datadogHelmRelease} \
+    --namespace ${datadogNamespace} -o jsonpath="{.status.desiredNumberScheduled}"`).stdout
+
+  let datadogReady = sh.exec(`kubectl get daemonset ${datadogHelmRelease} \
+    --namespace ${datadogNamespace} -o jsonpath="{.status.numberReady}"`).stdout
+  
+  while (datadogReady != datadogDesired) {
+    sh.exec('sleep 2')
+    datadogDesired = sh.exec(`kubectl get daemonset ${datadogHelmRelease} \
+      --namespace ${datadogNamespace} -o jsonpath="{.status.desiredNumberScheduled}"`).stdout
+
+    datadogReady = sh.exec(`kubectl get daemonset ${datadogHelmRelease} \
+      --namespace ${datadogNamespace} -o jsonpath="{.status.numberReady}"`).stdout
+  }
+
+  const tmpFile = tmp.fileSync()
+  fs.writeFileSync(tmpFile.name, deployYaml)
+  sh.exec(`kubectl create namespace ${testNamespace}`)
+  t.is(
+    0,
+    sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
+    'creating a deployment should work.'
+  )
+
+  t.is(
+    0,
+    sh.exec(`kubectl create secret generic datadog-secrets --from-literal=apiKey=${datadogApiKey} \
+      --from-literal=appKey=${datadogAppKey} --from-literal=datadogSite=${datadogSite} --namespace ${testNamespace}`).code,
+    'creating a generic secret should work.'
+  )
+
+  // Sleeping 1m to make sure we are already sending nginx metrics to Datadog
+  sh.exec('sleep 1m')
+})
+
+test.serial('Deployment should have 1 replicas on start', t => {
+  const replicaCount = sh.exec(
+    `kubectl get deployment nginx --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+  ).stdout
+  t.is(replicaCount, '1', 'replica count should start out as 1')
+})
+
+
+test.serial(`NGINX deployment should scale to 3 (the max) when getting too many HTTP requests then back to 1`, t => {
+  // generate fake traffic to the NGINX pod to for scaling up
+  const tmpFile = tmp.fileSync()
+  fs.writeFileSync(tmpFile.name, generateRequestsYaml)
+  t.is(
+    0,
+    sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
+    'creating fake-traffic should work.'
+  )
+
+  // keda based deployment should start scaling up with http requests issued
+  let replicaCount = '1'
+  for (let i = 0; i < 60 && replicaCount !== '3'; i++) {
+    t.log(`Waited ${5 * i} seconds for nginx deployment to scale up`)
+
+    replicaCount = sh.exec(
+      `kubectl get deployment nginx --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+    ).stdout
+    if (replicaCount !== '3') {
+      sh.exec('sleep 15')
+    }
+  }
+
+  t.is('3', replicaCount, 'Replica count should be maxed at 3')
+
+  // Delete fake-traffic to force scaling down
+  t.is(
+    0,
+    sh.exec(`kubectl delete -f ${tmpFile.name} --namespace ${testNamespace}`).code,
+    'deleting fake-traffic should work.'
+  )
+
+  for (let i = 0; i < 50 && replicaCount !== '1'; i++) {
+    replicaCount = sh.exec(
+      `kubectl get deployment nginx --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+    ).stdout
+    if (replicaCount !== '1') {
+      sh.exec('sleep 5')
+    }
+  }
+
+  t.is('1', replicaCount, 'Replica count should be back to 1 after removing the fake traffic')
+  sh.exec('sleep 10')
+})
+
+test.after.always.cb('clean up datadog resources', t => {
+  sh.exec(`helm repo rm datadog`)
+  sh.exec(`kubectl delete namespace ${datadogNamespace} --force`)
+  sh.exec(`kubectl delete namespace ${testNamespace} --force`)
+  t.end()
+})
+
+const generateRequestsYaml = `apiVersion: v1
+kind: Pod 
+metadata:
+  name: fake-traffic
+spec:
+  containers:
+  - image: busybox 
+    name: test
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do wget -O /dev/null -o /dev/null http://nginx/; sleep 0.1; done"]`
+
+const deployYaml = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data:
+  status.conf: |
+    server {
+      listen 81;
+
+      location /nginx_status {
+        stub_status on;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+      annotations:
+        ad.datadoghq.com/nginx.check_names: '["nginx"]'
+        ad.datadoghq.com/nginx.init_configs: '[{}]'
+        ad.datadoghq.com/nginx.instances: |
+          [
+            {
+              "nginx_status_url":"http://%%host%%:81/nginx_status/"
+            }
+          ]      
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        ports:
+        - containerPort: 80
+        - containerPort: 81 
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d/status.conf 
+          subPath: status.conf
+          readOnly: true
+          name: "config" 
+      volumes:
+      - name: "config"
+        configMap:
+          name: "nginx-conf"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+    name: default
+  - port: 81
+    protocol: TCP
+    targetPort: 81 
+    name: status
+  selector:
+    app: nginx
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-datadog-secret
+spec:
+  secretTargetRef:
+  - parameter: apiKey
+    name: datadog-secrets
+    key: apiKey
+  - parameter: appKey
+    name: datadog-secrets
+    key: appKey
+  - parameter: datadogSite 
+    name: datadog-secrets
+    key: datadogSite 
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: datadog-scaledobject
+spec:
+  scaleTargetRef:
+    name: nginx 
+  minReplicaCount: 1
+  maxReplicaCount: 3 
+  pollingInterval: 5
+  cooldownPeriod:  10
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 10
+  triggers:
+  - type: datadog
+    metadata:
+      query: "avg:nginx.net.request_per_s{cluster_name:keda-datadog-cluster}"
+      queryValue: "2"
+      type: "global"
+      age: "60"
+    authenticationRef:
+      name: keda-trigger-auth-datadog-secret
+`

--- a/tests/scalers/datadog.test.ts
+++ b/tests/scalers/datadog.test.ts
@@ -39,8 +39,16 @@ test.before(t => {
     datadogSite = 'datadoghq.com'
   }
 
+  sh.config.silent = true
+
+  sh.exec(`kubectl delete namespace ${datadogNamespace} --force`)
+  sh.exec(`kubectl delete namespace ${testNamespace} --force`)
+
   sh.exec(`helm repo add datadog ${datadogHelmRepo}`)
   sh.exec(`helm repo update`)
+
+  sh.config.silent = false
+
   let helmInstallStatus = sh.exec(`helm upgrade \
   		--install \
   		--set datadog.apiKey=${datadogApiKey} \

--- a/tests/scalers/datadog.test.ts
+++ b/tests/scalers/datadog.test.ts
@@ -57,7 +57,7 @@ test.before(t => {
     'deploying the Datadog Helm chart should work.'
   )
 
-//  sh.config.silent = true
+  sh.config.silent = true
 
   // Let's wait until the Datadog agent is ready
   let datadogDesired = sh.exec(`kubectl get daemonset ${datadogHelmRelease} \
@@ -65,7 +65,7 @@ test.before(t => {
 
   let datadogReady = sh.exec(`kubectl get daemonset ${datadogHelmRelease} \
     --namespace ${datadogNamespace} -o jsonpath="{.status.numberReady}"`).stdout
-  
+
   while (datadogReady != datadogDesired) {
     sh.exec('sleep 2')
     datadogDesired = sh.exec(`kubectl get daemonset ${datadogHelmRelease} \
@@ -205,7 +205,7 @@ spec:
             {
               "nginx_status_url":"http://%%host%%:81/nginx_status/"
             }
-          ]      
+          ]
     spec:
       containers:
       - image: nginx


### PR DESCRIPTION
This PR adds a new Datadog scaler. Right now, it uses Datadog metrics to drive HPA, both on a target value and a target average value. In the future, it could grow to also allow to scale based on events, monitor statuses, etc.

Related docs PR: https://github.com/kedacore/keda-docs/pull/602

This is an example of what the TriggerAuthentication and the ScaledObject definitions would look like:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: datadog-secrets
  namespace: my-project
type: Opaque
data:
  apiKey: # Required: base64 encoded value of Datadog apiKey
  appKey: # Required: base64 encoded value of Datadog appKey
  datadogSite: # Optional: base64 encoded value of Datadog site
---
apiVersion: keda.sh/v1alpha1
kind: TriggerAuthentication
metadata:
  name: keda-trigger-auth-datadog-secret
  namespace: my-project
spec:
  secretTargetRef:
    # Required: API key for your Datadog account
  - parameter: apiKey
    name: datadog-secrets
    key: apiKey
    # Required: APP key for your Datadog account
  - parameter: appKey
    name: datadog-secrets
    key: appKey
    # Optional: Datadog site. Default: "datadoghq.com"
  - parameter: datadogSite
    name: datadog-secrets
    key: datadogSite
---
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: datadog-scaledobject
  namespace: my-project
spec:
  scaleTargetRef:
    name: worker
  triggers:
  - type: datadog
    metadata:
      # Required: datadog metric query
      query: "sum:trace.redis.command.hits{env:none,service:redis}.as_count()"
      # Required: according to the number of query result, to scale the TargetRef
      queryValue: "7"
      # Optional: (global or average). Whether the target value is global or average per pod. Default: average
      type: "global"
      # Optional: The time window (in seconds) to retrieve metrics from Datadog. Default: 90
      age: "60"
    authenticationRef:
      name: keda-trigger-auth-datadog-secret
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Relates to #1002
