### PR TITLE
fix: add list and watch access for service accounts to cluster role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - Graphite Scaler: use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))
 - Kubernetes Workload Scaler: ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))
+- `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2383](https://github.com/kedacore/keda/issues/2383))
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,6 +26,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'


### PR DESCRIPTION
Signed-off-by: tomasspi <tom-300@hotmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added `list` and `watch` access for service accounts to `keda-operator` cluster role.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [X] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] ~~A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*~~
- [X] Changelog has been updated

Fixes #2383
