### PR TITLE
Fail e2e tests if no test matches regex

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -12,6 +12,7 @@ lookup=()
 failed_count=0
 failed_lookup=()
 counter=0
+executed_count=0
 
 function run_setup {
     ./node_modules/.bin/ava setup.test.ts
@@ -85,6 +86,7 @@ function wait_for_jobs {
     for job in "${pids[@]}"; do
         wait $job || mark_failed $job
         echo "Job $job finished"
+        executed_count=$((executed_count+1))
     done
 
     printf "\n$failed_count jobs failed\n"
@@ -128,10 +130,14 @@ wait_for_jobs
 print_logs
 run_cleanup
 
-if [ "$failed_count" == "0" ];
+if [ "$executed_count" == "0" ];
 then
-    exit 0
-else
+    echo "No test has been executed, please review your regex: '$E2E_TEST_REGEX'"
+    exit 1
+elif [ "$failed_count" != "0" ];
+then
     print_failed
     exit 1
+else
+    exit 0
 fi


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

By error, we could add extra spaces or new lines to the e2e command. It seems correct from GH UI but the workflow doesn't execute any test. This PR adds a check to return a failure from run-all.sh if there isn't any e2e test matching the regex.
![image](https://user-images.githubusercontent.com/36899226/165101534-7d66b1c3-7dc6-49e5-a3f1-159272334589.png)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

