### PR TITLE
fix: use gh-cli instead of hub

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "^1.17"
+          go-version: 1.17
       - run: go version
       # Runs a set of commands to initialize and analyze with FOSSA
       - name: run FOSSA analysis

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -51,7 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: checkout
         run: |
-          hub pr checkout ${{ needs.triage.outputs.pr_num }}
+          gh pr checkout ${{ needs.triage.outputs.pr_num }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -83,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: checkout
         run: |
-          hub pr checkout ${{ needs.triage.outputs.pr_num }}
+          gh pr checkout ${{ needs.triage.outputs.pr_num }}
 
       - name: Run end to end tests
         continue-on-error: true

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -67,7 +67,8 @@ ENV PATH=${PATH}:/usr/local/go/bin \
 # Install FOSSA tooling
 RUN curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
 
-# Install hub
-RUN curl -LJO https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz && \
-    tar zxvf hub-linux-amd64-2.14.2.tgz
-ENV PATH="/hub-linux-amd64-2.14.2/bin:${PATH}"
+# Install gh
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt update && \
+    apt install -y gh


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

Github Hub hasn't been updated for 2 years and it's failing right now. This PR switch from github hub to github-cli for e2e test on PRs (adding the tool also to the build-tools image).

*This PR solves another problem related with FOSSA

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

