### PR TITLE
feat: improve e2e tests reliability

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -12,6 +12,7 @@ lookup=()
 failed_count=0
 failed_lookup=()
 counter=0
+executed_count=0
 
 function run_setup {
     ./node_modules/.bin/ava setup.test.ts
@@ -85,6 +86,7 @@ function wait_for_jobs {
     for job in "${pids[@]}"; do
         wait $job || mark_failed $job
         echo "Job $job finished"
+        executed_count=$((executed_count+1))
     done
 
     printf "\n$failed_count jobs failed\n"
@@ -128,10 +130,14 @@ wait_for_jobs
 print_logs
 run_cleanup
 
-if [ "$failed_count" == "0" ];
+if [ "$executed_count" == "0" ];
 then
-    exit 0
-else
+    echo "No test has been executed, please review your regex: '$E2E_TEST_REGEX'"
+    exit 1
+elif [ "$failed_count" != "0" ];
+then
     print_failed
     exit 1
+else
+    exit 0
 fi

--- a/tests/scalers/argo-rollouts.test.ts
+++ b/tests/scalers/argo-rollouts.test.ts
@@ -16,7 +16,7 @@ test.before(async t => {
 
   // install argo-rollouts
   createNamespace(argoRolloutsNamespace)
-  sh.exec(`curl -L https://raw.githubusercontent.com/argoproj/argo-rollouts/stable/manifests/install.yaml > ${argoRolloutsYamlFile.name}`)
+  sh.exec(`curl -L https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.2.0/manifests/install.yaml > ${argoRolloutsYamlFile.name}`)
 	t.is(
 		0,
 		sh.exec(`kubectl apply -f ${argoRolloutsYamlFile.name} --namespace ${argoRolloutsNamespace}`).code,

--- a/tests/scalers/influxdb.test.ts
+++ b/tests/scalers/influxdb.test.ts
@@ -150,24 +150,11 @@ spec:
                 ports:
                   - containerPort: 8086
                     name: influxdb
-                volumeMounts:
-                  - mountPath: /root/.influxdbv2
-                    name: data
                 readinessProbe:
                   tcpSocket:
                     port: 8086
                   initialDelaySeconds: 5
                   periodSeconds: 10
-    volumeClaimTemplates:
-      - metadata:
-            name: data
-            namespace: influxdb
-        spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-                requests:
-                    storage: 10G
 ---
 apiVersion: v1
 kind: Service

--- a/tests/scalers/mysql.test.ts
+++ b/tests/scalers/mysql.test.ts
@@ -56,11 +56,8 @@ test.before(t => {
 
 })
 
-test.serial('Deployment should have 0 replicas on start', t => {
-    const replicaCount = sh.exec(
-        `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-    ).stdout
-    t.is(replicaCount, '0', 'replica count should start out as 0')
+test.serial('Deployment should have 0 replicas on start', async t => {
+  t.true(await waitForDeploymentReplicaCount(0, deploymentName, testNamespace, 60, 1000), 'replica count should start out as 0')
 })
 
 test.serial(`Deployment should scale to 2 (the max) then back to 0`, async t => {
@@ -75,7 +72,7 @@ test.serial(`Deployment should scale to 2 (the max) then back to 0`, async t => 
     const maxReplicaCount = 2
     t.true(await waitForDeploymentReplicaCount(maxReplicaCount, deploymentName, testNamespace, 120, 1000), 'Replica count should be 0 after 2 minutes')
 
-    t.true(await waitForDeploymentReplicaCount(0, deploymentName, testNamespace, 300, 1000), 'Replica count should be 0 after 5 minutes')
+    t.true(await waitForDeploymentReplicaCount(0, deploymentName, testNamespace, 360, 1000), 'Replica count should be 0 after 5 minutes')
 })
 
 test.after.always.cb('clean up mysql deployment', t => {
@@ -124,7 +121,7 @@ spec:
           - update
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "10000"
+            value: "4000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:
@@ -189,7 +186,7 @@ spec:
           - insert
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "1000"
+            value: "4000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/tests/scalers/mysql.test.ts
+++ b/tests/scalers/mysql.test.ts
@@ -63,7 +63,7 @@ test.serial('Deployment should have 0 replicas on start', t => {
     t.is(replicaCount, '0', 'replica count should start out as 0')
 })
 
-test.serial(`Deployment should scale to 5 (the max) then back to 0`, t => {
+test.serial(`Deployment should scale to 2 (the max) then back to 0`, t => {
     const tmpFile = tmp.fileSync()
     fs.writeFileSync(tmpFile.name, insertRecordsJobYaml)
     t.is(
@@ -74,7 +74,7 @@ test.serial(`Deployment should scale to 5 (the max) then back to 0`, t => {
 
     let replicaCount = '0'
 
-    const maxReplicaCount = '5'
+    const maxReplicaCount = '2'
 
     for (let i = 0; i < 60 && replicaCount !== maxReplicaCount; i++) {
         replicaCount = sh.exec(
@@ -180,7 +180,7 @@ spec:
   pollingInterval: 5
   cooldownPeriod:  10
   minReplicaCount: 0
-  maxReplicaCount: 5
+  maxReplicaCount: 2
   triggers:
   - type: mysql
     metadata:

--- a/tests/scalers/postgresql-hashicorp-vault.test.ts
+++ b/tests/scalers/postgresql-hashicorp-vault.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import test from 'ava'
-import { createNamespace } from './helpers'
+import { createNamespace, waitForDeploymentReplicaCount } from './helpers'
 
 const testNamespace = 'postgresql-hashicorp-vault'
 const postgreSQLUsername = 'test-user'
@@ -72,47 +72,24 @@ test.before(t => {
   )
 })
 
-test.serial('Deployment should have 0 replicas on start', t => {
-  const replicaCount = sh.exec(
-      `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-  ).stdout
-  t.is(replicaCount, '0', 'replica count should start out as 0')
+test.serial('Deployment should have 0 replicas on start', async t => {
+  t.true(await waitForDeploymentReplicaCount(0, deploymentName, testNamespace, 60, 1000), 'replica count should start out as 0')
+
 })
 
-test.serial(`Deployment should scale to 5 (the max) then back to 0`, t => {
-  const tmpFile = tmp.fileSync()
-  fs.writeFileSync(tmpFile.name, insertRecordsJobYaml)
-  t.is(
-      0,
-      sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
-      'creating job should work.'
-  )
+test.serial(`Deployment should scale to 2 (the max) then back to 0`, async t => {
+    const tmpFile = tmp.fileSync()
+    fs.writeFileSync(tmpFile.name, insertRecordsJobYaml)
+    t.is(
+        0,
+        sh.exec(`kubectl apply -f ${tmpFile.name} --namespace ${testNamespace}`).code,
+        'creating job should work.'
+    )
 
-  let replicaCount = '0'
+    const maxReplicaCount = 2
+    t.true(await waitForDeploymentReplicaCount(maxReplicaCount, deploymentName, testNamespace, 120, 1000), 'Replica count should be 0 after 2 minutes')
 
-  const maxReplicaCount = '5'
-
-  for (let i = 0; i < 30 && replicaCount !== maxReplicaCount; i++) {
-      replicaCount = sh.exec(
-          `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-      ).stdout
-      if (replicaCount !== maxReplicaCount) {
-          sh.exec('sleep 2s')
-      }
-  }
-
-  t.is(maxReplicaCount, replicaCount, `Replica count should be ${maxReplicaCount} after 60 seconds`)
-
-  for (let i = 0; i < 36 && replicaCount !== '0'; i++) {
-    replicaCount = sh.exec(
-      `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-    ).stdout
-    if (replicaCount !== '0') {
-      sh.exec('sleep 5s')
-    }
-  }
-
-  t.is('0', replicaCount, 'Replica count should be 0 after 3 minutes')
+    t.true(await waitForDeploymentReplicaCount(0, deploymentName, testNamespace, 360, 1000), 'Replica count should be 0 after 5 minutes')
 })
 
 test.after.always.cb('clean up postgresql deployment', t => {
@@ -163,7 +140,7 @@ spec:
           - update
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "10000"
+            value: "4000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:
@@ -203,7 +180,7 @@ spec:
   pollingInterval: 5
   cooldownPeriod:  10
   minReplicaCount: 0
-  maxReplicaCount: 5
+  maxReplicaCount: 2
   triggers:
   - type: postgresql
     metadata:
@@ -233,7 +210,7 @@ spec:
           - insert
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "10000"
+            value: "4000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/tests/scalers/postgresql-hashicorp-vault.test.ts
+++ b/tests/scalers/postgresql-hashicorp-vault.test.ts
@@ -140,7 +140,7 @@ spec:
           - update
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "4000"
+            value: "6000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:
@@ -210,7 +210,7 @@ spec:
           - insert
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "4000"
+            value: "6000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/tests/scalers/postgresql.test.ts
+++ b/tests/scalers/postgresql.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import test from 'ava'
-import { createNamespace } from './helpers'
+import { createNamespace, waitForDeploymentReplicaCount } from './helpers'
 
 const testNamespace = 'postgresql-test'
 const postgreSQLNamespace = 'postgresql'
@@ -50,14 +50,12 @@ test.before(t => {
     )
 })
 
-test.serial('Deployment should have 0 replicas on start', t => {
-    const replicaCount = sh.exec(
-        `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-    ).stdout
-    t.is(replicaCount, '0', 'replica count should start out as 0')
+test.serial('Deployment should have 0 replicas on start', async t => {
+  t.true(await waitForDeploymentReplicaCount(0, deploymentName, testNamespace, 60, 1000), 'replica count should start out as 0')
+
 })
 
-test.serial(`Deployment should scale to 5 (the max) then back to 0`, t => {
+test.serial(`Deployment should scale to 2 (the max) then back to 0`, async t => {
     const tmpFile = tmp.fileSync()
     fs.writeFileSync(tmpFile.name, insertRecordsJobYaml)
     t.is(
@@ -66,31 +64,10 @@ test.serial(`Deployment should scale to 5 (the max) then back to 0`, t => {
         'creating job should work.'
     )
 
-    let replicaCount = '0'
+    const maxReplicaCount = 2
+    t.true(await waitForDeploymentReplicaCount(maxReplicaCount, deploymentName, testNamespace, 120, 1000), 'Replica count should be 0 after 2 minutes')
 
-    const maxReplicaCount = '5'
-
-    for (let i = 0; i < 30 && replicaCount !== maxReplicaCount; i++) {
-        replicaCount = sh.exec(
-            `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-        ).stdout
-        if (replicaCount !== maxReplicaCount) {
-            sh.exec('sleep 2s')
-        }
-    }
-
-    t.is(maxReplicaCount, replicaCount, `Replica count should be ${maxReplicaCount} after 60 seconds`)
-
-    for (let i = 0; i < 36 && replicaCount !== '0'; i++) {
-      replicaCount = sh.exec(
-        `kubectl get deployment.apps/${deploymentName} --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
-      ).stdout
-      if (replicaCount !== '0') {
-        sh.exec('sleep 5s')
-      }
-    }
-
-    t.is('0', replicaCount, 'Replica count should be 0 after 3 minutes')
+    t.true(await waitForDeploymentReplicaCount(0, deploymentName, testNamespace, 360, 1000), 'Replica count should be 0 after 5 minutes')
 })
 
 test.after.always.cb('clean up postgresql deployment', t => {
@@ -139,7 +116,7 @@ spec:
           - update
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "10000"
+            value: "4000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:
@@ -174,7 +151,7 @@ spec:
   pollingInterval: 5
   cooldownPeriod:  10
   minReplicaCount: 0
-  maxReplicaCount: 5
+  maxReplicaCount: 2
   triggers:
   - type: postgresql
     metadata:
@@ -204,7 +181,7 @@ spec:
           - insert
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "10000"
+            value: "4000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/tests/scalers/postgresql.test.ts
+++ b/tests/scalers/postgresql.test.ts
@@ -116,7 +116,7 @@ spec:
           - update
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "4000"
+            value: "6000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:
@@ -181,7 +181,7 @@ spec:
           - insert
         env:
           - name: TASK_INSTANCES_COUNT
-            value: "4000"
+            value: "6000"
           - name: CONNECTION_STRING
             valueFrom:
               secretKeyRef:

--- a/tests/scalers/redis-cluster-helper.ts
+++ b/tests/scalers/redis-cluster-helper.ts
@@ -1,0 +1,379 @@
+import * as sh from 'shelljs'
+import * as tmp from 'tmp'
+import * as fs from 'fs'
+import {createNamespace, waitForRollout} from "./helpers";
+
+export class RedisClusterHelper {
+
+    static install(t, password: string, namespace: string) {
+        const clusterTmpFile = tmp.fileSync()
+        fs.writeFileSync(clusterTmpFile.name, redisClusterYaml
+                                              .replace('{{PASSWORD}}', password)
+                                              .replace('{{NAMESPACE}}', namespace))
+        createNamespace(namespace)
+        t.is(0, sh.exec(`kubectl apply -f ${clusterTmpFile.name} --namespace ${namespace}`).code, 'creating a redis cluster should work.')
+        // wait for rabbitmq to load
+        t.is(0, waitForRollout('statefulset', 'redis-cluster', namespace))
+    }
+
+    static uninstall(namespace: string) {
+        sh.exec(`kubectl delete namespace ${namespace}`)
+    }
+}
+
+const redisClusterYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-cluster
+  labels:
+    app.kubernetes.io/name: redis-cluster
+    helm.sh/chart: redis-cluster-7.5.1
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  redis-password: "{{PASSWORD}}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-cluster-default
+  labels:
+    app.kubernetes.io/name: redis-cluster
+    helm.sh/chart: redis-cluster-7.5.1
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: Helm
+data:
+  redis-default.conf: |-
+    bind 127.0.0.1
+    protected-mode yes
+    port 6379
+    tcp-backlog 511
+    timeout 0
+    tcp-keepalive 300
+    daemonize no
+    supervised no
+    pidfile /opt/bitnami/redis/tmp/redis_6379.pid
+    loglevel notice
+    logfile ""
+    databases 16
+    always-show-logo yes
+    save 900 1
+    save 300 10
+    save 60 10000
+    stop-writes-on-bgsave-error yes
+    rdbcompression yes
+    rdbchecksum yes
+    dbfilename dump.rdb
+    rdb-del-sync-files no
+    dir /bitnami/redis/data
+    replica-serve-stale-data yes
+    replica-read-only yes
+    repl-diskless-sync no
+    repl-diskless-sync-delay 5
+    repl-diskless-load disabled
+    repl-disable-tcp-nodelay no
+    replica-priority 100
+    acllog-max-len 128
+    lazyfree-lazy-eviction no
+    lazyfree-lazy-expire no
+    lazyfree-lazy-server-del no
+    replica-lazy-flush no
+    lazyfree-lazy-user-del no
+    appendonly no
+    appendfilename "appendonly.aof"
+    appendfsync everysec
+    no-appendfsync-on-rewrite no
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+    aof-load-truncated yes
+    aof-use-rdb-preamble yes
+    lua-time-limit 5000
+    cluster-enabled yes
+    cluster-config-file /bitnami/redis/data/nodes.conf
+    slowlog-log-slower-than 10000
+    slowlog-max-len 128
+    latency-monitor-threshold 0
+    notify-keyspace-events ""
+    hash-max-ziplist-entries 512
+    hash-max-ziplist-value 64
+    list-max-ziplist-size -2
+    list-compress-depth 0
+    set-max-intset-entries 512
+    zset-max-ziplist-entries 128
+    zset-max-ziplist-value 64
+    hll-sparse-max-bytes 3000
+    stream-node-max-bytes 4096
+    stream-node-max-entries 100
+    activerehashing yes
+    client-output-buffer-limit normal 0 0 0
+    client-output-buffer-limit replica 256mb 64mb 60
+    client-output-buffer-limit pubsub 32mb 8mb 60
+    hz 10
+    dynamic-hz yes
+    aof-rewrite-incremental-fsync yes
+    rdb-save-incremental-fsync yes
+    jemalloc-bg-thread yes
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-cluster-scripts
+  labels:
+    app.kubernetes.io/name: redis-cluster
+    helm.sh/chart: redis-cluster-7.5.1
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: Helm
+data:
+  ping_readiness_local.sh: |-
+    #!/bin/sh
+    set -e
+    REDIS_STATUS_FILE=/tmp/.redis_cluster_check
+    if [ ! -z "$REDIS_PASSWORD" ]; then export REDISCLI_AUTH=$REDIS_PASSWORD; fi;
+    response=$(
+      timeout -s 3 $1 \\
+      redis-cli \\
+        -h localhost \\
+        -p $REDIS_PORT \\
+        ping
+    )
+    if [ "$?" -eq "124" ]; then
+      echo "Timed out"
+      exit 1
+    fi
+    if [ "$response" != "PONG" ]; then
+      echo "$response"
+      exit 1
+    fi
+    if [ ! -f "$REDIS_STATUS_FILE" ]; then
+      response=$(
+        timeout -s 3 $1 \\
+        redis-cli \\
+          -h localhost \\
+          -p $REDIS_PORT \\
+          CLUSTER INFO | grep cluster_state | tr -d '[:space:]'
+      )
+      if [ "$?" -eq "124" ]; then
+        echo "Timed out"
+        exit 1
+      fi
+      if [ "$response" != "cluster_state:ok" ]; then
+        echo "$response"
+        exit 1
+      else
+        touch "$REDIS_STATUS_FILE"
+      fi
+    fi
+  ping_liveness_local.sh: |-
+    #!/bin/sh
+    set -e
+    if [ ! -z "$REDIS_PASSWORD" ]; then export REDISCLI_AUTH=$REDIS_PASSWORD; fi;
+    response=$(
+      timeout -s 3 $1 \\
+      redis-cli \\
+        -h localhost \\
+        -p $REDIS_PORT \\
+        ping
+    )
+    if [ "$?" -eq "124" ]; then
+      echo "Timed out"
+      exit 1
+    fi
+    responseFirstWord=$(echo $response | head -n1 | awk '{print $1;}')
+    if [ "$response" != "PONG" ] && [ "$responseFirstWord" != "LOADING" ] && [ "$responseFirstWord" != "MASTERDOWN" ]; then
+      echo "$response"
+      exit 1
+    fi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-cluster-headless
+  labels:
+    app.kubernetes.io/name: redis-cluster
+    helm.sh/chart: redis-cluster-7.5.1
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-redis
+      port: 6379
+      targetPort: tcp-redis
+    - name: tcp-redis-bus
+      port: 16379
+      targetPort: tcp-redis-bus
+  selector:
+    app.kubernetes.io/name: redis-cluster
+    app.kubernetes.io/instance: redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-cluster
+  labels:
+    app.kubernetes.io/name: redis-cluster
+    helm.sh/chart: redis-cluster-7.5.1
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      targetPort: tcp-redis
+      protocol: TCP
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: redis-cluster
+    app.kubernetes.io/instance: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis-cluster
+  labels:
+    app.kubernetes.io/name: redis-cluster
+    helm.sh/chart: redis-cluster-7.5.1
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: Helm
+spec:
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis-cluster
+      app.kubernetes.io/instance: redis
+  replicas: 6
+  serviceName: redis-cluster-headless
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis-cluster
+        helm.sh/chart: redis-cluster-7.5.1
+        app.kubernetes.io/instance: redis
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        checksum/scripts: ce1a29fc397d40685cec7ddd4275fe0bda4455d37d622ca301781996a1dc0fa1
+        checksum/secret: 289df422d0e95311f552b860b794245d1372a2bd362835f6431f1ba128a90843
+        checksum/config: 5c811a8da6bdb4552e50761422ae69932819fffd90a8c705455296107accc667
+    spec:
+      hostNetwork: false
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        sysctls: []
+      serviceAccountName: default
+      affinity:
+        podAffinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: redis-cluster
+                    app.kubernetes.io/instance: redis
+                namespaces:
+                  - {{NAMESPACE}}
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+      containers:
+        - name: redis-cluster
+          image: docker.io/bitnami/redis-cluster:6.2.7-debian-10-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          command: ['/bin/bash', '-c']
+          args:
+            - |
+              if ! [[ -f /opt/bitnami/redis/etc/redis.conf ]]; then
+                  echo COPYING FILE
+                  cp  /opt/bitnami/redis/etc/redis-default.conf /opt/bitnami/redis/etc/redis.conf
+              fi
+              pod_index=($(echo "$POD_NAME" | tr "-" "\\n"))
+              pod_index="\${pod_index[-1]}"
+              if [[ "$pod_index" == "0" ]]; then
+                export REDIS_CLUSTER_CREATOR="yes"
+                export REDIS_CLUSTER_REPLICAS="1"
+              fi
+              /opt/bitnami/scripts/redis-cluster/entrypoint.sh /opt/bitnami/scripts/redis-cluster/run.sh
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: REDIS_NODES
+              value: "redis-cluster-0.redis-cluster-headless redis-cluster-1.redis-cluster-headless redis-cluster-2.redis-cluster-headless redis-cluster-3.redis-cluster-headless redis-cluster-4.redis-cluster-headless redis-cluster-5.redis-cluster-headless "
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: redis-cluster
+                  key: redis-password
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-cluster
+                  key: redis-password
+            - name: REDIS_AOF_ENABLED
+              value: "yes"
+            - name: REDIS_TLS_ENABLED
+              value: "no"
+            - name: REDIS_PORT
+              value: "6379"
+          ports:
+            - name: tcp-redis
+              containerPort: 6379
+            - name: tcp-redis-bus
+              containerPort: 16379
+          livenessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 6
+            successThreshold: 1
+            failureThreshold: 5
+            exec:
+              command:
+                - sh
+                - -c
+                - /scripts/ping_liveness_local.sh 5
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 5
+            exec:
+              command:
+                - sh
+                - -c
+                - /scripts/ping_readiness_local.sh 1
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            - name: default-config
+              mountPath: /opt/bitnami/redis/etc/redis-default.conf
+              subPath: redis-default.conf
+            - name: redis-tmp-conf
+              mountPath: /opt/bitnami/redis/etc/
+      volumes:
+        - name: scripts
+          configMap:
+            name: redis-cluster-scripts
+            defaultMode: 0755
+        - name: default-config
+          configMap:
+            name: redis-cluster-default
+        - name: redis-tmp-conf
+          emptyDir: {}`

--- a/tests/scalers/redis-cluster-streams.test.ts
+++ b/tests/scalers/redis-cluster-streams.test.ts
@@ -2,12 +2,10 @@ import test from 'ava'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import * as fs from 'fs'
-import {createNamespace, waitForDeploymentReplicaCount, waitForRollout} from "./helpers";
+import {createNamespace, waitForDeploymentReplicaCount} from "./helpers";
+import { RedisClusterHelper } from './redis-cluster-helper';
 
 const redisNamespace = 'redis-cluster-streams'
-const redisClusterName = 'redis-cluster-streams'
-const redisStatefulSetName = 'redis-cluster-streams'
-const redisService = 'redis-cluster-streams'
 const testNamespace = 'redis-cluster-streams-test'
 const redisPassword = 'foobared'
 let redisHost = ''
@@ -15,28 +13,18 @@ const numMessages = 100
 
 test.before(t => {
     // Deploy Redis cluster.
-    createNamespace(redisNamespace)
-    sh.exec(`helm repo add bitnami https://charts.bitnami.com/bitnami`)
-
-    let clusterStatus = sh.exec(`helm install --timeout 900s ${redisClusterName} --namespace ${redisNamespace} --set "global.redis.password=${redisPassword}" bitnami/redis-cluster`).code
-    t.is(0,
-        clusterStatus,
-        'creating a Redis cluster should work.'
-    )
-
-    // Wait for Redis cluster to be ready.
-    let exitCode = waitForRollout('statefulset', redisStatefulSetName, redisNamespace, 600)
-    t.is(0, exitCode, 'expected rollout status for redis to finish successfully')
+    const base64Password = Buffer.from(redisPassword).toString('base64')
+    RedisClusterHelper.install(t,base64Password, redisNamespace)
 
     // Get Redis cluster address.
-    redisHost = sh.exec(`kubectl get svc ${redisService} -n ${redisNamespace} -o jsonpath='{.spec.clusterIP}'`)
+    redisHost = sh.exec(`kubectl get svc redis-cluster -n ${redisNamespace} -o jsonpath='{.spec.clusterIP}'`)
 
     // Create test namespace.
     createNamespace(testNamespace)
 
     // Deploy streams consumer app, scaled object etc.
     const tmpFile = tmp.fileSync()
-    const base64Password = Buffer.from(redisPassword).toString('base64')
+
 
     fs.writeFileSync(tmpFile.name, redisStreamsDeployYaml.replace('{{REDIS_PASSWORD}}', base64Password).replace('{{REDIS_HOSTS}}', redisHost))
     t.is(
@@ -94,8 +82,7 @@ test.after.always.cb('clean up deployment', t => {
   }
   sh.exec(`kubectl delete namespace ${testNamespace}`)
 
-  sh.exec(`helm delete ${redisClusterName} --namespace ${redisNamespace}`)
-  sh.exec(`kubectl delete namespace ${redisNamespace}`)
+  RedisClusterHelper.uninstall(redisNamespace)
   t.end()
 })
 
@@ -163,6 +150,11 @@ spec:
   cooldownPeriod: 10
   minReplicaCount: 1
   maxReplicaCount: 5
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 15
   triggers:
     - type: redis-cluster-streams
       metadata:

--- a/tests/scalers/redis-sentinel-lists.test.ts
+++ b/tests/scalers/redis-sentinel-lists.test.ts
@@ -31,7 +31,7 @@ test.before(t => {
     createNamespace(redisNamespace)
     sh.exec(`helm repo add bitnami https://charts.bitnami.com/bitnami`)
 
-    let sentinelStatus = sh.exec(`helm install --timeout 900s ${redisSentinelName} --namespace ${redisNamespace} --set "sentinel.enabled=true" --set "global.redis.password=${redisPassword}" bitnami/redis`).code
+    let sentinelStatus = sh.exec(`helm install --timeout 900s ${redisSentinelName} --namespace ${redisNamespace} --set "sentinel.enabled=true" --set "master.persistence.enabled=false" --set "replica.persistence.enabled=false" --set "global.redis.password=${redisPassword}" bitnami/redis`).code
     t.is(0,
         sentinelStatus,
         'creating a Redis sentinel setup should work.'

--- a/tests/scalers/redis-sentinel-streams.test.ts
+++ b/tests/scalers/redis-sentinel-streams.test.ts
@@ -19,7 +19,7 @@ test.before(t => {
     createNamespace(redisNamespace)
     sh.exec(`helm repo add bitnami https://charts.bitnami.com/bitnami`)
 
-    let sentinelStatus = sh.exec(`helm install --timeout 900s ${redisSentinelName} --namespace ${redisNamespace} --set "sentinel.enabled=true" --set "global.redis.password=${redisPassword}" bitnami/redis`).code
+    let sentinelStatus = sh.exec(`helm install --timeout 900s ${redisSentinelName} --namespace ${redisNamespace} --set "sentinel.enabled=true" --set "master.persistence.enabled=false" --set "replica.persistence.enabled=false" --set "global.redis.password=${redisPassword}" bitnami/redis`).code
     t.is(0,
         sentinelStatus,
         'creating a Redis Sentinel setup should work.'


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

Summary of changes:


- [argo-rollouts](https://github.com/argoproj/argo-rollouts) e2e test used outdated manifest and that's why it fails:
![image](https://user-images.githubusercontent.com/36899226/165620940-83ac6e44-4fb6-4417-b90b-1f99ff211773.png)

- Small improvements in mysql
- Small improvements in postgresql
- Redis e2e tests don't use pvc any more (slow responses sometimes provisioning them produces timeout on tests)
- Influxdb e2e test doesn't use pvc any more (slow responses sometimes provisioning them produces timeout on test)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->

