### PR TITLE
fix: create buildx context on github workflow 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -70,7 +70,6 @@ RUN apt-get update \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
     && apt-get update \
     && apt-get install -y docker-ce-cli \
-    && docker buildx create --use \
     #
     # Install pip & pre-commit
     && apt-get -y install python3-pip \

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -53,6 +53,9 @@ jobs:
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Publish on GitHub Container Registry
         run: make publish-multiarch
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -59,6 +59,9 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Publish KEDA images on GitHub Container Registry
         run: make publish-multiarch
         env:

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -28,8 +28,7 @@ RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent soft
     curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" && \
     apt-get update &&\
-    apt-get install -y docker-ce-cli && \
-    docker buildx create --use
+    apt-get install -y docker-ce-cli
 
 # Install golang
 RUN GO_VERSION=1.17.3 && \


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes https://github.com/kedacore/keda/issues/2263
