### PR TITLE
Allow for setting Minimum TLS Version for Adapter/Metrics Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 - **General:** Synchronize HPA annotations from ScaledObject ([#2659](https://github.com/kedacore/keda/pull/2659))
 - **General:** Updated HTTPClient to be proxy-aware, if available, from environment variables. ([#2577](https://github.com/kedacore/keda/issues/2577))
+- **General:** Support configuring the Minimum TLS version supported by Keda Adapter Server ([]())
 - **Azure Application Insights Scaler:** Provide support for non-public clouds ([#2735](https://github.com/kedacore/keda/issues/2735))
 - **Azure Event Hub Scaler:** Improve logging when blob container not found ([#2363](https://github.com/kedacore/keda/issues/2363))
 - **Azure Event Hub Scaler:** Provide support for non-public clouds ([#1915](https://github.com/kedacore/keda/issues/1915))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,12 @@
 - **General:** Introduce ARM-based container image for KEDA ([#2263](https://github.com/kedacore/keda/issues/2263)|[#2262](https://github.com/kedacore/keda/issues/2262))
 - **General:** Provide support for authentication via Azure Key Vault ([#900](https://github.com/kedacore/keda/issues/900)|[#2733](https://github.com/kedacore/keda/issues/2733))
 - **General**: Support for `ValueMetricType` in `ScaledObject` for all scalers except CPU/Memory ([#2030](https://github.com/kedacore/keda/issues/2030))
+- **General:** Support configuring the Minimum TLS version supported by Keda Adapter Server ([#2850](https://github.com/kedacore/keda/issues/2850))
 
 ### Improvements
 
 - **General:** Synchronize HPA annotations from ScaledObject ([#2659](https://github.com/kedacore/keda/pull/2659))
 - **General:** Updated HTTPClient to be proxy-aware, if available, from environment variables. ([#2577](https://github.com/kedacore/keda/issues/2577))
-- **General:** Support configuring the Minimum TLS version supported by Keda Adapter Server ([]())
 - **Azure Application Insights Scaler:** Provide support for non-public clouds ([#2735](https://github.com/kedacore/keda/issues/2735))
 - **Azure Event Hub Scaler:** Improve logging when blob container not found ([#2363](https://github.com/kedacore/keda/issues/2363))
 - **Azure Event Hub Scaler:** Provide support for non-public clouds ([#1915](https://github.com/kedacore/keda/issues/1915))

--- a/adapter/main.go
+++ b/adapter/main.go
@@ -207,6 +207,11 @@ func main() {
 		return
 	}
 
+	kedaMinTLSVersion, found := os.LookupEnv("KEDA_MIN_TLS_VERSION")
+	if found {
+		cmd.SecureServing.MinTLSVersion = kedaMinTLSVersion
+	}
+
 	controllerMaxReconciles, err := kedautil.ResolveOsEnvInt("KEDA_METRICS_CTRL_MAX_RECONCILES", 1)
 	if err != nil {
 		logger.Error(err, "Invalid KEDA_METRICS_CTRL_MAX_RECONCILES")

--- a/adapter/main.go
+++ b/adapter/main.go
@@ -209,6 +209,7 @@ func main() {
 
 	kedaMinTLSVersion, found := os.LookupEnv("KEDA_MIN_TLS_VERSION")
 	if found {
+		// Matches to values listed here: https://pkg.go.dev/crypto/tls#pkg-constants as a string
 		cmd.SecureServing.MinTLSVersion = kedaMinTLSVersion
 	}
 


### PR DESCRIPTION
Adds support for environment variable ```KEDA_MIN_TLS_VERSION``` which can be set to a value from https://pkg.go.dev/crypto/tls#pkg-constants to override the default Minimum TLS version from the upstream kubernetes apiserver implementation.

This allows for using TLS1.3 as the minimum version in stricter-security deployments.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #2850 
