### PR TITLE
feat: improve e2e on PR workflow

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -28,7 +28,7 @@ jobs:
           body: |
             **Update:** You can check the progres [here](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
           reactions: rocket
-      
+
       - name: Get Pull Request number
         id: parser
         run: |

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -8,6 +8,8 @@ jobs:
     name: Comment evaluate
     outputs:
       run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.check-permission.outputs.has-permission }}
+      pr_num: ${{ steps.checkout.outputs.pr_num }}
+      image_tag: "pr-${{ steps.checkout.outputs.pr_num }}-${{ github.event.comment.id }}"
     steps:
       - name: Check user permission
         if: startsWith(github.event.comment.body,'/run-e2e')
@@ -26,13 +28,20 @@ jobs:
           body: |
             **Update:** You can check the progres [here](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
           reactions: rocket
+      
+      - name: Get Pull Request number
+        id: pull
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_NUM=${PR_URL##*/}
+          echo "Checking out from PR #$PR_NUM based on URL: $PR_URL"
+          echo "::set-output name=pr_num::$PR_NUM"
 
-  run-test:
+  build-test-images:
     needs: check
     runs-on: ubuntu-latest
-    name: Execute e2e tests
+    name: Build images
     container: ghcr.io/kedacore/build-tools:main
-    concurrency: pr-e2e-tests
     if: needs.check.outputs.run-e2e == '1'
     steps:
       - uses: actions/checkout@v3
@@ -42,11 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: checkout
         run: |
-          PR_URL="${{ github.event.issue.pull_request.url }}"
-          PR_NUM=${PR_URL##*/}
-          echo "Checking out from PR #$PR_NUM based on URL: $PR_URL"
-          hub pr checkout $PR_NUM
-          echo "::set-output name=pr_num::$PR_NUM"
+          hub pr checkout ${{ needs.check.outputs.pr_num }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -61,7 +66,24 @@ jobs:
       - name: Publish on GitHub Container Registry
         run: make publish
         env:
-          E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+          E2E_IMAGE_TAG: ${{ needs.check.outputs.image_tag }}
+
+  run-test:
+    needs: build-test-images
+    runs-on: ubuntu-latest
+    name: Execute e2e tests
+    container: ghcr.io/kedacore/build-tools:main
+    concurrency: pr-e2e-tests
+    if: needs.check.outputs.run-e2e == '1'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Checkout Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: checkout
+        run: |
+          hub pr checkout ${{ needs.check.outputs.pr_num }}
 
       - name: Run end to end tests
         continue-on-error: true
@@ -94,7 +116,7 @@ jobs:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
           DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
-          E2E_IMAGE_TAG: "pr-${{ steps.checkout.outputs.pr_num }}"
+          E2E_IMAGE_TAG: ${{ needs.check.outputs.image_tag }}
           GCP_SP_KEY: ${{ secrets.GCP_SP_KEY }}
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
@@ -113,7 +135,7 @@ jobs:
           then
             export E2E_TEST_REGEX="${BASH_REMATCH[1]}"
           fi
-          echo "${{ steps.checkout.outputs.pr_num }}"
+          echo "${{ needs.check.outputs.pr_num }}"
           make e2e-test
 
       - name: Delete all e2e related namespaces

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -8,8 +8,8 @@ jobs:
     name: Comment evaluate
     outputs:
       run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.check-permission.outputs.has-permission }}
-      pr_num: ${{ steps.checkout.outputs.pr_num }}
-      image_tag: "pr-${{ steps.checkout.outputs.pr_num }}-${{ github.event.comment.id }}"
+      pr_num: ${{ steps.parser.outputs.pr_num }}
+      image_tag: "pr-${{ steps.parser.outputs.pr_num }}-${{ github.event.comment.id }}"
     steps:
       - name: Check user permission
         if: startsWith(github.event.comment.body,'/run-e2e')
@@ -30,7 +30,7 @@ jobs:
           reactions: rocket
       
       - name: Get Pull Request number
-        id: pull
+        id: parser
         run: |
           PR_URL="${{ github.event.issue.pull_request.url }}"
           PR_NUM=${PR_URL##*/}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -3,7 +3,7 @@ on:
   issue_comment:
     types: [created]
 jobs:
-  check:
+  triage:
     runs-on: ubuntu-latest
     name: Comment evaluate
     outputs:
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build images
     container: ghcr.io/kedacore/build-tools:main
-    if: needs.check.outputs.run-e2e == '1'
+    if: needs.triage.outputs.run-e2e == '1'
     steps:
       - uses: actions/checkout@v3
 
@@ -51,7 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: checkout
         run: |
-          hub pr checkout ${{ needs.check.outputs.pr_num }}
+          hub pr checkout ${{ needs.triage.outputs.pr_num }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -66,7 +66,7 @@ jobs:
       - name: Publish on GitHub Container Registry
         run: make publish
         env:
-          E2E_IMAGE_TAG: ${{ needs.check.outputs.image_tag }}
+          E2E_IMAGE_TAG: ${{ needs.triage.outputs.image_tag }}
 
   run-test:
     needs: build-test-images
@@ -74,7 +74,7 @@ jobs:
     name: Execute e2e tests
     container: ghcr.io/kedacore/build-tools:main
     concurrency: pr-e2e-tests
-    if: needs.check.outputs.run-e2e == '1'
+    if: needs.triage.outputs.run-e2e == '1'
     steps:
       - uses: actions/checkout@v3
 
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: checkout
         run: |
-          hub pr checkout ${{ needs.check.outputs.pr_num }}
+          hub pr checkout ${{ needs.triage.outputs.pr_num }}
 
       - name: Run end to end tests
         continue-on-error: true
@@ -116,7 +116,7 @@ jobs:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY}}
           DATADOG_APP_KEY: ${{ secrets.DATADOG_APP_KEY}}
           DATADOG_SITE: ${{ secrets.DATADOG_SITE}}
-          E2E_IMAGE_TAG: ${{ needs.check.outputs.image_tag }}
+          E2E_IMAGE_TAG: ${{ needs.triage.outputs.image_tag }}
           GCP_SP_KEY: ${{ secrets.GCP_SP_KEY }}
           NEWRELIC_ACCOUNT_ID: ${{ secrets.NEWRELIC_ACCOUNT_ID}}
           NEWRELIC_API_KEY: ${{ secrets.NEWRELIC_API_KEY}}
@@ -135,7 +135,7 @@ jobs:
           then
             export E2E_TEST_REGEX="${BASH_REMATCH[1]}"
           fi
-          echo "${{ needs.check.outputs.pr_num }}"
+          echo "${{ needs.triage.outputs.pr_num }}"
           make e2e-test
 
       - name: Delete all e2e related namespaces


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

right now, the process is split in 2 jobs:
1. check permissions
2. the rest (single execution)

This PR adds an extra job to build images in parallel, non-blocking the e2e-concurrency for building images
1. triage
2. build images
3. the rest (single execution)

With current approach, we don't parallelize the image generation because it's inside the exclusive job, this PR solves the problem saving up to 7-8 minutes if there is an e2e test pending in the queue


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

