### PR TITLE
Add managed identity client id parameter to data explorer scaler

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -80,6 +80,7 @@ jobs:
           AZURE_DEVOPS_PROJECT: ${{ secrets.AZURE_DEVOPS_PROJECT }}
           AZURE_KEYVAULT_URI:  ${{ secrets.AZURE_KEYVAULT_URI }}
           AZURE_LOG_ANALYTICS_WORKSPACE_ID: ${{ secrets.AZURE_LOG_ANALYTICS_WORKSPACE_ID }}
+          AZURE_MSI_CLIENT_ID: ${{ secrets.AZURE_MSI_CLIENT_ID }}
           AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
           AZURE_SP_ID: ${{ secrets.AZURE_SP_ID }}
           AZURE_SP_KEY: ${{ secrets.AZURE_SP_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - **Prometheus Scaler:** Support for `X-Scope-OrgID` header ([#2667](https://github.com/kedacore/keda/issues/2667))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
 - **Selenium Grid Scaler:** Consider `maxSession` grid info when scaling. ([#2618](https://github.com/kedacore/keda/issues/2618))
+- **Azure Data Explorer Scaler:** Adding managed identity client id parameter ([#2770](https://github.com/kedacore/keda/issues/2770))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 - **General:** Synchronize HPA annotations from ScaledObject ([#2659](https://github.com/kedacore/keda/pull/2659))
 - **Azure Application Insights Scaler:** Provide support for non-public clouds ([#2735](https://github.com/kedacore/keda/issues/2735))
+- **Azure Data Explorer Scaler:** Adding managed identity client id parameter ([#2770](https://github.com/kedacore/keda/issues/2770))
 - **Azure Event Hub Scaler:** Improve logging when blob container not found ([#2363](https://github.com/kedacore/keda/issues/2363)
 - **Azure Event Hub Scaler:** Provide support for non-public clouds ([#1915](https://github.com/kedacore/keda/issues/1915))
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
@@ -53,7 +54,6 @@
 - **Prometheus Scaler:** Support for `X-Scope-OrgID` header ([#2667](https://github.com/kedacore/keda/issues/2667))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
 - **Selenium Grid Scaler:** Consider `maxSession` grid info when scaling. ([#2618](https://github.com/kedacore/keda/issues/2618))
-- **Azure Data Explorer Scaler:** Adding managed identity client id parameter ([#2770](https://github.com/kedacore/keda/issues/2770))
 
 ### Breaking Changes
 

--- a/pkg/scalers/azure/azure_data_explorer.go
+++ b/pkg/scalers/azure/azure_data_explorer.go
@@ -35,6 +35,7 @@ type DataExplorerMetadata struct {
 	DatabaseName string
 	Endpoint     string
 	MetricName   string
+	MSIClientID  string
 	PodIdentity  string
 	Query        string
 	TenantID     string
@@ -60,9 +61,11 @@ func CreateAzureDataExplorerClient(metadata *DataExplorerMetadata) (*kusto.Clien
 func getDataExplorerAuthConfig(metadata *DataExplorerMetadata) (*auth.AuthorizerConfig, error) {
 	var authConfig auth.AuthorizerConfig
 
-	if metadata.PodIdentity != "" {
-		authConfig = auth.NewMSIConfig()
-		azureDataExplorerLogger.V(1).Info("Creating Azure Data Explorer Client using Pod Identity")
+	if metadata.PodIdentity != "" && metadata.MSIClientID != "" {
+		msiConfig := auth.NewMSIConfig()
+		msiConfig.ClientID = metadata.MSIClientID
+		authConfig = msiConfig
+		azureDataExplorerLogger.V(1).Info("Creating Azure Data Explorer Client using Pod Identity and managedIdentityClientID")
 		return &authConfig, nil
 	}
 

--- a/pkg/scalers/azure/azure_data_explorer_test.go
+++ b/pkg/scalers/azure/azure_data_explorer_test.go
@@ -37,6 +37,7 @@ type testGetDataExplorerAuthConfig struct {
 
 var (
 	clientID                 = "test_client_id"
+	msiClientID              = "test_msi_client_id"
 	rowName                  = "result"
 	rowType     types.Column = "long"
 	rowValue    int64        = 3
@@ -64,9 +65,11 @@ var testGetDataExplorerAuthConfigs = []testGetDataExplorerAuthConfig{
 	// Auth with aad app - pass
 	{testMetadata: &DataExplorerMetadata{ClientID: clientID, ClientSecret: secret, TenantID: tenantID}, isError: false},
 	// Auth with podIdentity - pass
-	{testMetadata: &DataExplorerMetadata{PodIdentity: podIdentity}, isError: false},
+	{testMetadata: &DataExplorerMetadata{PodIdentity: podIdentity, MSIClientID: msiClientID}, isError: false},
 	// Empty metadata - fail
 	{testMetadata: &DataExplorerMetadata{}, isError: true},
+	// Empty msiClientID - fail
+	{testMetadata: &DataExplorerMetadata{PodIdentity: podIdentity}, isError: true},
 	// Empty tenantID - fail
 	{testMetadata: &DataExplorerMetadata{ClientID: clientID, ClientSecret: secret}, isError: true},
 	// Empty clientID - fail

--- a/pkg/scalers/azure_data_explorer_scaler.go
+++ b/pkg/scalers/azure_data_explorer_scaler.go
@@ -119,6 +119,12 @@ func parseAzureDataExplorerAuthParams(config *ScalerConfig) (*azure.DataExplorer
 	switch config.PodIdentity {
 	case kedav1alpha1.PodIdentityProviderAzure:
 		metadata.PodIdentity = string(config.PodIdentity)
+
+		msiClientId, err := getParameterFromConfig(config, "msiClientId", true)
+		if err != nil {
+			return nil, err
+		}
+		metadata.MSIClientID = msiClientId
 	case "", kedav1alpha1.PodIdentityProviderNone:
 		dataExplorerLogger.V(1).Info("Pod Identity is not provided. Trying to resolve clientId, clientSecret and tenantId.")
 

--- a/pkg/scalers/azure_data_explorer_scaler.go
+++ b/pkg/scalers/azure_data_explorer_scaler.go
@@ -120,11 +120,11 @@ func parseAzureDataExplorerAuthParams(config *ScalerConfig) (*azure.DataExplorer
 	case kedav1alpha1.PodIdentityProviderAzure:
 		metadata.PodIdentity = string(config.PodIdentity)
 
-		msiClientId, err := getParameterFromConfig(config, "msiClientId", true)
+		msiClientID, err := getParameterFromConfig(config, "msiClientID", true)
 		if err != nil {
 			return nil, err
 		}
-		metadata.MSIClientID = msiClientId
+		metadata.MSIClientID = msiClientID
 	case "", kedav1alpha1.PodIdentityProviderNone:
 		dataExplorerLogger.V(1).Info("Pod Identity is not provided. Trying to resolve clientId, clientSecret and tenantId.")
 

--- a/pkg/scalers/azure_data_explorer_scaler_test.go
+++ b/pkg/scalers/azure_data_explorer_scaler_test.go
@@ -44,7 +44,7 @@ var (
 	dataExplorerQuery     = "print 3"
 	dataExplorerThreshold = "1"
 	dataExplorerEndpoint  = "https://test-keda-e2e.eastus.kusto.windows.net"
-	msiClientId           = "b31c38ca-0a20-4770-b3ea-568acc8dec99"
+	msiClientID           = "b31c38ca-0a20-4770-b3ea-568acc8dec99"
 )
 
 // Valid auth params with aad application and passwd
@@ -79,15 +79,15 @@ var testDataExplorerMetadataWithPodIdentity = []parseDataExplorerMetadataTestDat
 	// Empty metadata - fail
 	{map[string]string{}, true},
 	// Missing endpoint - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientID": msiClientID, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
 	// Missing query - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientID": msiClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, true},
 	// Missing threshold - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, true},
-	// Missing msiClientId - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": "", "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientID": msiClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, true},
+	// Missing msiClientID - fail
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientID": "", "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
 	// All parameters set - pass
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, false},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientID": msiClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, false},
 }
 
 var testDataExplorerMetricIdentifiers = []dataExplorerMetricIdentifier{

--- a/pkg/scalers/azure_data_explorer_scaler_test.go
+++ b/pkg/scalers/azure_data_explorer_scaler_test.go
@@ -19,9 +19,9 @@ package scalers
 import (
 	"context"
 	"fmt"
-	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"testing"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 

--- a/pkg/scalers/azure_data_explorer_scaler_test.go
+++ b/pkg/scalers/azure_data_explorer_scaler_test.go
@@ -19,9 +19,9 @@ package scalers
 import (
 	"context"
 	"fmt"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"testing"
 
-	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
@@ -44,6 +44,7 @@ var (
 	dataExplorerQuery     = "print 3"
 	dataExplorerThreshold = "1"
 	dataExplorerEndpoint  = "https://test-keda-e2e.eastus.kusto.windows.net"
+	msiClientId           = "b31c38ca-0a20-4770-b3ea-568acc8dec99"
 )
 
 // Valid auth params with aad application and passwd
@@ -78,13 +79,15 @@ var testDataExplorerMetadataWithPodIdentity = []parseDataExplorerMetadataTestDat
 	// Empty metadata - fail
 	{map[string]string{}, true},
 	// Missing endpoint - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
 	// Missing query - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, true},
 	// Missing threshold - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, true},
+	// Missing msiClientId - fail
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": "", "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
 	// All parameters set - pass
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, false},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "msiClientId": msiClientId, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, false},
 }
 
 var testDataExplorerMetricIdentifiers = []dataExplorerMetricIdentifier{

--- a/tests/scalers/azure-data-explorer.test.ts
+++ b/tests/scalers/azure-data-explorer.test.ts
@@ -5,6 +5,7 @@ import test from 'ava'
 
 const dataExplorerDb = process.env['AZURE_DATA_EXPLORER_DB']
 const dataExplorerEndpoint = process.env['AZURE_DATA_EXPLORER_ENDPOINT']
+const msiClientId = process.env['AZURE_MSI_CLIENT_ID']
 const spId = process.env['AZURE_SP_ID']
 const spSecret = process.env['AZURE_SP_KEY']
 const spTenantId = process.env['AZURE_SP_TENANT']
@@ -197,6 +198,7 @@ spec:
     metadata:
       databaseName: ${dataExplorerDb}
       endpoint: ${dataExplorerEndpoint}
+      msiClientId: ${msiClientId}
       query: print result = ${scaleOutMetricValue}
       threshold: "5"
     authenticationRef:


### PR DESCRIPTION
Signed-off-by: Yarden Siboni [yardensib@gmail.com](mailto:yardensib@gmail.com)

Add support for new parameter in trigger metadata for Azure Data Explorer scaler - `msiClientId`.
This parameter is mandatory when user choose to authenticate through pod identity.

keda-docs PR: https://github.com/kedacore/keda-docs/pull/731

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #2770
