### PR TITLE
chore: Fix incompatible pre-commit validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [commit, push]
 minimum_pre_commit_version: "1.20.0"
 repos:
-  - repo: git://github.com/dnephin/pre-commit-golang
+  - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.3.5
     hooks:
       - id: go-fmt


### PR DESCRIPTION
Fix incompatible pre-commit validation to rely on HTTPS instead of GIT

Relates to https://github.com/pre-commit/action/issues/137#issuecomment-1009978115

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/pre-commit/action/issues/137#issuecomment-1009978115