### PR TITLE
Allow using simple queue names in aws sqs scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - **External Scaler:** fix wrong calculation of retry backoff duration ([#2416](https://github.com/kedacore/keda/pull/2416))
 - **Kafka Scaler:** allow flag `topic` to be optional, where lag of all topics within the consumer group will be used for scaling ([#2409](https://github.com/kedacore/keda/pull/2409))
 - **CPU Scaler:** Adding e2e test for the cpu scaler ([#2441](https://github.com/kedacore/keda/pull/2441))
+- **AWS SQS Scaler**: allow using simple queue name instead of URL ([#2457](https://github.com/kedacore/keda/pull/2457))
 
 ### Breaking Changes
 

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -85,16 +85,17 @@ func parseAwsSqsQueueMetadata(config *ScalerConfig) (*awsSqsQueueMetadata, error
 
 	queueURL, err := url.ParseRequestURI(meta.queueURL)
 	if err != nil {
-		return nil, fmt.Errorf("queueURL is not a valid URL")
-	}
+		// queueURL is not a valid URL, using it as queueName
+		meta.queueName = meta.queueURL
+	} else {
+		queueURLPath := queueURL.Path
+		queueURLPathParts := strings.Split(queueURLPath, "/")
+		if len(queueURLPathParts) != 3 || len(queueURLPathParts[2]) == 0 {
+			return nil, fmt.Errorf("cannot get queueName from queueURL")
+		}
 
-	queueURLPath := queueURL.Path
-	queueURLPathParts := strings.Split(queueURLPath, "/")
-	if len(queueURLPathParts) != 3 || len(queueURLPathParts[2]) == 0 {
-		return nil, fmt.Errorf("cannot get queueName from queueURL")
+		meta.queueName = queueURLPathParts[2]
 	}
-
-	meta.queueName = queueURLPathParts[2]
 
 	if val, ok := config.TriggerMetadata["awsRegion"]; ok && val != "" {
 		meta.awsRegion = val

--- a/pkg/scalers/aws_sqs_queue_test.go
+++ b/pkg/scalers/aws_sqs_queue_test.go
@@ -20,6 +20,7 @@ const (
 	testAWSSQSProperQueueURL    = "https://sqs.eu-west-1.amazonaws.com/account_id/DeleteArtifactQ"
 	testAWSSQSImproperQueueURL1 = "https://sqs.eu-west-1.amazonaws.com/account_id"
 	testAWSSQSImproperQueueURL2 = "https://sqs.eu-west-1.amazonaws.com"
+	testAWSSimpleQueueURL       = "my-queue"
 
 	testAWSSQSErrorQueueURL   = "https://sqs.eu-west-1.amazonaws.com/account_id/Error"
 	testAWSSQSBadDataQueueURL = "https://sqs.eu-west-1.amazonaws.com/account_id/BadData"
@@ -165,6 +166,13 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		},
 		false,
 		"with AWS Role assigned on KEDA operator itself"},
+	{map[string]string{
+		"queueURL":    testAWSSimpleQueueURL,
+		"queueLength": "1",
+		"awsRegion":   "eu-west-1"},
+		testAWSSQSAuthentication,
+		false,
+		"properly formed queue and region"},
 }
 
 var awsSQSMetricIdentifiers = []awsSQSMetricIdentifier{


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

AWS SQS autoscaler does not really need a full queueURL, it also works with simple queue names, but there was some code that tried to parse the URL to get the queue name for building a metric ID.

The example in the doc already [uses a simple name](https://keda.sh/docs/2.5/scalers/aws-sqs/#scaling-a-deployment-using-podidentity-providers).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #
