### PR TITLE
Return 1 or 0 instead of -1 when detecting an invalid offset in Kafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2657](https://github.com/kedacore/keda/issues/2657))
 - **Datadog Scaler:** Rely on Datadog API to validate the query ([2761](https://github.com/kedacore/keda/issues/2761))
 - **Kafka Scaler:** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
+- **Kafka Scaler:** New `scaleToZeroOnInvalidOffset` to control behavior when partitions have an invalid offset ([#2033](https://github.com/kedacore/keda/issues/2033)[#2612](https://github.com/kedacore/keda/issues/2612))
 - **Metric API Scaler:** Improve error handling on not-ok response ([#2317](https://github.com/kedacore/keda/issues/2317))
 - **Prometheus Scaler:** Check and properly inform user that `threshold` is not set ([#2793](https://github.com/kedacore/keda/issues/2793))
 - **Prometheus Scaler:** Support for `X-Scope-OrgID` header ([#2667](https://github.com/kedacore/keda/issues/2667))

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -367,7 +367,7 @@ func (s *kafkaScaler) getLagForPartition(topic string, partitionID int32, offset
 			retVal = 0
 		}
 		errMsg := fmt.Errorf(
-			"invalid offset found for topic %s in group %s and partition %d, probably no offset is committed yet. Scaling to %d",
+			"invalid offset found for topic %s in group %s and partition %d, probably no offset is committed yet. Returning with lag of %d",
 			topic, s.metadata.group, partitionID, retVal)
 		kafkaLog.V(0).Info(errMsg.Error())
 		return retVal, errMsg

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -362,7 +362,7 @@ func (s *kafkaScaler) getLagForPartition(topic string, partitionID int32, offset
 	}
 	consumerOffset := block.Offset
 	if consumerOffset == invalidOffset && s.metadata.offsetResetPolicy == latest {
-		retVal := 1;
+		retVal := int64(1)
 		if s.metadata.scaleToZeroOnInvalidOffset {
 			retVal = 0;
 		}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -374,11 +374,11 @@ func (s *kafkaScaler) getLagForPartition(topic string, partitionID int32, offset
 		if s.metadata.scaleToZeroOnInvalidOffset {
 			retVal = 0
 		}
-		errMsg := fmt.Errorf(
+		msg := fmt.Sprintf(
 			"invalid offset found for topic %s in group %s and partition %d, probably no offset is committed yet. Returning with lag of %d",
 			topic, s.metadata.group, partitionID, retVal)
-		kafkaLog.V(0).Info(errMsg.Error())
-		return retVal, errMsg
+		kafkaLog.V(0).Info(msg)
+		return retVal, nil
 	}
 
 	if _, found := topicPartitionOffsets[topic]; !found {

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -364,7 +364,7 @@ func (s *kafkaScaler) getLagForPartition(topic string, partitionID int32, offset
 	if consumerOffset == invalidOffset && s.metadata.offsetResetPolicy == latest {
 		retVal := int64(1)
 		if s.metadata.scaleToZeroOnInvalidOffset {
-			retVal = 0;
+			retVal = 0
 		}
 		errMsg := fmt.Errorf(
 			"invalid offset found for topic %s in group %s and partition %d, probably no offset is committed yet. Scaling to %d",

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -191,6 +191,17 @@ func TestKafkaAuthParams(t *testing.T) {
 		if meta.enableTLS != testData.enableTLS {
 			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
 		}
+		if meta.enableTLS {
+			if meta.ca != testData.authParams["ca"] {
+				t.Errorf("Expected ca to be set to %v but got %v\n", testData.authParams["ca"], meta.enableTLS)
+			}
+			if meta.cert != testData.authParams["cert"] {
+				t.Errorf("Expected cert to be set to %v but got %v\n", testData.authParams["cert"], meta.cert)
+			}
+			if meta.key != testData.authParams["key"] {
+				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["key"], meta.key)
+			}
+		}
 	}
 }
 

--- a/tests/scalers/kafka.test.ts
+++ b/tests/scalers/kafka.test.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
-import test from 'ava';
-import { createNamespace } from './helpers';
+import test, { Assertions } from 'ava';
+import { createNamespace, waitForDeploymentReplicaCount } from './helpers';
 
 const defaultNamespace = 'kafka-test'
 const defaultCluster = 'kafka-cluster'
@@ -10,8 +10,7 @@ const timeToWait = 300
 const defaultTopic = 'kafka-topic'
 const defaultTopic2 = 'kafka-topic-2'
 const defaultKafkaClient = 'kafka-client'
-const strimziOperatorVersion = '0.18.0'
-const commandToCheckReplicas = `kubectl get deployments/kafka-consumer --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`
+const strimziOperatorVersion = '0.23.0'
 
 const strimziOperatorYamlFile = tmp.fileSync()
 const kafkaClusterYamlFile = tmp.fileSync()
@@ -24,123 +23,61 @@ const scaledObjectEarliestYamlFile = tmp.fileSync()
 const scaledObjectLatestYamlFile = tmp.fileSync()
 const scaledObjectMultipleTopicsYamlFile = tmp.fileSync()
 
-test.before('Set up, create necessary resources.', t => {
-  sh.config.silent = true
-	createNamespace(defaultNamespace)
-
-  const strimziOperatorYaml = sh.exec(`curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimziOperatorVersion}/strimzi-cluster-operator-${strimziOperatorVersion}.yaml`).stdout
-  fs.writeFileSync(strimziOperatorYamlFile.name, strimziOperatorYaml.replace(/myproject/g, `${defaultNamespace}`))
-	t.is(
-		0,
-		sh.exec(`kubectl apply -f ${strimziOperatorYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Strimzi operator should work.'
-	)
-
-	fs.writeFileSync(kafkaClusterYamlFile.name, kafkaClusterYaml)
-	t.is(
-		0,
-		sh.exec(`kubectl apply -f ${kafkaClusterYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Kafka cluster instance should work.'
-	)
-	t.is(
-		0,
-		sh.exec(`kubectl wait kafka/${defaultCluster} --for=condition=Ready --timeout=${timeToWait}s --namespace ${defaultNamespace}`).code,
-		'Kafka instance should be ready within given time limit.'
-    )
-
-    fs.writeFileSync(kafkaTopicYamlFile.name, kafkaTopicsYaml)
-	t.is(
-		0,
-		sh.exec(`kubectl apply -f ${kafkaTopicYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Kafka topic should work.'
-	)
-	t.is(
-		0,
-		sh.exec(`kubectl wait kafkatopic/${defaultTopic} --for=condition=Ready --timeout=${timeToWait}s --namespace ${defaultNamespace}`).code,
-		'Kafka topic should be ready withlanguage-mattersin given time limit.'
-    )
-    t.is(
-        0,
-        sh.exec(`kubectl wait kafkatopic/${defaultTopic2} --for=condition=Ready --timeout=${timeToWait}s --namespace ${defaultNamespace}`).code,
-        'Kafka topic2 should be ready within given time limit.'
-    )
-
-	fs.writeFileSync(kafkaClientYamlFile.name, kafkaClientYaml)
-	t.is(
-		0,
-		sh.exec(`kubectl apply -f ${kafkaClientYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Kafka client should work.'
-	)
-	t.is(
-		0,
-		sh.exec(`kubectl wait pod/${defaultKafkaClient} --for=condition=Ready --timeout=${timeToWait}s --namespace ${defaultNamespace}`).code,
-		'Kafka client should be ready within given time limit.'
-    )
-
-  fs.writeFileSync(kafkaApplicationEarliestYamlFile.name, kafkaApplicationEarliestYaml)
-
-	t.is(
-		0,
-		sh.exec(`kubectl apply -f ${kafkaApplicationEarliestYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Kafka application should work.'
-  )
-  fs.writeFileSync(scaledObjectEarliestYamlFile.name, scaledObjectEarliestYaml)
-	t.is(
-		0,
-		sh.exec(`kubectl apply -f ${scaledObjectEarliestYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Scaled Object should work.'
-	)
-	t.is(
-		0,
-		sh.exec(`kubectl wait deployment/kafka-consumer --for=condition=Available --timeout=${timeToWait}s --namespace ${defaultNamespace}`).code,
-		'Kafka application should be ready within given time limit.'
-	)
-  waitForReplicaCount(0, commandToCheckReplicas)
-  t.is('0', sh.exec(commandToCheckReplicas).stdout, 'Replica count should be 0.')
-});
-
-function waitForReplicaCount(desiredReplicaCount: number, commandToCheck: string) {
-  let replicaCount = undefined
-  let changed = undefined
-  for (let i = 0; i < 10; i++) {
-    changed = false
-    // checks the replica count 3 times, it tends to fluctuate from the beginning
-    for (let j = 0; j < 3; j++) {
-      replicaCount = sh.exec(commandToCheck).stdout
-      if (replicaCount === desiredReplicaCount.toString()) {
-        sh.exec('sleep 2s')
-      } else {
-        changed = true
-        break
-      }
-    }
-    if (changed === false) {
-      return
-    } else {
-      sh.exec('sleep 3s')
-    }
-  }
+function deployFromYaml(t: Assertions, filename: string, yaml: string, name: string) {
+  sh.exec(`echo Deploying ${name}`)
+  fs.writeFileSync(filename, yaml)
+	t.is(0, sh.exec(`kubectl apply -f ${filename} --namespace ${defaultNamespace}`).code, `Deploying ${name} should work.`)
 }
 
-test.serial('Scale application with kafka messages.', t => {
+function waitForReady(t: Assertions, app: string, name: string, condition: string = 'Ready') {
+  sh.exec(`echo Waiting for ${app} for ${timeToWait} seconds to be ${condition}`)
+  t.is(
+		0,
+		sh.exec(`kubectl wait ${app} --for=condition=${condition} --timeout=${timeToWait}s --namespace ${defaultNamespace}`).code,
+		`${name} should be ready within given time limit.`
+    )
+}
+
+test.before('Set up, create necessary resources.', async t => {
+	createNamespace(defaultNamespace)
+
+  sh.config.silent = true
+  const strimziOperatorYaml = sh.exec(`curl -L https://github.com/strimzi/strimzi-kafka-operator/releases/download/${strimziOperatorVersion}/strimzi-cluster-operator-${strimziOperatorVersion}.yaml`).stdout
+  sh.config.silent = false
+
+  deployFromYaml(t, strimziOperatorYamlFile.name, strimziOperatorYaml.replace(/myproject/g, `${defaultNamespace}`), 'Strimzi operator')
+  deployFromYaml(t, kafkaClusterYamlFile.name, kafkaClusterYaml, 'Kafka cluster')
+  waitForReady(t, `kafka/${defaultCluster}`,'Kafka instance')
+
+  deployFromYaml(t, kafkaTopicYamlFile.name, kafkaTopicsYaml, 'Kafka topic')
+  waitForReady(t, `kafkatopic/${defaultTopic}`,'Kafka topic')
+  waitForReady(t, `kafkatopic/${defaultTopic2}`,'Kafka topic2')
+
+  deployFromYaml(t, kafkaClientYamlFile.name, kafkaClientYaml, 'Kafka client')
+  waitForReady(t, `pod/${defaultKafkaClient}`,'Kafka client')
+
+  deployFromYaml(t, kafkaApplicationEarliestYamlFile.name, kafkaApplicationEarliestYaml, 'Kafka application')
+  deployFromYaml(t, scaledObjectEarliestYamlFile.name, scaledObjectEarliestYaml, 'Scaled Object')
+  waitForReady(t, 'deployment/kafka-consumer','Kafka application', 'Available')
+
+  t.true(await waitForDeploymentReplicaCount(0, 'kafka-consumer', defaultNamespace, 30, 2000), 'replica count should start out as 0')
+});
+
+test.serial('Scale application with kafka messages.', async t => {
   for (let r = 1; r <= 3; r++) {
 
     sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -c 'echo "{\"text\": \"foo\"}" | kafka-console-producer --broker-list ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092 --topic ${defaultTopic}'`)
     sh.exec(`sleep 5s`)
 
-    waitForReplicaCount(r, commandToCheckReplicas)
-
-    t.is(r.toString(), sh.exec(commandToCheckReplicas).stdout, `Replica count should be ${r}.`)
+    t.true(await waitForDeploymentReplicaCount(r, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be ${r}.`)
   }
 })
 
-test.serial('Scale application beyond partition max.', t => {
+test.serial('Scale application beyond partition max.', async t => {
   sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -c 'echo "{\"text\": \"foo\"}" | kafka-console-producer --broker-list ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092 --topic ${defaultTopic}'`)
   sh.exec(`sleep 5s`)
 
-  waitForReplicaCount(3, commandToCheckReplicas)
-
-  t.is('3', sh.exec(commandToCheckReplicas).stdout, `Replica count should be 3.`)
+  t.true(await waitForDeploymentReplicaCount(3, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be 3.`)
 })
 
 test.serial('cleanup after earliest policy test', t=> {
@@ -158,40 +95,27 @@ test.serial('cleanup after earliest policy test', t=> {
   sh.exec(`sleep 30s`)
 })
 
-test.serial('Applying ScaledObject latest policy should not scale up pods', t => {
+test.serial('Applying ScaledObject latest policy should not scale up pods', async t => {
 
   //Make the consumer commit the first offset for each partition.
   sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -c 'kafka-console-consumer --bootstrap-server ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092 --topic ${defaultTopic} --group latest --from-beginning --consumer-property enable.auto.commit=true --timeout-ms 15000'`)
 
-  fs.writeFileSync(kafkaApplicationLatestYamlFile.name, kafkaApplicationLatestYaml)
-	t.is(
-		0,
-		sh.exec(`kubectl apply -f ${kafkaApplicationLatestYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Kafka application should work.'
-  )
+  deployFromYaml(t, kafkaApplicationLatestYamlFile.name, kafkaApplicationLatestYaml, 'Kafka application')
   sh.exec(`sleep 10s`)
-  fs.writeFileSync(scaledObjectLatestYamlFile.name, scaledObjectLatestYaml)
-  t.is(
-		0,
-		sh.exec(`kubectl apply -f ${scaledObjectLatestYamlFile.name} --namespace ${defaultNamespace}`).code,
-		'Deploying Scaled Object should work.'
-  )
+  deployFromYaml(t, scaledObjectLatestYamlFile.name, scaledObjectLatestYaml, 'Scaled Object')
   sh.exec(`sleep 5s`)
-  waitForReplicaCount(1, commandToCheckReplicas)
-  t.is('0', sh.exec(commandToCheckReplicas).stdout, 'Replica count should be 0.')
+  t.true(await waitForDeploymentReplicaCount(0, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be 0.`)
 })
 
 
-test.serial('Latest Scale object should scale with new messages', t => {
+test.serial('Latest Scale object should scale with new messages', async t => {
 
   for (let r = 1; r <= 3; r++) {
 
     sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -c 'echo "{\"text\": \"foo\"}" | kafka-console-producer --broker-list ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092 --topic ${defaultTopic}'`)
     sh.exec(`sleep 5s`)
 
-    waitForReplicaCount(r, commandToCheckReplicas)
-
-    t.is(r.toString(), sh.exec(commandToCheckReplicas).stdout, `Replica count should be ${r}.`)
+    t.true(await waitForDeploymentReplicaCount(r, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be ${r}.`)
   }
 })
 
@@ -209,37 +133,24 @@ test.serial('Cleanup after latest policy test', t=> {
     sh.exec(`sleep 10s`)
 })
 
-test.serial('Applying ScaledObject with multiple topics should scale up pods', t => {
+test.serial('Applying ScaledObject with multiple topics should scale up pods', async t => {
     // Make the consumer commit the all offsets for all topics in the group
     sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -c 'kafka-console-consumer --bootstrap-server "${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092" --topic ${defaultTopic}  --group multiTopic --from-beginning --consumer-property enable.auto.commit=true --timeout-ms 15000'`)
     sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -c 'kafka-console-consumer --bootstrap-server "${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092" --topic ${defaultTopic2} --group multiTopic --from-beginning --consumer-property enable.auto.commit=true --timeout-ms 15000'`)
 
-    fs.writeFileSync(kafkaApplicationMultipleTopicsYamlFile.name, kafkaApplicationMultipleTopicsYaml)
-    t.is(
-        0,
-        sh.exec(`kubectl apply -f ${kafkaApplicationMultipleTopicsYamlFile.name} --namespace ${defaultNamespace}`).code,
-        'Deploying Kafka application should work.'
-    )
+    deployFromYaml(t, kafkaApplicationMultipleTopicsYamlFile.name, kafkaApplicationMultipleTopicsYaml, 'Kafka application')
     sh.exec(`sleep 5s`)
-    fs.writeFileSync(scaledObjectMultipleTopicsYamlFile.name, scaledObjectMultipleTopicsYaml)
-
-    t.is(
-        0,
-        sh.exec(`kubectl apply -f ${scaledObjectMultipleTopicsYamlFile.name} --namespace ${defaultNamespace}`).code,
-        'Deploying Scaled Object should work.'
-    )
+    deployFromYaml(t, scaledObjectMultipleTopicsYamlFile.name, scaledObjectMultipleTopicsYaml, ' Scaled Object')
     sh.exec(`sleep 5s`)
 
     // when lag is 0, scaled object is not active, replica = 0
-    waitForReplicaCount(0, commandToCheckReplicas)
-    t.is('0', sh.exec(commandToCheckReplicas).stdout, 'Replica count should be 0.')
+    t.true(await waitForDeploymentReplicaCount(0, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be 0.`)
 
     // produce a single msg to the default topic
     // should turn scale object active, replica = 1
     sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -exc 'echo "{\"text\": \"foo\"}" | kafka-console-producer --broker-list ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092 --topic ${defaultTopic}'`)
     sh.exec(`sleep 5s`)
-    waitForReplicaCount(1, commandToCheckReplicas)
-    t.is('1', sh.exec(commandToCheckReplicas).stdout, 'Replica count should be 1.')
+    t.true(await waitForDeploymentReplicaCount(1, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be 1.`)
 
     // produce one more msg to the different topic within the same group
     // will turn total consumer group lag to 2.
@@ -248,14 +159,12 @@ test.serial('Applying ScaledObject with multiple topics should scale up pods', t
     // as desiredReplicaCount = totalLag / avgThreshold
     sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -exc 'echo "{\"text\": \"foo\"}" | kafka-console-producer --broker-list ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092 --topic ${defaultTopic2}'`)
     sh.exec(`sleep 5s`)
-    waitForReplicaCount(2, commandToCheckReplicas)
-    t.is('2', sh.exec(commandToCheckReplicas).stdout, 'Replica count should be 2.')
+    t.true(await waitForDeploymentReplicaCount(2, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be 2.`)
 
     // make it 3 cause why not?
     sh.exec(`kubectl exec --namespace ${defaultNamespace} ${defaultKafkaClient} -- sh -exc 'echo "{\"text\": \"foo\"}" | kafka-console-producer --broker-list ${defaultCluster}-kafka-bootstrap.${defaultNamespace}:9092 --topic ${defaultTopic}'`)
     sh.exec(`sleep 5s`)
-    waitForReplicaCount(3, commandToCheckReplicas)
-    t.is('3', sh.exec(commandToCheckReplicas).stdout, 'Replica count should be 3.')
+    t.true(await waitForDeploymentReplicaCount(3, 'kafka-consumer', defaultNamespace, 30, 2000), `Replica count should be 3.`)
 })
 
 test.serial('Cleanup after multiple topics test', t=> {
@@ -289,23 +198,31 @@ test.after.always('Clean up, delete created resources.', t => {
   ]
 
   for (const resource of resources) {
-    sh.exec(`kubectl delete ${resource} --namespace ${defaultNamespace}`)
+    sh.exec(`echo Deleting resource from file ${resource}`)
+    sh.exec(`kubectl delete -f ${resource} --namespace ${defaultNamespace}`)
   }
+  sh.exec(`echo Deleting namespace ${defaultNamespace}`)
   sh.exec(`kubectl delete namespace ${defaultNamespace}`)
 })
 
-const kafkaClusterYaml = `apiVersion: kafka.strimzi.io/v1beta1
+const kafkaClusterYaml = `apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: ${defaultCluster}
   namespace: ${defaultNamespace}
 spec:
   kafka:
-    version: 2.5.0
+    version: "2.6.0"
     replicas: 3
     listeners:
-      plain: {}
-      tls: {}
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
@@ -321,7 +238,7 @@ spec:
     topicOperator: {}
     userOperator: {}`
 
-const kafkaTopicsYaml = `apiVersion: kafka.strimzi.io/v1beta1
+const kafkaTopicsYaml = `apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: ${defaultTopic}
@@ -335,7 +252,7 @@ spec:
     retention.ms: 604800000
     segment.bytes: 1073741824
 ---
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: ${defaultTopic2}


### PR DESCRIPTION
When getting the consumer offset of a Kafka topic for which no offset
was committed yet, the scaler returns with -1 instead of 0, which
causes to scale to the maximum number of replicas.

This fix changes the behavior to return in that case either '1' (the default) or '0', depending on a new scaler parameter scaleToZeroOnInvalidOffset which default to 'false'

Also fixed some typos and used interim variables for error strings.

Fixes #2612 #2033