### PR TITLE
Add support for datadog query function wrappers - WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 - **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))
 - **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2657](https://github.com/kedacore/keda/issues/2657))
+- **Datadog Scaler:** Fix handling of queries which are wrapped with a function (eg. ```per_second()```) ([#2761](https://github.com/kedacore/keda/issues/2761))
 - **GCP Pubsub Scaler** Adding e2e test for GCP PubSub scaler ([#1528](https://github.com/kedacore/keda/issues/1528))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -75,8 +75,8 @@ func NewDatadogScaler(ctx context.Context, config *ScalerConfig) (Scaler, error)
 
 // parseAndTransformDatadogQuery checks correctness of the user query and adds rollup if not available
 func parseAndTransformDatadogQuery(q string, age int) (string, error) {
-	// Queries should start with a valid aggregator. If not found, prepend avg as default
-	if !aggregator.MatchString(q) {
+	// Queries should start with a valid aggregator. If not found, prepend avg as default, if no functions used
+	if !aggregator.MatchString(q) && !ddfuncpresent.MatchString(q) {
 		q = "avg:" + q
 	}
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -49,11 +49,11 @@ var datadogLog = logf.Log.WithName("datadog_scaler")
 var aggregator, filter, rollup, ddfuncpresent, ddfunc *regexp.Regexp
 
 func init() {
-	aggregator = regexp.MustCompile(`^([\w]+\()?(avg|sum|min|max):.*`)
+	aggregator = regexp.MustCompile(`^([\w]+\((.*()?))?(avg|sum|min|max):.*`)
 	filter = regexp.MustCompile(`.*\{.*\}.*`)
 	rollup = regexp.MustCompile(`.*\.rollup\(([a-z]+,)?\s*(\w+)\)(\))?`)
 	ddfuncpresent = regexp.MustCompile(`^[\w]+\(`)
-	ddfunc = regexp.MustCompile(`^[\w]+\(.*\.rollup\(.*\)\)$`)
+	ddfunc = regexp.MustCompile(`^[\w]+\(.*\.rollup\(.*\).*\)$`)
 }
 
 // NewDatadogScaler creates a new Datadog scaler

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -105,7 +105,7 @@ func parseAndTransformDatadogQuery(q string, age int) (string, error) {
 	// Optional datadog function wrappers
 	if ddfuncpresent.MatchString(q) {
 		if !ddfunc.MatchString(q) {
-		    return "", fmt.Errorf("malformed Datadog query - invalid function wrapper")
+			return "", fmt.Errorf("malformed Datadog query - invalid function wrapper")
 		}
 	}
 

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -30,6 +30,8 @@ var testParseQueries = []datadogQueries{
 	{"avg:system.cpu.user{*}.rollup(sum, 30)", 120, "avg:system.cpu.user{*}.rollup(sum, 30)", false},
 	{"sum:system.cpu.user{*}.rollup(30)", 30, "sum:system.cpu.user{*}.rollup(30)", false},
 	{"avg:system.cpu.user{automatic-restart:false,bosh_address:192.168.101.12}.rollup(avg, 30)", 120, "avg:system.cpu.user{automatic-restart:false,bosh_address:192.168.101.12}.rollup(avg, 30)", false},
+	{"per_second(sum:system.cpu.user{*}.rollup(avg, 30))", 120, "per_second(sum:system.cpu.user{*}.rollup(avg, 30))", false},
+	{"log10(sum:system.cpu.user{*}.rollup(avg, 30))", 120, "log10(sum:system.cpu.user{*}.rollup(avg, 30))", false},
 
 	// Default aggregator
 	{"system.cpu.user{*}.rollup(sum, 30)", 120, "avg:system.cpu.user{*}.rollup(sum, 30)", false},
@@ -42,6 +44,9 @@ var testParseQueries = []datadogQueries{
 
 	// Malformed rollup
 	{"min:system.cpu.user{*}.rollup(avg)", 120, "", true},
+
+	// Malformed function wrapper -- missing end bracket
+	{"per_second(sum:system.cpu.user{*}.rollup(avg, 30)", 120, "", true},
 }
 
 func TestDatadogScalerParseQueries(t *testing.T) {

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -49,6 +49,7 @@ var testParseQueries = []datadogQueries{
 
 	// Malformed function wrapper -- missing end bracket
 	{"per_second(sum:system.cpu.user{*}.rollup(avg, 30)", 120, "", true},
+	{"top(per_second(abs(sum:http.requests{*}.rollup(max, 2))), 5, 'mean', 'desc'", 120, "", true},
 }
 
 func TestDatadogScalerParseQueries(t *testing.T) {

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -32,6 +32,8 @@ var testParseQueries = []datadogQueries{
 	{"avg:system.cpu.user{automatic-restart:false,bosh_address:192.168.101.12}.rollup(avg, 30)", 120, "avg:system.cpu.user{automatic-restart:false,bosh_address:192.168.101.12}.rollup(avg, 30)", false},
 	{"per_second(sum:system.cpu.user{*}.rollup(avg, 30))", 120, "per_second(sum:system.cpu.user{*}.rollup(avg, 30))", false},
 	{"log10(sum:system.cpu.user{*}.rollup(avg, 30))", 120, "log10(sum:system.cpu.user{*}.rollup(avg, 30))", false},
+	// Multiple functions
+	{"top(per_second(abs(sum:http.requests{*}.rollup(max, 2))), 5, 'mean', 'desc')", 120, "top(per_second(abs(sum:http.requests{*}.rollup(max, 2))), 5, 'mean', 'desc')", false},
 
 	// Default aggregator
 	{"system.cpu.user{*}.rollup(sum, 30)", 120, "avg:system.cpu.user{*}.rollup(sum, 30)", false},


### PR DESCRIPTION
Allow the Datadog Scaler to parse/validate queries which contain a wrapping function; eg:
```
per_second(sum:system.cpu.user{*}.rollup(avg, 30))
```
Previously, the code would see these as missing an aggregator; and prefix them with ```avg:``` resulting in an invalid query of:
```
avg:per_second(sum:system.cpu.user{*}.rollup(avg, 30))
```

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #2761 