### PR TITLE
feat: Provide e2e variables for GCP auth

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -87,6 +87,7 @@ jobs:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
           DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
+          GCP_SP_KEY: ${{ secrets.GCP_SP_KEY }}
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
           NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -32,6 +32,7 @@ jobs:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
           DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
+          GCP_SP_KEY: ${{ secrets.GCP_SP_KEY }}
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
           NEWRELIC_LICENSE: ${{ secrets.NEWRELIC_LICENSE}}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -81,6 +81,7 @@ jobs:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
           DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
+          GCP_SP_KEY: ${{ secrets.GCP_SP_KEY }}
           E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}


### PR DESCRIPTION
Provide e2e variables for GCP auth by exposing the JSON key for our service account.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/2628
