### PR TITLE
Add 'gci' linter for deterministic import order.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - dogsled
     - errcheck
     #- funlen
+    - gci
     - goconst
     - gocritic
     - gocyclo
@@ -74,7 +75,13 @@ issues:
     - path: azure/azure_app_insights.go
       linters:
         - bodyclose
+
 linters-settings:
   funlen:
     lines: 80
     statements: 40
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/kedacore/keda)

--- a/adapter/main.go
+++ b/adapter/main.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-
 	basecmd "sigs.k8s.io/custom-metrics-apiserver/pkg/cmd"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 

--- a/controllers/keda/suite_test.go
+++ b/controllers/keda/suite_test.go
@@ -23,7 +23,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	//nolint:gci
 	// +kubebuilder:scaffold:imports
 )
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	kedacontrollers "github.com/kedacore/keda/v2/controllers/keda"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	"github.com/kedacore/keda/v2/version"
+	//nolint:gci
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/scalers/authentication/authentication_helpers.go
+++ b/pkg/scalers/authentication/authentication_helpers.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"time"
 
-	pConfig "github.com/prometheus/common/config"
-
 	libs "github.com/dysnix/predictkube-libs/external/configs"
 	"github.com/dysnix/predictkube-libs/external/http_transport"
+	pConfig "github.com/prometheus/common/config"
 
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedautil "github.com/kedacore/keda/v2/pkg/util"

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -7,10 +7,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/gobwas/glob"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/gobwas/glob"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kedacore/keda/v2/pkg/scalers/azure"
-
 	eventhub "github.com/Azure/azure-event-hubs-go/v3"
 	"github.com/Azure/azure-storage-blob-go/azblob"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 )
 
 const (

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -9,13 +9,14 @@ import (
 	"strconv"
 	"strings"
 
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 const (

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -22,8 +22,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/kedacore/keda/v2/pkg/scalers/azure"
-
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
 	servicebus "github.com/Azure/azure-service-bus-go"
 	az "github.com/Azure/go-autorest/autorest/azure"
-	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	datadog "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	datadog "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 )
 
 type parseExternalScalerMetadataTestData struct {

--- a/pkg/scalers/gcp_storage_scaler.go
+++ b/pkg/scalers/gcp_storage_scaler.go
@@ -9,7 +9,6 @@ import (
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
 	option "google.golang.org/api/option"
-
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -8,13 +8,14 @@ import (
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	api "github.com/influxdata/influxdb-client-go/v2/api"
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 type influxDBScaler struct {

--- a/pkg/scalers/liiklus_scaler_test.go
+++ b/pkg/scalers/liiklus_scaler_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+
 	"github.com/kedacore/keda/v2/pkg/scalers/liiklus"
 	mock_liiklus "github.com/kedacore/keda/v2/pkg/scalers/liiklus/mocks"
-	"github.com/pkg/errors"
 )
 
 type parseLiiklusMetadataTestData struct {

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	neturl "net/url"
 	"strconv"
 	"strings"
-
-	neturl "net/url"
 
 	"github.com/tidwall/gjson"
 	"k8s.io/api/autoscaling/v2beta2"

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -9,14 +9,14 @@ import (
 
 	// mssql driver required for this scaler
 	_ "github.com/denisenkom/go-mssqldb"
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 // mssqlScaler exposes a data pointer to mssqlMetadata and sql.DB connection

--- a/pkg/scalers/openstack/keystone_authentication.go
+++ b/pkg/scalers/openstack/keystone_authentication.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	openstackutil "github.com/kedacore/keda/v2/pkg/scalers/openstack/utils"
-
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 

--- a/pkg/scalers/openstack_metrics_scaler.go
+++ b/pkg/scalers/openstack_metrics_scaler.go
@@ -11,14 +11,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 const (

--- a/pkg/scalers/openstack_metrics_scaler_test.go
+++ b/pkg/scalers/openstack_metrics_scaler_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
 )
 
 type parseOpenstackMetricMetadataTestData struct {

--- a/pkg/scalers/openstack_swift_scaler.go
+++ b/pkg/scalers/openstack_swift_scaler.go
@@ -10,15 +10,15 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 const (

--- a/pkg/scalers/openstack_swift_scaler_test.go
+++ b/pkg/scalers/openstack_swift_scaler_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/openstack"
 )
 
 type parseOpenstackSwiftMetadataTestData struct {

--- a/pkg/scalers/predictkube_scaler.go
+++ b/pkg/scalers/predictkube_scaler.go
@@ -10,6 +10,11 @@ import (
 	"strconv"
 	"time"
 
+	libs "github.com/dysnix/predictkube-libs/external/configs"
+	pc "github.com/dysnix/predictkube-libs/external/grpc/client"
+	tc "github.com/dysnix/predictkube-libs/external/types_convertation"
+	"github.com/dysnix/predictkube-proto/external/proto/commonproto"
+	pb "github.com/dysnix/predictkube-proto/external/proto/services"
 	"github.com/go-playground/validator/v10"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -26,12 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	libs "github.com/dysnix/predictkube-libs/external/configs"
-	pc "github.com/dysnix/predictkube-libs/external/grpc/client"
-	tc "github.com/dysnix/predictkube-libs/external/types_convertation"
-	"github.com/dysnix/predictkube-proto/external/proto/commonproto"
-	pb "github.com/dysnix/predictkube-proto/external/proto/services"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/authentication"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"

--- a/pkg/scalers/predictkube_scaler_test.go
+++ b/pkg/scalers/predictkube_scaler_test.go
@@ -9,13 +9,12 @@ import (
 	"testing"
 	"time"
 
+	libsSrv "github.com/dysnix/predictkube-libs/external/grpc/server"
+	pb "github.com/dysnix/predictkube-proto/external/proto/services"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	libsSrv "github.com/dysnix/predictkube-libs/external/grpc/server"
-	pb "github.com/dysnix/predictkube-proto/external/proto/services"
 )
 
 type server struct {

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -22,13 +22,13 @@ import (
 	"strings"
 	"time"
 
+	metrics "github.com/rcrowley/go-metrics"
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-	metrics "github.com/rcrowley/go-metrics"
 )
 
 func init() {

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -21,15 +21,16 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-	"github.com/kedacore/keda/v2/pkg/eventreason"
-	"github.com/kedacore/keda/v2/pkg/scalers"
 	"k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/eventreason"
+	"github.com/kedacore/keda/v2/pkg/scalers"
 )
 
 type ScalersCache struct {

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -30,7 +30,6 @@ import (
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kedacontrollerutil "github.com/kedacore/keda/v2/controllers/keda/util"
-
 	"github.com/kedacore/keda/v2/pkg/eventreason"
 )
 


### PR DESCRIPTION
Signed-off-by: Vighnesh Shenoy <vshenoy@microsoft.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #
