### PR TITLE
Automatically release container image for ARM

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
     && apt-get update \
     && apt-get install -y docker-ce-cli \
+    && docker buildx create --use \
     #
     # Install pip & pre-commit
     && apt-get -y install python3-pip \

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -3,10 +3,9 @@ on:
   push:
     branches:
       - main
-concurrency: e2e-tests
 jobs:
-  validate:
-    name: Validate
+  build:
+    name: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -55,7 +54,7 @@ jobs:
           registry: ghcr.io
 
       - name: Publish on GitHub Container Registry
-        run: make publish
+        run: make publish-multiarch
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
@@ -69,6 +68,19 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: make sign-images
+        
+  validate:
+    needs: build
+    name: validate
+    runs-on: ubuntu-latest
+    # build-tools is built from ../../tools/build-tools.Dockerfile
+    container: ghcr.io/kedacore/build-tools:main
+    concurrency: e2e-tests
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
       - name: Run end to end tests
         env:
@@ -111,3 +123,27 @@ jobs:
           AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
           AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
           AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
+
+  validate-arm64:
+    needs: build
+    name: validate-arm64
+    runs-on: ARM64
+    container: arm64v8/ubuntu:focal
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Create k8s v1.23 Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          node_image: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+
+      - name: Install dependecies
+        run : |
+          apt update
+          apt install npm -y
+
+      - name: Run smoke test
+        run: make arm-smoke-test

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -68,7 +68,7 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: make sign-images
-        
+
   validate:
     needs: build
     name: validate

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -60,7 +60,7 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 
       - name: Publish KEDA images on GitHub Container Registry
-        run: make publish
+        run: make publish-multiarch
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### New
 
-- TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
+- **General:** Automatically release container image for ARM ([#2457](https://github.com/kedacore/keda/pull/2457))
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### New
 
-- **General:** Automatically release container image for ARM ([#2457](https://github.com/kedacore/keda/pull/2457))
+- **General:** Automatically release container image for ARM ([#2263]https://github.com/kedacore/keda/issues/2263))
 
 ### Improvements
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17.3 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17.3 AS builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD
@@ -26,7 +26,9 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} make manager
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+ARG TARGETOS TARGETARCH
+RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} TARGET_OS=$TARGETOS ARCH=$TARGETARCH make manager
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -1,5 +1,5 @@
 # Build the adapter binary
-FROM golang:1.17.3 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17.3 as builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD
@@ -28,7 +28,9 @@ COPY pkg/ pkg/
 RUN mkdir -p /apiserver.local.config/certificates && chmod -R 777 /apiserver.local.config
 
 # Build
-RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} make adapter
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+ARG TARGETOS TARGETARCH
+RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} TARGET_OS=$TARGETOS ARCH=$TARGETARCH make adapter
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,11 @@ e2e-test-local: ## Run e2e tests against Kubernetes cluster configured in ~/.kub
 e2e-test-clean: get-cluster-context ## Delete all namespaces labeled with type=e2e
 	kubectl delete ns -l type=e2e
 
+.PHONY: arm-smoke-test
+arm-smoke-test: ## Run e2e tests against Kubernetes cluster configured in ~/.kube/config.
+	npm install --prefix tests
+	./tests/run-arm-smoke-tests.sh
+
 ##################################################
 # Development                                    #
 ##################################################
@@ -182,6 +187,10 @@ docker-build: ## Build docker images with the KEDA Operator and Metrics Server.
 publish: docker-build ## Push images on to Container Registry (default: ghcr.io).
 	docker push $(IMAGE_CONTROLLER)
 	docker push $(IMAGE_ADAPTER)
+
+publish-multiarch:
+	docker buildx build --push --platform=linux/amd64,linux/arm64 . -t ${IMAGE_CONTROLLER} --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+	docker buildx build --push --platform=linux/amd64,linux/arm64 -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
 
 release: manifests kustomize set-version ## Produce new KEDA release in keda-$(VERSION).yaml file.
 	cd config/manager && \

--- a/tests/run-arm-smoke-tests.sh
+++ b/tests/run-arm-smoke-tests.sh
@@ -1,0 +1,102 @@
+#! /bin/bash
+set -eu
+
+DIR=$(dirname "$0")
+cd $DIR
+
+test_files=(
+    "influxdb.test.ts" #ScaledObject
+    "mongodb.test.ts" #ScaledJob
+)
+
+concurrent_tests_limit=5
+pids=()
+lookup=()
+failed_count=0
+failed_lookup=()
+counter=0
+
+function run_setup {
+    ./node_modules/.bin/ava setup.test.ts
+}
+
+function run_tests {
+    counter=0
+
+    for scaler in ${test_files[@]}
+    do
+        test_case="scalers/${scaler}"
+        counter=$((counter+1))
+        ./node_modules/.bin/ava $test_case > "${test_case}.log" 2>&1 &
+        pid=$!
+        echo "Running $test_case with pid: $pid"
+        pids+=($pid)
+        lookup[$pid]=$test_case
+        # limit concurrent runs
+        if [[ "$counter" -gt "$concurrent_tests_limit" ]]; then
+            wait_for_jobs
+            counter=0
+            pids=()
+        fi
+    done
+}
+
+function mark_failed {
+    failed_lookup[$1]=${lookup[$1]}
+    let "failed_count+=1"
+}
+
+function wait_for_jobs {
+    for job in "${pids[@]}"; do
+        wait $job || mark_failed $job
+        echo "Job $job finished"
+    done
+
+    printf "\n$failed_count jobs failed\n"
+    printf '%s\n' "${failed_lookup[@]}"
+}
+
+function print_logs {
+    for test_log in $(find scalers -name "*.log")
+    do
+        echo ">>> $test_log <<<"
+        cat $test_log
+        printf "\n\n##############################################\n"
+        printf "##############################################\n\n"
+    done
+
+    echo ">>> KEDA Operator log <<<"
+    kubectl get pods --no-headers -n keda | awk '{print $1}' | grep keda-operator | xargs kubectl -n keda logs
+    printf "\n\n##############################################\n"
+    printf "##############################################\n\n"
+
+    echo ">>> KEDA Metrics Server log <<<"
+    kubectl get pods --no-headers -n keda | awk '{print $1}' | grep keda-metrics-apiserver | xargs kubectl -n keda logs
+    printf "\n\n##############################################\n"
+    printf "##############################################\n\n"
+}
+
+function run_cleanup {
+    ./node_modules/.bin/ava cleanup.test.ts
+}
+
+function print_failed {
+    echo "$failed_count e2e tests failed"
+    for failed_test in "${failed_lookup[@]}"; do
+        echo $failed_test
+    done
+}
+
+run_setup
+run_tests
+wait_for_jobs
+print_logs
+run_cleanup
+
+if [ "$failed_count" == "0" ];
+then
+    exit 0
+else
+    print_failed
+    exit 1
+fi

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -29,7 +29,8 @@ RUN curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-19.03
     echo "$docker_sha256 docker-19.03.2.tgz" | sha256sum -c - && \
     tar xvzf docker-19.03.2.tgz && \
     mv docker/* /usr/local/bin && \
-    rm -rf docker docker-19.03.2.tgz
+    rm -rf docker docker-19.03.2.tgz && \
+    docker buildx create --use
 
 # Install golang
 RUN GO_VERSION=1.17.3 && \


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR adds (using buildx and cross compilation) support for ARM arch (https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)
Also removes the support to dockerhub

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes https://github.com/kedacore/keda/issues/2263
