### PR TITLE
chore: No longer push to Docker Hub on release

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -54,12 +54,6 @@ jobs:
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
 
-      - name: Login to Docker Hub
-        env:
-          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
-
       - name: Publish on GitHub Container Registry
         run: make publish
 
@@ -75,9 +69,6 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: make sign-images
-
-      - name: Publish on Docker Hub
-        run: make publish-dockerhub
 
       - name: Run end to end tests
         env:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -51,12 +51,6 @@ jobs:
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
 
-      - name: Login to Docker Hub
-        env:
-          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-        run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
-
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
@@ -83,11 +77,6 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: make sign-images
-        env:
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
-
-      - name: Publish KEDA images on Docker Hub
-        run: make publish-dockerhub
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@
 
 ### Breaking Changes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/pull/XXX))
+- No longer push to Docker Hub as of v2.5 as per our [announcement in March 2021](https://github.com/kedacore/keda/discussions/1700).
+  - Learn more about the background on [kedacore/governance#16](https://github.com/kedacore/governance/issues/16)
 
 ### Other
 

--- a/Makefile
+++ b/Makefile
@@ -176,12 +176,6 @@ publish: docker-build ## Push images on to Container Registry (default: ghcr.io)
 	docker push $(IMAGE_CONTROLLER)
 	docker push $(IMAGE_ADAPTER)
 
-publish-dockerhub: ## Mirror images on Docker Hub.
-	docker tag $(IMAGE_CONTROLLER) docker.io/$(IMAGE_REPO)/keda:$(VERSION)
-	docker tag $(IMAGE_ADAPTER) docker.io/$(IMAGE_REPO)/keda-metrics-apiserver:$(VERSION)
-	docker push docker.io/$(IMAGE_REPO)/keda:$(VERSION)
-	docker push docker.io/$(IMAGE_REPO)/keda-metrics-apiserver:$(VERSION)
-
 release: manifests kustomize set-version ## Produce new KEDA release in keda-$(VERSION).yaml file.
 	cd config/manager && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda=${IMAGE_CONTROLLER}


### PR DESCRIPTION
On June 21, 2021, [GitHub Container Registry became generally available](https://github.blog/2021-06-21-github-packages-container-registry-generally-available/) which means that we will no longer push to Docker Hub on release as per https://github.com/kedacore/governance/issues/16 and our [announcement in March 2021](https://github.com/kedacore/keda/discussions/1700).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

Fixes https://github.com/kedacore/governance/issues/16
