### PR TITLE
Graphite scaler should use latest datapoint, not earliest, returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ## Unreleased
 
+- bugfix: Graphite scaler should use latest datapoint returned, not earliest  (https://github.com/kedacore/keda/pull/2365)
+  
+
 ### New
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@
 
 ## Unreleased
 
-- bugfix: Graphite scaler should use latest datapoint returned, not earliest  (https://github.com/kedacore/keda/pull/2365)
-  
+- bugfix: Graphite scaler should use latest datapoint returned, not earliest  (https://github.com/kedacore/keda/pull/2365)  
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ## Unreleased
 
-- bugfix: Graphite scaler should use latest datapoint returned, not earliest  (https://github.com/kedacore/keda/pull/2365)  
+- bugfix: Graphite scaler should use latest datapoint returned, not earliest  (https://github.com/kedacore/keda/pull/2365)
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@
 
 ## Unreleased
 
-- bugfix: Graphite scaler should use latest datapoint returned, not earliest  (https://github.com/kedacore/keda/pull/2365)
-
 ### New
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 
 ### Improvements
+
+- Graphite Scaler: use the latest datapoint returned, not the earliest (https://github.com/kedacore/keda/pull/2365)
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 

--- a/pkg/scalers/graphite_scaler.go
+++ b/pkg/scalers/graphite_scaler.go
@@ -194,7 +194,8 @@ func (s *graphiteScaler) ExecuteGrapQuery(ctx context.Context) (float64, error) 
 	}
 
 	// https://graphite-api.readthedocs.io/en/latest/api.html#json
-	datapoint := result[0].Datapoints[0][0]
+	latestDatapoint := len(result[0].Datapoints) - 1
+	datapoint := result[0].Datapoints[latestDatapoint][0]
 
 	return datapoint, nil
 }

--- a/pkg/scalers/graphite_scaler.go
+++ b/pkg/scalers/graphite_scaler.go
@@ -194,6 +194,10 @@ func (s *graphiteScaler) ExecuteGrapQuery(ctx context.Context) (float64, error) 
 	}
 
 	// https://graphite-api.readthedocs.io/en/latest/api.html#json
+	if len(result[0].Datapoints) == 0 {
+		return 0, nil
+	}
+
 	latestDatapoint := len(result[0].Datapoints) - 1
 	datapoint := result[0].Datapoints[latestDatapoint][0]
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Graphite query responses return values in order of oldest to latest. With the final element of the response array being the most up-to-date timestamp. Graphite's scaler should be on the most recent datapoint, not on data potentially hours old.

https://graphite-api.readthedocs.io/en/latest/api.html#json
https://github.com/kedacore/keda/blob/main/pkg/scalers/graphite_scaler.go#L197


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

Fixes #2366
