### PR TITLE
Remove arm64 smoke tests

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -126,27 +126,3 @@ jobs:
           AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}
           AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
           AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
-
-  validate-arm64:
-    needs: build
-    name: validate-arm64
-    runs-on: ARM64
-    container: arm64v8/ubuntu:focal
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-
-      - name: Create k8s v1.23 Kind Cluster
-        uses: helm/kind-action@v1.2.0
-        with:
-          node_image: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
-
-      - name: Install dependecies
-        run : |
-          apt update
-          apt install npm -y
-
-      - name: Run smoke test
-        run: make arm-smoke-test


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

Till [this is](https://github.com/kedacore/keda/issues/2262) ready, doesn't make sense to break main workflow

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Related https://github.com/kedacore/keda/issues/2262
