### PR TITLE
test: move account id to trigger auth on integration test for new relic

### DIFF
--- a/tests/scalers/new-relic.test.ts
+++ b/tests/scalers/new-relic.test.ts
@@ -70,7 +70,7 @@ test.before(t => {
   const tmpFile = tmp.fileSync()
   fs.writeFileSync(tmpFile.name, deployYaml
     .replace('{{NEWRELIC_API_KEY}}', Buffer.from(newRelicApiKey).toString('base64'))
-    .replace('{{NEWRELIC_ACCOUNT_ID}}', newRelicAccountId)
+    .replace('{{NEWRELIC_ACCOUNT_ID}}', Buffer.from(newRelicAccountId).toString('base64'))
     .replace('{{NEWRELIC_REGION}}', newRelicRegion)
   )
   createNamespace(testNamespace)
@@ -253,6 +253,9 @@ spec:
   - parameter: queryKey
     name: newrelic-secret
     key: newRelicApiKey
+  - parameter: account
+    name: newrelic-secret
+    key: account
 ---
 apiVersion: v1
 kind: Secret
@@ -261,6 +264,7 @@ metadata:
 type: Opaque
 data:
   newRelicApiKey: {{NEWRELIC_API_KEY}}
+  account: {{NEWRELIC_ACCOUNT_ID}}
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -276,7 +280,6 @@ spec:
   triggers:
   - type: new-relic
     metadata:
-      account: '{{NEWRELIC_ACCOUNT_ID}}'
       region: '{{NEWRELIC_REGION}}'
       threshold: '10'
       nrql: SELECT average(\`http_requests_total\`) FROM Metric where serviceName='test-app' and namespaceName='new-relic-test' since 60 seconds ago


### PR DESCRIPTION
Moves account id to TriggerAuthentication for New Relic Integration Tests
### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Tests have been added
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Relates to https://github.com/kedacore/keda/issues/2883
