### PR TITLE
fix: Use our own docker image for MongoDB e2e tes

### DIFF
--- a/.github/assets/test-upgrade-manifest.yml
+++ b/.github/assets/test-upgrade-manifest.yml
@@ -48,7 +48,7 @@ spec:
   fallback:
     failureThreshold: 3
     replicas: 5
-  advanced: 
+  advanced:
     restoreToOriginalReplicaCount: true
     horizontalPodAutoscalerConfig:
       behavior:

--- a/.github/workflows/upgrade-validation-template.yml
+++ b/.github/workflows/upgrade-validation-template.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Helm install
       uses: Azure/setup-helm@v1
-      
+
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
@@ -96,5 +96,5 @@ jobs:
       run: kubectl apply -f .github/assets/test-upgrade-manifest.yml
 
     - name: Clean resources
-      run: kubectl delete -f .github/assets/test-upgrade-manifest.yml 
+      run: kubectl delete -f .github/assets/test-upgrade-manifest.yml
       if: always()

--- a/RELEASE-PROCESS.MD
+++ b/RELEASE-PROCESS.MD
@@ -63,7 +63,7 @@ Learn how to deploy KEDA by reading [our documentation](https://keda.sh/docs/INS
 ### Other
 
 - <list items>
-  
+
 ### New Contributors
 
 <generated new contributors info>
@@ -75,7 +75,7 @@ In order to generate a list of new contributors, use the `Auto-generate release 
 
 <details>
   <summary>Screenshot</summary>
-  
+
 ![image](https://user-images.githubusercontent.com/4345663/148563945-ad75816d-739b-4e8d-a063-aa0e77f6e98d.png)
 </details>
 

--- a/tests/scalers/mongodb.test.ts
+++ b/tests/scalers/mongodb.test.ts
@@ -202,7 +202,7 @@ spec:
       spec:
         containers:
           - name: mongodb-update
-            image: 1314520999/mongodb-update:latest
+            image: ghcr.io/kedacore/tests-mongodb:latest
             args:
             - --connectStr={{MONGODB_CONNECTION_STRING}}
             - --dataBase={{MONGODB_DATABASE}}


### PR DESCRIPTION
Signed-off-by: Jorge Turrado Ferrero <Jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Right now MongoDB e2e test are broken because the current image doesn't exist anymore. This PR changes the used image from new one under our ownership. The image from [this PR](https://github.com/kedacore/test-tools/pull/25) is needed

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

