### PR TITLE
reduce gRPC connection create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 - **General:** Use `mili` scale for the returned metrics ([#3135](https://github.com/kedacore/keda/issue/3135))
 - **General:** Use more readable timestamps in KEDA Operator logs ([#3066](https://github.com/kedacore/keda/issue/3066))
+- **General:** `external` extension reduces connection establishment with long links ([#3193](https://github.com/kedacore/keda/issues/3193))
 - **AWS SQS Queue Scaler:** Support for scaling to include in-flight messages. ([#3133](https://github.com/kedacore/keda/issues/3133))
 - **Prometheus Scaler:** Add ignoreNullValues to return error when prometheus return null in values ([#3065](https://github.com/kedacore/keda/issues/3065))
 - **Selenium Grid Scaler:** Edge active sessions not being properly counted ([#2709](https://github.com/kedacore/keda/issues/2709))
@@ -55,7 +56,6 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 - **General:** Use metricName from GetMetricsSpec in ScaledJobs instead of `queueLength` ([#3032](https://github.com/kedacore/keda/issue/3032))
 - **ActiveMQ Scaler:** KEDA doesn't respect restAPITemplate ([#3188](https://github.com/kedacore/keda/issues/3188))
 - **Azure Eventhub Scaler:** KEDA operator crashes on nil memory panic if the eventhub connectionstring for Azure Eventhub Scaler contains an invalid character ([#3082](https://github.com/kedacore/keda/issues/3082))
-- **General:** `external` extension reduces connection establishment with long links ([#3184](https://github.com/kedacore/keda/pull/3184))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 - **General:** Refactor adapter startup to ensure proper log initilization. ([2316](https://github.com/kedacore/keda/issues/2316))
 - **Azure Eventhub Scaler:** KEDA operator crashes on nil memory panic if the eventhub connectionstring for Azure Eventhub Scaler contains an invalid character ([#3082](https://github.com/kedacore/keda/issues/3082))
 - **General:** Scaleobject ready condition 'False/Unknow' to 'True' requeue([#3096](https://github.com/kedacore/keda/issues/3096))
+- **General:** `external` extension reduces connection establishment with long links ([#3184](https://github.com/kedacore/keda/pull/3184))
 
 ### Deprecations
 

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -7,16 +7,16 @@ import (
 	"sync"
 	"time"
 
+	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 	"github.com/mitchellh/hashstructure"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 )
 
 type externalScaler struct {
@@ -38,7 +38,6 @@ type externalScalerMetadata struct {
 
 type connectionGroup struct {
 	grpcConnection *grpc.ClientConn
-	waitGroup      *sync.WaitGroup
 }
 
 // a pool of connectionGroup per metadata hash
@@ -130,11 +129,10 @@ func parseExternalScalerMetadata(config *ScalerConfig) (externalScalerMetadata, 
 
 // IsActive checks if there are any messages in the subscription
 func (s *externalScaler) IsActive(ctx context.Context) (bool, error) {
-	grpcClient, done, err := getClientForConnectionPool(s.metadata)
+	grpcClient, err := getClientForConnectionPool(s.metadata)
 	if err != nil {
 		return false, err
 	}
-	defer done()
 
 	response, err := grpcClient.IsActive(ctx, &s.scaledObjectRef)
 	if err != nil {
@@ -153,12 +151,11 @@ func (s *externalScaler) Close(context.Context) error {
 func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.MetricSpec {
 	var result []v2beta2.MetricSpec
 
-	grpcClient, done, err := getClientForConnectionPool(s.metadata)
+	grpcClient, err := getClientForConnectionPool(s.metadata)
 	if err != nil {
 		externalLog.Error(err, "error building grpc connection")
 		return result
 	}
-	defer done()
 
 	response, err := grpcClient.GetMetricSpec(ctx, &s.scaledObjectRef)
 	if err != nil {
@@ -189,11 +186,10 @@ func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2beta2.
 // GetMetrics connects calls the gRPC interface to get the metrics with a specific name
 func (s *externalScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	var metrics []external_metrics.ExternalMetricValue
-	grpcClient, done, err := getClientForConnectionPool(s.metadata)
+	grpcClient, err := getClientForConnectionPool(s.metadata)
 	if err != nil {
 		return metrics, err
 	}
-	defer done()
 
 	// Remove the sX- prefix as the external scaler shouldn't have to know about it
 	metricNameWithoutIndex, err := RemoveIndexFromMetricName(s.metadata.scalerIndex, metricName)
@@ -225,7 +221,7 @@ func (s *externalPushScaler) Run(ctx context.Context, active chan<- bool) {
 	defer close(active)
 	// It's possible for the connection to get terminated anytime, we need to run this in a retry loop
 	runWithLog := func() {
-		grpcClient, done, err := getClientForConnectionPool(s.metadata)
+		grpcClient, err := getClientForConnectionPool(s.metadata)
 		if err != nil {
 			externalLog.Error(err, "error running internalRun")
 			return
@@ -234,7 +230,6 @@ func (s *externalPushScaler) Run(ctx context.Context, active chan<- bool) {
 			externalLog.Error(err, "error running internalRun")
 			return
 		}
-		done()
 	}
 
 	// retry on error from runWithLog() starting by 2 sec backing off * 2 with a max of 1 minute
@@ -287,7 +282,7 @@ var connectionPoolMutex sync.Mutex
 
 // getClientForConnectionPool returns a grpcClient and a done() Func. The done() function must be called once the client is no longer
 // in use to clean up the shared grpc.ClientConn
-func getClientForConnectionPool(metadata externalScalerMetadata) (pb.ExternalScalerClient, func(), error) {
+func getClientForConnectionPool(metadata externalScalerMetadata) (pb.ExternalScalerClient, error) {
 	connectionPoolMutex.Lock()
 	defer connectionPoolMutex.Unlock()
 
@@ -307,43 +302,61 @@ func getClientForConnectionPool(metadata externalScalerMetadata) (pb.ExternalSca
 	// in the metadata, they will share the same grpc.ClientConn
 	key, err := hashstructure.Hash(metadata.scalerAddress, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if i, ok := connectionPool.Load(key); ok {
 		if connGroup, ok := i.(*connectionGroup); ok {
-			connGroup.waitGroup.Add(1)
-			return pb.NewExternalScalerClient(connGroup.grpcConnection), func() {
-				connGroup.waitGroup.Done()
-			}, nil
+			return pb.NewExternalScalerClient(connGroup.grpcConnection), nil
 		}
 	}
 
 	conn, err := buildGRPCConnection(metadata)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	waitGroup := &sync.WaitGroup{}
-	waitGroup.Add(1)
 	connGroup := &connectionGroup{
 		grpcConnection: conn,
-		waitGroup:      waitGroup,
 	}
 
 	connectionPool.Store(key, connGroup)
 
 	go func() {
 		// clean up goroutine.
-		// once all waitGroup is done, remove the connection from the pool and Close() grpc.ClientConn
-		connGroup.waitGroup.Wait()
+		// once gRPC client is shutdown, remove the connection from the pool and Close() grpc.ClientConn
+		<-waitForState(context.TODO(), connGroup.grpcConnection, connectivity.Shutdown)
 		connectionPoolMutex.Lock()
 		defer connectionPoolMutex.Unlock()
 		connectionPool.Delete(key)
 		connGroup.grpcConnection.Close()
 	}()
 
-	return pb.NewExternalScalerClient(connGroup.grpcConnection), func() {
-		connGroup.waitGroup.Done()
-	}, nil
+	return pb.NewExternalScalerClient(connGroup.grpcConnection), nil
+}
+
+func waitForState(ctx context.Context, conn *grpc.ClientConn, states ...connectivity.State) (done chan struct{}) {
+	done = make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for {
+			changeState := conn.WaitForStateChange(ctx, conn.GetState())
+			if !changeState {
+				// ctx is done, return
+				continue
+			}
+
+			nowState := conn.GetState()
+			for _, state := range states {
+				if state == nowState {
+					// match one of the state passed return
+					return
+				}
+			}
+		}
+	}()
+
+	return done
 }

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -305,7 +305,7 @@ func getClientForConnectionPool(metadata externalScalerMetadata) (pb.ExternalSca
 
 	// create a unique key per-metadata. If scaledObjects share the same connection properties
 	// in the metadata, they will share the same grpc.ClientConn
-	key, err := hashstructure.Hash(metadata, nil)
+	key, err := hashstructure.Hash(metadata.scalerAddress, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -326,7 +326,7 @@ func getClientForConnectionPool(metadata externalScalerMetadata) (pb.ExternalSca
 
 	waitGroup := &sync.WaitGroup{}
 	waitGroup.Add(1)
-	connGroup := connectionGroup{
+	connGroup := &connectionGroup{
 		grpcConnection: conn,
 		waitGroup:      waitGroup,
 	}

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 	"github.com/mitchellh/hashstructure"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -17,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 )
 
 type externalScaler struct {

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/status"
 
 	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
@@ -169,4 +170,77 @@ func (e *testExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef)
 
 func (e *testExternalScaler) GetMetrics(context.Context, *pb.GetMetricsRequest) (*pb.GetMetricsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetMetrics not implemented")
+}
+
+func TestWaitForState(t *testing.T) {
+	grpcServer := grpc.NewServer()
+	address := fmt.Sprintf("127.0.0.1:%d", 15050)
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Errorf("start grpcServer with %s failed:%s", address, err)
+		return
+	}
+	activeCh := make(chan bool)
+	pb.RegisterExternalScalerServer(grpcServer, &testExternalScaler{
+		t:      t,
+		active: activeCh,
+	})
+
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			t.Error(err, "error from grpcServer")
+		}
+	}()
+	// send active data
+	go func() {
+		activeCh <- true
+	}()
+
+	// build client connect to server
+	grpcClient, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		t.Errorf("connect grpc server %s failed:%s", address, err)
+		return
+	}
+	graceDone := make(chan struct{})
+	go func() {
+		// server stop will lead to Idle.
+		<-waitForState(context.TODO(), grpcClient, connectivity.Idle, connectivity.Shutdown)
+		grpcClient.Close()
+		// after close the state to Shutdown.
+		t.Log("close state:", grpcClient.GetState().String())
+		close(graceDone)
+	}()
+	client := pb.NewExternalScalerClient(grpcClient)
+
+	// request StreamIsActive interface
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
+	defer cancel()
+	stream, err := client.StreamIsActive(ctx, &pb.ScaledObjectRef{})
+	if err != nil {
+		t.Errorf("StreamIsActive request failed:%s", err)
+		return
+	}
+
+	// check result value
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if !resp.Result {
+		t.Error("StreamIsActive should receive")
+	}
+
+	// stop server
+	time.Sleep(time.Second * 5)
+	grpcServer.GracefulStop()
+
+	select {
+	case <-graceDone:
+		// test ok.
+		return
+	case <-time.After(time.Second * 1):
+		t.Error("waitForState should be get connectivity.Shutdown.")
+	}
 }

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
@@ -197,7 +198,7 @@ func TestWaitForState(t *testing.T) {
 	}()
 
 	// build client connect to server
-	grpcClient, err := grpc.Dial(address, grpc.WithInsecure())
+	grpcClient, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Errorf("connect grpc server %s failed:%s", address, err)
 		return


### PR DESCRIPTION
Signed-off-by: champly <champly@outlook.com>

- Reduce gRPC connections and `scalerAddress` multiplexing connections with the same address.
- Fix `WaitGroup is reused before previous Wait has returned` panic error.

Fix: #3193 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
