### PR TITLE
Datadog: `isActive()` should react on `num > 0`

### DIFF
--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -204,7 +204,7 @@ func (s *datadogScaler) Close(context.Context) error {
 	return nil
 }
 
-// IsActive checks whether the value returned by Datadog is higher than the target value
+// IsActive checks whether the scaler is active
 func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 	num, err := s.getQueryResult(ctx)
 
@@ -212,7 +212,7 @@ func (s *datadogScaler) IsActive(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	return num > float64(s.metadata.queryValue), nil
+	return num > 0, nil
 }
 
 // getQueryResult returns result of the scaler query


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

I confused @arapulido on https://github.com/kedacore/keda/pull/2694 to include a wrong implementation of `IsActive()` function, fixing this here.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Relates #2657
