### PR TITLE
Include vhost for RabbitMQ when retrieving queue info with useRegex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 - **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
-- **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2591](https://github.com/kedacore/keda/pull/2591))
+- **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 - **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
+- **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2591](https://github.com/kedacore/keda/pull/2591))
 
 ### Breaking Changes
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -423,7 +423,12 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 
 	// Override vhost if requested.
 	if s.metadata.vhostName != nil {
-		vhost = "/" + url.QueryEscape(*s.metadata.vhostName)
+		// If the desired vhost is "All" vhosts, no path is necessary
+		if *s.metadata.vhostName == "" {
+			vhost = ""
+		} else {
+			vhost = "/" + url.QueryEscape(*s.metadata.vhostName)
+		}
 	}
 
 	// Encode the '/' vhost if necessary.

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -36,6 +36,7 @@ const (
 	rabbitModeMessageRate        = "MessageRate"
 	defaultRabbitMQQueueLength   = 20
 	rabbitMetricType             = "External"
+	rabbitRootVhostPath          = "/%2F"
 )
 
 const (
@@ -433,7 +434,7 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 
 	// Encode the '/' vhost if necessary.
 	if vhost == "//" {
-		vhost = "/%2F"
+		vhost = rabbitRootVhostPath
 	}
 
 	// Clear URL path to get the correct host.

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -426,7 +426,7 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 	parsedURL.Path = ""
 	var getQueueInfoManagementURI string
 	if s.metadata.useRegex {
-		getQueueInfoManagementURI = fmt.Sprintf("%s/api/queues?page=1&use_regex=true&pagination=false&name=%s&page_size=%d", parsedURL.String(), url.QueryEscape(s.metadata.queueName), s.metadata.pageSize)
+		getQueueInfoManagementURI = fmt.Sprintf("%s/api/queues%s?page=1&use_regex=true&pagination=false&name=%s&page_size=%d", parsedURL.String(), vhost, url.QueryEscape(s.metadata.queueName), s.metadata.pageSize)
 	} else {
 		getQueueInfoManagementURI = fmt.Sprintf("%s/api/queues%s/%s", parsedURL.String(), vhost, url.QueryEscape(s.metadata.queueName))
 	}

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -412,18 +412,28 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 		return nil, err
 	}
 
+	// Extract vhost from URL's path.
 	vhost := parsedURL.Path
+
+	// If the URL's path only contains a slash, it represents the trailing slash and
+	// must be ignored because it may cause confusion with the '/' vhost.
+	if vhost == "/" {
+		vhost = ""
+	}
 
 	// Override vhost if requested.
 	if s.metadata.vhostName != nil {
 		vhost = "/" + url.QueryEscape(*s.metadata.vhostName)
 	}
 
-	if vhost == "" || vhost == "/" || vhost == "//" {
+	// Encode the '/' vhost if necessary.
+	if vhost == "//" {
 		vhost = "/%2F"
 	}
 
+	// Clear URL path to get the correct host.
 	parsedURL.Path = ""
+
 	var getQueueInfoManagementURI string
 	if s.metadata.useRegex {
 		getQueueInfoManagementURI = fmt.Sprintf("%s/api/queues%s?page=1&use_regex=true&pagination=false&name=%s&page_size=%d", parsedURL.String(), vhost, url.QueryEscape(s.metadata.queueName), s.metadata.pageSize)

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -328,7 +328,7 @@ var testRegexQueueInfoTestData = []getQueueInfoTestData{
 func TestGetQueueInfoWithRegex(t *testing.T) {
 	for _, testData := range testRegexQueueInfoTestData {
 		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedPath := fmt.Sprintf("/api/queues%s?page=1&use_regex=true&pagination=false&name=%%5Eevaluate_trials%%24&page_size=100", testData.vhostPath)
+			expectedPath := "/api/queues/%2F?page=1&use_regex=true&pagination=false&name=%5Eevaluate_trials%24&page_size=100"
 			if r.RequestURI != expectedPath {
 				t.Error("Expect request path to =", expectedPath, "but it is", r.RequestURI)
 			}

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -192,14 +192,14 @@ var testQueueInfoTestData = []getQueueInfoTestData{
 	{`Password is incorrect`, http.StatusUnauthorized, false, nil, ""},
 }
 
-var vhostPathes = []string{"/myhost", "", "/", "//", "/%2F"}
+var vhostPathes = []string{"/myhost", "", "/", "//", rabbitRootVhostPath}
 
 var testQueueInfoTestDataSingleVhost = []getQueueInfoTestData{
 	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
 	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "//"},
 	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 1.4}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, ""},
 	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "myhost"}, "/myhost"},
-	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, "/%2F"},
+	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": "/"}, rabbitRootVhostPath},
 	{`{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}}, "name": "evaluate_trials"}`, http.StatusOK, true, map[string]string{"hostFromEnv": "plainHost", "vhostName": ""}, "/"},
 }
 
@@ -221,8 +221,8 @@ func TestGetQueueInfo(t *testing.T) {
 		switch testData.vhostPath {
 		case "/myhost":
 			expectedVhostPath = "/myhost"
-		case "/%2F", "//":
-			expectedVhostPath = "/%2F"
+		case rabbitRootVhostPath, "//":
+			expectedVhostPath = rabbitRootVhostPath
 		default:
 			expectedVhostPath = ""
 		}
@@ -330,7 +330,7 @@ var testRegexQueueInfoTestData = []getQueueInfoTestData{
 	{`{"items":[]}`, http.StatusOK, false, map[string]string{"mode": "MessageRate", "value": "1000", "useRegex": "true", "operation": "avg"}, ""},
 }
 
-var vhostPathesForRegex = []string{"", "/test-vh", "/%2F"}
+var vhostPathesForRegex = []string{"", "/test-vh", rabbitRootVhostPath}
 
 func TestGetQueueInfoWithRegex(t *testing.T) {
 	allTestData := []getQueueInfoTestData{}

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -328,7 +328,7 @@ var testRegexQueueInfoTestData = []getQueueInfoTestData{
 func TestGetQueueInfoWithRegex(t *testing.T) {
 	for _, testData := range testRegexQueueInfoTestData {
 		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedPath := "/api/queues?page=1&use_regex=true&pagination=false&name=%5Eevaluate_trials%24&page_size=100"
+			expectedPath := fmt.Sprintf("/api/queues%s?page=1&use_regex=true&pagination=false&name=%%5Eevaluate_trials%%24&page_size=100", testData.vhostPath)
 			if r.RequestURI != expectedPath {
 				t.Error("Expect request path to =", expectedPath, "but it is", r.RequestURI)
 			}
@@ -399,7 +399,7 @@ var testRegexPageSizeTestData = []getRegexPageSizeTestData{
 func TestGetPageSizeWithRegex(t *testing.T) {
 	for _, testData := range testRegexPageSizeTestData {
 		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedPath := fmt.Sprintf("/api/queues?page=1&use_regex=true&pagination=false&name=%%5Eevaluate_trials%%24&page_size=%d", testData.pageSize)
+			expectedPath := fmt.Sprintf("/api/queues/%%2F?page=1&use_regex=true&pagination=false&name=%%5Eevaluate_trials%%24&page_size=%d", testData.pageSize)
 			if r.RequestURI != expectedPath {
 				t.Error("Expect request path to =", expectedPath, "but it is", r.RequestURI)
 			}
@@ -521,7 +521,7 @@ var testRegexQueueInfoNavigationTestData = []getQueueInfoNavigationTestData{
 func TestRegexQueueMissingError(t *testing.T) {
 	for _, testData := range testRegexQueueInfoNavigationTestData {
 		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedPath := "/api/queues?page=1&use_regex=true&pagination=false&name=evaluate_trials&page_size=100"
+			expectedPath := "/api/queues/%2F?page=1&use_regex=true&pagination=false&name=evaluate_trials&page_size=100"
 			if r.RequestURI != expectedPath {
 				t.Error("Expect request path to =", expectedPath, "but it is", r.RequestURI)
 			}

--- a/tests/scalers/rabbitmq-queue-http-regex-vhost.test.ts
+++ b/tests/scalers/rabbitmq-queue-http-regex-vhost.test.ts
@@ -6,8 +6,8 @@ import test from 'ava'
 import { RabbitMQHelper } from './rabbitmq-helpers'
 import {waitForDeploymentReplicaCount} from "./helpers";
 
-const testNamespace = 'rabbitmq-queue-http-regex-test'
-const rabbitmqNamespace = 'rabbitmq-http-regex-test'
+const testNamespace = 'rabbitmq-queue-http-regex-vhost-test'
+const rabbitmqNamespace = 'rabbitmq-http-regex-vhost-test'
 const queueName = 'hello'
 const dummyQueueName1 = 'hello-1'
 const dummyQueueName2 = 'hellohellohello'
@@ -22,7 +22,7 @@ test.before(t => {
 
   sh.config.silent = true
   // create deployment
-  const httpConnectionString = `http://${username}:${password}@rabbitmq.${rabbitmqNamespace}.svc.cluster.local`
+  const httpConnectionString = `http://${username}:${password}@rabbitmq.${rabbitmqNamespace}.svc.cluster.local/${vhost}`
 
   RabbitMQHelper.createDeployment(t, testNamespace, deployYaml, connectionString, httpConnectionString, queueName)
 })

--- a/tests/scalers/rabbitmq-queue-http-regex-vhost.test.ts
+++ b/tests/scalers/rabbitmq-queue-http-regex-vhost.test.ts
@@ -27,7 +27,6 @@ test.before(t => {
   RabbitMQHelper.installRabbit(t, username, password, vhost, rabbitmqNamespace)
 
   sh.config.silent = true
-  
   // create deployment
   const httpConnectionString = `http://${connectionHostWithAuth}/${vhost}`
 

--- a/tests/scalers/rabbitmq-queue-http-regex-vhost.test.ts
+++ b/tests/scalers/rabbitmq-queue-http-regex-vhost.test.ts
@@ -14,12 +14,12 @@ const dummyQueueName2 = 'hellohellohello'
 const username = "test-user"
 const password = "test-password"
 const vhost = "test-vh-regex"
-const dummyVhost = "test-vh-regex-dummy"
+const dummyVhost1 = "test-vh-regex-dummy-one"
 const dummyVhost2 = "test-vh-regex-dummy-two"
 const connectionHost = `rabbitmq.${rabbitmqNamespace}.svc.cluster.local`
 const connectionHostWithAuth = `${username}:${password}@${connectionHost}`
 const connectionString = `amqp://${connectionHostWithAuth}/${vhost}`
-const connectionStringDummy = `amqp://${connectionHostWithAuth}/${dummyVhost}`
+const connectionStringDummy1 = `amqp://${connectionHostWithAuth}/${dummyVhost1}`
 const connectionStringDummy2 = `amqp://${connectionHostWithAuth}/${dummyVhost2}`
 const messageCount = 500
 
@@ -32,7 +32,7 @@ test.before(t => {
 
   RabbitMQHelper.createDeployment(t, testNamespace, deployYaml, connectionString, httpConnectionString, queueName)
 
-  RabbitMQHelper.createVhost(t, testNamespace, connectionHost, username, password, dummyVhost)
+  RabbitMQHelper.createVhost(t, testNamespace, connectionHost, username, password, dummyVhost1)
   RabbitMQHelper.createVhost(t, testNamespace, connectionHost, username, password, dummyVhost2)
 })
 
@@ -44,7 +44,7 @@ test.serial('Deployment should have 0 replicas on start', t => {
 })
 
 test.serial(`Deployment should scale to 4 with ${messageCount} messages on the queue then back to 0`, async t => {
-  RabbitMQHelper.publishMessages(t, testNamespace, connectionStringDummy, messageCount, dummyQueueName1)
+  RabbitMQHelper.publishMessages(t, testNamespace, connectionStringDummy1, messageCount, dummyQueueName1)
   RabbitMQHelper.publishMessages(t, testNamespace, connectionStringDummy2, messageCount, dummyQueueName2)
   RabbitMQHelper.publishMessages(t, testNamespace, connectionString, messageCount, queueName)
 

--- a/tests/scalers/rabbitmq-queue-http-regex.test.ts
+++ b/tests/scalers/rabbitmq-queue-http-regex.test.ts
@@ -22,7 +22,7 @@ test.before(t => {
 
   sh.config.silent = true
   // create deployment
-  const httpConnectionString = `http://${username}:${password}@rabbitmq.${rabbitmqNamespace}.svc.cluster.local`
+  const httpConnectionString = `http://${username}:${password}@rabbitmq.${rabbitmqNamespace}.svc.cluster.local/${vhost}`
 
   RabbitMQHelper.createDeployment(t, testNamespace, deployYaml, connectionString, httpConnectionString, queueName)
 })


### PR DESCRIPTION
The vhost is included when you don't use `useRegex: true`. It makes
sense to have consistent behaviour between the two modes.

Fixes #2498

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated

Fixes #
