### PR TITLE
Non-public cloud support for Azure Monitor scaler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - **Azure Application Insights Scaler:** Provide support for non-public clouds ([#2735](https://github.com/kedacore/keda/issues/2735))
 - **Azure Event Hub Scaler:** Improve logging when blob container not found ([#2363](https://github.com/kedacore/keda/issues/2363)
 - **Azure Event Hub Scaler:** Provide support for non-public clouds ([#1915](https://github.com/kedacore/keda/issues/1915))
+- **Azure Monitor Scaler:** Provide support for non-public clouds ([#1917](https://github.com/kedacore/keda/issues/1917))
 - **Azure Queue:** Don't call Azure queue GetProperties API unnecessarily ([#2613](https://github.com/kedacore/keda/pull/2613))
 - **Datadog Scaler:** Validate query to contain `{` to prevent panic on invalid query ([#2625](https://github.com/kedacore/keda/issues/2625))
 - **Datadog Scaler:** Several improvements, including a new optional parameter `metricUnavailableValue` to fill data when no Datadog metric was returned ([#2657](https://github.com/kedacore/keda/issues/2657))

--- a/pkg/scalers/azure/azure_monitor.go
+++ b/pkg/scalers/azure/azure_monitor.go
@@ -49,19 +49,19 @@ type azureExternalMetricRequest struct {
 
 // MonitorInfo to create metric request
 type MonitorInfo struct {
-	ResourceURI             string
-	TenantID                string
-	SubscriptionID          string
-	ResourceGroupName       string
-	Name                    string
-	Namespace               string
-	Filter                  string
-	AggregationInterval     string
-	AggregationType         string
-	ClientID                string
-	ClientPassword          string
-	ResourceManagerEndpoint string
-	ActiveDirectoryEndpoint string
+	ResourceURI                  string
+	TenantID                     string
+	SubscriptionID               string
+	ResourceGroupName            string
+	Name                         string
+	Namespace                    string
+	Filter                       string
+	AggregationInterval          string
+	AggregationType              string
+	ClientID                     string
+	ClientPassword               string
+	AzureResourceManagerEndpoint string
+	ActiveDirectoryEndpoint      string
 }
 
 var azureMonitorLog = logf.Log.WithName("azure_monitor_scaler")
@@ -84,16 +84,16 @@ func GetAzureMetricValue(ctx context.Context, info MonitorInfo, podIdentity keda
 }
 
 func createMetricsClient(info MonitorInfo, podIdentityEnabled bool) insights.MetricsClient {
-	client := insights.NewMetricsClientWithBaseURI(info.ResourceManagerEndpoint, info.SubscriptionID)
+	client := insights.NewMetricsClientWithBaseURI(info.AzureResourceManagerEndpoint, info.SubscriptionID)
 	var authConfig auth.AuthorizerConfig
 	if podIdentityEnabled {
 		config := auth.NewMSIConfig()
-		config.Resource = info.ResourceManagerEndpoint
+		config.Resource = info.AzureResourceManagerEndpoint
 
 		authConfig = config
 	} else {
 		config := auth.NewClientCredentialsConfig(info.ClientID, info.ClientPassword, info.TenantID)
-		config.Resource = info.ResourceManagerEndpoint
+		config.Resource = info.AzureResourceManagerEndpoint
 		config.AADEndpoint = info.ActiveDirectoryEndpoint
 
 		authConfig = config

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -149,14 +149,14 @@ func parseAzureMonitorMetadata(config *ScalerConfig) (*azureMonitorMetadata, err
 
 	meta.scalerIndex = config.ScalerIndex
 
-	resourceManagerEndpointProvider := func(env az.Environment) (string, error) {
+	azureResourceManagerEndpointProvider := func(env az.Environment) (string, error) {
 		return env.ResourceManagerEndpoint, nil
 	}
-	resourceManagerEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "resourceManagerEndpoint", resourceManagerEndpointProvider)
+	azureResourceManagerEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "azureResourceManagerEndpoint", azureResourceManagerEndpointProvider)
 	if err != nil {
 		return nil, err
 	}
-	meta.azureMonitorInfo.ResourceManagerEndpoint = resourceManagerEndpoint
+	meta.azureMonitorInfo.AzureResourceManagerEndpoint = azureResourceManagerEndpoint
 
 	activeDirectoryEndpointProvider := func(env az.Environment) (string, error) {
 		return env.ActiveDirectoryEndpoint, nil

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	az "github.com/Azure/go-autorest/autorest/azure"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,6 +148,24 @@ func parseAzureMonitorMetadata(config *ScalerConfig) (*azureMonitorMetadata, err
 	meta.azureMonitorInfo.ClientPassword = clientPassword
 
 	meta.scalerIndex = config.ScalerIndex
+
+	resourceManagerEndpointProvider := func(env az.Environment) (string, error) {
+		return env.ResourceManagerEndpoint, nil
+	}
+	resourceManagerEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "resourceManagerEndpoint", resourceManagerEndpointProvider)
+	if err != nil {
+		return nil, err
+	}
+	meta.azureMonitorInfo.ResourceManagerEndpoint = resourceManagerEndpoint
+
+	activeDirectoryEndpointProvider := func(env az.Environment) (string, error) {
+		return env.ActiveDirectoryEndpoint, nil
+	}
+	activeDirectoryEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "activeDirectoryEndpoint", activeDirectoryEndpointProvider)
+	if err != nil {
+		return nil, err
+	}
+	meta.azureMonitorInfo.ActiveDirectoryEndpoint = activeDirectoryEndpoint
 
 	return &meta, nil
 }

--- a/pkg/scalers/azure_monitor_scaler_test.go
+++ b/pkg/scalers/azure_monitor_scaler_test.go
@@ -23,6 +23,11 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 )
 
+const (
+	testResourceManagerEndpoint = "testResourceManagerEndpoint"
+	testActiveDirectoryEndpoint = "testActiveDirectoryEndpoint"
+)
+
 type parseAzMonitorMetadataTestData struct {
 	metadata    map[string]string
 	isError     bool
@@ -79,6 +84,17 @@ var testParseAzMonitorMetadata = []parseAzMonitorMetadataTestData{
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, false, map[string]string{}, map[string]string{}, kedav1alpha1.PodIdentityProviderAzure},
 	// wrong podIdentity
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "targetValue": "5"}, true, map[string]string{}, map[string]string{}, kedav1alpha1.PodIdentityProvider("notAzure")},
+	// known azure cloud
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "azureChinaCloud"}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
+	// private cloud
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "private",
+		"resourceManagerEndpoint": testResourceManagerEndpoint, "activeDirectoryEndpoint": testActiveDirectoryEndpoint}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
+	// private cloud with missing resource manager endpoint
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "private",
+		"activeDirectoryEndpoint": testActiveDirectoryEndpoint}, true, testAzMonitorResolvedEnv, map[string]string{}, ""},
+	// private cloud
+	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "private",
+		"resourceManagerEndpoint": testResourceManagerEndpoint}, true, testAzMonitorResolvedEnv, map[string]string{}, ""},
 }
 
 var azMonitorMetricIdentifiers = []azMonitorMetricIdentifier{

--- a/pkg/scalers/azure_monitor_scaler_test.go
+++ b/pkg/scalers/azure_monitor_scaler_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	testResourceManagerEndpoint = "testResourceManagerEndpoint"
-	testActiveDirectoryEndpoint = "testActiveDirectoryEndpoint"
+	testAzureResourceManagerEndpoint = "testAzureResourceManagerEndpoint"
+	testActiveDirectoryEndpoint      = "testActiveDirectoryEndpoint"
 )
 
 type parseAzMonitorMetadataTestData struct {
@@ -88,13 +88,13 @@ var testParseAzMonitorMetadata = []parseAzMonitorMetadataTestData{
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "azureChinaCloud"}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
 	// private cloud
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "private",
-		"resourceManagerEndpoint": testResourceManagerEndpoint, "activeDirectoryEndpoint": testActiveDirectoryEndpoint}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
+		"azureResourceManagerEndpoint": testAzureResourceManagerEndpoint, "activeDirectoryEndpoint": testActiveDirectoryEndpoint}, false, testAzMonitorResolvedEnv, map[string]string{}, ""},
 	// private cloud with missing resource manager endpoint
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "private",
 		"activeDirectoryEndpoint": testActiveDirectoryEndpoint}, true, testAzMonitorResolvedEnv, map[string]string{}, ""},
-	// private cloud
+	// private cloud with missing active directory endpoint
 	{map[string]string{"resourceURI": "test/resource/uri", "tenantId": "123", "subscriptionId": "456", "resourceGroupName": "test", "metricName": "metric", "metricAggregationInterval": "0:15:0", "metricAggregationType": "Average", "activeDirectoryClientId": "CLIENT_ID", "activeDirectoryClientPasswordFromEnv": "CLIENT_PASSWORD", "targetValue": "5", "metricNamespace": "namespace", "cloud": "private",
-		"resourceManagerEndpoint": testResourceManagerEndpoint}, true, testAzMonitorResolvedEnv, map[string]string{}, ""},
+		"azureResourceManagerEndpoint": testAzureResourceManagerEndpoint}, true, testAzMonitorResolvedEnv, map[string]string{}, ""},
 }
 
 var azMonitorMetricIdentifiers = []azMonitorMetricIdentifier{


### PR DESCRIPTION
Signed-off-by: Vighnesh Shenoy <vshenoy@microsoft.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Supporting non-public clouds for the Azure Monitor scaler using the `cloud` parameter.

Sample ScaledObject definition -
```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: monitor-so
spec:
  scaleTargetRef: 
    name: monitor-deployment
  pollingInterval: 10
  cooldownPeriod: 30
  minReplicaCount: 0
  maxReplicaCount: 2
  triggers:
    - type: azure-monitor
      metadata:
        resourceURI: <resource-uri>
        tenantId: <tenant-id>
        subscriptionId: <subscription-id>
        resourceGroupName: <rg-name>
        targetValue: <target>
        metricName: <metric-name>
        metricAggregationType: <metric-agg-type>
        cloud: "private" 
        resourceManagerEndpoint: <resource-manager-endpoint>
        activeDirectoryEndpoint: <active-directory-endpoint>
      authenticationRef:
        name: monitor-ta
```

Documentation PR - https://github.com/kedacore/keda-docs/pull/735

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #1917
