### PR TITLE
Rely on Datadog API to validate the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 - **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))
 - **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2657](https://github.com/kedacore/keda/issues/2657))
+- **Datadog Scaler:** Rely on Datadog API to validate the query ([2761](https://github.com/kedacore/keda/issues/2761))
 - **GCP Pubsub Scaler** Adding e2e test for GCP PubSub scaler ([#1528](https://github.com/kedacore/keda/issues/1528))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
 - **Metric API Scaler:** Improve error handling on not-ok response ([#2317](https://github.com/kedacore/keda/issues/2317))

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -71,7 +71,6 @@ func NewDatadogScaler(ctx context.Context, config *ScalerConfig) (Scaler, error)
 
 // parseDatadogQuery checks correctness of the user query
 func parseDatadogQuery(q string) (bool, error) {
-
 	// Wellformed Datadog queries require a filter (between curly brackets)
 	if !filter.MatchString(q) {
 		return false, fmt.Errorf("malformed Datadog query: missing query scope")
@@ -257,7 +256,6 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 	if resp.GetStatus() == "error" {
 		if msg, ok := resp.GetErrorOk(); ok {
 			return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", *msg)
-
 		}
 		return -1, fmt.Errorf("error when retrieving Datadog metrics")
 	}

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -46,12 +46,10 @@ type datadogMetadata struct {
 
 var datadogLog = logf.Log.WithName("datadog_scaler")
 
-var aggregator, filter, rollup *regexp.Regexp
+var filter *regexp.Regexp
 
 func init() {
-	aggregator = regexp.MustCompile(`^(avg|sum|min|max):.*`)
 	filter = regexp.MustCompile(`.*\{.*\}.*`)
-	rollup = regexp.MustCompile(`.*\.rollup\(([a-z]+,)?\s*(.+)\)`)
 }
 
 // NewDatadogScaler creates a new Datadog scaler
@@ -71,36 +69,15 @@ func NewDatadogScaler(ctx context.Context, config *ScalerConfig) (Scaler, error)
 	}, nil
 }
 
-// parseAndTransformDatadogQuery checks correctness of the user query and adds rollup if not available
-func parseAndTransformDatadogQuery(q string, age int) (string, error) {
-	// Queries should start with a valid aggregator. If not found, prepend avg as default
-	if !aggregator.MatchString(q) {
-		q = "avg:" + q
-	}
+// parseDatadogQuery checks correctness of the user query
+func parseDatadogQuery(q string) (bool, error) {
 
 	// Wellformed Datadog queries require a filter (between curly brackets)
 	if !filter.MatchString(q) {
-		return "", fmt.Errorf("malformed Datadog query")
+		return false, fmt.Errorf("malformed Datadog query: missing query scope")
 	}
 
-	// Queries can contain rollup functions.
-	match := rollup.FindStringSubmatch(q)
-	if match != nil {
-		// If added, check that the number of seconds is an int
-		rollupAgg, err := strconv.Atoi(match[2])
-		if err != nil {
-			return "", fmt.Errorf("malformed Datadog query")
-		}
-
-		if rollupAgg > age {
-			return "", fmt.Errorf("rollup cannot be bigger than time window")
-		}
-	} else { // If not added, use a default rollup based on the time window size
-		s := fmt.Sprintf(".rollup(avg, %d)", age/5)
-		q += s
-	}
-
-	return q, nil
+	return true, nil
 }
 
 func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
@@ -121,12 +98,12 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["query"]; ok {
-		query, err := parseAndTransformDatadogQuery(val, meta.age)
+		_, err := parseDatadogQuery(val)
 
 		if err != nil {
 			return nil, fmt.Errorf("error in query: %s", err.Error())
 		}
-		meta.query = query
+		meta.query = val
 	} else {
 		return nil, fmt.Errorf("no query given")
 	}
@@ -262,19 +239,27 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 
 	resp, r, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)
 
+	if err != nil {
+		return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", err)
+	}
+
 	if r.StatusCode == 429 {
 		rateLimit := r.Header.Get("X-Ratelimit-Limit")
 		rateLimitReset := r.Header.Get("X-Ratelimit-Reset")
 
-		return -1, fmt.Errorf("your Datadog account reached the %s queries per hour rate limit, next limit reset will happen in %s seconds: %s", rateLimit, rateLimitReset, err)
+		return -1, fmt.Errorf("your Datadog account reached the %s queries per hour rate limit, next limit reset will happen in %s seconds", rateLimit, rateLimitReset)
 	}
 
 	if r.StatusCode != 200 {
-		return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", err)
+		return -1, fmt.Errorf("error when retrieving Datadog metrics")
 	}
 
-	if err != nil {
-		return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", err)
+	if resp.GetStatus() == "error" {
+		if msg, ok := resp.GetErrorOk(); ok {
+			return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", *msg)
+
+		}
+		return -1, fmt.Errorf("error when retrieving Datadog metrics")
 	}
 
 	series := resp.GetSeries()


### PR DESCRIPTION
Instead of trying to validate all potential valid queries ahead of creating the scaledobject, rely on the Datadog API to do so and return the error returned by the API if that happens. Also, rely on the Datadog API to apply the default rollup time frame if one is not specified in the query.

This way, if there are any addition to the query language down the line, we won't need to change the scaler code, while simplifying it.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #2761
