### PR TITLE
Fix Cloudwatch Scaler test data

### DIFF
--- a/pkg/scalers/aws_cloudwatch_test.go
+++ b/pkg/scalers/aws_cloudwatch_test.go
@@ -96,7 +96,7 @@ var testAWSCloudwatchMetadata = []parseAWSCloudwatchMetadataTestData{
 		"Missing namespace"},
 	// Missing dimensionName
 	{map[string]string{
-		"dimensionName":     "QueueName",
+		"namespace":         "AWS/SQS",
 		"dimensionValue":    "keda",
 		"metricName":        "ApproximateNumberOfMessagesVisible",
 		"targetMetricValue": "2",


### PR DESCRIPTION
Very small and silly change.
I noticed that the test data values didn't match the comment :-) 

(probably copy/paste of the previous use case)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
