### PR TITLE
Internally represent `value` and `threshold` as int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - **General:** Fix mismatched errors for updating HPA ([#2719](https://github.com/kedacore/keda/issues/2719))
 - **General:** Improve e2e tests reliability ([#2580](https://github.com/kedacore/keda/issues/2580))
 - **General:** Improve e2e tests to always cleanup resources in cluster ([#2584](https://github.com/kedacore/keda/issues/2584))
+- **General:** Internally represent value and threshold as int64 ([#2790](https://github.com/kedacore/keda/issues/2790))
 - **GCP Pubsub Scaler:** Adding e2e test ([#1528](https://github.com/kedacore/keda/issues/1528))
 - **Memory Scaler:** Adding e2e test ([#2220](https://github.com/kedacore/keda/issues/2220))
 

--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -53,7 +53,7 @@ For example:
 >**Note:** There is a naming helper function `GenerateMetricNameWithIndex(scalerIndex int, metricName string)`, that receives the current index and the original metric name (without the prefix) and returns the concatenated string using the convention (please use this function).<br>Next lines are an example about how to use it:
 >```golang
 >func (s *artemisScaler) GetMetricSpecForScaling() []v2beta2.MetricSpec {
->	targetMetricValue := resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI)
+>	targetMetricValue := resource.NewQuantity(s.metadata.queueLength, resource.DecimalSI)
 >	externalMetric := &v2beta2.ExternalMetricSource{
 >		Metric: v2beta2.MetricIdentifier{
 >			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", "artemis", s.metadata.brokerName, s.metadata.queueName))),

--- a/pkg/scalers/activemq_scaler.go
+++ b/pkg/scalers/activemq_scaler.go
@@ -34,7 +34,7 @@ type activeMQMetadata struct {
 	username           string
 	password           string
 	restAPITemplate    string
-	targetQueueSize    int
+	targetQueueSize    int64
 	metricName         string
 	scalerIndex        int
 }
@@ -94,7 +94,7 @@ func parseActiveMQMetadata(config *ScalerConfig) (*activeMQMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["targetQueueSize"]; ok {
-		queueSize, err := strconv.Atoi(val)
+		queueSize, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid targetQueueSize - must be an integer")
 		}
@@ -200,9 +200,9 @@ func (s *activeMQScaler) getMonitoringEndpoint() (string, error) {
 	return monitoringEndpoint, nil
 }
 
-func (s *activeMQScaler) getQueueMessageCount(ctx context.Context) (int, error) {
+func (s *activeMQScaler) getQueueMessageCount(ctx context.Context) (int64, error) {
 	var monitoringInfo *activeMQMonitoring
-	var queueMessageCount int
+	var queueMessageCount int64
 
 	client := s.httpClient
 	url, err := s.getMonitoringEndpoint()
@@ -230,7 +230,7 @@ func (s *activeMQScaler) getQueueMessageCount(ctx context.Context) (int, error) 
 		return -1, err
 	}
 	if resp.StatusCode == 200 && monitoringInfo.Status == 200 {
-		queueMessageCount = monitoringInfo.MsgCount
+		queueMessageCount = int64(monitoringInfo.MsgCount)
 	} else {
 		return -1, fmt.Errorf("ActiveMQ management endpoint response error code : %d %d", resp.StatusCode, monitoringInfo.Status)
 	}
@@ -242,7 +242,7 @@ func (s *activeMQScaler) getQueueMessageCount(ctx context.Context) (int, error) 
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler
 func (s *activeMQScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetMetricValue := resource.NewQuantity(int64(s.metadata.targetQueueSize), resource.DecimalSI)
+	targetMetricValue := resource.NewQuantity(s.metadata.targetQueueSize, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: s.metadata.metricName,
@@ -266,7 +266,7 @@ func (s *activeMQScaler) GetMetrics(ctx context.Context, metricName string, metr
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(queueSize), resource.DecimalSI),
+		Value:      *resource.NewQuantity(queueSize, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -34,7 +34,7 @@ type artemisMetadata struct {
 	username           string
 	password           string
 	restAPITemplate    string
-	queueLength        int
+	queueLength        int64
 	corsHeader         string
 	scalerIndex        int
 }
@@ -115,7 +115,7 @@ func parseArtemisMetadata(config *ScalerConfig) (*artemisMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["queueLength"]; ok {
-		queueLength, err := strconv.Atoi(val)
+		queueLength, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("can't parse queueLength: %s", err)
 		}
@@ -214,9 +214,9 @@ func (s *artemisScaler) getMonitoringEndpoint() string {
 	return monitoringEndpoint
 }
 
-func (s *artemisScaler) getQueueMessageCount(ctx context.Context) (int, error) {
+func (s *artemisScaler) getQueueMessageCount(ctx context.Context) (int64, error) {
 	var monitoringInfo *artemisMonitoring
-	messageCount := 0
+	var messageCount int64
 
 	client := s.httpClient
 	url := s.getMonitoringEndpoint()
@@ -240,7 +240,7 @@ func (s *artemisScaler) getQueueMessageCount(ctx context.Context) (int, error) {
 		return -1, err
 	}
 	if resp.StatusCode == 200 && monitoringInfo.Status == 200 {
-		messageCount = monitoringInfo.MsgCount
+		messageCount = int64(monitoringInfo.MsgCount)
 	} else {
 		return -1, fmt.Errorf("artemis management endpoint response error code : %d %d", resp.StatusCode, monitoringInfo.Status)
 	}
@@ -251,7 +251,7 @@ func (s *artemisScaler) getQueueMessageCount(ctx context.Context) (int, error) {
 }
 
 func (s *artemisScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
-	targetMetricValue := resource.NewQuantity(int64(s.metadata.queueLength), resource.DecimalSI)
+	targetMetricValue := resource.NewQuantity(s.metadata.queueLength, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("artemis-%s", s.metadata.queueName))),
@@ -276,7 +276,7 @@ func (s *artemisScaler) GetMetrics(ctx context.Context, metricName string, metri
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(messages), resource.DecimalSI),
+		Value:      *resource.NewQuantity(messages, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 

--- a/pkg/scalers/aws_dynamodb_scaler.go
+++ b/pkg/scalers/aws_dynamodb_scaler.go
@@ -35,7 +35,7 @@ type awsDynamoDBMetadata struct {
 	keyConditionExpression    string
 	expressionAttributeNames  map[string]*string
 	expressionAttributeValues map[string]*dynamodb.AttributeValue
-	targetValue               int
+	targetValue               int64
 	awsAuthorization          awsAuthorizationMetadata
 	scalerIndex               int
 	metricName                string
@@ -101,7 +101,7 @@ func parseAwsDynamoDBMetadata(config *ScalerConfig) (*awsDynamoDBMetadata, error
 	}
 
 	if val, ok := config.TriggerMetadata["targetValue"]; ok && val != "" {
-		n, err := strconv.Atoi(val)
+		n, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing metadata targetValue")
 		}
@@ -171,7 +171,7 @@ func (c *awsDynamoDBScaler) GetMetrics(ctx context.Context, metricName string, m
 }
 
 func (c *awsDynamoDBScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetMetricValue := resource.NewQuantity(int64(c.metadata.targetValue), resource.DecimalSI)
+	targetMetricValue := resource.NewQuantity(c.metadata.targetValue, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: c.metadata.metricName,

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -32,7 +32,7 @@ type awsKinesisStreamScaler struct {
 }
 
 type awsKinesisStreamMetadata struct {
-	targetShardCount int
+	targetShardCount int64
 	streamName       string
 	awsRegion        string
 	awsAuthorization awsAuthorizationMetadata
@@ -59,7 +59,7 @@ func parseAwsKinesisStreamMetadata(config *ScalerConfig) (*awsKinesisStreamMetad
 	meta.targetShardCount = targetShardCountDefault
 
 	if val, ok := config.TriggerMetadata["shardCount"]; ok && val != "" {
-		shardCount, err := strconv.Atoi(val)
+		shardCount, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			meta.targetShardCount = targetShardCountDefault
 			kinesisStreamLog.Error(err, "Error parsing Kinesis stream metadata shardCount, using default %n", targetShardCountDefault)
@@ -133,7 +133,7 @@ func (s *awsKinesisStreamScaler) Close(context.Context) error {
 }
 
 func (s *awsKinesisStreamScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetShardCountQty := resource.NewQuantity(int64(s.metadata.targetShardCount), resource.DecimalSI)
+	targetShardCountQty := resource.NewQuantity(s.metadata.targetShardCount, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-kinesis-%s", s.metadata.streamName))),

--- a/pkg/scalers/azure/azure_app_insights.go
+++ b/pkg/scalers/azure/azure_app_insights.go
@@ -64,7 +64,7 @@ func getAuthConfig(info AppInsightsInfo, podIdentity kedav1alpha1.PodIdentityPro
 	return config
 }
 
-func extractAppInsightValue(info AppInsightsInfo, metric ApplicationInsightsMetric) (int32, error) {
+func extractAppInsightValue(info AppInsightsInfo, metric ApplicationInsightsMetric) (int64, error) {
 	if _, ok := metric.Value[info.MetricID]; !ok {
 		return -1, fmt.Errorf("metric named %s not found in app insights response", info.MetricID)
 	}
@@ -81,7 +81,7 @@ func extractAppInsightValue(info AppInsightsInfo, metric ApplicationInsightsMetr
 
 	azureAppInsightsLog.V(2).Info("value extracted from metric request", "metric type", info.AggregationType, "metric value", floatVal)
 
-	return int32(math.Round(floatVal)), nil
+	return int64(math.Round(floatVal)), nil
 }
 
 func queryParamsForAppInsightsRequest(info AppInsightsInfo) (map[string]interface{}, error) {
@@ -102,7 +102,7 @@ func queryParamsForAppInsightsRequest(info AppInsightsInfo) (map[string]interfac
 }
 
 // GetAzureAppInsightsMetricValue returns the value of an Azure App Insights metric, rounded to the nearest int
-func GetAzureAppInsightsMetricValue(ctx context.Context, info AppInsightsInfo, podIdentity kedav1alpha1.PodIdentityProvider) (int32, error) {
+func GetAzureAppInsightsMetricValue(ctx context.Context, info AppInsightsInfo, podIdentity kedav1alpha1.PodIdentityProvider) (int64, error) {
 	config := getAuthConfig(info, podIdentity)
 	authorizer, err := config.Authorizer()
 	if err != nil {

--- a/pkg/scalers/azure/azure_app_insights_test.go
+++ b/pkg/scalers/azure/azure_app_insights_test.go
@@ -11,7 +11,7 @@ import (
 type testExtractAzAppInsightsTestData struct {
 	testName      string
 	isError       bool
-	expectedValue int32
+	expectedValue int64
 	info          AppInsightsInfo
 	metricResult  ApplicationInsightsMetric
 }

--- a/pkg/scalers/azure/azure_blob.go
+++ b/pkg/scalers/azure/azure_blob.go
@@ -26,7 +26,7 @@ import (
 )
 
 // GetAzureBlobListLength returns the count of the blobs in blob container in int
-func GetAzureBlobListLength(ctx context.Context, httpClient util.HTTPDoer, podIdentity kedav1alpha1.PodIdentityProvider, connectionString, blobContainerName string, accountName string, blobDelimiter string, blobPrefix string, endpointSuffix string) (int, error) {
+func GetAzureBlobListLength(ctx context.Context, httpClient util.HTTPDoer, podIdentity kedav1alpha1.PodIdentityProvider, connectionString, blobContainerName string, accountName string, blobDelimiter string, blobPrefix string, endpointSuffix string) (int64, error) {
 	credential, endpoint, err := ParseAzureStorageBlobConnection(ctx, httpClient, podIdentity, connectionString, accountName, endpointSuffix)
 	if err != nil {
 		return -1, err
@@ -44,5 +44,5 @@ func GetAzureBlobListLength(ctx context.Context, httpClient util.HTTPDoer, podId
 		return -1, err
 	}
 
-	return len(props.Segment.BlobItems), nil
+	return int64(len(props.Segment.BlobItems)), nil
 }

--- a/pkg/scalers/azure/azure_monitor.go
+++ b/pkg/scalers/azure/azure_monitor.go
@@ -65,7 +65,7 @@ type MonitorInfo struct {
 var azureMonitorLog = logf.Log.WithName("azure_monitor_scaler")
 
 // GetAzureMetricValue returns the value of an Azure Monitor metric, rounded to the nearest int
-func GetAzureMetricValue(ctx context.Context, info MonitorInfo, podIdentity kedav1alpha1.PodIdentityProvider) (int32, error) {
+func GetAzureMetricValue(ctx context.Context, info MonitorInfo, podIdentity kedav1alpha1.PodIdentityProvider) (int64, error) {
 	var podIdentityEnabled = true
 
 	if podIdentity == "" || podIdentity == kedav1alpha1.PodIdentityProviderNone {
@@ -121,14 +121,14 @@ func createMetricsRequest(info MonitorInfo) (*azureExternalMetricRequest, error)
 	return &metricRequest, nil
 }
 
-func executeRequest(ctx context.Context, client insights.MetricsClient, request *azureExternalMetricRequest) (int32, error) {
+func executeRequest(ctx context.Context, client insights.MetricsClient, request *azureExternalMetricRequest) (int64, error) {
 	metricResponse, err := getAzureMetric(ctx, client, *request)
 	if err != nil {
 		return -1, fmt.Errorf("error getting azure monitor metric %s: %w", request.MetricName, err)
 	}
 
 	// casting drops everything after decimal, so round first
-	metricValue := int32(math.Round(metricResponse))
+	metricValue := int64(math.Round(metricResponse))
 
 	return metricValue, nil
 }

--- a/pkg/scalers/azure/azure_queue.go
+++ b/pkg/scalers/azure/azure_queue.go
@@ -30,7 +30,7 @@ const (
 )
 
 // GetAzureQueueLength returns the length of a queue in int
-func GetAzureQueueLength(ctx context.Context, httpClient util.HTTPDoer, podIdentity kedav1alpha1.PodIdentityProvider, connectionString, queueName, accountName, endpointSuffix string) (int32, error) {
+func GetAzureQueueLength(ctx context.Context, httpClient util.HTTPDoer, podIdentity kedav1alpha1.PodIdentityProvider, connectionString, queueName, accountName, endpointSuffix string) (int64, error) {
 	credential, endpoint, err := ParseAzureStorageQueueConnection(ctx, httpClient, podIdentity, connectionString, accountName, endpointSuffix)
 	if err != nil {
 		return -1, err
@@ -46,7 +46,7 @@ func GetAzureQueueLength(ctx context.Context, httpClient util.HTTPDoer, podIdent
 	}
 
 	// Queue has less messages than we allowed to peek for, so no need to get the approximation
-	if visibleMessageCount < maxPeekMessages {
+	if visibleMessageCount < int64(maxPeekMessages) {
 		return visibleMessageCount, nil
 	}
 
@@ -55,15 +55,15 @@ func GetAzureQueueLength(ctx context.Context, httpClient util.HTTPDoer, podIdent
 		return -1, err
 	}
 
-	return props.ApproximateMessagesCount(), nil
+	return int64(props.ApproximateMessagesCount()), nil
 }
 
-func getVisibleCount(ctx context.Context, queueURL *azqueue.QueueURL, maxCount int32) (int32, error) {
+func getVisibleCount(ctx context.Context, queueURL *azqueue.QueueURL, maxCount int32) (int64, error) {
 	messagesURL := queueURL.NewMessagesURL()
 	queue, err := messagesURL.Peek(ctx, maxCount)
 	if err != nil {
 		return 0, err
 	}
 	num := queue.NumMessages()
-	return num, nil
+	return int64(num), nil
 }

--- a/pkg/scalers/azure_app_insights_scaler.go
+++ b/pkg/scalers/azure_app_insights_scaler.go
@@ -30,7 +30,7 @@ const (
 
 type azureAppInsightsMetadata struct {
 	azureAppInsightsInfo azure.AppInsightsInfo
-	targetValue          int
+	targetValue          int64
 	scalerIndex          int
 }
 
@@ -63,7 +63,7 @@ func parseAzureAppInsightsMetadata(config *ScalerConfig) (*azureAppInsightsMetad
 	if err != nil {
 		return nil, err
 	}
-	meta.targetValue, err = strconv.Atoi(val)
+	meta.targetValue, err = strconv.ParseInt(val, 10, 64)
 	if err != nil {
 		azureAppInsightsLog.Error(err, "Error parsing azure app insights metadata", "targetValue", targetValueName)
 		return nil, fmt.Errorf("error parsing azure app insights metadata %s: %s", targetValueName, err.Error())
@@ -139,7 +139,7 @@ func (s *azureAppInsightsScaler) Close(context.Context) error {
 }
 
 func (s *azureAppInsightsScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetMetricVal := resource.NewQuantity(int64(s.metadata.targetValue), resource.DecimalSI)
+	targetMetricVal := resource.NewQuantity(s.metadata.targetValue, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-app-insights-%s", s.metadata.azureAppInsightsInfo.MetricID))),
@@ -163,7 +163,7 @@ func (s *azureAppInsightsScaler) GetMetrics(ctx context.Context, metricName stri
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(val), resource.DecimalSI),
+		Value:      *resource.NewQuantity(val, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -48,7 +48,7 @@ type azureBlobScaler struct {
 }
 
 type azureBlobMetadata struct {
-	targetBlobCount   int
+	targetBlobCount   int64
 	blobContainerName string
 	blobDelimiter     string
 	blobPrefix        string
@@ -82,7 +82,7 @@ func parseAzureBlobMetadata(config *ScalerConfig) (*azureBlobMetadata, kedav1alp
 	meta.blobPrefix = defaultBlobPrefix
 
 	if val, ok := config.TriggerMetadata[blobCountMetricName]; ok {
-		blobCount, err := strconv.Atoi(val)
+		blobCount, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			azureBlobLog.Error(err, "Error parsing azure blob metadata", "blobCountMetricName", blobCountMetricName)
 			return nil, "", fmt.Errorf("error parsing azure blob metadata %s: %s", blobCountMetricName, err.Error())
@@ -181,7 +181,7 @@ func (s *azureBlobScaler) Close(context.Context) error {
 }
 
 func (s *azureBlobScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetBlobCount := resource.NewQuantity(int64(s.metadata.targetBlobCount), resource.DecimalSI)
+	targetBlobCount := resource.NewQuantity(s.metadata.targetBlobCount, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
@@ -216,7 +216,7 @@ func (s *azureBlobScaler) GetMetrics(ctx context.Context, metricName string, met
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(bloblen), resource.DecimalSI),
+		Value:      *resource.NewQuantity(bloblen, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -46,7 +46,7 @@ type azureMonitorScaler struct {
 
 type azureMonitorMetadata struct {
 	azureMonitorInfo azure.MonitorInfo
-	targetValue      int
+	targetValue      int64
 	scalerIndex      int
 }
 
@@ -71,7 +71,7 @@ func parseAzureMonitorMetadata(config *ScalerConfig) (*azureMonitorMetadata, err
 	}
 
 	if val, ok := config.TriggerMetadata[targetValueName]; ok && val != "" {
-		targetValue, err := strconv.Atoi(val)
+		targetValue, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			azureMonitorLog.Error(err, "Error parsing azure monitor metadata", "targetValue", targetValueName)
 			return nil, fmt.Errorf("error parsing azure monitor metadata %s: %s", targetValueName, err.Error())
@@ -191,7 +191,7 @@ func (s *azureMonitorScaler) Close(context.Context) error {
 }
 
 func (s *azureMonitorScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetMetricVal := resource.NewQuantity(int64(s.metadata.targetValue), resource.DecimalSI)
+	targetMetricVal := resource.NewQuantity(s.metadata.targetValue, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-monitor-%s", s.metadata.azureMonitorInfo.Name))),
@@ -215,7 +215,7 @@ func (s *azureMonitorScaler) GetMetrics(ctx context.Context, metricName string, 
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(val), resource.DecimalSI),
+		Value:      *resource.NewQuantity(val, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -42,7 +42,7 @@ type azurePipelinesMetadata struct {
 	organizationName           string
 	personalAccessToken        string
 	poolID                     int
-	targetPipelinesQueueLength int
+	targetPipelinesQueueLength int64
 	scalerIndex                int
 }
 
@@ -68,7 +68,7 @@ func parseAzurePipelinesMetadata(ctx context.Context, config *ScalerConfig, http
 	meta.targetPipelinesQueueLength = defaultTargetPipelinesQueueLength
 
 	if val, ok := config.TriggerMetadata["targetPipelinesQueueLength"]; ok {
-		queueLength, err := strconv.Atoi(val)
+		queueLength, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing azure pipelines metadata targetPipelinesQueueLength: %s", err.Error())
 		}
@@ -200,14 +200,14 @@ func (s *azurePipelinesScaler) GetMetrics(ctx context.Context, metricName string
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(queuelen), resource.DecimalSI),
+		Value:      *resource.NewQuantity(queuelen, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context) (int, error) {
+func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context) (int64, error) {
 	url := fmt.Sprintf("%s/_apis/distributedtask/pools/%d/jobrequests", s.metadata.organizationURL, s.metadata.poolID)
 	body, err := getAzurePipelineRequest(ctx, url, s.metadata, s.httpClient)
 	if err != nil {
@@ -220,7 +220,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 		return -1, err
 	}
 
-	var count = 0
+	var count int64
 	jobs, ok := result["value"].([]interface{})
 
 	if !ok {
@@ -238,7 +238,7 @@ func (s *azurePipelinesScaler) GetAzurePipelinesQueueLength(ctx context.Context)
 }
 
 func (s *azurePipelinesScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetPipelinesQueueLengthQty := resource.NewQuantity(int64(s.metadata.targetPipelinesQueueLength), resource.DecimalSI)
+	targetPipelinesQueueLengthQty := resource.NewQuantity(s.metadata.targetPipelinesQueueLength, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("azure-pipelines-%d", s.metadata.poolID))),

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -168,7 +168,7 @@ func TestGetServiceBusLength(t *testing.T) {
 		if connectionString != "" {
 			// Can actually test that numbers return
 			scaler.metadata.connection = connectionString
-			length, err := scaler.GetAzureServiceBusLength(context.TODO())
+			length, err := scaler.getAzureServiceBusLength(context.TODO())
 
 			if err != nil {
 				t.Errorf("Expected success but got error: %s", err)
@@ -179,7 +179,7 @@ func TestGetServiceBusLength(t *testing.T) {
 			}
 		} else {
 			// Just test error message
-			length, err := scaler.GetAzureServiceBusLength(context.TODO())
+			length, err := scaler.getAzureServiceBusLength(context.TODO())
 
 			if length != -1 || err == nil {
 				t.Errorf("Expected error but got success")

--- a/pkg/scalers/cassandra_scaler.go
+++ b/pkg/scalers/cassandra_scaler.go
@@ -33,7 +33,7 @@ type CassandraMetadata struct {
 	protocolVersion  int
 	keyspace         string
 	query            string
-	targetQueryValue int
+	targetQueryValue int64
 	metricName       string
 	scalerIndex      int
 }
@@ -69,7 +69,7 @@ func ParseCassandraMetadata(config *ScalerConfig) (*CassandraMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["targetQueryValue"]; ok {
-		targetQueryValue, err := strconv.Atoi(val)
+		targetQueryValue, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("targetQueryValue parsing error %s", err.Error())
 		}
@@ -175,7 +175,7 @@ func (s *cassandraScaler) IsActive(ctx context.Context) (bool, error) {
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler.
 func (s *cassandraScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
-	targetQueryValue := resource.NewQuantity(int64(s.metadata.targetQueryValue), resource.DecimalSI)
+	targetQueryValue := resource.NewQuantity(s.metadata.targetQueryValue, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, s.metadata.metricName),
@@ -201,7 +201,7 @@ func (s *cassandraScaler) GetMetrics(ctx context.Context, metricName string, met
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(num), resource.DecimalSI),
+		Value:      *resource.NewQuantity(num, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 
@@ -209,8 +209,8 @@ func (s *cassandraScaler) GetMetrics(ctx context.Context, metricName string, met
 }
 
 // GetQueryResult returns the result of the scaler query.
-func (s *cassandraScaler) GetQueryResult(ctx context.Context) (int, error) {
-	var value int
+func (s *cassandraScaler) GetQueryResult(ctx context.Context) (int64, error) {
+	var value int64
 	if err := s.session.Query(s.metadata.query).WithContext(ctx).Scan(&value); err != nil {
 		if err != gocql.ErrNotFound {
 			cassandraLog.Error(err, "query failed")

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -153,8 +153,8 @@ func parseCronTimeFormat(s string) string {
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *cronScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	specReplicas := 1
-	targetMetricValue := resource.NewQuantity(int64(specReplicas), resource.DecimalSI)
+	var specReplicas int64 = 1
+	targetMetricValue := resource.NewQuantity(specReplicas, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("cron-%s-%s-%s", s.metadata.timezone, parseCronTimeFormat(s.metadata.start), parseCronTimeFormat(s.metadata.end)))),

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -36,7 +36,7 @@ type datadogMetadata struct {
 	appKey      string
 	datadogSite string
 	query       string
-	queryValue  int
+	queryValue  int64
 	vType       valueType
 	metricName  string
 	age         int
@@ -108,7 +108,7 @@ func parseDatadogMetadata(config *ScalerConfig) (*datadogMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["queryValue"]; ok {
-		queryValue, err := strconv.Atoi(val)
+		queryValue, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("queryValue parsing error %s", err.Error())
 		}
@@ -290,7 +290,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 func (s *datadogScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	externalMetric := new(v2beta2.ExternalMetricSource)
 
-	targetQueryValue := resource.NewQuantity(int64(s.metadata.queryValue), resource.DecimalSI)
+	targetQueryValue := resource.NewQuantity(s.metadata.queryValue, resource.DecimalSI)
 
 	switch s.metadata.vType {
 	case average:

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -38,7 +38,7 @@ type pubsubScaler struct {
 
 type pubsubMetadata struct {
 	mode  string
-	value int
+	value int64
 
 	subscriptionName string
 	gcpAuthorization *gcpAuthorizationMetadata
@@ -72,7 +72,7 @@ func parsePubSubMetadata(config *ScalerConfig) (*pubsubMetadata, error) {
 		}
 		gcpPubSubLog.Info("subscriptionSize field is deprecated. Use mode and value fields instead")
 		meta.mode = pubsubModeSubscriptionSize
-		subSizeValue, err := strconv.Atoi(subSize)
+		subSizeValue, err := strconv.ParseInt(subSize, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("value parsing error %s", err.Error())
 		}
@@ -92,7 +92,7 @@ func parsePubSubMetadata(config *ScalerConfig) (*pubsubMetadata, error) {
 		}
 
 		if valuePresent {
-			triggerValue, err := strconv.Atoi(value)
+			triggerValue, err := strconv.ParseInt(value, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("value parsing error %s", err.Error())
 			}
@@ -156,7 +156,7 @@ func (s *pubsubScaler) Close(context.Context) error {
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *pubsubScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	// Construct the target value as a quantity
-	targetValueQty := resource.NewQuantity(int64(s.metadata.value), resource.DecimalSI)
+	targetValueQty := resource.NewQuantity(s.metadata.value, resource.DecimalSI)
 
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -109,14 +109,14 @@ func (s *kubernetesWorkloadScaler) GetMetrics(ctx context.Context, metricName st
 
 	metric := external_metrics.ExternalMetricValue{
 		MetricName: metricName,
-		Value:      *resource.NewQuantity(int64(pods), resource.DecimalSI),
+		Value:      *resource.NewQuantity(pods, resource.DecimalSI),
 		Timestamp:  metav1.Now(),
 	}
 
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (s *kubernetesWorkloadScaler) getMetricValue(ctx context.Context) (int, error) {
+func (s *kubernetesWorkloadScaler) getMetricValue(ctx context.Context) (int64, error) {
 	podList := &corev1.PodList{}
 	listOptions := client.ListOptions{}
 	listOptions.LabelSelector = s.metadata.podSelector
@@ -130,7 +130,7 @@ func (s *kubernetesWorkloadScaler) getMetricValue(ctx context.Context) (int, err
 		return 0, err
 	}
 
-	count := 0
+	var count int64
 	for _, pod := range podList.Items {
 		count += getCountValue(pod)
 	}
@@ -138,7 +138,7 @@ func (s *kubernetesWorkloadScaler) getMetricValue(ctx context.Context) (int, err
 	return count, nil
 }
 
-func getCountValue(pod corev1.Pod) int {
+func getCountValue(pod corev1.Pod) int64 {
 	for _, ignore := range phasesCountedAsTerminated {
 		if pod.Status.Phase == ignore {
 			return 0

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -127,7 +127,7 @@ func TestMSSQLMetadataParsing(t *testing.T) {
 			t.Errorf("Wrong query. Expected '%s' but got '%s'", expectedQuery, outputMetadata.query)
 		}
 
-		expectedTargetValue := 1
+		var expectedTargetValue int64 = 1
 		if outputMetadata.targetValue != expectedTargetValue {
 			t.Errorf("Wrong targetValue. Expected %d but got %d", expectedTargetValue, outputMetadata.targetValue)
 		}

--- a/pkg/scalers/newrelic_scaler.go
+++ b/pkg/scalers/newrelic_scaler.go
@@ -39,7 +39,7 @@ type newrelicMetadata struct {
 	queryKey    string
 	noDataError bool
 	nrql        string
-	threshold   int
+	threshold   int64
 	scalerIndex int
 }
 
@@ -99,7 +99,7 @@ func parseNewRelicMetadata(config *ScalerConfig) (*newrelicMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata[threshold]; ok && val != "" {
-		t, err := strconv.Atoi(val)
+		t, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %s", threshold)
 		}
@@ -124,7 +124,7 @@ func parseNewRelicMetadata(config *ScalerConfig) (*newrelicMetadata, error) {
 }
 
 func (s *newrelicScaler) IsActive(ctx context.Context) (bool, error) {
-	val, err := s.ExecuteNewRelicQuery(ctx)
+	val, err := s.executeNewRelicQuery(ctx)
 	if err != nil {
 		newrelicLog.Error(err, "error executing NRQL")
 		return false, err
@@ -136,7 +136,7 @@ func (s *newrelicScaler) Close(context.Context) error {
 	return nil
 }
 
-func (s *newrelicScaler) ExecuteNewRelicQuery(ctx context.Context) (float64, error) {
+func (s *newrelicScaler) executeNewRelicQuery(ctx context.Context) (float64, error) {
 	nrdbQuery := nrdb.NRQL(s.metadata.nrql)
 	resp, err := s.nrClient.Nrdb.QueryWithContext(ctx, s.metadata.account, nrdbQuery)
 	if err != nil {
@@ -156,7 +156,7 @@ func (s *newrelicScaler) ExecuteNewRelicQuery(ctx context.Context) (float64, err
 }
 
 func (s *newrelicScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
-	val, err := s.ExecuteNewRelicQuery(ctx)
+	val, err := s.executeNewRelicQuery(ctx)
 	if err != nil {
 		newrelicLog.Error(err, "error executing NRQL query")
 		return []external_metrics.ExternalMetricValue{}, err
@@ -172,7 +172,7 @@ func (s *newrelicScaler) GetMetrics(ctx context.Context, metricName string, metr
 }
 
 func (s *newrelicScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetMetricValue := resource.NewQuantity(int64(s.metadata.threshold), resource.DecimalSI)
+	targetMetricValue := resource.NewQuantity(s.metadata.threshold, resource.DecimalSI)
 	metricName := kedautil.NormalizeString(scalerName)
 
 	externalMetric := &v2beta2.ExternalMetricSource{

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -40,7 +40,7 @@ type prometheusMetadata struct {
 	serverAddress  string
 	metricName     string
 	query          string
-	threshold      int
+	threshold      int64
 	prometheusAuth *authentication.AuthMeta
 	namespace      string
 	scalerIndex    int
@@ -109,7 +109,7 @@ func parsePrometheusMetadata(config *ScalerConfig) (meta *prometheusMetadata, er
 	}
 
 	if val, ok := config.TriggerMetadata[promThreshold]; ok && val != "" {
-		t, err := strconv.Atoi(val)
+		t, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing %s: %s", promThreshold, err)
 		}
@@ -153,7 +153,7 @@ func (s *prometheusScaler) Close(context.Context) error {
 }
 
 func (s *prometheusScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetMetricValue := resource.NewQuantity(int64(s.metadata.threshold), resource.DecimalSI)
+	targetMetricValue := resource.NewQuantity(s.metadata.threshold, resource.DecimalSI)
 	metricName := kedautil.NormalizeString(fmt.Sprintf("prometheus-%s", s.metadata.metricName))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -45,7 +45,7 @@ type redisConnectionInfo struct {
 }
 
 type redisMetadata struct {
-	targetListLength int
+	targetListLength int64
 	listName         string
 	databaseIndex    int
 	connectionInfo   redisConnectionInfo
@@ -191,7 +191,7 @@ func parseRedisMetadata(config *ScalerConfig, parserFn redisAddressParser) (*red
 	meta.targetListLength = defaultTargetListLength
 
 	if val, ok := config.TriggerMetadata["listLength"]; ok {
-		listLength, err := strconv.Atoi(val)
+		listLength, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("list length parsing error %s", err.Error())
 		}
@@ -234,7 +234,7 @@ func (s *redisScaler) Close(context.Context) error {
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *redisScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetListLengthQty := resource.NewQuantity(int64(s.metadata.targetListLength), resource.DecimalSI)
+	targetListLengthQty := resource.NewQuantity(s.metadata.targetListLength, resource.DecimalSI)
 	metricName := kedautil.NormalizeString(fmt.Sprintf("redis-%s", s.metadata.listName))
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{

--- a/pkg/scalers/redis_streams_scaler.go
+++ b/pkg/scalers/redis_streams_scaler.go
@@ -37,7 +37,7 @@ type redisStreamsScaler struct {
 }
 
 type redisStreamsMetadata struct {
-	targetPendingEntriesCount int
+	targetPendingEntriesCount int64
 	streamName                string
 	consumerGroupName         string
 	databaseIndex             int
@@ -167,7 +167,7 @@ func parseRedisStreamsMetadata(config *ScalerConfig, parseFn redisAddressParser)
 	meta.targetPendingEntriesCount = defaultTargetPendingEntriesCount
 
 	if val, ok := config.TriggerMetadata[pendingEntriesCountMetadata]; ok {
-		pendingEntriesCount, err := strconv.Atoi(val)
+		pendingEntriesCount, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing pending entries count %v", err)
 		}
@@ -218,7 +218,7 @@ func (s *redisStreamsScaler) Close(context.Context) error {
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *redisStreamsScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
-	targetPendingEntriesCount := resource.NewQuantity(int64(s.metadata.targetPendingEntriesCount), resource.DecimalSI)
+	targetPendingEntriesCount := resource.NewQuantity(s.metadata.targetPendingEntriesCount, resource.DecimalSI)
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("redis-streams-%s", s.metadata.streamName))),

--- a/pkg/scalers/redis_streams_scaler_test.go
+++ b/pkg/scalers/redis_streams_scaler_test.go
@@ -51,7 +51,7 @@ func TestParseRedisStreamsMetadata(t *testing.T) {
 			assert.Nil(t, err)
 			assert.Equal(t, m.streamName, tc.metadata[streamNameMetadata])
 			assert.Equal(t, m.consumerGroupName, tc.metadata[consumerGroupNameMetadata])
-			assert.Equal(t, strconv.Itoa(m.targetPendingEntriesCount), tc.metadata[pendingEntriesCountMetadata])
+			assert.Equal(t, strconv.FormatInt(m.targetPendingEntriesCount, 10), tc.metadata[pendingEntriesCountMetadata])
 			if authParams != nil {
 				// if authParam is used
 				assert.Equal(t, m.connectionInfo.username, authParams[usernameMetadata])

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -3,8 +3,6 @@ package scalers
 import (
 	"reflect"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func Test_getCountFromSeleniumResponse(t *testing.T) {
@@ -16,7 +14,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *resource.Quantity
+		want    int64
 		wantErr bool
 	}{
 		{
@@ -25,7 +23,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				b:           []byte(nil),
 				browserName: "",
 			},
-			// want:    resource.NewQuantity(0, resource.DecimalSI),
+			// want:    0,
 			wantErr: true,
 		},
 		{
@@ -53,7 +51,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				}`),
 				browserName: "",
 			},
-			want:    resource.NewQuantity(0, resource.DecimalSI),
+			want:    0,
 			wantErr: false,
 		},
 		{
@@ -79,7 +77,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:    "",
 				browserVersion: "latest",
 			},
-			want:    resource.NewQuantity(0, resource.DecimalSI),
+			want:    0,
 			wantErr: false,
 		},
 		{
@@ -99,7 +97,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:    "chrome",
 				browserVersion: "latest",
 			},
-			want:    resource.NewQuantity(2, resource.DecimalSI),
+			want:    2,
 			wantErr: false,
 		},
 		{
@@ -119,7 +117,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:    "chrome",
 				browserVersion: "latest",
 			},
-			want:    resource.NewQuantity(1, resource.DecimalSI),
+			want:    1,
 			wantErr: false,
 		},
 		{
@@ -145,7 +143,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:    "chrome",
 				browserVersion: "latest",
 			},
-			want:    resource.NewQuantity(3, resource.DecimalSI),
+			want:    3,
 			wantErr: false,
 		},
 		{
@@ -171,7 +169,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:    "chrome",
 				browserVersion: "91.0",
 			},
-			want:    resource.NewQuantity(2, resource.DecimalSI),
+			want:    2,
 			wantErr: false,
 		},
 	}

--- a/pkg/scalers/solace_scaler.go
+++ b/pkg/scalers/solace_scaler.go
@@ -73,8 +73,8 @@ type SolaceMetadata struct {
 	// Basic Auth Password
 	password string
 	// Target Message Count
-	msgCountTarget      int
-	msgSpoolUsageTarget int // Spool Use Target in Megabytes
+	msgCountTarget      int64
+	msgSpoolUsageTarget int64 // Spool Use Target in Megabytes
 	// Scaler index
 	scalerIndex int
 }
@@ -152,7 +152,7 @@ func parseSolaceMetadata(config *ScalerConfig) (*SolaceMetadata, error) {
 	//	GET METRIC TARGET VALUES
 	//	GET msgCountTarget
 	if val, ok := config.TriggerMetadata[solaceMetaMsgCountTarget]; ok && val != "" {
-		if msgCount, err := strconv.Atoi(val); err == nil {
+		if msgCount, err := strconv.ParseInt(val, 10, 64); err == nil {
 			meta.msgCountTarget = msgCount
 		} else {
 			return nil, fmt.Errorf("can't parse [%s], not a valid integer: %s", solaceMetaMsgCountTarget, err)
@@ -160,7 +160,7 @@ func parseSolaceMetadata(config *ScalerConfig) (*SolaceMetadata, error) {
 	}
 	//	GET msgSpoolUsageTarget
 	if val, ok := config.TriggerMetadata[solaceMetaMsgSpoolUsageTarget]; ok && val != "" {
-		if msgSpoolUsage, err := strconv.Atoi(val); err == nil {
+		if msgSpoolUsage, err := strconv.ParseInt(val, 10, 64); err == nil {
 			meta.msgSpoolUsageTarget = msgSpoolUsage * 1024 * 1024
 		} else {
 			return nil, fmt.Errorf("can't parse [%s], not a valid integer: %s", solaceMetaMsgSpoolUsageTarget, err)
@@ -243,7 +243,7 @@ func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Metric
 	var metricSpecList []v2beta2.MetricSpec
 	// Message Count Target Spec
 	if s.metadata.msgCountTarget > 0 {
-		targetMetricValue := resource.NewQuantity(int64(s.metadata.msgCountTarget), resource.DecimalSI)
+		targetMetricValue := resource.NewQuantity(s.metadata.msgCountTarget, resource.DecimalSI)
 		metricName := kedautil.NormalizeString(fmt.Sprintf("solace-%s-%s", s.metadata.queueName, solaceTriggermsgcount))
 		externalMetric := &v2beta2.ExternalMetricSource{
 			Metric: v2beta2.MetricIdentifier{
@@ -259,7 +259,7 @@ func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Metric
 	}
 	// Message Spool Usage Target Spec
 	if s.metadata.msgSpoolUsageTarget > 0 {
-		targetMetricValue := resource.NewQuantity(int64(s.metadata.msgSpoolUsageTarget), resource.DecimalSI)
+		targetMetricValue := resource.NewQuantity(s.metadata.msgSpoolUsageTarget, resource.DecimalSI)
 		metricName := kedautil.NormalizeString(fmt.Sprintf("solace-%s-%s", s.metadata.queueName, solaceTriggermsgspoolusage))
 		externalMetric := &v2beta2.ExternalMetricSource{
 			Metric: v2beta2.MetricIdentifier{

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -49,8 +49,8 @@ func TestTargetAverageValue(t *testing.T) {
 	assert.Equal(t, int64(4), targetAverageValue)
 }
 
-func createMetricSpec(averageValue int) v2beta2.MetricSpec {
-	qty := resource.NewQuantity(int64(averageValue), resource.DecimalSI)
+func createMetricSpec(averageValue int64) v2beta2.MetricSpec {
+	qty := resource.NewQuantity(averageValue, resource.DecimalSI)
 	return v2beta2.MetricSpec{
 		External: &v2beta2.ExternalMetricSource{
 			Target: v2beta2.MetricTarget{
@@ -68,9 +68,9 @@ func TestIsScaledJobActive(t *testing.T) {
 	// Assme 1 trigger only
 	scaledJobSingle := createScaledObject(100, "") // testing default = max
 	scalerSingle := []ScalerBuilder{{
-		Scaler: createScaler(ctrl, int64(20), int32(2), true),
+		Scaler: createScaler(ctrl, int64(20), int64(2), true),
 		Factory: func() (scalers.Scaler, error) {
-			return createScaler(ctrl, int64(20), int32(2), true), nil
+			return createScaler(ctrl, int64(20), int64(2), true), nil
 		},
 	}}
 
@@ -88,9 +88,9 @@ func TestIsScaledJobActive(t *testing.T) {
 
 	// Non-Active trigger only
 	scalerSingle = []ScalerBuilder{{
-		Scaler: createScaler(ctrl, int64(0), int32(2), false),
+		Scaler: createScaler(ctrl, int64(0), int64(2), false),
 		Factory: func() (scalers.Scaler, error) {
-			return createScaler(ctrl, int64(0), int32(2), false), nil
+			return createScaler(ctrl, int64(0), int64(2), false), nil
 		},
 	}}
 
@@ -176,16 +176,16 @@ func newScalerTestData(
 		MaxReplicaCount:            int32(maxReplicaCount),
 		MultipleScalersCalculation: multipleScalersCalculation,
 		Scaler1QueueLength:         int64(scaler1QueueLength),
-		Scaler1AverageValue:        int32(scaler1AverageValue),
+		Scaler1AverageValue:        int64(scaler1AverageValue),
 		Scaler1IsActive:            scaler1IsActive,
 		Scaler2QueueLength:         int64(scaler2QueueLength),
-		Scaler2AverageValue:        int32(scaler2AverageValue),
+		Scaler2AverageValue:        int64(scaler2AverageValue),
 		Scaler2IsActive:            scaler2IsActive,
 		Scaler3QueueLength:         int64(scaler3QueueLength),
-		Scaler3AverageValue:        int32(scaler3AverageValue),
+		Scaler3AverageValue:        int64(scaler3AverageValue),
 		Scaler3IsActive:            scaler3IsActive,
 		Scaler4QueueLength:         int64(scaler4QueueLength),
-		Scaler4AverageValue:        int32(scaler4AverageValue),
+		Scaler4AverageValue:        int64(scaler4AverageValue),
 		Scaler4IsActive:            scaler4IsActive,
 		ResultIsActive:             resultIsActive,
 		ResultQueueLength:          int64(resultQueueLength),
@@ -197,16 +197,16 @@ type scalerTestData struct {
 	MaxReplicaCount            int32
 	MultipleScalersCalculation string
 	Scaler1QueueLength         int64
-	Scaler1AverageValue        int32
+	Scaler1AverageValue        int64
 	Scaler1IsActive            bool
 	Scaler2QueueLength         int64
-	Scaler2AverageValue        int32
+	Scaler2AverageValue        int64
 	Scaler2IsActive            bool
 	Scaler3QueueLength         int64
-	Scaler3AverageValue        int32
+	Scaler3AverageValue        int64
 	Scaler3IsActive            bool
 	Scaler4QueueLength         int64
-	Scaler4AverageValue        int32
+	Scaler4AverageValue        int64
 	Scaler4IsActive            bool
 	ResultIsActive             bool
 	ResultQueueLength          int64
@@ -231,10 +231,10 @@ func createScaledObject(maxReplicaCount int32, multipleScalersCalculation string
 	}
 }
 
-func createScaler(ctrl *gomock.Controller, queueLength int64, averageValue int32, isActive bool) *mock_scalers.MockScaler {
+func createScaler(ctrl *gomock.Controller, queueLength int64, averageValue int64, isActive bool) *mock_scalers.MockScaler {
 	metricName := "queueLength"
 	scaler := mock_scalers.NewMockScaler(ctrl)
-	metricsSpecs := []v2beta2.MetricSpec{createMetricSpec(int(averageValue))}
+	metricsSpecs := []v2beta2.MetricSpec{createMetricSpec(averageValue)}
 	metrics := []external_metrics.ExternalMetricValue{
 		{
 			MetricName: metricName,

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -134,8 +134,8 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 	assert.Equal(t, true, isError)
 }
 
-func createMetricSpec(averageValue int) v2beta2.MetricSpec {
-	qty := resource.NewQuantity(int64(averageValue), resource.DecimalSI)
+func createMetricSpec(averageValue int64) v2beta2.MetricSpec {
+	qty := resource.NewQuantity(averageValue, resource.DecimalSI)
 	return v2beta2.MetricSpec{
 		External: &v2beta2.ExternalMetricSource{
 			Target: v2beta2.MetricTarget{


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Internally represent `value` and `threshold` as int64 to avoid mutliple conversions, this is not user facing, not breaking change from UX. It is a first step towards full implemenation of https://github.com/kedacore/keda/issues/2790

Breaking changes from UX (ie conversion from float) needed to be done in a separate PR preferrably.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Relates https://github.com/kedacore/keda/issues/2790
