### PR TITLE
Fix azure-blob e2e test

### DIFF
--- a/tests/scalers/azure-blob.test.ts
+++ b/tests/scalers/azure-blob.test.ts
@@ -41,7 +41,7 @@ test.serial('Deployment should have 0 replicas on start', t => {
 test.serial.cb('Deployment should scale to 2 with 150 blobs on the blob container then back to 0', t => {
     // add 2000 files
     const blobSvc = azure.createBlobService(connectionString)
-   
+
     async.mapLimit(Array(350).keys(), 50, (n, cb) => blobSvc.createBlockBlobFromText('container-name',`blobsubpath/blob-name-${n}`,'test text', cb), async () => {
         t.is(await waitForDeploymentReplicaCount(2,"test-deployment", defaultNamespace, 180, 1000),true, "Replica count should be 2 after 3 minute")
 

--- a/tests/scalers/azure-blob.test.ts
+++ b/tests/scalers/azure-blob.test.ts
@@ -4,20 +4,26 @@ import * as fs from 'fs'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import test from 'ava'
-import { createNamespace } from './helpers'
+import { createNamespace, waitForDeploymentReplicaCount } from './helpers'
 
 const defaultNamespace = 'azure-blob-test'
 const connectionString = process.env['AZURE_STORAGE_CONNECTION_STRING']
 // const blobSubPath = process.env['BLOB_SUB_PATH'];
 
-test.before(t => {
+test.before(async t => {
     if (!connectionString) {
         t.fail('AZURE_STORAGE_CONNECTION_STRING environment variable is required for blob tests')
     }
     // if (!blobSubPath) {
     //   t.fail('BLOB_SUB_PATH environment variable is required for blob tests');
   // }
-
+    const createContainerAsync = () => new Promise((resolve, _) => {
+      const blobSvc = azure.createBlobService(connectionString)
+      blobSvc.createContainerIfNotExists('container-name', err => {
+        resolve(undefined);
+      })
+    })
+    await createContainerAsync()
 
     sh.config.silent = true
     const base64ConStr = Buffer.from(connectionString).toString('base64')
@@ -35,29 +41,13 @@ test.serial('Deployment should have 0 replicas on start', t => {
 test.serial.cb('Deployment should scale to 2 with 150 blobs on the blob container then back to 0', t => {
     // add 2000 files
     const blobSvc = azure.createBlobService(connectionString)
-    blobSvc.createContainerIfNotExists('container-name', err => {
-        t.falsy(err, 'unable to create blob')
-        async.mapLimit(Array(350).keys(), 50, (n, cb) => blobSvc.createBlockBlobFromText('container-name',`blobsubpath/blob-name-${n}`,'test text', cb), () => {
-            let replicaCount = '0'
-            for (let i = 0; i < 40 && replicaCount !== '2'; i++) {
-                replicaCount = sh.exec(`kubectl get deployment.apps/test-deployment --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`).stdout
-                if (replicaCount !== '2') {
-                    sh.exec('sleep 1s')
-                }
-            }
+   
+    async.mapLimit(Array(350).keys(), 50, (n, cb) => blobSvc.createBlockBlobFromText('container-name',`blobsubpath/blob-name-${n}`,'test text', cb), async () => {
+        t.is(await waitForDeploymentReplicaCount(2,"test-deployment", defaultNamespace, 180, 1000),true, "Replica count should be 2 after 3 minute")
 
-            t.is('2', replicaCount, 'Replica count should be 2 after 40 seconds')
+        t.is(await waitForDeploymentReplicaCount(0,"test-deployment", defaultNamespace, 300, 1000),true, "Replica count should be 0 after 5 minute")
 
-            for (let i = 0; i < 50 && replicaCount !== '0'; i++) {
-                replicaCount = sh.exec(`kubectl get deployment.apps/test-deployment --namespace ${defaultNamespace} -o jsonpath="{.spec.replicas}"`).stdout
-                if (replicaCount !== '0') {
-                    sh.exec('sleep 5s')
-                }
-            }
-
-            t.is('0', replicaCount, 'Replica count should be 0 after 3 minutes')
-            t.end()
-        })
+        t.end()
     })
 })
 
@@ -140,4 +130,5 @@ spec:
     metadata:
       blobContainerName: container-name
       blobPrefix: blobsubpath
+      blobCount: '1'
       connectionFromEnv: AzureWebJobsStorage`

--- a/tests/scalers/azure-blob.test.ts
+++ b/tests/scalers/azure-blob.test.ts
@@ -107,7 +107,7 @@ spec:
             secretKeyRef:
               name: test-secrets
               key: AzureWebJobsStorage
-        - name: AZURE_STORAGE_CONNECTION_STRING
+        - name: TEST_STORAGE_CONNECTION_STRING
           valueFrom:
             secretKeyRef:
               name: test-secrets


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

After renaming env variables, we changed `TEST_STORAGE_CONNECTION_STRING` in the deployments env variables too but the consumer still uses it. This PR clears the code of the tests and revert the change of that variable

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
