### PR TITLE
chore: Update `kind-action` task to use the upstream

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 1
 
       - name: Create k8s v1.23 Kind Cluster
-        uses: JorTurFer/kind-action@main
+        uses: helm/kind-action@main
         with:
           node_image: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
           cluster_name: smoke-tests-cluster

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 1
 
       - name: Create k8s v1.23 Kind Cluster
-        uses: JorTurFer/kind-action@main
+        uses: helm/kind-action@main
         with:
           node_image: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
           cluster_name: smoke-tests-cluster


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

Helm team has merged the PR adding support to ARM to their action, this PR switches from mine action to the upstream action

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

