### PR TITLE
Add New Relic variables for e2e tests

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -79,4 +79,7 @@ jobs:
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
+          NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
+          NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
+          NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}
         run: make e2e-test

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -33,4 +33,7 @@ jobs:
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
+          NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
+          NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
+          NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}
         run: make e2e-test

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -79,6 +79,9 @@ jobs:
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
+          NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
+          NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
+          NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}
           E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
           TEST_CLUSTER_NAME: keda-pr-run
         run: |


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

In order to be able to test [this PR](https://github.com/kedacore/keda/pull/2387), New Relic environment variables are needed, otherwise the pr-e2e workflow will fail because it gets the definition from main branch.
Those variables are already defined inside repo secrets

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

