### PR TITLE
fix: add list and watch access for service accounts to cluster role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 - Graphite Scaler: use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))
 - Kubernetes Workload Scaler: ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))
-- `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2383](https://github.com/kedacore/keda/issues/2383))|([#2410](https://github.com/kedacore/keda/issues/2410))
+- `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2406](https://github.com/kedacore/keda/pull/2406))|([#2410](https://github.com/kedacore/keda/pull/2410))
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 - Graphite Scaler: use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))
 - Kubernetes Workload Scaler: ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))
-- `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2383](https://github.com/kedacore/keda/issues/2383))
+- `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2383](https://github.com/kedacore/keda/issues/2383))|([#2410](https://github.com/kedacore/keda/issues/2410))
 
 - TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
 

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -57,6 +57,7 @@ import (
 // +kubebuilder:rbac:groups="",resources=configmaps;configmaps/status;events,verbs="*"
 // +kubebuilder:rbac:groups="",resources=pods;services;services;secrets;external,verbs=get;list;watch
 // +kubebuilder:rbac:groups="*",resources="*/scale",verbs="*"
+// +kubebuilder:rbac:groups="",resources="serviceaccounts",verbs=list;watch
 // +kubebuilder:rbac:groups="*",resources="*",verbs=get
 // +kubebuilder:rbac:groups="apps",resources=deployments;statefulsets,verbs=list;watch
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs="*"


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR fixes the missing changes in [this](https://github.com/kedacore/keda/pull/2406)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #2383
