### PR TITLE
Rabbitmq Add create queue and binding routing

### DIFF
--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -111,6 +111,14 @@ var testRabbitMQMetadata = []parseRabbitMQMetadataTestData{
 	{map[string]string{"mode": "MessageRate", "value": "1000", "queueName": "sample", "host": "http://", "useRegex": "true", "pageSize": "-1"}, true, map[string]string{}},
 	// invalid pageSize
 	{map[string]string{"mode": "MessageRate", "value": "1000", "queueName": "sample", "host": "http://", "useRegex": "true", "pageSize": "a"}, true, map[string]string{}},
+	// CreateQueue
+	{map[string]string{"queueLength": "10", "queueName": "sample", "hostFromEnv": host, "createQueue": "true"}, false, map[string]string{}},
+	// invalide CreateQueue useRegex
+	{map[string]string{"queueLength": "10", "queueName": "sample", "hostFromEnv": host, "createQueue": "true", "useRegex": "true"}, true, map[string]string{}},
+	// binding
+	{map[string]string{"queueLength": "10", "queueName": "sample", "hostFromEnv": host, "createQueue": "true", "createBindingsRoutingKeys": "*.sample.# *.sample2.#", "bindingsRoutingExchange": "exchange"}, false, map[string]string{}},
+	// missing binding exchange
+	{map[string]string{"queueLength": "10", "queueName": "sample", "hostFromEnv": host, "createQueue": "true", "createBindingsRoutingKeys": "*.sample.# *.sample2.#"}, true, map[string]string{}},
 }
 
 var rabbitMQMetricIdentifiers = []rabbitMQMetricIdentifier{


### PR DESCRIPTION
This a new option for the rabbitMQ scaler.

It will create the queue that the scaler is monitoring.

This is very useful for jobscaler. Since rabbitmq has a strong philosophy that code should just generate their queues and bindings topics.
It is a chicken/egg situation. The application (job) needs to be run for the queue to be created and the job will be only run if there is a message in the queue.

Like this, the scaler is creating the queue and proper bindings for the proper exchange.

Documentation: [#620](https://github.com/kedacore/keda-docs/pull/620)

### Checklist

- [ x]Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ x] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ]x A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated

Fixes #
