### PR TITLE
fix: Use a user with permissions for ghcr login always

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -50,9 +50,12 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
+          # Username used to log in to a Docker registry. If not set then no login will occur
+          username: ${{ github.repository_owner }}
+          # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
+          password: ${{ secrets.GHCR_AUTH_PAT }}
+          # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish on GitHub Container Registry
         run: make publish

--- a/.github/workflows/upgrade-validation-template.yml
+++ b/.github/workflows/upgrade-validation-template.yml
@@ -13,9 +13,12 @@ jobs:
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:
+        # Username used to log in to a Docker registry. If not set then no login will occur
+        username: ${{ github.repository_owner }}
+        # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
+        password: ${{ secrets.GHCR_AUTH_PAT }}
+        # Server address of Docker registry. If not set then will default to Docker Hub
         registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build current version
       run : make publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ### Other
 
-- **General:** Add workflow for testing breaking changes on CRDs (`Scaled{Object|Job}`) ([#2450](https://github.com/kedacore/keda/pull/2450))
+- **General:** Add workflow for testing breaking changes on CRDs (`Scaled{Object|Job}`) ([#2450](https://github.com/kedacore/keda/pull/2450))|([#2465](https://github.com/kedacore/keda/pull/2465))
 
 ## v2.5.0
 


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #
