### PR TITLE
Pin cosign-installer to `v1`

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -61,7 +61,7 @@ jobs:
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v1
         with:
           cosign-release: 'v1.4.1'
       - name: Check Cosign install!

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -69,7 +69,7 @@ jobs:
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@v1
         with:
           cosign-release: 'v1.4.1'
       - name: Check Cosign install!


### PR DESCRIPTION
We now have tags available in the cosign-installer, which allows us to pin the latest release via `v1`.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


