### PR TITLE
chore: Remove PR checkbox for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
   "commitBodyTable": true,
   "extends": [
     "config:base",
-    ":gitSignOff"
+    ":gitSignOff",
+    "default:disablePrControls"
   ]
 }


### PR DESCRIPTION
Remove PR checkbox for Renovate PRs which are blocking our checklist PR check.
https://docs.renovatebot.com/presets-default/#disableprcontrols

![image](https://user-images.githubusercontent.com/4345663/143882318-995e2f0d-4484-4633-9b70-61cc89d37101.png)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Follow-up for #2361
