### PR TITLE
chore: choose if init scale when no LastActiveTime

### DIFF
--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -79,6 +79,8 @@ type ScaledObjectSpec struct {
 	// +optional
 	MaxReplicaCount *int32 `json:"maxReplicaCount,omitempty"`
 	// +optional
+	AllowInitScale *bool `json:"allowInitScale,omitempty"`
+	// +optional
 	Advanced *AdvancedConfig `json:"advanced,omitempty"`
 
 	Triggers []ScaleTriggers `json:"triggers"`

--- a/apis/keda/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/keda/v1alpha1/zz_generated.deepcopy.go
@@ -579,6 +579,11 @@ func (in *ScaledObjectSpec) DeepCopyInto(out *ScaledObjectSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.AllowInitScale != nil {
+		in, out := &in.AllowInitScale, &out.AllowInitScale
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Advanced != nil {
 		in, out := &in.Advanced, &out.Advanced
 		*out = new(AdvancedConfig)

--- a/config/crd/bases/keda.sh_scaledobjects.yaml
+++ b/config/crd/bases/keda.sh_scaledobjects.yaml
@@ -216,6 +216,8 @@ spec:
                 - failureThreshold
                 - replicas
                 type: object
+              allowInitScale:
+                type: boolean
               idleReplicaCount:
                 format: int32
                 type: integer


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

We can now disable the Scale to MinReplicaCount / IdleReplicaCount when LastActiveTime is nil by just providing the `allowInitScale` parameter to false. On such case, the Scale will wait for the CoolDown period

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #
