### PR TITLE
fix: Consider maxSessions in Selenium Grid Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - **GCP Pubsub Scaler** Adding e2e test for GCP PubSub scaler ([#1528](https://github.com/kedacore/keda/issues/1528))
 - **Kafka Scaler** Make "disable" a valid value for tls auth parameter ([#2608](https://github.com/kedacore/keda/issues/2608))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
+- **Selenium Grid Scaler** Consider `maxSession` grid info when scaling. ([#2618](https://github.com/kedacore/keda/issues/2618))
 
 ### Breaking Changes
 

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -42,6 +42,9 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			args: args{
 				b: []byte(`{
 					"data": {
+						"grid":{
+							"maxSession": 1
+						},
 						"sessionsInfo": {
 							"sessionQueueRequests": [],
 							"sessions": []
@@ -58,6 +61,9 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			args: args{
 				b: []byte(`{
 					"data": {
+						"grid":{
+							"maxSession": 1
+						},
 						"sessionsInfo": {
 							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
 							"sessions": [
@@ -81,6 +87,9 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			args: args{
 				b: []byte(`{
 					"data": {
+						"grid":{
+							"maxSession": 1
+						},
 						"sessionsInfo": {
 							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
 							"sessions": []
@@ -94,11 +103,34 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "active sessions with matching browsername and maxSession=2 should return count as 1",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"grid":{
+							"maxSession": 2
+						},
+						"sessionsInfo": {
+							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\",\n \"browserVersion\": \"91.0\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
+							"sessions": []
+						}
+					}
+				}`),
+				browserName:    "chrome",
+				browserVersion: "latest",
+			},
+			want:    resource.NewQuantity(1, resource.DecimalSI),
+			wantErr: false,
+		},
+		{
 			name: "active sessions with matching browsername should return count as 3",
 			args: args{
 				b: []byte(`{
 					"data": {
 						"sessionsInfo": {
+							"grid":{
+								"maxSession": 1
+							},
 							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
 							"sessions": [
 								{
@@ -121,6 +153,9 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			args: args{
 				b: []byte(`{
 					"data": {
+						"grid":{
+							"maxSession": 1
+						},
 						"sessionsInfo": {
 							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\",\n \"browserVersion\": \"91.0\"\n}","{\n  \"browserName\": \"chrome\"\n}"],
 							"sessions": [


### PR DESCRIPTION
Signed-off-by: Alejandro Dominguez <adborroto90@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Consider grid `maxSession` to scale Selenium Grid.  Since each node can handle a number of parallel sessions defined by `maxSession`  then  is not needed to scale for each pending session. 

Example:  if maxSession=5 each node can hold up to 5 concurrent sessions. Therefore, if there are 10 requests in the queue, only 2 nodes are necessary to fulfill the requirements. Currently, the Selenium Grid Scaler of KEDA will scale up to 10 nodes in this case, ignoring the maxSessions per node.

Documentation changes: [PR](https://github.com/kedacore/keda-docs/pull/716) 

More info: 
* https://www.selenium.dev/documentation/grid/_print/#specific-browsers-and-a-limit-of-max-sessions
* https://www.selenium.dev/documentation/grid/advanced_features/graphql_support/#querying-the-number-of-maxsession-and-sessioncount-in-the-grid-

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes [#2618](https://github.com/kedacore/keda/issues/2618)
