### PR TITLE
Kubernetes Workload Scaler: ignore terminated pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 - Graphite Scaler: use the latest datapoint returned, not the earliest (https://github.com/kedacore/keda/pull/2365)
 
+- Kubernetes Workload Scaler: ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))
+
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,7 @@
 
 ### Improvements
 
-- Graphite Scaler: use the latest datapoint returned, not the earliest (https://github.com/kedacore/keda/pull/2365)
-
+- Graphite Scaler: use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))
 - Kubernetes Workload Scaler: ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -27,10 +27,9 @@ const (
 	valueKey                     = "value"
 )
 
-var countIgnoresPhases = []corev1.PodPhase{
+var phasesCountedAsTerminated = []corev1.PodPhase{
 	corev1.PodSucceeded,
 	corev1.PodFailed,
-	corev1.PodUnknown,
 }
 
 type kubernetesWorkloadMetadata struct {
@@ -140,7 +139,7 @@ func (s *kubernetesWorkloadScaler) getMetricValue(ctx context.Context) (int, err
 }
 
 func getCountValue(pod corev1.Pod) int {
-	for _, ignore := range countIgnoresPhases {
+	for _, ignore := range phasesCountedAsTerminated {
 		if pod.Status.Phase == ignore {
 			return 0
 		}

--- a/pkg/scalers/kubernetes_workload_scaler_test.go
+++ b/pkg/scalers/kubernetes_workload_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -137,4 +138,56 @@ func createPodlist(count int) *v1.PodList {
 		list.Items = append(list.Items, *pod)
 	}
 	return list
+}
+
+func TestWorkloadPhase(t *testing.T) {
+	phases := map[v1.PodPhase]bool{
+		v1.PodRunning:   true,
+		v1.PodSucceeded: false,
+		v1.PodFailed:    false,
+		v1.PodUnknown:   false,
+		v1.PodPending:   true, // polling means we have a delay, so count pending in order to avoid more delays
+	}
+	for phase, active := range phases {
+		list := &v1.PodList{}
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        strings.ToLower(fmt.Sprintf("phase-%s", phase)),
+				Namespace:   "default",
+				Annotations: map[string]string{},
+				Labels: map[string]string{
+					"app": "testphases",
+				},
+			},
+			Status: v1.PodStatus{
+				Phase: phase,
+			},
+		}
+		list.Items = append(list.Items, *pod)
+		s, err := NewKubernetesWorkloadScaler(
+			fake.NewClientBuilder().WithRuntimeObjects(list).Build(),
+			&ScalerConfig{
+				TriggerMetadata: map[string]string{
+					"podSelector": "app=testphases",
+					"value":       "1",
+				},
+				AuthParams:        map[string]string{},
+				GlobalHTTPTimeout: 1000 * time.Millisecond,
+				Namespace:         "default",
+			},
+		)
+		if err != nil {
+			t.Errorf("Failed to create test scaler -- %v", err)
+		}
+		isActive, err := s.IsActive(context.TODO())
+		if err != nil {
+			t.Errorf("Failed to count active -- %v", err)
+		}
+		if active && !isActive {
+			t.Errorf("Expected active for phase %s but got inactive", phase)
+		}
+		if !active && isActive {
+			t.Errorf("Expected inactive for phase %s but got active", phase)
+		}
+	}
 }

--- a/pkg/scalers/kubernetes_workload_scaler_test.go
+++ b/pkg/scalers/kubernetes_workload_scaler_test.go
@@ -142,11 +142,14 @@ func createPodlist(count int) *v1.PodList {
 
 func TestWorkloadPhase(t *testing.T) {
 	phases := map[v1.PodPhase]bool{
-		v1.PodRunning:   true,
+		v1.PodRunning: true,
+		// succeeded and failed clearly count as terminated
 		v1.PodSucceeded: false,
 		v1.PodFailed:    false,
-		v1.PodUnknown:   false,
-		v1.PodPending:   true, // polling means we have a delay, so count pending in order to avoid more delays
+		// unknown could be for example a temporarily unresponsive node; count the pod
+		v1.PodUnknown: true,
+		// count pre-Running to avoid an additional delay on top of the poll interval
+		v1.PodPending: true,
 	}
 	for phase, active := range phases {
 		list := &v1.PodList{}


### PR DESCRIPTION
The kubernetes-workload scaler is great, but I was surprised to discover that it counts terminated pods. While it's useful to have Shutdown or Completed pods stay around to aid for example troubleshooting I fail to come up with a use case where scaling should count them together with running. This PR excludes the two obvious terminated states from the metric value.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation: https://github.com/kedacore/keda-docs/pull/605
- [x] Changelog has been updated
