### PR TITLE
Improve the Datadog scaler with non-breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,10 @@
 
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 - **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))
+- **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2657](https://github.com/kedacore/keda/issues/2657))
 - **GCP Pubsub Scaler** Adding e2e test for GCP PubSub scaler ([#1528](https://github.com/kedacore/keda/issues/1528))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
-- **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2657](https://github.com/kedacore/keda/issues/2657))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - **GCP Pubsub Scaler** Adding e2e test for GCP PubSub scaler ([#1528](https://github.com/kedacore/keda/issues/1528))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
+- **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2694](https://github.com/kedacore/keda/pull/2694))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - **GCP Pubsub Scaler** Adding e2e test for GCP PubSub scaler ([#1528](https://github.com/kedacore/keda/issues/1528))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
-- **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2694](https://github.com/kedacore/keda/pull/2694))
+- **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2657](https://github.com/kedacore/keda/issues/2657))
 
 ### Breaking Changes
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -269,6 +269,10 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 		tries++
 	}
 
+	if len(series) > 1 {
+		return 0, fmt.Errorf("query returned more than 1 series; modify the query to return only 1 series")
+	}
+
 	if len(series) == 0 {
 		return 0, fmt.Errorf("no Datadog metrics returned for the given time window")
 	}
@@ -279,7 +283,9 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 		return 0, fmt.Errorf("no Datadog metrics returned for the given time window")
 	}
 
-	return float64(*points[0][1]), nil
+	// Return the last point from the series
+	index := len(points) - 1
+	return float64(*points[index][1]), nil
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -224,8 +224,15 @@ func (s *datadogScaler) Close(context.Context) error {
 	return nil
 }
 
+// IsActive checks whether the value returned by Datadog is higher than the target value
 func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
-	return true, nil
+	num, err := s.getQueryResult(ctx)
+
+	if err != nil {
+		return false, err
+	}
+
+	return num > float64(s.metadata.queryValue), nil
 }
 
 // getQueryResult returns result of the scaler query

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -179,7 +179,7 @@ func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 }
 
 // getQueryResult returns result of the scaler query
-func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
+func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 	ctx = context.WithValue(
 		ctx,
 		datadog.ContextAPIKeys,
@@ -254,7 +254,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("no Datadog metrics returned for the given time window")
 	}
 
-	return int(*points[0][1]), nil
+	return float64(*points[0][1]), nil
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
@@ -301,7 +301,7 @@ func (s *datadogScaler) GetMetrics(ctx context.Context, metricName string, metri
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: s.metadata.metricName,
-		Value:      *resource.NewQuantity(int64(num), resource.DecimalSI),
+		Value:      *resource.NewMilliQuantity(int64(num*1000), resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -174,45 +174,7 @@ func (s *datadogScaler) Close(context.Context) error {
 	return nil
 }
 
-// IsActive returns true if we are able to get metrics from Datadog
 func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
-	ctx = context.WithValue(
-		ctx,
-		datadog.ContextAPIKeys,
-		map[string]datadog.APIKey{
-			"apiKeyAuth": {
-				Key: s.metadata.apiKey,
-			},
-			"appKeyAuth": {
-				Key: s.metadata.appKey,
-			},
-		},
-	)
-
-	ctx = context.WithValue(ctx,
-		datadog.ContextServerVariables,
-		map[string]string{
-			"site": s.metadata.datadogSite,
-		})
-
-	resp, _, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)
-
-	if err != nil {
-		return false, err
-	}
-
-	series := resp.GetSeries()
-
-	if len(series) == 0 {
-		return false, nil
-	}
-
-	points := series[0].GetPointlist()
-
-	if len(points) == 0 {
-		return false, nil
-	}
-
 	return true, nil
 }
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -79,9 +79,8 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 
 		if err != nil {
 			return nil, fmt.Errorf("error in query: %s", err.Error())
-		} else {
-			meta.query = query
 		}
+		meta.query = query
 	} else {
 		return nil, fmt.Errorf("no query given")
 	}
@@ -180,20 +179,19 @@ func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 
 // parseAndTransformDatadogQuery checks correctness of the user query and adds rollup if not available
 func parseAndTransformDatadogQuery(q string, age int) (string, error) {
-
-	aggregator, _ := regexp.Compile(`^(avg|sum|min|max):.*`)
+	aggregator := regexp.MustCompile(`^(avg|sum|min|max):.*`)
 
 	if !aggregator.MatchString(q) {
 		q = "avg:" + q
 	}
 
-	filter, _ := regexp.Compile(`.*\{.*\}.*`)
+	filter := regexp.MustCompile(`.*\{.*\}.*`)
 
 	if !filter.MatchString(q) {
 		return "", fmt.Errorf("malformed Datadog query")
 	}
 
-	rollup, _ := regexp.Compile(`.*\.rollup\(.*\)`)
+	rollup := regexp.MustCompile(`.*\.rollup\(.*\)`)
 
 	if !rollup.MatchString(q) {
 		s := fmt.Sprintf(".rollup(avg, %d)", age)
@@ -285,7 +283,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 
 	// Return the last point from the series
 	index := len(points) - 1
-	return float64(*points[index][1]), nil
+	return *points[index][1], nil
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -32,6 +32,8 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// wrong query value type
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "notanint", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
+	// malformed query
+	{map[string]string{"query": "sum:trace.redis.command.hits", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 
 	// success api/app keys
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -21,7 +21,7 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 	{map[string]string{}, map[string]string{}, true},
 
 	// all properly formed
-	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricUnavailableValue": "1.5", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// default age
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "type": "average"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},
 	// default type
@@ -34,6 +34,8 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "notanint", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 	// malformed query
 	{map[string]string{"query": "sum:trace.redis.command.hits", "queryValue": "7", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
+	// wrong unavailableMetricValue type
+	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7", "metricUnavailableValue": "notafloat", "type": "average", "age": "60"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, true},
 
 	// success api/app keys
 	{map[string]string{"query": "sum:trace.redis.command.hits{env:none,service:redis}.as_count()", "queryValue": "7"}, map[string]string{"apiKey": "apiKey", "appKey": "appKey", "datadogSite": "datadogSite"}, false},

--- a/tests/scalers/datadog.test.ts
+++ b/tests/scalers/datadog.test.ts
@@ -164,6 +164,7 @@ test.serial(`NGINX deployment should scale to 3 (the max) when getting too many 
 })
 
 test.after.always.cb('clean up datadog resources', t => {
+  sh.exec(`kubectl delete scaledobject -n ${testNamespace} --all`)
   sh.exec(`helm repo rm datadog`)
   sh.exec(`kubectl delete namespace ${datadogNamespace} --force`)
   sh.exec(`kubectl delete namespace ${testNamespace} --force`)
@@ -282,7 +283,6 @@ spec:
     name: nginx
   minReplicaCount: 1
   maxReplicaCount: 3
-  pollingInterval: 5
   cooldownPeriod: 10
   advanced:
     horizontalPodAutoscalerConfig:
@@ -295,7 +295,7 @@ spec:
       query: "avg:nginx.net.request_per_s{cluster_name:keda-datadog-cluster}"
       queryValue: "2"
       type: "global"
-      age: "60"
+      age: "120"
     authenticationRef:
       name: keda-trigger-auth-datadog-secret
 `

--- a/tests/scalers/datadog.test.ts
+++ b/tests/scalers/datadog.test.ts
@@ -130,7 +130,7 @@ test.serial(`NGINX deployment should scale to 3 (the max) when getting too many 
   // keda based deployment should start scaling up with http requests issued
   let replicaCount = '1'
   for (let i = 0; i < 60 && replicaCount !== '3'; i++) {
-    t.log(`Waited ${5 * i} seconds for nginx deployment to scale up`)
+    t.log(`Waited ${15 * i} seconds for nginx deployment to scale up`)
 
     replicaCount = sh.exec(
       `kubectl get deployment nginx --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
@@ -151,11 +151,12 @@ test.serial(`NGINX deployment should scale to 3 (the max) when getting too many 
   )
 
   for (let i = 0; i < 50 && replicaCount !== '1'; i++) {
+    t.log(`Waited ${15 * i} seconds for nginx deployment to scale down`)
     replicaCount = sh.exec(
       `kubectl get deployment nginx --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
     ).stdout
     if (replicaCount !== '1') {
-      sh.exec('sleep 5')
+      sh.exec('sleep 15')
     }
   }
 


### PR DESCRIPTION
Several non-breaking fixes for the Datadog scaler. Fixes #2657

The problem described in #2657 is partially caused by the selection of a time window that is too small (15 seconds). Datadog doesn't have that metric yet in many cases, and returns an empty value, that logs as a warning in the HPA.

To avoid this from happening often, the user should select a bigger window, and also added some retries before giving up. I also changed the documentation, to discourage reducing the time window: https://github.com/kedacore/keda-docs/pull/682

To avoid this, we should remove the "age" parameter going forward, but as this is a breaking change, I will create a different PR for 2.7.

Other improvements in this PR:

* If more than one point is returned, return the last one,  instead of the first one, for more recent results
* More parsing of the initial query, and some potential fixes to a incomplete query: default to avg aggregator, and only add a rollup if one wasn't added by the user
* Moved to MilliQuantities and floats for query results for more granularity
* Return a specific error if Datadog didn't return a metric value due to reaching rate limits for the organization
* IsActive doesn't try to get a metric value, to reduce rate limiting

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] Tests have been added
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

 Fixes #2657
