### PR TITLE
feat: use safe `securityContext` as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 ### Improvements
 
 - **General:** Properly handle `restoreToOriginalReplicaCount` if `ScaleTarget` is missing ([#2872](https://github.com/kedacore/keda/issues/2872))
+- **General:** Support for running in non-root ([#2933](https://github.com/kedacore/keda/issues/2933))
 - **General:** Synchronize HPA annotations from ScaledObject ([#2659](https://github.com/kedacore/keda/pull/2659))
 - **General:** Updated HTTPClient to be proxy-aware, if available, from environment variables. ([#2577](https://github.com/kedacore/keda/issues/2577))
 - **ActiveMQ Scaler:** Add CorsHeader information to ActiveMQ Scaler ([#2884](https://github.com/kedacore/keda/issues/2884))

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,6 +22,11 @@ spec:
         name: keda-operator
       name: keda-operator
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
       serviceAccountName: keda-operator
       containers:
         - name: keda-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,12 @@ spec:
               value: ""
             - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: ""
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       terminationGracePeriodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -71,6 +71,8 @@ spec:
               drop:
               - ALL
             allowPrivilegeEscalation: false
+            ## Metrics server needs to write the self-signed cert so it's not possible set this
+            # readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
       volumes:

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -66,6 +66,11 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: temp-vol
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
       nodeSelector:
         kubernetes.io/os: linux
       volumes:

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -19,6 +19,11 @@ spec:
         app: keda-metrics-apiserver
       name: keda-metrics-apiserver
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
       serviceAccountName: keda-operator
       containers:
         - name: keda-metrics-apiserver


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>


_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Related #2933
