### PR TITLE
Refactor active directory endpoint parsing for Azure scalers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - **General:** Improve e2e tests reliability ([#2580](https://github.com/kedacore/keda/issues/2580))
 - **General:** Improve e2e tests to always cleanup resources in cluster ([#2584](https://github.com/kedacore/keda/issues/2584))
 - **General:** Internally represent value and threshold as int64 ([#2790](https://github.com/kedacore/keda/issues/2790))
+- **General:** Refactor active directory endpoint parsing for Azure scalers. ([#2853](https://github.com/kedacore/keda/pull/2853))
 - **AWS CloudWatch:** Adding e2e test ([#1525](https://github.com/kedacore/keda/issues/1525))
 - **AWS DynamoDB:** Setup AWS DynamoDB test account ([#2803](https://github.com/kedacore/keda/issues/2803))
 - **AWS Kinesis Stream:** Adding e2e test ([#1526](https://github.com/kedacore/keda/issues/1526))

--- a/pkg/scalers/azure/azure_cloud_environment.go
+++ b/pkg/scalers/azure/azure_cloud_environment.go
@@ -20,6 +20,10 @@ const (
 // EnvironmentPropertyProvider for different types of Azure scalers
 type EnvironmentPropertyProvider func(env az.Environment) (string, error)
 
+var activeDirectoryEndpointProvider = func(env az.Environment) (string, error) {
+	return env.ActiveDirectoryEndpoint, nil
+}
+
 // ParseEnvironmentProperty parses cloud metadata and returns the resolved property
 func ParseEnvironmentProperty(metadata map[string]string, propertyKey string, envPropertyProvider EnvironmentPropertyProvider) (string, error) {
 	if val, ok := metadata["cloud"]; ok && val != "" {
@@ -40,4 +44,8 @@ func ParseEnvironmentProperty(metadata map[string]string, propertyKey string, en
 
 	// Use public cloud suffix if `cloud` isn't specified
 	return envPropertyProvider(az.PublicCloud)
+}
+
+func ParseActiveDirectoryEndpoint(metadata map[string]string) (string, error) {
+	return ParseEnvironmentProperty(metadata, "activeDirectoryEndpoint", activeDirectoryEndpointProvider)
 }

--- a/pkg/scalers/azure/azure_cloud_environment_test.go
+++ b/pkg/scalers/azure/azure_cloud_environment_test.go
@@ -52,3 +52,40 @@ func TestParseEnvironmentProperty(t *testing.T) {
 		}
 	}
 }
+
+const testADEndpoint = "testADEndpoint"
+
+type parseActiveDirectoryEndpointTestData struct {
+	metadata           map[string]string
+	expectedADEndpoint string
+	isError            bool
+}
+
+var parseActiveDirectoryEndpointTestDataset = []parseActiveDirectoryEndpointTestData{
+	{metadata: map[string]string{}, isError: false, expectedADEndpoint: az.PublicCloud.ActiveDirectoryEndpoint},
+	{metadata: map[string]string{"cloud": "AzureChinaCloud"}, isError: false, expectedADEndpoint: az.ChinaCloud.ActiveDirectoryEndpoint},
+	{metadata: map[string]string{"cloud": "private", "activeDirectoryEndpoint": testADEndpoint}, isError: false,
+		expectedADEndpoint: testADEndpoint},
+	{metadata: map[string]string{"cloud": "private"}, isError: true},
+	{metadata: map[string]string{"cloud": "invalid"}, isError: true},
+}
+
+func TestParseActiveDirectoryEndpoint(t *testing.T) {
+	for _, testData := range parseActiveDirectoryEndpointTestDataset {
+		activeDirectoryEndpoint, err := ParseActiveDirectoryEndpoint(testData.metadata)
+		if !testData.isError && err != nil {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+		if err == nil {
+			if activeDirectoryEndpoint != testData.expectedADEndpoint {
+				t.Error(
+					"For", testData.metadata,
+					"expected activeDirectoryEndpoint=", testData.expectedADEndpoint,
+					"but got", activeDirectoryEndpoint)
+			}
+		}
+	}
+}

--- a/pkg/scalers/azure_app_insights_scaler.go
+++ b/pkg/scalers/azure_app_insights_scaler.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	az "github.com/Azure/go-autorest/autorest/azure"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,10 +120,7 @@ func parseAzureAppInsightsMetadata(config *ScalerConfig) (*azureAppInsightsMetad
 		}
 	}
 
-	activeDirectoryEndpointProvider := func(env az.Environment) (string, error) {
-		return env.ActiveDirectoryEndpoint, nil
-	}
-	activeDirectoryEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "activeDirectoryEndpoint", activeDirectoryEndpointProvider)
+	activeDirectoryEndpoint, err := azure.ParseActiveDirectoryEndpoint(config.TriggerMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/azure_data_explorer_scaler.go
+++ b/pkg/scalers/azure_data_explorer_scaler.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 
 	"github.com/Azure/azure-kusto-go/kusto"
-	az "github.com/Azure/go-autorest/autorest/azure"
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,10 +110,7 @@ func parseAzureDataExplorerMetadata(config *ScalerConfig) (*azure.DataExplorerMe
 	// Generate metricName.
 	metadata.MetricName = GenerateMetricNameWithIndex(config.ScalerIndex, kedautil.NormalizeString(fmt.Sprintf("%s-%s", adxName, metadata.DatabaseName)))
 
-	activeDirectoryEndpointProvider := func(env az.Environment) (string, error) {
-		return env.ActiveDirectoryEndpoint, nil
-	}
-	activeDirectoryEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "activeDirectoryEndpoint", activeDirectoryEndpointProvider)
+	activeDirectoryEndpoint, err := azure.ParseActiveDirectoryEndpoint(config.TriggerMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -143,10 +143,7 @@ func parseAzureEventHubMetadata(config *ScalerConfig) (*eventHubMetadata, error)
 	}
 	meta.eventHubInfo.ServiceBusEndpointSuffix = serviceBusEndpointSuffix
 
-	activeDirectoryEndpointProvider := func(env az.Environment) (string, error) {
-		return env.ActiveDirectoryEndpoint, nil
-	}
-	activeDirectoryEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "activeDirectoryEndpoint", activeDirectoryEndpointProvider)
+	activeDirectoryEndpoint, err := azure.ParseActiveDirectoryEndpoint(config.TriggerMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -31,7 +31,6 @@ import (
 	"sync"
 	"time"
 
-	az "github.com/Azure/go-autorest/autorest/azure"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -221,10 +220,7 @@ func parseAzureLogAnalyticsMetadata(config *ScalerConfig) (*azureLogAnalyticsMet
 		}
 	}
 
-	activeDirectoryEndpointProvider := func(env az.Environment) (string, error) {
-		return env.ActiveDirectoryEndpoint, nil
-	}
-	activeDirectoryEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "activeDirectoryEndpoint", activeDirectoryEndpointProvider)
+	activeDirectoryEndpoint, err := azure.ParseActiveDirectoryEndpoint(config.TriggerMetadata)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -165,10 +165,7 @@ func parseAzureMonitorMetadata(config *ScalerConfig) (*azureMonitorMetadata, err
 	}
 	meta.azureMonitorInfo.AzureResourceManagerEndpoint = azureResourceManagerEndpoint
 
-	activeDirectoryEndpointProvider := func(env az.Environment) (string, error) {
-		return env.ActiveDirectoryEndpoint, nil
-	}
-	activeDirectoryEndpoint, err := azure.ParseEnvironmentProperty(config.TriggerMetadata, "activeDirectoryEndpoint", activeDirectoryEndpointProvider)
+	activeDirectoryEndpoint, err := azure.ParseActiveDirectoryEndpoint(config.TriggerMetadata)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Vighnesh Shenoy <vshenoy@microsoft.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Refactor active directory endpoint parsing for Azure scalers.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Relates to #1285 
