### PR TITLE
Enable saving of KEDA container images locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ ARCH       ?=amd64
 CGO        ?=0
 TARGET_OS  ?=linux
 
+BUILD_PLATFORMS ?= linux/amd64,linux/arm64
+OUTPUT_TYPE     ?= registry
+
 GIT_VERSION ?= $(shell git describe --always --abbrev=7)
 GIT_COMMIT  ?= $(shell git rev-list -1 HEAD)
 DATE        = $(shell date -u +"%Y.%m.%d.%H.%M.%S")
@@ -188,9 +191,14 @@ publish: docker-build ## Push images on to Container Registry (default: ghcr.io)
 	docker push $(IMAGE_CONTROLLER)
 	docker push $(IMAGE_ADAPTER)
 
-publish-multiarch:
-	docker buildx build --push --platform=linux/amd64,linux/arm64 . -t ${IMAGE_CONTROLLER} --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
-	docker buildx build --push --platform=linux/amd64,linux/arm64 -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+publish-controller-multiarch: ## Build and push multi-arch Docker image for KEDA Operator.
+	docker buildx build --output=type=${OUTPUT_TYPE} --platform=${BUILD_PLATFORMS} . -t ${IMAGE_CONTROLLER} --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+
+publish-adapter-multiarch: ## Build and push multi-arch Docker image for KEDA Metrics Server.
+	docker buildx build --output=type=${OUTPUT_TYPE} --platform=${BUILD_PLATFORMS} -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
+
+# Push multi-arch Docker images to Container Registry (default: ghcr.io).
+publish-multiarch: publish-controller-multiarch publish-adapter-multiarch
 
 release: manifests kustomize set-version ## Produce new KEDA release in keda-$(VERSION).yaml file.
 	cd config/manager && \

--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,7 @@ publish-controller-multiarch: ## Build and push multi-arch Docker image for KEDA
 publish-adapter-multiarch: ## Build and push multi-arch Docker image for KEDA Metrics Server.
 	docker buildx build --output=type=${OUTPUT_TYPE} --platform=${BUILD_PLATFORMS} -f Dockerfile.adapter -t ${IMAGE_ADAPTER} . --build-arg BUILD_VERSION=${VERSION} --build-arg GIT_VERSION=${GIT_VERSION} --build-arg GIT_COMMIT=${GIT_COMMIT}
 
-# Push multi-arch Docker images to Container Registry (default: ghcr.io).
-publish-multiarch: publish-controller-multiarch publish-adapter-multiarch
+publish-multiarch: publish-controller-multiarch publish-adapter-multiarch ## Push multi-arch Docker images on to Container Registry (default: ghcr.io).
 
 release: manifests kustomize set-version ## Produce new KEDA release in keda-$(VERSION).yaml file.
 	cd config/manager && \


### PR DESCRIPTION
The KEDA images that are hosted on the Microsoft Container Registry (mcr.microsoft.com) are separately built with a Microsoft-internal pipeline that uses Microsoft's security-compliant build infrastructure. We recently found about #2457 that updated the Makefile target for release-build from `publish` to `publish-multiarch`.

Our internal pipeline used to execute `make docker-build` which would add the image local repository and then call `docker save` on them to export them into tar files. At present, the Makefile does not allow this for multi-arch images. Hence, this PR is created to enable saving of docker images targeting different platforms.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
