### PR TITLE
WIP - fix: trim so name when is longer than 63 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 - **General:** Properly handle `restoreToOriginalReplicaCount` if `ScaleTarget` is missing ([#2872](https://github.com/kedacore/keda/issues/2872))
 - **General:** Support for running KEDA secure-by-default as non-root ([#2933](https://github.com/kedacore/keda/issues/2933))
 - **General:** Synchronize HPA annotations from ScaledObject ([#2659](https://github.com/kedacore/keda/pull/2659))
+- **General:** Trim ScaledObject name when is longer than 63 chars ([#2915](https://github.com/kedacore/keda/issues/2915))
 - **General:** Updated HTTPClient to be proxy-aware, if available, from environment variables. ([#2577](https://github.com/kedacore/keda/issues/2577))
 - **General:** Using manager client in KEDA Metrics Server to avoid flush request to Kubernetes Apiserver([2914](https://github.com/kedacore/keda/issues/2914))
 - **ActiveMQ Scaler:** Add CorsHeader information to ActiveMQ Scaler ([#2884](https://github.com/kedacore/keda/issues/2884))

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -257,18 +257,20 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(ctx context.Context, logg
 // This is how the MetricsAdapter will know which ScaledObject a metric is for when the HPA queries it.
 func (r *ScaledObjectReconciler) ensureScaledObjectLabel(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) error {
 	const labelScaledObjectName = "scaledobject.keda.sh/name"
+	// label can have max 63 chars
+	scaledObjectName := kedacontrollerutil.Trim(scaledObject.Name, 63)
 
 	if scaledObject.Labels == nil {
-		scaledObject.Labels = map[string]string{labelScaledObjectName: scaledObject.Name}
+		scaledObject.Labels = map[string]string{labelScaledObjectName: scaledObjectName}
 	} else {
 		value, found := scaledObject.Labels[labelScaledObjectName]
-		if found && value == scaledObject.Name {
+		if found && value == scaledObjectName {
 			return nil
 		}
-		scaledObject.Labels[labelScaledObjectName] = scaledObject.Name
+		scaledObject.Labels[labelScaledObjectName] = scaledObjectName
 	}
 
-	logger.V(1).Info("Adding \"scaledobject.keda.sh/name\" label on ScaledObject", "value", scaledObject.Name)
+	logger.V(1).Info("Adding \"scaledobject.keda.sh/name\" label on ScaledObject", "value", scaledObjectName)
 	return r.Client.Update(ctx, scaledObject)
 }
 

--- a/controllers/keda/util/strings.go
+++ b/controllers/keda/util/strings.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Trim checks if the given string is longer than given value and trim it in that case.
+func Trim(s string, length int) string {
+	result := s
+	if len(result) > length {
+		result = result[:length]
+		result = strings.TrimRightFunc(result, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+		})
+	}
+	return result
+}

--- a/tests/scalers/kubernetes-workload-long-so-names.test.ts
+++ b/tests/scalers/kubernetes-workload-long-so-names.test.ts
@@ -1,0 +1,134 @@
+import * as fs from 'fs'
+import * as sh from 'shelljs'
+import * as tmp from 'tmp'
+import test from 'ava'
+import {createNamespace, waitForDeploymentReplicaCount} from "./helpers";
+
+const testNamespace = 'scaled-object-name-trimming'
+const monitoredDeploymentFile = tmp.fileSync()
+const sutDeploymentFile = tmp.fileSync()
+
+test.before(t => {
+  sh.config.silent = true
+	createNamespace(testNamespace)
+
+  fs.writeFileSync(monitoredDeploymentFile.name, monitoredDeploymentYaml)
+	t.is(
+		0,
+		sh.exec(`kubectl apply -f ${monitoredDeploymentFile.name} --namespace ${testNamespace}`).code,
+		'Deploying monitored deployment should work.'
+	)
+
+  fs.writeFileSync(sutDeploymentFile.name, sutDeploymentYaml)
+	t.is(
+		0,
+		sh.exec(`kubectl apply -f ${sutDeploymentFile.name} --namespace ${testNamespace}`).code,
+		'Deploying monitored deployment should work.'
+	)
+})
+
+test.serial('Deployment should have 0 replicas on start', t => {
+  const replicaCount = sh.exec(
+    `kubectl get deployment.apps/sut-deployment --namespace ${testNamespace} -o jsonpath="{.spec.replicas}"`
+  ).stdout
+  t.is(replicaCount, '0', 'replica count should start out as 0')
+})
+
+test.serial(`Deployment should scale to fit the amount of pods which match the selector`, async t => {
+
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=5`
+  )
+  t.true(await waitForDeploymentReplicaCount(5, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 5 after 60 seconds')
+
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=10`
+  )
+  t.true(await waitForDeploymentReplicaCount(10, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 10 after 60 seconds')
+
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=5`
+  )
+  t.true(await waitForDeploymentReplicaCount(5, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 5 after 60 seconds')
+
+  sh.exec(
+    `kubectl scale deployment.apps/monitored-deployment --namespace ${testNamespace} --replicas=0`
+  )
+  t.true(await waitForDeploymentReplicaCount(0, 'sut-deployment', testNamespace, 6, 10000), 'Replica count should be 0 after 60 seconds')
+})
+
+test.after.always.cb('clean up workload test related deployments', t => {
+  const resources = [
+    'scaledobject.keda.sh/sut-scaledobject',
+    'deployment.apps/sut-deployment',
+    'deployment.apps/monitored-deployment',
+  ]
+
+  for (const resource of resources) {
+    sh.exec(`kubectl delete ${resource} --namespace ${testNamespace}`)
+  }
+  sh.exec(`kubectl delete namespace ${testNamespace}`)
+  t.end()
+})
+
+const monitoredDeploymentYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitored-deployment
+  labels:
+    deploy: workload-test
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      pod: workload-test
+  template:
+    metadata:
+      labels:
+        pod: workload-test
+    spec:
+      containers:
+        - name: nginx
+          image: 'nginx'`
+
+const sutDeploymentYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sut-deployment
+  labels:
+    deploy: workload-sut
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      pod: workload-sut
+  template:
+    metadata:
+      labels:
+        pod: workload-sut
+    spec:
+      containers:
+        - name: nginx
+          image: 'nginx'
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: this-scaledobject-name-is-longer-than-63-characters-to-check-that-it-is-trimmed
+spec:
+  scaleTargetRef:
+    name: sut-deployment
+  pollingInterval: 5
+  cooldownPeriod: 5
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 15
+  triggers:
+  - type: kubernetes-workload
+    metadata:
+      podSelector: 'pod=workload-test'
+      value: '1'`


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

If the SO Name is longer than 63 characters, KEDA fails because that length is valid for the SO Name but not for other resources where it's used. This PR trims the SO Name when is longer than 63 characters on every place where is needed

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)


Fixes https://github.com/kedacore/keda/issues/2915
