### PR TITLE
chore: Automatically add labels for all e2e-tests stages to PRs

### DIFF
--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -1,0 +1,21 @@
+name: new-pr-opened
+on:
+  pull_request:
+    types:
+      - opened
+
+env:
+  DEFAULT_LABEL: e2e-tests/not-run
+
+jobs:
+  prepare_pr:
+    name: Prepare new PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add '${{ env.DEFAULT_LABEL}}' label
+        id: add-label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          gh pr edit ${{ github.event.number }} --add-label '${{ env.DEFAULT_LABEL}}'

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -17,5 +17,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          gh pr edit ${{ github.event.number }} --add-label '${{ env.DEFAULT_LABEL}}'
+          gh pr edit ${{ github.event.number }} --add-label '${{ env.DEFAULT_LABEL}}' --repo $GITHUB_REPOSITORY

--- a/.github/workflows/pr-e2e-pr-validation.yml
+++ b/.github/workflows/pr-e2e-pr-validation.yml
@@ -8,6 +8,9 @@ on:
       - labeled
       - unlabeled
 
+env:
+  E2E_LABEL: e2e-tests/ok-to-merge
+  
 jobs:
   validate-e2e-labels:
     name: Check e2e labels

--- a/.github/workflows/pr-e2e-pr-validation.yml
+++ b/.github/workflows/pr-e2e-pr-validation.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   E2E_LABEL: e2e-tests/ok-to-merge
-  
+
 jobs:
   validate-e2e-labels:
     name: Check e2e labels

--- a/.github/workflows/pr-e2e-pr-validation.yml
+++ b/.github/workflows/pr-e2e-pr-validation.yml
@@ -18,5 +18,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          any_of: ok-to-merge
+          any_of: ${{ env.E2E_LABEL}}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -4,7 +4,7 @@ on:
     types: [created]
 
 env:
-  E2E_LABEL: ok-to-merge
+  E2E_LABEL: e2e-tests/ok-to-merge
 
 jobs:
   triage:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -4,7 +4,8 @@ on:
     types: [created]
 
 env:
-  E2E_LABEL: e2e-tests/ok-to-merge
+  E2E_LABELS_NOTRUN: e2e-tests/not-run
+  E2E_LABELS_PASSED: e2e-tests/ok-to-merge
 
 jobs:
   triage:
@@ -48,13 +49,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Remove '${{ env.E2E_LABEL}}' label
+      - name: Remove '${{ env.E2E_LABELS_PASSED}}' label
         id: remove-label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABEL}}'
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABELS_PASSED}}'
 
       - name: Checkout Pull Request
         env:
@@ -89,13 +90,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Remove '${{ env.E2E_LABEL}}' label
+      - name: Remove '${{ env.E2E_LABELS_NOTRUN}}' label
         id: remove-label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABEL}}'
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABELS_NOTRUN}}'
+
+      - name: Remove '${{ env.E2E_LABELS_PASSED}}' label
+        id: remove-label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABELS_PASSED}}'
 
       - name: Checkout Pull Request
         env:
@@ -176,14 +185,14 @@ jobs:
           commentId: ${{ github.event.comment.id }}
           reaction: "+1"
 
-      - name: Add '${{ env.E2E_LABEL}}' label
+      - name: Add '${{ env.E2E_LABELS_PASSED}}' label
         id: add-label
         if: steps.test.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          gh pr edit ${{ needs.triage.outputs.pr_num }} --add-label '${{ env.E2E_LABEL}}'
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --add-label '${{ env.E2E_LABELS_PASSED}}'
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -6,6 +6,8 @@ on:
 env:
   E2E_LABELS_NOTRUN: e2e-tests/not-run
   E2E_LABELS_PASSED: e2e-tests/ok-to-merge
+  E2E_LABELS_FAILED: e2e-tests/failed
+  E2E_LABELS_RUNNING: e2e-tests/running
 
 jobs:
   triage:
@@ -49,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Remove '${{ env.E2E_LABELS_PASSED}}' label
+      - name: Remove '${{ env.E2E_LABELS_PASSED }}' label
         id: remove-label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -91,7 +93,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Remove '${{ env.E2E_LABELS_NOTRUN}}' label
-        id: remove-label
+        id: remove-not-run-label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -99,12 +101,28 @@ jobs:
           gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABELS_NOTRUN}}'
 
       - name: Remove '${{ env.E2E_LABELS_PASSED}}' label
-        id: remove-label
+        id: remove-pass-label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABELS_PASSED}}'
+
+      - name: Remove '${{ env.E2E_LABELS_FAILED }}' label
+        id: remove-failed-label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABELS_FAILED }}'
+
+      - name: Add '${{ env.E2E_LABELS_RUNNING }}' label
+        id: add-running-label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --add-label '${{ env.E2E_LABELS_RUNNING }}'
 
       - name: Checkout Pull Request
         env:
@@ -177,6 +195,14 @@ jobs:
           AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
           TEST_CLUSTER_NAME: keda-pr-run
 
+      - name: Remove '${{ env.E2E_LABELS_RUNNING }}' label
+        id: remove-running-label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --remove-label '${{ env.E2E_LABELS_RUNNING }}'
+
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1
         if: steps.test.outcome == 'success'
@@ -185,14 +211,14 @@ jobs:
           commentId: ${{ github.event.comment.id }}
           reaction: "+1"
 
-      - name: Add '${{ env.E2E_LABELS_PASSED}}' label
-        id: add-label
+      - name: Add '${{ env.E2E_LABELS_PASSED }}' label
+        id: add-pass-label
         if: steps.test.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          gh pr edit ${{ needs.triage.outputs.pr_num }} --add-label '${{ env.E2E_LABELS_PASSED}}'
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --add-label '${{ env.E2E_LABELS_PASSED }}'
 
       - name: React to comment with failure
         uses: dkershner6/reaction-action@v1
@@ -201,3 +227,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commentId: ${{ github.event.comment.id }}
           reaction: "-1"
+
+      - name: Add '${{ env.E2E_LABELS_FAILED }}' label
+        id: add-failure-label
+        if: steps.test.outcome != 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          gh pr edit ${{ needs.triage.outputs.pr_num }} --add-label '${{ env.E2E_LABELS_FAILED }}'


### PR DESCRIPTION
Automatically add labels for all e2e-tests stages to PRs:
- Automatically add 'e2e-tests/not-run' label to new PRs
- Automatically add 'e2e-tests/failed-run' when tests have failed for a PR
- Automatically add 'e2e-tests/running' when tests are running for a PR
- Rename `ok-to-merge` to `e2e-tests/ok-to-merge` so that it's clear to end-users what the label stands for.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
