### PR TITLE
Clear scalers cache correctly both in Operator and Metrics Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 ### Improvements
 
 - **General:** `keda-operator` Cluster Role: add `list` and `watch` access to service accounts ([#2406](https://github.com/kedacore/keda/pull/2406))|([#2410](https://github.com/kedacore/keda/pull/2410))
-- **General:** Delete the cache entry when a ScaledObject is deleted ([#2408](https://github.com/kedacore/keda/pull/2408))
+- **General:** Delete the cache entry when a ScaledObject is deleted ([#2564](https://github.com/kedacore/keda/pull/2564))
 - **General:** Sign KEDA images published on GitHub Container Registry ([#2501](https://github.com/kedacore/keda/pull/2501))|([#2502](https://github.com/kedacore/keda/pull/2502))|([#2504](https://github.com/kedacore/keda/pull/2504))
 - **Azure Pipelines Scaler:** support `poolName` or `poolID` validation ([#2370](https://github.com/kedacore/keda/pull/2370))
 - **Graphite Scaler:** use the latest datapoint returned, not the earliest ([#2365](https://github.com/kedacore/keda/pull/2365))

--- a/pkg/mock/mock_scaling/mock_interface.go
+++ b/pkg/mock/mock_scaling/mock_interface.go
@@ -36,15 +36,17 @@ func (m *MockScaleHandler) EXPECT() *MockScaleHandlerMockRecorder {
 }
 
 // ClearScalersCache mocks base method.
-func (m *MockScaleHandler) ClearScalersCache(ctx context.Context, name, namespace string) {
+func (m *MockScaleHandler) ClearScalersCache(ctx context.Context, scalableObject interface{}) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClearScalersCache", ctx, name, namespace)
+	ret := m.ctrl.Call(m, "ClearScalersCache", ctx, scalableObject)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ClearScalersCache indicates an expected call of ClearScalersCache.
-func (mr *MockScaleHandlerMockRecorder) ClearScalersCache(ctx, name, namespace interface{}) *gomock.Call {
+func (mr *MockScaleHandlerMockRecorder) ClearScalersCache(ctx, scalableObject interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearScalersCache", reflect.TypeOf((*MockScaleHandler)(nil).ClearScalersCache), ctx, name, namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearScalersCache", reflect.TypeOf((*MockScaleHandler)(nil).ClearScalersCache), ctx, scalableObject)
 }
 
 // DeleteScalableObject mocks base method.

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -19,7 +19,6 @@ package scaling
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -46,7 +45,7 @@ type ScaleHandler interface {
 	HandleScalableObject(ctx context.Context, scalableObject interface{}) error
 	DeleteScalableObject(ctx context.Context, scalableObject interface{}) error
 	GetScalersCache(ctx context.Context, scalableObject interface{}) (*cache.ScalersCache, error)
-	ClearScalersCache(ctx context.Context, name, namespace string)
+	ClearScalersCache(ctx context.Context, scalableObject interface{}) error
 }
 
 type scaleHandler struct {
@@ -126,7 +125,10 @@ func (h *scaleHandler) DeleteScalableObject(ctx context.Context, scalableObject 
 			cancel()
 		}
 		h.scaleLoopContexts.Delete(key)
-		delete(h.scalerCaches, key)
+		err := h.ClearScalersCache(ctx, scalableObject)
+		if err != nil {
+			h.logger.Error(err, "error clearing scalers cache")
+		}
 		h.recorder.Event(withTriggers, corev1.EventTypeNormal, eventreason.KEDAScalersStopped, "Stopped scalers watch")
 	} else {
 		h.logger.V(1).Info("ScaleObject was not found in controller cache", "key", key)
@@ -151,7 +153,10 @@ func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1a
 			tmr.Stop()
 		case <-ctx.Done():
 			logger.V(1).Info("Context canceled")
-			h.ClearScalersCache(ctx, withTriggers.Name, withTriggers.Namespace)
+			err := h.ClearScalersCache(ctx, scalableObject)
+			if err != nil {
+				logger.Error(err, "error clearing scalers cache")
+			}
 			tmr.Stop()
 			return
 		}
@@ -201,15 +206,23 @@ func (h *scaleHandler) GetScalersCache(ctx context.Context, scalableObject inter
 	return h.scalerCaches[key], nil
 }
 
-func (h *scaleHandler) ClearScalersCache(ctx context.Context, name, namespace string) {
+func (h *scaleHandler) ClearScalersCache(ctx context.Context, scalableObject interface{}) error {
+	withTriggers, err := asDuckWithTriggers(scalableObject)
+	if err != nil {
+		return err
+	}
+
+	key := withTriggers.GenerateIdenitifier()
+
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	key := strings.ToLower(fmt.Sprintf("%s.%s", name, namespace))
 	if cache, ok := h.scalerCaches[key]; ok {
 		cache.Close(ctx)
 		delete(h.scalerCaches, key)
 	}
+
+	return nil
 }
 
 func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, scalableObject interface{}, scalingMutex sync.Locker) {


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This fix should correctly clear/invalidate cache in both KEDA Operator and Metrics Server, when ScaledObject is deleted from cluster, when there is a problem in resolving secrets/credentials or when there is a general problem in scraping metrics from a scaler.
The previous fix https://github.com/kedacore/keda/pull/2408 worked only partially - in KEDA Operator, because it didn't use `ClearScalersCache()` function, but tried to delete the map entry directly. But the main problem was, that the `ClearScalersCache()` which is being used in Metrics Server, operated on a wrong key, ie. `name.namespace` instead of `kind.namespace.name` generated by `withTriggers.GenerateIdenitifier()`.  That resulted in cache not being invalidated in Metrics Server.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated

Fixes #2407
