### PR TITLE
Don't call Azure queue GetProperties API unnecessarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@
 
 ### Improvements
 
-- **General:** Fix generation of metric names if any of ScaledObject's triggers is unavailable ([#2592](https://github.com/kedacore/keda/issues/2592))
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Improvements
 
 - **General:** Fix generation of metric names if any of ScaledObject's triggers is unavailable ([#2592](https://github.com/kedacore/keda/issues/2592))
+- **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 
 ### Breaking Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ check the [test documentation](./tests/README.md). Those tests are run nightly o
 
 ## Changelog
 
-Every change should bve added to our changelog under `Unreleased` which is located in `CHANGELOG.md`. This helps us keep track of all changes in a given release.
+Every change should be added to our changelog under `Unreleased` which is located in `CHANGELOG.md`. This helps us keep track of all changes in a given release.
 
 Here are some guidelines to follow:
 - Always use `General: ` or `<Scaler Name>: ` as a prefix and sort them alphabetically


### PR DESCRIPTION
This PR reorders the logic of getting an Azure queue size in a way
that skips the call to get the queue properties (for getting the
ApproximateMessagesCount) if the queue has less than 32 messages.

Signed-off-by: Ram Cohen <ram.cohen@gmail.com>
