### PR TITLE
fix: use metricName from GetMetricsSpec in ScaledJobs instead of `queueLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 ### Improvements
 
+- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+
+### Fixes
+
 - **General:** Use metricName from GetMetricsSpec in ScaledJobs instead of `queueLength` ([#3032](https://github.com/kedacore/keda/issue/3032))
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 ### Improvements
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+- **General:** Use metricName from GetMetricsSpec in ScaledJobs instead of `queueLength` ([#3032](https://github.com/kedacore/keda/issue/3032))
 
 ### Deprecations
 

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -198,13 +198,13 @@ func (s *externalScaler) GetMetrics(ctx context.Context, metricName string, metr
 	defer done()
 
 	// Remove the sX- prefix as the external scaler shouldn't have to know about it
-	metricName, err = RemoveIndexFromMetricName(s.metadata.scalerIndex, metricName)
+	metricNameWithoutIndex, err := RemoveIndexFromMetricName(s.metadata.scalerIndex, metricName)
 	if err != nil {
 		return metrics, err
 	}
 
 	request := &pb.GetMetricsRequest{
-		MetricName:      metricName,
+		MetricName:      metricNameWithoutIndex,
 		ScaledObjectRef: &s.scaledObjectRef,
 	}
 
@@ -216,7 +216,7 @@ func (s *externalScaler) GetMetrics(ctx context.Context, metricName string, metr
 
 	for _, metricResult := range response.MetricValues {
 		metric := external_metrics.ExternalMetricValue{
-			MetricName: metricResult.MetricName,
+			MetricName: metricName,
 			Value:      *resource.NewQuantity(metricResult.MetricValue, resource.DecimalSI),
 			Timestamp:  metav1.Now(),
 		}

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -33,10 +33,6 @@ import (
 	"github.com/kedacore/keda/v2/pkg/scalers"
 )
 
-const (
-	scaledJobMetricName = "s0-queueLength"
-)
-
 type ScalersCache struct {
 	Generation int64
 	Scalers    []ScalerBuilder

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -275,7 +275,7 @@ func (c *ScalersCache) getScaledJobMetrics(ctx context.Context, scaledJob *kedav
 
 		targetAverageValue = getTargetAverageValue(metricSpecs)
 
-		metrics, err := s.Scaler.GetMetrics(ctx, scaledJobMetricName, nil)
+		metrics, err := s.Scaler.GetMetrics(ctx, metricSpecs[0].External.Metric.Name, nil)
 		if err != nil {
 			scalerLogger.V(1).Info("Error getting scaler metrics, but continue", "Error", err)
 			c.Recorder.Event(scaledJob, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, err.Error())
@@ -285,12 +285,12 @@ func (c *ScalersCache) getScaledJobMetrics(ctx context.Context, scaledJob *kedav
 		var metricValue int64
 
 		for _, m := range metrics {
-			if m.MetricName == scaledJobMetricName {
+			if m.MetricName == metricSpecs[0].External.Metric.Name {
 				metricValue, _ = m.Value.AsInt64()
 				queueLength += metricValue
 			}
 		}
-		scalerLogger.V(1).Info("Scaler Metric value", "isTriggerActive", isTriggerActive, scaledJobMetricName, queueLength, "targetAverageValue", targetAverageValue)
+		scalerLogger.V(1).Info("Scaler Metric value", "isTriggerActive", isTriggerActive, metricSpecs[0].External.Metric.Name, queueLength, "targetAverageValue", targetAverageValue)
 
 		if isTriggerActive {
 			isActive = true

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -33,6 +33,10 @@ import (
 	"github.com/kedacore/keda/v2/pkg/scalers"
 )
 
+const (
+	scaledJobMetricName = "s0-queueLength"
+)
+
 type ScalersCache struct {
 	Generation int64
 	Scalers    []ScalerBuilder
@@ -271,7 +275,7 @@ func (c *ScalersCache) getScaledJobMetrics(ctx context.Context, scaledJob *kedav
 
 		targetAverageValue = getTargetAverageValue(metricSpecs)
 
-		metrics, err := s.Scaler.GetMetrics(ctx, "queueLength", nil)
+		metrics, err := s.Scaler.GetMetrics(ctx, scaledJobMetricName, nil)
 		if err != nil {
 			scalerLogger.V(1).Info("Error getting scaler metrics, but continue", "Error", err)
 			c.Recorder.Event(scaledJob, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, err.Error())
@@ -281,12 +285,12 @@ func (c *ScalersCache) getScaledJobMetrics(ctx context.Context, scaledJob *kedav
 		var metricValue int64
 
 		for _, m := range metrics {
-			if m.MetricName == "queueLength" {
+			if m.MetricName == scaledJobMetricName {
 				metricValue, _ = m.Value.AsInt64()
 				queueLength += metricValue
 			}
 		}
-		scalerLogger.V(1).Info("Scaler Metric value", "isTriggerActive", isTriggerActive, "queueLength", queueLength, "targetAverageValue", targetAverageValue)
+		scalerLogger.V(1).Info("Scaler Metric value", "isTriggerActive", isTriggerActive, scaledJobMetricName, queueLength, "targetAverageValue", targetAverageValue)
 
 		if isTriggerActive {
 			isActive = true

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -21,7 +21,7 @@ import (
 func TestTargetAverageValue(t *testing.T) {
 	// count = 0
 	specs := []v2beta2.MetricSpec{}
-	metricName := "queueLength"
+	metricName := "s0-messageCount"
 	targetAverageValue := getTargetAverageValue(specs)
 	assert.Equal(t, int64(0), targetAverageValue)
 	// 1 1

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -232,7 +232,7 @@ func createScaledObject(maxReplicaCount int32, multipleScalersCalculation string
 }
 
 func createScaler(ctrl *gomock.Controller, queueLength int64, averageValue int64, isActive bool) *mock_scalers.MockScaler {
-	metricName := scaledJobMetricName
+	metricName := "queueLength"
 	scaler := mock_scalers.NewMockScaler(ctrl)
 	metricsSpecs := []v2beta2.MetricSpec{createMetricSpec(averageValue)}
 	metrics := []external_metrics.ExternalMetricValue{

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -65,16 +65,16 @@ func createMetricSpec(averageValue int64, metricName string) v2beta2.MetricSpec 
 }
 
 func TestIsScaledJobActive(t *testing.T) {
+	metricName := "s0-queueLength"
 	ctrl := gomock.NewController(t)
 	recorder := record.NewFakeRecorder(1)
-
 	// Keep the current behavior
 	// Assme 1 trigger only
 	scaledJobSingle := createScaledObject(100, "") // testing default = max
 	scalerSingle := []ScalerBuilder{{
-		Scaler: createScaler(ctrl, int64(20), int64(2), true),
+		Scaler: createScaler(ctrl, int64(20), int64(2), true, metricName),
 		Factory: func() (scalers.Scaler, error) {
-			return createScaler(ctrl, int64(20), int64(2), true), nil
+			return createScaler(ctrl, int64(20), int64(2), true, metricName), nil
 		},
 	}}
 
@@ -92,9 +92,9 @@ func TestIsScaledJobActive(t *testing.T) {
 
 	// Non-Active trigger only
 	scalerSingle = []ScalerBuilder{{
-		Scaler: createScaler(ctrl, int64(0), int64(2), false),
+		Scaler: createScaler(ctrl, int64(0), int64(2), false, metricName),
 		Factory: func() (scalers.Scaler, error) {
-			return createScaler(ctrl, int64(0), int64(2), false), nil
+			return createScaler(ctrl, int64(0), int64(2), false, metricName), nil
 		},
 	}}
 
@@ -112,34 +112,34 @@ func TestIsScaledJobActive(t *testing.T) {
 
 	// Test the valiation
 	scalerTestDatam := []scalerTestData{
-		newScalerTestData(100, "max", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 20, 20),
-		newScalerTestData(100, "min", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 5, 2),
-		newScalerTestData(100, "avg", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 12, 9),
-		newScalerTestData(100, "sum", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 35, 27),
-		newScalerTestData(25, "sum", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 35, 25),
+		newScalerTestData("s0-queueLength", 100, "max", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 20, 20),
+		newScalerTestData("queueLength", 100, "min", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 5, 2),
+		newScalerTestData("messageCount", 100, "avg", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 12, 9),
+		newScalerTestData("s3-messageCount", 100, "sum", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 35, 27),
+		newScalerTestData("s10-messageCount", 25, "sum", 20, 1, true, 10, 2, true, 5, 3, true, 7, 4, false, true, 35, 25),
 	}
 
 	for index, scalerTestData := range scalerTestDatam {
 		scaledJob := createScaledObject(scalerTestData.MaxReplicaCount, scalerTestData.MultipleScalersCalculation)
 		scalersToTest := []ScalerBuilder{{
-			Scaler: createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive),
+			Scaler: createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive, scalerTestData.MetricName),
 			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive), nil
+				return createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive, scalerTestData.MetricName), nil
 			},
 		}, {
-			Scaler: createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive),
+			Scaler: createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive, scalerTestData.MetricName),
 			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive), nil
+				return createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive, scalerTestData.MetricName), nil
 			},
 		}, {
-			Scaler: createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive),
+			Scaler: createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive, scalerTestData.MetricName),
 			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive), nil
+				return createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive, scalerTestData.MetricName), nil
 			},
 		}, {
-			Scaler: createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive),
+			Scaler: createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive, scalerTestData.MetricName),
 			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive), nil
+				return createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive, scalerTestData.MetricName), nil
 			},
 		}}
 
@@ -159,6 +159,7 @@ func TestIsScaledJobActive(t *testing.T) {
 }
 
 func newScalerTestData(
+	metricName string,
 	maxReplicaCount int,
 	multipleScalersCalculation string,
 	scaler1QueueLength, //nolint:golint,unparam
@@ -177,6 +178,7 @@ func newScalerTestData(
 	resultQueueLength,
 	resultMaxLength int) scalerTestData {
 	return scalerTestData{
+		MetricName:                 metricName,
 		MaxReplicaCount:            int32(maxReplicaCount),
 		MultipleScalersCalculation: multipleScalersCalculation,
 		Scaler1QueueLength:         int64(scaler1QueueLength),
@@ -198,6 +200,7 @@ func newScalerTestData(
 }
 
 type scalerTestData struct {
+	MetricName                 string
 	MaxReplicaCount            int32
 	MultipleScalersCalculation string
 	Scaler1QueueLength         int64
@@ -235,8 +238,7 @@ func createScaledObject(maxReplicaCount int32, multipleScalersCalculation string
 	}
 }
 
-func createScaler(ctrl *gomock.Controller, queueLength int64, averageValue int64, isActive bool) *mock_scalers.MockScaler {
-	metricName := "s0-queueLength"
+func createScaler(ctrl *gomock.Controller, queueLength int64, averageValue int64, isActive bool, metricName string) *mock_scalers.MockScaler {
 	scaler := mock_scalers.NewMockScaler(ctrl)
 	metricsSpecs := []v2beta2.MetricSpec{createMetricSpec(averageValue, metricName)}
 

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -21,7 +21,7 @@ import (
 func TestTargetAverageValue(t *testing.T) {
 	// count = 0
 	specs := []v2beta2.MetricSpec{}
-	metricName := "s0-queueLength"
+	metricName := "queueLength"
 	targetAverageValue := getTargetAverageValue(specs)
 	assert.Equal(t, int64(0), targetAverageValue)
 	// 1 1

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -232,7 +232,7 @@ func createScaledObject(maxReplicaCount int32, multipleScalersCalculation string
 }
 
 func createScaler(ctrl *gomock.Controller, queueLength int64, averageValue int64, isActive bool) *mock_scalers.MockScaler {
-	metricName := "queueLength"
+	metricName := scaledJobMetricName
 	scaler := mock_scalers.NewMockScaler(ctrl)
 	metricsSpecs := []v2beta2.MetricSpec{createMetricSpec(averageValue)}
 	metrics := []external_metrics.ExternalMetricValue{

--- a/tests/scalers/external-scaler.sj.test.ts
+++ b/tests/scalers/external-scaler.sj.test.ts
@@ -1,0 +1,155 @@
+import * as sh from "shelljs"
+import test from "ava"
+import { createNamespace, createYamlFile, waitForDeploymentReplicaCount, waitForJobCount } from "./helpers"
+
+const testName = "test-external-scaler-sj"
+const testNamespace = `${testName}-ns`
+const scalerName = `${testName}-scaler`
+const serviceName = `${testName}-service`
+const deploymentName = `${testName}-deployment`
+const scaledJobName = `${testName}-scaled-job`
+
+const maxReplicaCount = 5
+const threshold = 10
+
+test.before(async t => {
+    sh.config.silent = true
+
+    // Create Kubernetes Namespace
+    createNamespace(testNamespace)
+
+    // Create external scaler deployment
+    t.is(
+        sh.exec(`kubectl apply -f ${createYamlFile(scalerYaml)} -n ${testNamespace}`).code,
+        0,
+        "Createing a external scaler deployment should work"
+    )
+
+    // Create service
+    t.is(
+        sh.exec(`kubectl apply -f ${createYamlFile(serviceYaml)} -n ${testNamespace}`).code,
+        0,
+        "Createing a service should work"
+    )
+
+    // Create scaled job
+    t.is(
+        sh.exec(`kubectl apply -f ${createYamlFile(scaledJobYaml.replace("{{VALUE}}", "0"))} -n ${testNamespace}`).code,
+        0,
+        "Creating a scaled job should work"
+    )
+
+    t.true(await waitForJobCount(0, testNamespace, 60, 1000),`Replica count should be 0 after 1 minute`)
+})
+
+test.serial("Deployment should scale up to maxReplicaCount", async t => {
+    // Modify scaled job's metricValue to induce scaling
+    t.is(
+        sh.exec(`kubectl apply -f ${createYamlFile(scaledJobYaml.replace("{{VALUE}}", `${threshold * 2}`))} -n ${testNamespace}`).code,
+        0,
+        "Modifying scaled job should work"
+    )
+
+    t.true(await waitForJobCount(maxReplicaCount, testNamespace, 60, 1000),`Replica count should be 0 after 1 minute`)
+})
+
+test.serial("Deployment should scale back down to 0", async t => {
+    // Modify scaled job's metricValue to induce scaling
+    t.is(
+        sh.exec(`kubectl apply -f ${createYamlFile(scaledJobYaml.replace("{{VALUE}}", "0"))} -n ${testNamespace}`).code,
+        0,
+        "Modifying scaled job should work"
+    )
+
+    t.true(await waitForJobCount(0, testNamespace, 120, 1000),`Replica count should be 0 after 2 minute`)
+})
+
+test.after.always("Clean up E2E K8s objects", async t => {
+    const resources = [
+        `scaledjob.keda.sh/${scaledJobName}`,
+        `deployments.apps/${deploymentName}`,
+        `service/${serviceName}`,
+        `deployments.apps/${scalerName}`,
+    ]
+
+    for (const resource of resources) {
+        sh.exec(`kubectl delete ${resource} -n ${testNamespace}`)
+    }
+
+    sh.exec(`kubectl delete ns ${testNamespace}`)
+})
+
+// YAML Definitions for Kubernetes resources
+// External Scaler Deployment
+const scalerYaml =
+`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${scalerName}
+  namespace: ${testNamespace}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${scalerName}
+  template:
+    metadata:
+      labels:
+        app: ${scalerName}
+    spec:
+      containers:
+      - name: scaler
+        image: ghcr.io/kedacore/tests-external-scaler-e2e:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 6000
+`
+
+const serviceYaml =
+`
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${serviceName}
+  namespace: ${testNamespace}
+spec:
+  ports:
+  - port: 6000
+    targetPort: 6000
+  selector:
+    app: ${scalerName}
+`
+
+// scaled job
+const scaledJobYaml =
+`
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: ${scaledJobName}
+  namespace: ${testNamespace}
+spec:
+  jobTargetRef:
+    template:
+      spec:
+        containers:
+          - name: external-executor
+            image: busybox
+            command:
+            - sleep 
+            - "30"
+            imagePullPolicy: IfNotPresent
+        restartPolicy: Never
+    backoffLimit: 1
+  pollingInterval: 5
+  maxReplicaCount: ${maxReplicaCount}
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 10
+  triggers:
+  - type: external
+    metadata:
+      scalerAddress: ${serviceName}.${testNamespace}:6000
+      metricThreshold: "${threshold}"
+      metricValue: "{{VALUE}}"
+`

--- a/tests/scalers/external-scaler.sj.test.ts
+++ b/tests/scalers/external-scaler.sj.test.ts
@@ -9,7 +9,7 @@ const serviceName = `${testName}-service`
 const deploymentName = `${testName}-deployment`
 const scaledJobName = `${testName}-scaled-job`
 
-const maxReplicaCount = 5
+const maxReplicaCount = 3
 const threshold = 10
 
 test.before(async t => {
@@ -45,7 +45,7 @@ test.before(async t => {
 test.serial("Deployment should scale up to maxReplicaCount", async t => {
     // Modify scaled job's metricValue to induce scaling
     t.is(
-        sh.exec(`kubectl apply -f ${createYamlFile(scaledJobYaml.replace("{{VALUE}}", `${threshold * 2}`))} -n ${testNamespace}`).code,
+        sh.exec(`kubectl apply -f ${createYamlFile(scaledJobYaml.replace("{{VALUE}}", `${threshold * maxReplicaCount}`))} -n ${testNamespace}`).code,
         0,
         "Modifying scaled job should work"
     )

--- a/tests/scalers/external-scaler.sj.test.ts
+++ b/tests/scalers/external-scaler.sj.test.ts
@@ -50,7 +50,7 @@ test.serial("Deployment should scale up to maxReplicaCount", async t => {
         "Modifying scaled job should work"
     )
 
-    t.true(await waitForJobCount(maxReplicaCount, testNamespace, 60, 1000),`Replica count should be 0 after 1 minute`)
+    t.true(await waitForJobCount(maxReplicaCount, testNamespace, 60, 1000),`Replica count should be ${maxReplicaCount} after 1 minute`)
 })
 
 test.serial("Deployment should scale back down to 0", async t => {

--- a/tests/scalers/external-scaler.sj.test.ts
+++ b/tests/scalers/external-scaler.sj.test.ts
@@ -137,7 +137,7 @@ spec:
           - name: external-executor
             image: busybox
             command:
-            - sleep 
+            - sleep
             - "30"
             imagePullPolicy: IfNotPresent
         restartPolicy: Never

--- a/tests/scalers/external-scaler.so.test.ts
+++ b/tests/scalers/external-scaler.so.test.ts
@@ -67,7 +67,7 @@ test.serial("Deployment should scale up to minReplicaCount", async t => {
 test.serial("Deployment should scale up to maxReplicaCount", async t => {
     // Modify scaled object's metricValue to induce scaling
     t.is(
-        sh.exec(`kubectl apply -f ${createYamlFile(scaledObjectYaml.replace("{{VALUE}}", `${threshold * 2}`))} -n ${testNamespace}`).code,
+        sh.exec(`kubectl apply -f ${createYamlFile(scaledObjectYaml.replace("{{VALUE}}", `${threshold * maxReplicaCount}`))} -n ${testNamespace}`).code,
         0,
         "Modifying scaled object should work"
     )

--- a/tests/scalers/external-scaler.so.test.ts
+++ b/tests/scalers/external-scaler.so.test.ts
@@ -2,7 +2,7 @@ import * as sh from "shelljs"
 import test from "ava"
 import { createNamespace, createYamlFile, waitForDeploymentReplicaCount } from "./helpers"
 
-const testName = "test-external-scaler"
+const testName = "test-external-scaler-so"
 const testNamespace = `${testName}-ns`
 const scalerName = `${testName}-scaler`
 const serviceName = `${testName}-service`

--- a/tests/scalers/helpers.ts
+++ b/tests/scalers/helpers.ts
@@ -29,7 +29,12 @@ export async function waitForJobCount(target: number, namespace: string, iterati
     for (let i = 0; i < iterations; i++) {
         let jobCountStr = sh.exec(`kubectl get job --namespace ${namespace} | wc -l`).stdout.replace(/[\r\n]/g,"")
         try {
-            const jobCount = parseInt(jobCountStr, 10)
+            let jobCount = parseInt(jobCountStr, 10)
+            // This method counts also the header line in the output, so we have to remove 1 if the jobCount is > 1
+            if (jobCount > 0) {
+                jobCount--
+            }
+
             if (jobCount === target) {
                 return true
             }

--- a/tests/scalers/helpers.ts
+++ b/tests/scalers/helpers.ts
@@ -25,6 +25,21 @@ export async function waitForDeploymentReplicaCount(target: number, name: string
     return false
 }
 
+export async function waitForJobCount(target: number, namespace: string, iterations = 10, interval = 3000): Promise<boolean> {
+    for (let i = 0; i < iterations; i++) {
+        let jobCountStr = sh.exec(`kubectl get job --namespace ${namespace} | wc -l`).stdout.replace(/[\r\n]/g,"")
+        try {
+            const jobCount = parseInt(jobCountStr, 10)
+            if (jobCount === target) {
+                return true
+            }
+        } catch { }
+
+        await sleep(interval)
+    }
+    return false
+}
+
 export async function createNamespace(namespace: string) {
     const namespaceFile = tmp.fileSync()
     fs.writeFileSync(namespaceFile.name, namespaceTemplate.replace('{{NAMESPACE}}', namespace))

--- a/tests/scalers/mongodb.test.ts
+++ b/tests/scalers/mongodb.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as sh from 'shelljs'
 import * as tmp from 'tmp'
 import test from 'ava'
-import { createNamespace } from './helpers'
+import { createNamespace, waitForJobCount } from './helpers'
 
 const mongoDBNamespace = 'mongodb'
 const testNamespace = 'mongodb-test'
@@ -61,14 +61,11 @@ test.before(t => {
 
 })
 
-test.serial('Job should have 0 job on start', t => {
-    const jobCount = sh.exec(
-        `kubectl get job --namespace ${testNamespace}`
-    ).stdout
-    t.is(jobCount, '', 'job count should start out as 0')
+test.serial('Job should have 0 job on start', async t => {
+    t.true(await waitForJobCount(0, testNamespace, 10, 1000), `job count should start out as 0`)
 })
 
-test.serial(`Job should scale to 5 then back to 0`, t => {
+test.serial(`Job should scale to 5 then back to 0`, async t => {
     // insert data to mongodb
     const InsertJS = `db.${mongodbCollection}.insert([
     {"region":"eu-1","state":"running","plan":"planA","goods":"apple"},
@@ -88,30 +85,13 @@ test.serial(`Job should scale to 5 then back to 0`, t => {
 
     let jobCount = '0'
     // maxJobCount = real Job + first line of output
-    const maxJobCount = '6'
+    const maxJobCount = 6
 
-    for (let i = 0; i < 30 && jobCount !== maxJobCount; i++) {
-        jobCount = sh.exec(
-            `kubectl get job --namespace ${testNamespace} | wc -l`
-        ).stdout.replace(/[\r\n]/g,"")
+    t.true(await waitForJobCount(maxJobCount, testNamespace, 60, 1000), `Job count should be ${maxJobCount} after 60 seconds`)
+    
+    // Process elements
 
-        if (jobCount !== maxJobCount) {
-            sh.exec('sleep 2s')
-        }
-    }
-
-    t.is(maxJobCount, jobCount, `Job count should be ${maxJobCount} after 60 seconds`)
-
-    for (let i = 0; i < 36 && jobCount !== '0'; i++) {
-        jobCount = sh.exec(
-            `kubectl get job --namespace ${testNamespace} | wc -l`
-        ).stdout.replace(/[\r\n]/g,"")
-        if (jobCount !== '0') {
-            sh.exec('sleep 5s')
-        }
-    }
-
-    t.is('0', jobCount, 'Job count should be 0 after 3 minutes')
+    t.true(await waitForJobCount(0, testNamespace, 180, 1000), `Job count should be 0 after 3 minutes`)
 })
 
 test.after.always.cb('clean up mongodb deployment', t => {

--- a/tests/scalers/mongodb.test.ts
+++ b/tests/scalers/mongodb.test.ts
@@ -82,8 +82,8 @@ test.serial(`Job should scale to 5 then back to 0`, async t => {
         sh.exec(`kubectl exec -n ${mongoDBNamespace} ${mongoDBPod} -- mongo --eval \'${InsertJS}\'`).code,
         'insert 5 mongo record'
     )
-
-    t.true(await waitForJobCount(5, testNamespace, 60, 1000), `Job count should be ${maxJobCount} after 60 seconds`)
+    let maxJobCount = 5
+    t.true(await waitForJobCount(maxJobCount, testNamespace, 60, 1000), `Job count should be ${maxJobCount} after 60 seconds`)
 
     // Process elements
 

--- a/tests/scalers/mongodb.test.ts
+++ b/tests/scalers/mongodb.test.ts
@@ -83,12 +83,11 @@ test.serial(`Job should scale to 5 then back to 0`, async t => {
         'insert 5 mongo record'
     )
 
-    let jobCount = '0'
     // maxJobCount = real Job + first line of output
     const maxJobCount = 6
 
     t.true(await waitForJobCount(maxJobCount, testNamespace, 60, 1000), `Job count should be ${maxJobCount} after 60 seconds`)
-    
+
     // Process elements
 
     t.true(await waitForJobCount(0, testNamespace, 180, 1000), `Job count should be 0 after 3 minutes`)

--- a/tests/scalers/mongodb.test.ts
+++ b/tests/scalers/mongodb.test.ts
@@ -83,10 +83,7 @@ test.serial(`Job should scale to 5 then back to 0`, async t => {
         'insert 5 mongo record'
     )
 
-    // maxJobCount = real Job + first line of output
-    const maxJobCount = 6
-
-    t.true(await waitForJobCount(maxJobCount, testNamespace, 60, 1000), `Job count should be ${maxJobCount} after 60 seconds`)
+    t.true(await waitForJobCount(5, testNamespace, 60, 1000), `Job count should be ${maxJobCount} after 60 seconds`)
 
     // Process elements
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

After introducing the unique metric names using the prefix and the solution for external scaler, it fails in case of ScaledJobs because we use `queueLength` as a metric name in case of ScaledJob (ignoring the given name from the external scaler) and this metric doesn't have the prefix. 

This PR modifies the behaviour to use the metric spec given from GetMetricSpec instead of the hardcoded value, Using this approach all the code in the scaler that work for ScaledObject work for ScaledJob because now they follow the same behavior (from scaler internal pov).

I have added also an e2e with ScaledJob and external scaler to ensure the behaviour in the future and other small improvements

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes # https://github.com/kedacore/keda/issues/3032
