### PR TITLE
fail fast on `buildScalers` when not able to resolve a secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - **Kafka Scaler:** concurrently query brokers for consumer and producer offsets ([#2405](https://github.com/kedacore/keda/pull/2405))
 - **External Scaler:** fix wrong calculation of retry backoff duration ([#2416](https://github.com/kedacore/keda/pull/2416))
 - **Kafka Scaler:** allow flag `topic` to be optional, where lag of all topics within the consumer group will be used for scaling ([#2409](https://github.com/kedacore/keda/pull/2409))
+- **General:**  fail fast on `buildScalers` when not able to resolve a secret that a deployment is relying on ([#2394](https://github.com/kedacore/keda/pull/2394))
 
 ### Breaking Changes
 

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -316,7 +316,10 @@ func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alp
 			if scaler != nil {
 				scaler.Close(ctx)
 			}
-			return result, err
+			for _, builder := range result {
+				builder.Scaler.Close(ctx)
+			}
+			return nil, err
 		}
 
 		result = append(result, cache.ScalerBuilder{

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -186,7 +186,10 @@ func (h *scaleHandler) GetScalersCache(ctx context.Context, scalableObject inter
 		return nil, err
 	}
 
-	scalers := h.buildScalers(ctx, withTriggers, podTemplateSpec, containerName)
+	scalers, err := h.buildScalers(ctx, withTriggers, podTemplateSpec, containerName)
+	if err != nil {
+		return nil, err
+	}
 
 	h.scalerCaches[key] = &cache.ScalersCache{
 		Generation: withTriggers.Generation,
@@ -273,7 +276,7 @@ func (h *scaleHandler) checkScalers(ctx context.Context, scalableObject interfac
 }
 
 // buildScalers returns list of Scalers for the specified triggers
-func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, podTemplateSpec *corev1.PodTemplateSpec, containerName string) []cache.ScalerBuilder {
+func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, podTemplateSpec *corev1.PodTemplateSpec, containerName string) ([]cache.ScalerBuilder, error) {
 	logger := h.logger.WithValues("type", withTriggers.Kind, "namespace", withTriggers.Namespace, "name", withTriggers.Name)
 	var err error
 	resolvedEnv := make(map[string]string)
@@ -313,7 +316,7 @@ func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alp
 			if scaler != nil {
 				scaler.Close(ctx)
 			}
-			continue
+			return result, err
 		}
 
 		result = append(result, cache.ScalerBuilder{
@@ -322,7 +325,7 @@ func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alp
 		})
 	}
 
-	return result
+	return result, nil
 }
 
 func buildScaler(ctx context.Context, client client.Client, triggerType string, config *scalers.ScalerConfig) (scalers.Scaler, error) {


### PR DESCRIPTION
Signed-off-by: Xiayang Wu <xwu@rippling.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Instead of creating an unexpected HPA, fail fast when not able to resolve a secret a deployment is relying on. 
the missing secret can be a mistake or just timing issue.  more details can be found from https://github.com/kedacore/keda/issues/2393



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2393
