### PR TITLE
Fix e2e test command

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -100,6 +100,27 @@ jobs:
       - name: Test
         run: make test
 
+  validate-dockerfiles:
+    name: Validate Dockerfiles
+    runs-on: ubuntu-latest
+    container: ghcr.io/kedacore/build-tools:main
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            dockerfiles:
+              - 'Dockerfile*'
+
+      - name: Build images
+        if: steps.filter.outputs.dockerfiles == 'true'
+        run: make docker-build
+
   validate-build-tools:
     name: Validate build-tools
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # Build the manager binary
+ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM golang:1.17.3 AS builder
 
 ARG BUILD_VERSION=main
@@ -27,7 +28,8 @@ COPY pkg/ pkg/
 
 # Build
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
-ARG TARGETOS TARGETARCH
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} TARGET_OS=$TARGETOS ARCH=$TARGETARCH make manager
 
 # Use distroless as minimal base image to package the manager binary

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -1,4 +1,5 @@
 # Build the adapter binary
+ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM golang:1.17.3 as builder
 
 ARG BUILD_VERSION=main
@@ -29,7 +30,8 @@ RUN mkdir -p /apiserver.local.config/certificates && chmod -R 777 /apiserver.loc
 
 # Build
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
-ARG TARGETOS TARGETARCH
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} TARGET_OS=$TARGETOS ARCH=$TARGETARCH make adapter
 
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

Locally, both multiarch Dockerfile work without the variables but in the CI, the default values are necessary for Dockerfile arguments.
This PR also adds a workflow which builds docker images (only build) if any change is detected in Dockerfiles to avoid this problem in the future

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Related https://github.com/kedacore/keda/issues/2263
