### PR TITLE
chore: Provide self-help in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -2,6 +2,17 @@ name: Report a bug 🐛
 description: Create a report to help us improve
 labels: "bug"
 body:
+- type: markdown
+  attributes:
+    value: |
+      ## Self-help
+      Thank you for considering to open a bug report!
+      
+      Before you do, however, make sure to check our existing resources to see if it has already been discussed/reported:
+      - [Reported bugs](https://github.com/kedacore/keda/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Abug)
+      - [Troubleshooting guide](https://keda.sh/docs/latest/troubleshooting/)
+      - [GitHub Discussions](https://github.com/kedacore/keda/discussions)
+      - [FAQ](https://keda.sh/docs/latest/faq/)
 - type: textarea
   attributes:
     label: Report

--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -7,7 +7,7 @@ body:
     value: |
       ## Self-help
       Thank you for considering to open a bug report!
-      
+
       Before you do, however, make sure to check our existing resources to see if it has already been discussed/reported:
       - [Reported bugs](https://github.com/kedacore/keda/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Abug)
       - [Troubleshooting guide](https://keda.sh/docs/latest/troubleshooting/)


### PR DESCRIPTION
Provide self-help in bug report template to reduce amount of bug reports that are documented in FAQ, troubleshooting guide or already reported in open bug or discussion.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

### Example
![image](https://user-images.githubusercontent.com/4345663/164173859-40859c7f-cd56-4236-8aa5-73ccb5c36397.png)
