### PR TITLE
Enable support for non-public clouds in Application Insights scaler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@
 ### Improvements
 
 - **General:** Synchronize HPA annotations from ScaledObject ([#2659](https://github.com/kedacore/keda/pull/2659))
-- **Azure Event Hub Scaler:** Improve logging when blob container not found ([#2363]https://github.com/kedacore/keda/issues/2363)
+- **Azure Application Insights Scaler:** Provide support for non-public clouds ([#2735](https://github.com/kedacore/keda/issues/2735))
+- **Azure Event Hub Scaler:** Improve logging when blob container not found ([#2363](https://github.com/kedacore/keda/issues/2363)
 - **Azure Event Hub Scaler:** Provide support for non-public clouds ([#1915](https://github.com/kedacore/keda/issues/1915))
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 - **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))

--- a/pkg/scalers/azure/azure_app_insights.go
+++ b/pkg/scalers/azure/azure_app_insights.go
@@ -34,7 +34,6 @@ type AppInsightsInfo struct {
 	Filter                  string
 	ClientID                string
 	ClientPassword          string
-	Cloud                   string
 	AppInsightsResourceURL  string
 	ActiveDirectoryEndpoint string
 }

--- a/pkg/scalers/azure/azure_app_insights.go
+++ b/pkg/scalers/azure/azure_app_insights.go
@@ -16,18 +16,27 @@ import (
 )
 
 const (
-	appInsightsResource = "https://api.applicationinsights.io"
+	DefaultAppInsightsResourceURL = "https://api.applicationinsights.io"
 )
 
+var AppInsightsResourceURLInCloud = map[string]string{
+	"AZUREPUBLICCLOUD":       "https://api.applicationinsights.io",
+	"AZUREUSGOVERNMENTCLOUD": "https://api.applicationinsights.us",
+	"AZURECHINACLOUD":        "https://api.applicationinsights.azure.cn",
+}
+
 type AppInsightsInfo struct {
-	ApplicationInsightsID string
-	TenantID              string
-	MetricID              string
-	AggregationTimespan   string
-	AggregationType       string
-	Filter                string
-	ClientID              string
-	ClientPassword        string
+	ApplicationInsightsID   string
+	TenantID                string
+	MetricID                string
+	AggregationTimespan     string
+	AggregationType         string
+	Filter                  string
+	ClientID                string
+	ClientPassword          string
+	Cloud                   string
+	AppInsightsResourceURL  string
+	ActiveDirectoryEndpoint string
 }
 
 type ApplicationInsightsMetric struct {
@@ -55,12 +64,13 @@ func toISO8601(time string) (string, error) {
 func getAuthConfig(info AppInsightsInfo, podIdentity kedav1alpha1.PodIdentityProvider) auth.AuthorizerConfig {
 	if podIdentity == "" || podIdentity == kedav1alpha1.PodIdentityProviderNone {
 		config := auth.NewClientCredentialsConfig(info.ClientID, info.ClientPassword, info.TenantID)
-		config.Resource = appInsightsResource
+		config.Resource = info.AppInsightsResourceURL
+		config.AADEndpoint = info.ActiveDirectoryEndpoint
 		return config
 	}
 
 	config := auth.NewMSIConfig()
-	config.Resource = appInsightsResource
+	config.Resource = info.AppInsightsResourceURL
 	return config
 }
 
@@ -115,7 +125,7 @@ func GetAzureAppInsightsMetricValue(ctx context.Context, info AppInsightsInfo, p
 	}
 
 	req, err := autorest.Prepare(&http.Request{},
-		autorest.WithBaseURL(appInsightsResource),
+		autorest.WithBaseURL(info.AppInsightsResourceURL),
 		autorest.WithPath("v1/apps"),
 		autorest.WithPath(info.ApplicationInsightsID),
 		autorest.WithPath("metrics"),

--- a/pkg/scalers/azure_app_insights_scaler.go
+++ b/pkg/scalers/azure_app_insights_scaler.go
@@ -98,11 +98,9 @@ func parseAzureAppInsightsMetadata(config *ScalerConfig) (*azureAppInsightsMetad
 		meta.azureAppInsightsInfo.Filter = ""
 	}
 
-	meta.azureAppInsightsInfo.Cloud = azure.DefaultCloud
 	meta.azureAppInsightsInfo.AppInsightsResourceURL = azure.DefaultAppInsightsResourceURL
 
 	if cloud, ok := config.TriggerMetadata["cloud"]; ok {
-		meta.azureAppInsightsInfo.Cloud = cloud
 		if strings.EqualFold(cloud, azure.PrivateCloud) {
 			if resource, ok := config.TriggerMetadata["appInsightsResourceURL"]; ok && resource != "" {
 				meta.azureAppInsightsInfo.AppInsightsResourceURL = resource

--- a/pkg/scalers/azure_app_insights_scaler.go
+++ b/pkg/scalers/azure_app_insights_scaler.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	az "github.com/Azure/go-autorest/autorest/azure"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,6 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	az "github.com/Azure/go-autorest/autorest/azure"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"

--- a/pkg/scalers/azure_app_insights_scaler_test.go
+++ b/pkg/scalers/azure_app_insights_scaler_test.go
@@ -140,6 +140,56 @@ var azureAppInsightsScalerData = []azureAppInsightsScalerTestData{
 			"AD_CLIENT_ID": "5678", "AD_CLIENT_PASSWORD": "pw", "APP_INSIGHTS_ID": "1234", "TENANT_ID": "1234",
 		},
 	}},
+	{name: "known Azure Cloud", isError: false, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"metricAggregationTimespan": "00:01", "metricAggregationType": "count", "metricId": "unittest/test", "targetValue": "10",
+			"applicationInsightsId": "appinsightid", "tenantId": "tenantid",
+			"cloud": "azureChinaCloud",
+		},
+		AuthParams: map[string]string{
+			"tenantId": "tenantId", "activeDirectoryClientId": "adClientId", "activeDirectoryClientPassword": "adClientPassword",
+		},
+	}},
+	{name: "private cloud", isError: false, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"metricAggregationTimespan": "00:01", "metricAggregationType": "count", "metricId": "unittest/test", "targetValue": "10",
+			"applicationInsightsId": "appinsightid", "tenantId": "tenantid",
+			"cloud": "private", "appInsightsResourceURL": "appInsightsResourceURL", "activeDirectoryEndpoint": "adEndpoint",
+		},
+		AuthParams: map[string]string{
+			"tenantId": "tenantId", "activeDirectoryClientId": "adClientId", "activeDirectoryClientPassword": "adClientPassword",
+		},
+	}},
+	{name: "private cloud - missing app insights resource URL", isError: true, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"metricAggregationTimespan": "00:01", "metricAggregationType": "count", "metricId": "unittest/test", "targetValue": "10",
+			"applicationInsightsId": "appinsightid", "tenantId": "tenantid",
+			"cloud": "private", "activeDirectoryEndpoint": "adEndpoint",
+		},
+		AuthParams: map[string]string{
+			"tenantId": "tenantId", "activeDirectoryClientId": "adClientId", "activeDirectoryClientPassword": "adClientPassword",
+		},
+	}},
+	{name: "private cloud - missing active directory endpoint", isError: true, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"metricAggregationTimespan": "00:01", "metricAggregationType": "count", "metricId": "unittest/test", "targetValue": "10",
+			"applicationInsightsId": "appinsightid", "tenantId": "tenantid",
+			"cloud": "private", "appInsightsResourceURL": "appInsightsResourceURL",
+		},
+		AuthParams: map[string]string{
+			"tenantId": "tenantId", "activeDirectoryClientId": "adClientId", "activeDirectoryClientPassword": "adClientPassword",
+		},
+	}},
+	{name: "unsupported cloud", isError: true, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"metricAggregationTimespan": "00:01", "metricAggregationType": "count", "metricId": "unittest/test", "targetValue": "10",
+			"applicationInsightsId": "appinsightid", "tenantId": "tenantid",
+			"cloud": "azureGermanCloud",
+		},
+		AuthParams: map[string]string{
+			"tenantId": "tenantId", "activeDirectoryClientId": "adClientId", "activeDirectoryClientPassword": "adClientPassword",
+		},
+	}},
 }
 
 func TestNewAzureAppInsightsScaler(t *testing.T) {

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -191,7 +191,7 @@ func newDatadogConnection(ctx context.Context, meta *datadogMetadata, config *Sc
 	configuration.HTTPClient = kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
 	apiClient := datadog.NewAPIClient(configuration)
 
-	_, _, err := apiClient.AuthenticationApi.Validate(ctx) //nolint:bodyclose
+	_, _, err := apiClient.AuthenticationApi.Validate(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to Datadog API endpoint: %v", err)
 	}
@@ -236,7 +236,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 			"site": s.metadata.datadogSite,
 		})
 
-	resp, r, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query) //nolint:bodyclose
+	resp, r, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)
 	if err != nil {
 		return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", err)
 	}

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -191,7 +191,7 @@ func newDatadogConnection(ctx context.Context, meta *datadogMetadata, config *Sc
 	configuration.HTTPClient = kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
 	apiClient := datadog.NewAPIClient(configuration)
 
-	_, _, err := apiClient.AuthenticationApi.Validate(ctx)
+	_, _, err := apiClient.AuthenticationApi.Validate(ctx) //nolint:bodyclose
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to Datadog API endpoint: %v", err)
 	}
@@ -236,7 +236,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 			"site": s.metadata.datadogSite,
 		})
 
-	resp, r, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query)
+	resp, r, err := s.apiClient.MetricsApi.QueryMetrics(ctx, time.Now().Unix()-int64(s.metadata.age), time.Now().Unix(), s.metadata.query) //nolint:bodyclose
 	if err != nil {
 		return -1, fmt.Errorf("error when retrieving Datadog metrics: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Vighnesh Shenoy <vshenoy@microsoft.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added support for three new fields in the trigger metadata for the eventhub scaler, `cloud`, `appInsightsResourceURL`, `activeDirectoryEndpoint`. The cloud parameter can be `azureChinaCloud`, `azureUSGovernmentCloud`, `azurePublicCloud`, or `private` (default is `azurePublicCloud`).

Sample ScaledObject definition -
```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: app-insights
  labels: {}
spec:
  scaleTargetRef:
    name: app-insights
  minReplicaCount: 0
  maxReplicaCount: 2
  pollingInterval: 10
  cooldownPeriod: 30
  triggers:
  - type: azure-app-insights
    metadata:
      metricAggregationTimespan: "0:1"
      metricAggregationType: count
      metricId: "customMetrics/testMetric"
      targetValue: "100"
      applicationInsightsId: <app-id>
      tenantId: <tenantId>
      activeDirectoryClientId: <ad-client-id>
      activeDirectoryClientPasswordFromEnv: <env-varialble-for-client-password>
      cloud: "private"
      appInsightsResourceURL: <resource-url>
      activeDirectoryEndpoint: <ad-endpoint>
---
```


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x]  Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Relates to #2735