### PR TITLE
adding CORS header to activemq scaler for issue #2884

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ## Unreleased
 
+- **ActiveMQ Scaler:** Add CorsHeader information to ActiveMQ Scaler ([#2884](https://github.com/kedacore/keda/issues/2884))
+
 ### New
 
 - **General:** Introduce new AWS DynamoDB Scaler ([#2486](https://github.com/kedacore/keda/issues/2482))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - **General:** Properly handle `restoreToOriginalReplicaCount` if `ScaleTarget` is missing ([#2872](https://github.com/kedacore/keda/issues/2872))
 - **General:** Synchronize HPA annotations from ScaledObject ([#2659](https://github.com/kedacore/keda/pull/2659))
 - **General:** Updated HTTPClient to be proxy-aware, if available, from environment variables. ([#2577](https://github.com/kedacore/keda/issues/2577))
+- **ActiveMQ Scaler:** Add CorsHeader information to ActiveMQ Scaler ([#2884](https://github.com/kedacore/keda/issues/2884))
 - **Azure Application Insights Scaler:** Provide support for non-public clouds ([#2735](https://github.com/kedacore/keda/issues/2735))
 - **Azure Blob Storage Scaler:** Add optional parameters for counting blobs recursively ([#1789](https://github.com/kedacore/keda/issues/1789))
 - **Azure Event Hub Scaler:** Improve logging when blob container not found ([#2363](https://github.com/kedacore/keda/issues/2363))
@@ -59,7 +60,6 @@
 - **Prometheus Scaler:** Support for `X-Scope-OrgID` header ([#2667](https://github.com/kedacore/keda/issues/2667))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
 - **Selenium Grid Scaler:** Consider `maxSession` grid info when scaling. ([#2618](https://github.com/kedacore/keda/issues/2618))
-- **ActiveMQ Scaler:** Add CorsHeader information to ActiveMQ Scaler ([#2884](https://github.com/kedacore/keda/issues/2884))
 
 ## Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@
 
 ## Unreleased
 
-- **ActiveMQ Scaler:** Add CorsHeader information to ActiveMQ Scaler ([#2884](https://github.com/kedacore/keda/issues/2884))
-
 ### New
 
 - **General:** Introduce new AWS DynamoDB Scaler ([#2486](https://github.com/kedacore/keda/issues/2482))
@@ -61,6 +59,7 @@
 - **Prometheus Scaler:** Support for `X-Scope-OrgID` header ([#2667](https://github.com/kedacore/keda/issues/2667))
 - **RabbitMQ Scaler:** Include `vhost` for RabbitMQ when retrieving queue info with `useRegex` ([#2498](https://github.com/kedacore/keda/issues/2498))
 - **Selenium Grid Scaler:** Consider `maxSession` grid info when scaling. ([#2618](https://github.com/kedacore/keda/issues/2618))
+- **ActiveMQ Scaler:** Add CorsHeader information to ActiveMQ Scaler ([#2884](https://github.com/kedacore/keda/issues/2884))
 
 ## Deprecations
 

--- a/pkg/scalers/activemq_scaler.go
+++ b/pkg/scalers/activemq_scaler.go
@@ -36,6 +36,7 @@ type activeMQMetadata struct {
 	password           string
 	restAPITemplate    string
 	targetQueueSize    int64
+	corsHeader         string
 	metricName         string
 	scalerIndex        int
 }
@@ -121,6 +122,12 @@ func parseActiveMQMetadata(config *ScalerConfig) (*activeMQMetadata, error) {
 		} else {
 			meta.username = username
 		}
+	}
+
+	if val, ok := config.TriggerMetadata["corsHeader"]; ok && val != "" {
+		meta.corsHeader = config.TriggerMetadata["corsHeader"]
+	} else {
+		meta.corsHeader = fmt.Sprintf(defaultCorsHeader, meta.managementEndpoint)
 	}
 
 	if meta.username == "" {
@@ -225,6 +232,7 @@ func (s *activeMQScaler) getQueueMessageCount(ctx context.Context) (int64, error
 	// Add HTTP Auth and Headers
 	req.SetBasicAuth(s.metadata.username, s.metadata.password)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", s.metadata.corsHeader)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/scalers/activemq_scaler_test.go
+++ b/pkg/scalers/activemq_scaler_test.go
@@ -202,6 +202,30 @@ var testActiveMQMetadata = []parseActiveMQMetadataTestData{
 	},
 }
 
+func TestActiveMQDefaultCorsHeader(t *testing.T) {
+	metadata := map[string]string{"managementEndpoint": "localhost:8161", "destinationName": "queue1", "brokerName": "broker-activemq", "username": "myUserName", "password": "myPassword"}
+	meta, err := parseActiveMQMetadata(&ScalerConfig{TriggerMetadata: metadata, AuthParams: nil})
+
+	if err != nil {
+		t.Error("Expected success but got error", err)
+	}
+	if !(meta.corsHeader == "http://localhost:8161") {
+		t.Errorf("Expected http://localhost:8161 but got %s", meta.corsHeader)
+	}
+}
+
+func TestActiveMQCorsHeader(t *testing.T) {
+	metadata := map[string]string{"managementEndpoint": "localhost:8161", "destinationName": "queue1", "brokerName": "broker-activemq", "username": "myUserName", "password": "myPassword", "corsHeader": "test"}
+	meta, err := parseActiveMQMetadata(&ScalerConfig{TriggerMetadata: metadata, AuthParams: nil})
+
+	if err != nil {
+		t.Error("Expected success but got error", err)
+	}
+	if !(meta.corsHeader == "test") {
+		t.Errorf("Expected test but got %s", meta.corsHeader)
+	}
+}
+
 func TestParseActiveMQMetadata(t *testing.T) {
 	for _, testData := range testActiveMQMetadata {
 		t.Run(testData.name, func(t *testing.T) {


### PR DESCRIPTION
This PR addresses issue #2884 and adds CoreHeaders to ActiveMQ scaler queries using the same logic used by the the Artemis scaler in the activemq scaler.

Signed-off-by: Mark DeNeve <xphyr@users.noreply.github.com>

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [NA] Tests have been added
- [NA] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [X] A PR is opened to update the documentation on ([Keda Docs PR #749](https://github.com/kedacore/keda-docs/pull/749))
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #2884 
