### PR TITLE
datadog_scaler: handle mising { on dd query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Improvements
 
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
+- **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))
 
 ### Breaking Changes
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -68,6 +68,9 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 	} else {
 		return nil, fmt.Errorf("no query given")
 	}
+	if !strings.Contains(meta.query, "{") {
+		return nil, fmt.Errorf("expecting query to contain `{`, got %s", meta.query)
+	}
 
 	if val, ok := config.TriggerMetadata["queryValue"]; ok {
 		queryValue, err := strconv.Atoi(val)

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -41,6 +41,8 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"appKey": "appKey"}, true},
 	// missing appKey
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"apiKey": "apiKey"}, true},
+	// invalid query missing {
+	{map[string]string{"query": "sum:trace.redis.command.hits.as_count()", "queryValue": "7"}, map[string]string{}, true},
 }
 
 func TestDatadogScalerAuthParams(t *testing.T) {


### PR DESCRIPTION
It's probably nice to handle the error gracefully rather than panic in case of unexpected datadog scaler query

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #2625 
