### PR TITLE
Add Datadog secrets for e2e-test

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -63,23 +63,26 @@ jobs:
 
       - name: Run end to end tests
         env:
-          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
-          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-          AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
-          AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
-          AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
-          TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
-          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
-          OPENSTACK_USER_ID: ${{ secrets.OPENSTACK_USER_ID }}
-          OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD }}
-          OPENSTACK_PROJECT_ID: ${{ secrets.OPENSTACK_PROJECT_ID }}
-          OPENSTACK_AUTH_URL: ${{ secrets.OPENSTACK_AUTH_URL }}
           AZURE_DEVOPS_BUILD_DEFINITON_ID: ${{ secrets.AZURE_DEVOPS_BUILD_DEFINITON_ID }}
           AZURE_DEVOPS_ORGANIZATION_URL: ${{ secrets.AZURE_DEVOPS_ORGANIZATION_URL }}
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
+          AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
+          AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
+          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
+          DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
           NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}
+          OPENSTACK_AUTH_URL: ${{ secrets.OPENSTACK_AUTH_URL }}
+          OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD }}
+          OPENSTACK_PROJECT_ID: ${{ secrets.OPENSTACK_PROJECT_ID }}
+          OPENSTACK_USER_ID: ${{ secrets.OPENSTACK_USER_ID }}
+          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
+          TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
         run: make e2e-test

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -17,23 +17,26 @@ jobs:
 
       - name: Run end to end test
         env:
-          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
-          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-          AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
-          AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
-          AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
-          TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
-          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
-          OPENSTACK_USER_ID: ${{ secrets.OPENSTACK_USER_ID }}
-          OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD }}
-          OPENSTACK_PROJECT_ID: ${{ secrets.OPENSTACK_PROJECT_ID }}
-          OPENSTACK_AUTH_URL: ${{ secrets.OPENSTACK_AUTH_URL }}
           AZURE_DEVOPS_BUILD_DEFINITON_ID: ${{ secrets.AZURE_DEVOPS_BUILD_DEFINITON_ID }}
           AZURE_DEVOPS_ORGANIZATION_URL: ${{ secrets.AZURE_DEVOPS_ORGANIZATION_URL }}
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
+          AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
+          AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
+          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
+          DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
           NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}
+          OPENSTACK_AUTH_URL: ${{ secrets.OPENSTACK_AUTH_URL }}
+          OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD }}
+          OPENSTACK_PROJECT_ID: ${{ secrets.OPENSTACK_PROJECT_ID }}
+          OPENSTACK_USER_ID: ${{ secrets.OPENSTACK_USER_ID }}
+          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
+          TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
         run: make e2e-test

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -63,27 +63,30 @@ jobs:
         continue-on-error: true
         id: test
         env:
-          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
-          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-          AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
-          AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
-          AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
-          TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
-          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
-          OPENSTACK_USER_ID: ${{ secrets.OPENSTACK_USER_ID }}
-          OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD }}
-          OPENSTACK_PROJECT_ID: ${{ secrets.OPENSTACK_PROJECT_ID }}
-          OPENSTACK_AUTH_URL: ${{ secrets.OPENSTACK_AUTH_URL }}
           AZURE_DEVOPS_BUILD_DEFINITON_ID: ${{ secrets.AZURE_DEVOPS_BUILD_DEFINITON_ID }}
           AZURE_DEVOPS_ORGANIZATION_URL: ${{ secrets.AZURE_DEVOPS_ORGANIZATION_URL }}
           AZURE_DEVOPS_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
           AZURE_DEVOPS_POOL_NAME: ${{ secrets.AZURE_DEVOPS_POOL_NAME }}
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
+          AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
+          AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
+          AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
+          AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
+          DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
+          DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
+          E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
           NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}
-          E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+          OPENSTACK_AUTH_URL: ${{ secrets.OPENSTACK_AUTH_URL }}
+          OPENSTACK_PASSWORD: ${{ secrets.OPENSTACK_PASSWORD }}
+          OPENSTACK_PROJECT_ID: ${{ secrets.OPENSTACK_PROJECT_ID }}
+          OPENSTACK_USER_ID: ${{ secrets.OPENSTACK_USER_ID }}
           TEST_CLUSTER_NAME: keda-pr-run
+          TEST_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.TEST_LOG_ANALYTICS_WORKSPACE_ID }}
+          TEST_STORAGE_CONNECTION_STRING: ${{ secrets.TEST_STORAGE_CONNECTION_STRING }}
         run: |
           MESSAGE="${{ github.event.comment.body }}"
           REGEX='/run-e2e (.+)'


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR adds the required variables for running [Datadog Scaler](https://github.com/kedacore/keda/pull/2354) e2e-test 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Related https://github.com/kedacore/keda/pull/2354
