### PR TITLE
Add GitHub OIDC Token into GITHUB_TOKEN for signing images

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -8,6 +8,11 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
+
     # build-tools is built from ../../tools/build-tools.Dockerfile
     container: ghcr.io/kedacore/build-tools:main
     steps:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -7,6 +7,12 @@ jobs:
   build:
     name: Push Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      deployments: write
+      id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
+
     # build-tools is built from ../../tools/build-tools.Dockerfile
     container: ghcr.io/kedacore/build-tools:main
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 - **General:** `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2406](https://github.com/kedacore/keda/pull/2406))|([#2410](https://github.com/kedacore/keda/pull/2410))
 - **General:** Delete the cache entry when a ScaledObject is deleted ([#2408](https://github.com/kedacore/keda/pull/2408))
-- **General:** Sign KEDA images published on GitHub Container Registry ([#2501](https://github.com/kedacore/keda/pull/2501))|([#2502](https://github.com/kedacore/keda/pull/2502))
+- **General:** Sign KEDA images published on GitHub Container Registry ([#2501](https://github.com/kedacore/keda/pull/2501))|([#2502](https://github.com/kedacore/keda/pull/2502))|([#2504](https://github.com/kedacore/keda/pull/2504))
 - **Azure Pipelines Scaler:** support `poolName` or `poolID` validation ([#2370](https://github.com/kedacore/keda/pull/2370))
 - **Graphite Scaler:** use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))
 - **Kubernetes Workload Scaler:** ignore terminated pods ([#2384](https://github.com/kedacore/keda/pull/2384))


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

For being able to sign the images with the token, we should specify the requirement of `GitHub OIDC Token` in GITHUB_TOKEN. This pushes to add all the needed permission because once you request 1, you have to specify all of them. 
Instead of adding all available permissions in the token, **I added those I think we use, but please review it**

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Related #2501 #2502
Fixes #2386