### PR TITLE
Disable azure-data-explorer e2e test

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -27,6 +27,12 @@ function run_tests {
             continue
         fi
 
+        # Disable until https://github.com/kedacore/keda/issues/2770 is solved.
+        if [[ $test_case == *azure-data-explorer.test.ts ]]
+        then
+            continue
+        fi
+
         counter=$((counter+1))
         ./node_modules/.bin/ava $test_case > "${test_case}.log" 2>&1 &
         pid=$!


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

This PR disables azure data explorer e2e test [till this is solved](https://github.com/kedacore/keda/issues/2770)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

