### PR TITLE
use more readable timestamps in KEDA operator logs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -178,6 +178,21 @@ Allowed values are `json` and `console`
 
 Default value: `console`
 
+To change the logging time encoding, find `--zap-time-encoding=` argument in Operator Deployment section in `config/manager/manager.yaml` file,
+ modify its value and redeploy.
+
+Allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
+
+Default value: `rfc3339`
+
+> Note: Example of some of the logging time encoding values and the output:
+```
+epoch - 1.6533943565181081e+09
+iso8601 - 2022-05-24T12:10:19.411Z
+rfc3339 - 2022-05-24T12:07:40Z
+rfc3339nano - 2022-05-24T12:10:19.411Z
+```
+
 ### Metrics Server logging
 
 Find `--v=0` argument in Operator Deployment section in `config/metrics-server/deployment.yaml` file, modify its value and redeploy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 ### Improvements
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+- **General:** Use more readable timestamps in KEDA Operator logs ([#3066](https://github.com/kedacore/keda/issue/3066))
 
 ### Deprecations
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,7 @@ spec:
             - --leader-elect
             - --zap-log-level=info
             - --zap-encoder=console
+            - --zap-time-encoding=rfc3339
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Before:
```
1.6520847646863375e+09    INFO    setup    KEDA Version: 2.7.0
1.652084764686349e+09    INFO    setup    Git Commit: 5f8af5cd90805d8b9c5964e1619a8b2bdcec6cfd
1.6520847646863651e+09    INFO    setup    Go Version: go1.17.3
1.6520847646863775e+09    INFO    setup    Go OS/Arch: linux/amd64 
```

After:
```
2022-05-24T12:07:40Z     INFO    setup    KEDA Version: 2.7.0
2022-05-24T12:07:40Z     INFO    setup    Git Commit: 5f8af5cd90805d8b9c5964e1619a8b2bdcec6cfd
2022-05-24T12:07:40Z     INFO    setup    Go Version: go1.17.3
2022-05-24T12:07:40Z     INFO    setup    Go OS/Arch: linux/amd64 
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update our Helm chart (https://github.com/kedacore/charts/pull/278) 
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #3066
