### PR TITLE
Kafka scaler: concurrent offset fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Graphite Scaler: use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))
 - Kubernetes Workload Scaler: ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))
 - `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2406](https://github.com/kedacore/keda/pull/2406))|([#2410](https://github.com/kedacore/keda/pull/2410))
+- Kafka Scaler: concurrent partition offset requests ([#2405](https://github.com/kedacore/keda/pull/2405))
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Graphite Scaler: use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))
 - Kubernetes Workload Scaler: ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))
 - `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2406](https://github.com/kedacore/keda/pull/2406))|([#2410](https://github.com/kedacore/keda/pull/2410))
-- Kafka Scaler: concurrent partition offset requests ([#2405](https://github.com/kedacore/keda/pull/2405))
+- Kafka Scaler: concurrently query brokers for consumer and producer offsets ([#2405](https://github.com/kedacore/keda/pull/2405))
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -442,9 +442,9 @@ func (s *kafkaScaler) getTopicOffsets(partitions []int32) (map[int32]int64, erro
 	wg.Add(len(requests))
 	for broker, request := range requests {
 		go func(brCopy *sarama.Broker, reqCopy *sarama.OffsetRequest) {
+			defer wg.Done()
 			response, err := brCopy.GetAvailableOffsets(reqCopy)
 			resultCh <- brokerOffsetResult{response, err}
-			wg.Done()
 		}(broker, request)
 	}
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -448,10 +448,8 @@ func (s *kafkaScaler) getTopicOffsets(partitions []int32) (map[int32]int64, erro
 		}(broker, request)
 	}
 
-	go func() {
-		wg.Wait()
-		close(resultCh)
-	}()
+	wg.Wait()
+	close(resultCh)
 
 	offsets := make(map[int32]int64)
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -437,7 +437,7 @@ func (s *kafkaScaler) getTopicOffsets(partitions []int32) (map[int32]int64, erro
 	}
 
 	// Step 2: send requests, one per broker, and collect offsets
-	resultCh := make(chan brokerOffsetResult)
+	resultCh := make(chan brokerOffsetResult, len(requests))
 	var wg sync.WaitGroup
 	wg.Add(len(requests))
 	for broker, request := range requests {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-## Prerequisits
+## Prerequisites
 
 - [node](https://nodejs.org/en/)
 - `kubectl` logged into a Kubernetes cluster.

--- a/tests/scalers/kafka.test.ts
+++ b/tests/scalers/kafka.test.ts
@@ -11,7 +11,7 @@ const defaultKafkaClient = 'kafka-client'
 const strimziOperatorVersion = '0.18.0'
 const commandToCheckReplicas = `kubectl get deployments/kafka-consumer --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`
 
-const strimziOperatroYamlFile = tmp.fileSync()
+const strimziOperatorYamlFile = tmp.fileSync()
 const kafkaClusterYamlFile = tmp.fileSync()
 const kafkaTopicYamlFile = tmp.fileSync()
 const kafkaClientYamlFile = tmp.fileSync()
@@ -25,10 +25,10 @@ test.before('Set up, create necessary resources.', t => {
 	sh.exec(`kubectl create namespace ${defaultNamespace}`)
 
   const strimziOperatorYaml = sh.exec(`curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimziOperatorVersion}/strimzi-cluster-operator-${strimziOperatorVersion}.yaml`).stdout
-  fs.writeFileSync(strimziOperatroYamlFile.name, strimziOperatorYaml.replace(/myproject/g, `${defaultNamespace}`))
+  fs.writeFileSync(strimziOperatorYamlFile.name, strimziOperatorYaml.replace(/myproject/g, `${defaultNamespace}`))
 	t.is(
 		0,
-		sh.exec(`kubectl apply -f ${strimziOperatroYamlFile.name} --namespace ${defaultNamespace}`).code,
+		sh.exec(`kubectl apply -f ${strimziOperatorYamlFile.name} --namespace ${defaultNamespace}`).code,
 		'Deploying Strimzi operator should work.'
 	)
 
@@ -195,7 +195,7 @@ test.after.always('Clean up, delete created resources.', t => {
     `${kafkaClientYamlFile.name}`,
     `${kafkaTopicYamlFile.name}`,
     `${kafkaClusterYamlFile.name}`,
-    `${strimziOperatroYamlFile}`
+    `${strimziOperatorYamlFile}`
   ]
 
   for (const resource of resources) {

--- a/tests/scalers/kafka.test.ts
+++ b/tests/scalers/kafka.test.ts
@@ -212,7 +212,7 @@ metadata:
 spec:
   kafka:
     version: 2.5.0
-    replicas: 1
+    replicas: 3
     listeners:
       plain: {}
       tls: {}


### PR DESCRIPTION
Concurrently query brokers for consumer and producer offsets

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #2377. 

Signed-off-by: VerstraeteBert <bertverstraete22@gmail.com>