### PR TITLE
use v2 tag and install always the latest cosign

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -61,9 +61,8 @@ jobs:
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v1
-        with:
-          cosign-release: 'v1.4.1'
+        uses: sigstore/cosign-installer@v2
+
       - name: Check Cosign install!
         run: cosign version
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -69,9 +69,8 @@ jobs:
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v1
-        with:
-          cosign-release: 'v1.4.1'
+        uses: sigstore/cosign-installer@v2
+
       - name: Check Cosign install!
         run: cosign version
 


### PR DESCRIPTION
_Provide a description of what has been changed_

- use v2 tag and install always the latest cosign
I saw the pipeline is using keyless and the version below `1.8.0` will not work anymore if use the keyless approach and the public sigstore services. Need to upgrade to `>1.8.0`

using the action with no parameter it always gets the latest available

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
