### PR TITLE
feat: improve e2e on PR process

### DIFF
--- a/.github/workflows/pr-e2e-pr-validation.yml
+++ b/.github/workflows/pr-e2e-pr-validation.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types:
       - opened
-      - synchronize
       - reopened
       - labeled
       - unlabeled

--- a/.github/workflows/pr-e2e-pr-validation.yml
+++ b/.github/workflows/pr-e2e-pr-validation.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
       - reopened
       - labeled
       - unlabeled

--- a/.github/workflows/pr-e2e-pr-validation.yml
+++ b/.github/workflows/pr-e2e-pr-validation.yml
@@ -1,0 +1,19 @@
+name: e2e-on-pr-validation
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  validate-e2e-labels:
+    name: Check e2e labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          any_of: ok-to-merge
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Comment evaluate
     outputs:
-      run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember }}
+      run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember == 'true' }}
       pr_num: ${{ steps.parser.outputs.pr_num }}
       image_tag: "pr-${{ steps.parser.outputs.pr_num }}-${{ github.event.comment.id }}"
     steps:
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_CHECKING_USER_AUTH }}
 
       - name: Update comment with the execution url
-        if: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember }}
+        if: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember == 'true' }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -7,21 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     name: Comment evaluate
     outputs:
-      run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.check-permission.outputs.has-permission }}
+      run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember }}
       pr_num: ${{ steps.parser.outputs.pr_num }}
       image_tag: "pr-${{ steps.parser.outputs.pr_num }}-${{ github.event.comment.id }}"
     steps:
-      - name: Check user permission
-        if: startsWith(github.event.comment.body,'/run-e2e')
-        id: check-permission
-        uses: scherermichael-oss/action-has-permission@master
+      - uses: tspascoal/get-user-teams-membership@v1
+        id: checkUserMember
         with:
-          required-permission: write
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          team: 'keda-e2e-test-executors'
+          GITHUB_TOKEN: ${{ secrets.GH_CHECKING_USER_AUTH }}
 
       - name: Update comment with the execution url
-        if: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.check-permission.outputs.has-permission }}
+        if: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{ github.event.comment.id }}
@@ -44,6 +42,11 @@ jobs:
     container: ghcr.io/kedacore/build-tools:main
     if: needs.triage.outputs.run-e2e == '1'
     steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: ok-to-merge
+          number: ${{ needs.triage.outputs.pr_num }}
+
       - uses: actions/checkout@v3
 
       - name: Checkout Pull Request
@@ -77,6 +80,11 @@ jobs:
     concurrency: pr-e2e-tests
     if: needs.triage.outputs.run-e2e == '1'
     steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: ok-to-merge
+          number: ${{ needs.triage.outputs.pr_num }}
+
       - uses: actions/checkout@v3
 
       - name: Checkout Pull Request
@@ -157,6 +165,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}
           reaction: "+1"
+
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: steps.test.outcome == 'success'
+        with:
+          labels: ok-to-merge
+          number: ${{ needs.triage.outputs.pr_num }}
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -2,6 +2,10 @@ name: pr-e2e-tests
 on:
   issue_comment:
     types: [created]
+
+env:
+  E2E_LABEL: ok-to-merge
+
 jobs:
   triage:
     runs-on: ubuntu-latest
@@ -185,7 +189,7 @@ jobs:
               issue_number: ${{ needs.triage.outputs.pr_num }},
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ['ok-to-merge']
+              labels: ['${{ env.E2E_LABEL}}']
             })
 
       - name: React to comment with failure

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           script: |
             github.rest.issues.removeAllLabels({
-              issue_number: ${{ steps.parser.outputs.pr_num }},
+              issue_number: ${{ needs.triage.outputs.pr_num }},
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
@@ -94,7 +94,7 @@ jobs:
         with:
           script: |
             github.rest.issues.removeAllLabels({
-              issue_number: ${{ steps.parser.outputs.pr_num }},
+              issue_number: ${{ needs.triage.outputs.pr_num }},
               owner: context.repo.owner,
               repo: context.repo.repo,
             })

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -42,10 +42,15 @@ jobs:
     container: ghcr.io/kedacore/build-tools:main
     if: needs.triage.outputs.run-e2e == '1'
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions/github-script@v6
+        name: Remove ok-to-merge label
         with:
-          labels: ok-to-merge
-          number: ${{ needs.triage.outputs.pr_num }}
+          script: |
+            github.rest.issues.removeAllLabels({
+              issue_number: ${{ steps.parser.outputs.pr_num }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
 
       - uses: actions/checkout@v3
 
@@ -80,10 +85,15 @@ jobs:
     concurrency: pr-e2e-tests
     if: needs.triage.outputs.run-e2e == '1'
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions/github-script@v6
+        name: Remove ok-to-merge label
         with:
-          labels: ok-to-merge
-          number: ${{ needs.triage.outputs.pr_num }}
+          script: |
+            github.rest.issues.removeAllLabels({
+              issue_number: ${{ steps.parser.outputs.pr_num }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
 
       - uses: actions/checkout@v3
 
@@ -166,11 +176,17 @@ jobs:
           commentId: ${{ github.event.comment.id }}
           reaction: "+1"
 
-      - uses: actions-ecosystem/action-add-labels@v1
+      - uses: actions/github-script@v6
         if: steps.test.outcome == 'success'
+        name: Add ok-to-merge label
         with:
-          labels: ok-to-merge
-          number: ${{ needs.triage.outputs.pr_num }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: ${{ needs.triage.outputs.pr_num }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['ok-to-merge']
+            })
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -46,17 +46,14 @@ jobs:
     container: ghcr.io/kedacore/build-tools:main
     if: needs.triage.outputs.run-e2e == '1'
     steps:
-      - uses: actions/github-script@v6
-        name: Remove ok-to-merge label
-        with:
-          script: |
-            github.rest.issues.removeAllLabels({
-              issue_number: ${{ needs.triage.outputs.pr_num }},
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            })
-
       - uses: actions/checkout@v3
+
+      - name: Remove label
+        id: remove
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABEL}}'
 
       - name: Checkout Pull Request
         env:
@@ -89,17 +86,14 @@ jobs:
     concurrency: pr-e2e-tests
     if: needs.triage.outputs.run-e2e == '1'
     steps:
-      - uses: actions/github-script@v6
-        name: Remove ok-to-merge label
-        with:
-          script: |
-            github.rest.issues.removeAllLabels({
-              issue_number: ${{ needs.triage.outputs.pr_num }},
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            })
-
       - uses: actions/checkout@v3
+
+      - name: Remove label
+        id: remove
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABEL}}'
 
       - name: Checkout Pull Request
         env:
@@ -180,17 +174,12 @@ jobs:
           commentId: ${{ github.event.comment.id }}
           reaction: "+1"
 
-      - uses: actions/github-script@v6
-        if: steps.test.outcome == 'success'
-        name: Add ok-to-merge label
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: ${{ needs.triage.outputs.pr_num }},
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['${{ env.E2E_LABEL}}']
-            })
+      - name: Remove label
+        id: remove
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --add-label '${{ env.E2E_LABEL}}'
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 ### Other
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+- **General:** Improve e2e on PR process. ([3004](https://github.com/kedacore/keda/issues/3004))
 
 ## v2.7.1
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

This PR introduces 2 big changes to improve the proces:

- All PRs will be blocked till e2e tests pass or till the label `ok-to-merge` is manually added
- Every member of the team @kedacore/keda-e2e-test-executors will be able to trigger the e2e tests

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes https://github.com/kedacore/keda/issues/3004
