### PR TITLE
chore: Don't consider dependencies for stale updates

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,7 @@ exemptLabels:
   - feature
   - security
   - Epic
+  - dependencies
 
 # Label to use when marking an issue as stale
 staleLabel: stale


### PR DESCRIPTION
Don't consider dependencies for stale updates by adding them to the exclusion list.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
See https://kubernetes.slack.com/archives/CKZJ36A5D/p1641256299483500
