### PR TITLE
fix: Fix error generating build-tools image

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -105,16 +105,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
 
-      - uses: marceloprado/has-changed-path@v1
-        id: changed-front
+      - uses: dorny/paths-filter@v2
+        id: filter
         with:
-          paths: tools
+          filters: |
+            tools:
+              - 'tools/**'
 
       - name: Build tools
-        if: steps.changed-front.outputs.changed == 'true'
+        if: steps.filter.outputs.tools == 'true'
         run: make docker-build-tools
 
   statics:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -100,6 +100,24 @@ jobs:
       - name: Test
         run: make test
 
+  validate-build-tools:
+    name: Validate build-tools
+    runs-on: ubuntu-latest
+    container: ubuntu:focal
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+
+      - uses: marceloprado/has-changed-path@v1
+        id: changed-front
+        with:
+          paths: tools
+
+      - name: Build tools
+        if: steps.changed-front.outputs.changed == 'true'
+        run: make docker-build-tools
+
   statics:
     name: Static Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -103,7 +103,6 @@ jobs:
   validate-build-tools:
     name: Validate build-tools
     runs-on: ubuntu-latest
-    container: ubuntu:focal
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,10 @@ endef
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: publish-build-tools
-publish-build-tools: ## Publish build-tools image
+.PHONY: docker-build-tools
+docker-build-tools: ## Build build-tools image
 	docker build -f tools/build-tools.Dockerfile -t $(IMAGE_BUILD_TOOLS) .
+
+.PHONY: publish-build-tools
+publish-build-tools: docker-build-tools ## Publish build-tools image
 	docker push $(IMAGE_BUILD_TOOLS)

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -23,13 +23,12 @@ RUN apt-get install apt-transport-https lsb-release dirmngr -y && \
     apt-get update && \
     apt-get install -y azure-cli
 
-# Install docker client
-RUN curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-19.03.2.tgz && \
-    docker_sha256=865038730c79ab48dfed1365ee7627606405c037f46c9ae17c5ec1f487da1375 && \
-    echo "$docker_sha256 docker-19.03.2.tgz" | sha256sum -c - && \
-    tar xvzf docker-19.03.2.tgz && \
-    mv docker/* /usr/local/bin && \
-    rm -rf docker docker-19.03.2.tgz && \
+# Install docker
+RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release && \
+    curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null && \
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" && \
+    apt-get update &&\
+    apt-get install -y docker-ce-cli && \
     docker buildx create --use
 
 # Install golang


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

This PR fixes the error generating build-tools image with buildx enabled and also adds a CI which runs only if there are changes inside `tools` folder for checking the image

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Related #2263