### PR TITLE
Template variable for e2e log

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -118,18 +118,22 @@ type templateData struct {
     ...
 }
 
+// templateValues consists of templates and their names
+type templateValues map[string] string
+
+
 func TestScaler(t *testing.T) {
     setupTest(t)
 
     kc := GetKubernetesClient(t)
     data, templates := getTemplateData()
 
-    CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+    CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
     testScaleUp(t)
 
     // Ensure that this gets run. Using defer is necessary
-    DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+    DeleteKubernetesResources(t, kc, testNamespace, data, templates)
     cleanupTest(t)
 }
 
@@ -142,12 +146,12 @@ func setupTest(t *testing.T) {
     assert.NoErrorf(t, err, "error while installing redis - %s", err)
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, map[string]string) {
     return templateData{
         // Populate fields required in YAML templates
         ...
         ...
-    }, []string{deploymentTemplate, scaledObjectTemplate}
+    }, templateValues{"deploymentTemplate":deploymentTemplate,  "scaledObjectTemplate":scaledObjectTemplate}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -178,11 +178,11 @@ func WaitForHpaCreation(t *testing.T, kc *kubernetes.Clientset, name, namespace 
 	return hpa, err
 }
 
-func KubectlApplyWithTemplate(t *testing.T, data interface{}, config string) {
+func KubectlApplyWithTemplate(t *testing.T, data interface{}, templateName string, config string) {
 	tmpl, err := template.New("kubernetes resource template").Parse(config)
 	assert.NoErrorf(t, err, "cannot parse template - %s", err)
 
-	tempFile, err := ioutil.TempFile("", "tempTemplateFile")
+	tempFile, err := ioutil.TempFile("", templateName)
 	assert.NoErrorf(t, err, "cannot create temp file - %s", err)
 
 	defer os.Remove(tempFile.Name())
@@ -197,18 +197,19 @@ func KubectlApplyWithTemplate(t *testing.T, data interface{}, config string) {
 	assert.NoErrorf(t, err, "cannot close temp file - %s", err)
 }
 
-func KubectlApplyMultipleWithTemplate(t *testing.T, data interface{}, configs ...string) {
-	for _, config := range configs {
-		KubectlApplyWithTemplate(t, data, config)
+func KubectlApplyMultipleWithTemplate(t *testing.T, data interface{}, configs map[string]string) {
+	for templateName, config := range configs {
+		t.Logf("Key: %s", templateName)
+		KubectlApplyWithTemplate(t, data, templateName, config)
 	}
 }
 
-func KubectlDeleteWithTemplate(t *testing.T, data interface{}, config string) {
+func KubectlDeleteWithTemplate(t *testing.T, data interface{}, templateName, config string) {
 	tmpl, err := template.New("kubernetes resource template").Parse(config)
 	assert.NoErrorf(t, err, "cannot parse template - %s", err)
 
-	tempFile, err := ioutil.TempFile("", "tempTemplateFile")
-	assert.NoErrorf(t, err, "cannot create temp file - %s", err)
+	tempFile, err := ioutil.TempFile("", templateName)
+	assert.NoErrorf(t, err, "cannot delete temp file - %s", err)
 
 	defer os.Remove(tempFile.Name())
 
@@ -222,18 +223,18 @@ func KubectlDeleteWithTemplate(t *testing.T, data interface{}, config string) {
 	assert.NoErrorf(t, err, "cannot close temp file - %s", err)
 }
 
-func KubectlDeleteMultipleWithTemplate(t *testing.T, data interface{}, configs ...string) {
-	for _, config := range configs {
-		KubectlDeleteWithTemplate(t, data, config)
+func KubectlDeleteMultipleWithTemplate(t *testing.T, data interface{}, configs map[string]string) {
+	for templateName, config := range configs {
+		KubectlDeleteWithTemplate(t, data, templateName, config)
 	}
 }
 
-func CreateKubernetesResources(t *testing.T, kc *kubernetes.Clientset, nsName string, data interface{}, configs ...string) {
+func CreateKubernetesResources(t *testing.T, kc *kubernetes.Clientset, nsName string, data interface{}, configs map[string]string) {
 	CreateNamespace(t, kc, nsName)
-	KubectlApplyMultipleWithTemplate(t, data, configs...)
+	KubectlApplyMultipleWithTemplate(t, data, configs)
 }
 
-func DeleteKubernetesResources(t *testing.T, kc *kubernetes.Clientset, nsName string, data interface{}, configs ...string) {
+func DeleteKubernetesResources(t *testing.T, kc *kubernetes.Clientset, nsName string, data interface{}, configs map[string]string) {
 	DeleteNamespace(t, kc, nsName)
-	KubectlDeleteMultipleWithTemplate(t, data, configs...)
+	KubectlDeleteMultipleWithTemplate(t, data, configs)
 }

--- a/tests/scalers_go/aws_dynamodb/aws_dynamodb_test.go
+++ b/tests/scalers_go/aws_dynamodb/aws_dynamodb_test.go
@@ -44,6 +44,8 @@ type templateData struct {
 	ExpressionAttributeValues string
 }
 
+type templateValues map[string]string
+
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -147,7 +149,7 @@ func TestDynamoDBScaler(t *testing.T) {
 	// Create kubernetes resources
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
-	CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 1),
 		"replica count should be %s after a minute", minReplicaCount)
@@ -157,7 +159,7 @@ func TestDynamoDBScaler(t *testing.T) {
 	testScaleDown(t, kc, dynamodbClient)
 
 	// cleanup
-	DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 	cleanupTable(t, dynamodbClient)
 }
 
@@ -253,7 +255,7 @@ func createDynamoDBClient() *dynamodb.DynamoDB {
 	})
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, templateValues) {
 	return templateData{
 		TestNamespace:             testNamespace,
 		DeploymentName:            deploymentName,
@@ -266,5 +268,5 @@ func getTemplateData() (templateData, []string) {
 		ExpressionAttributeNames:  expressionAttributeNames,
 		KeyConditionExpression:    keyConditionExpression,
 		ExpressionAttributeValues: expressionAttributeValues,
-	}, []string{secretTemplate, triggerAuthenticationTemplate, deploymentTemplate, scaledObjectTemplate}
+	}, templateValues{"secretTemplate": secretTemplate, "triggerAuthenticationTemplate": triggerAuthenticationTemplate, "deploymentTemplate": deploymentTemplate, "scaledObjectTemplate": scaledObjectTemplate}
 }

--- a/tests/scalers_go/aws_kinesis_stream/aws_kinesis_stream_test.go
+++ b/tests/scalers_go/aws_kinesis_stream/aws_kinesis_stream_test.go
@@ -40,6 +40,8 @@ type templateData struct {
 	KinesisStream      string
 }
 
+type templateValues map[string]string
+
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -142,7 +144,7 @@ func TestKiensisScaler(t *testing.T) {
 	// Create kubernetes resources
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
-	CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 1),
 		"replica count should be %s after a minute", minReplicaCount)
@@ -152,7 +154,7 @@ func TestKiensisScaler(t *testing.T) {
 	testScaleDown(t, kc, kinesisClient)
 
 	// cleanup
-	DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 	cleanupStream(t, kinesisClient)
 }
 
@@ -229,7 +231,7 @@ func createKinesisClient() *kinesis.Kinesis {
 	})
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, templateValues) {
 	return templateData{
 		TestNamespace:      testNamespace,
 		DeploymentName:     deploymentName,
@@ -239,5 +241,5 @@ func getTemplateData() (templateData, []string) {
 		AwsSecretAccessKey: base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
 		AwsRegion:          awsRegion,
 		KinesisStream:      kinesisStreamName,
-	}, []string{secretTemplate, triggerAuthenticationTemplate, deploymentTemplate, scaledObjectTemplate}
+	}, templateValues{"secretTemplate": secretTemplate, "triggerAuthenticationTemplate": triggerAuthenticationTemplate, "deploymentTemplate": deploymentTemplate, "scaledObjectTemplate": scaledObjectTemplate}
 }

--- a/tests/scalers_go/azure_queue/azure_queue_test.go
+++ b/tests/scalers_go/azure_queue/azure_queue_test.go
@@ -47,6 +47,7 @@ type templateData struct {
 	ScaledObjectName string
 	QueueName        string
 }
+type templateValues map[string]string
 
 const (
 	secretTemplate = `
@@ -123,7 +124,7 @@ func TestScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
 
-	CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after a minute")
@@ -133,7 +134,7 @@ func TestScaler(t *testing.T) {
 	testScaleDown(t, kc, messageURL)
 
 	// cleanup
-	DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 	cleanupQueue(t, queueURL)
 }
 
@@ -157,17 +158,20 @@ func createQueue(t *testing.T) (azqueue.QueueURL, azqueue.MessagesURL) {
 	return queueURL, messageURL
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, templateValues) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
-		TestNamespace:    testNamespace,
-		SecretName:       secretName,
-		Connection:       base64ConnectionString,
-		DeploymentName:   deploymentName,
-		ScaledObjectName: scaledObjectName,
-		QueueName:        queueName,
-	}, []string{secretTemplate, deploymentTemplate, scaledObjectTemplate}
+			TestNamespace:    testNamespace,
+			SecretName:       secretName,
+			Connection:       base64ConnectionString,
+			DeploymentName:   deploymentName,
+			ScaledObjectName: scaledObjectName,
+			QueueName:        queueName,
+		}, templateValues{
+			"secretTemplate":       secretTemplate,
+			"deploymentTemplate":   deploymentTemplate,
+			"scaledObjectTemplate": scaledObjectTemplate}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {

--- a/tests/scalers_go/azure_service_bus_queue/azure_service_bus_queue_test.go
+++ b/tests/scalers_go/azure_service_bus_queue/azure_service_bus_queue_test.go
@@ -47,6 +47,8 @@ type templateData struct {
 	QueueName        string
 }
 
+type templateValues map[string]string
+
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -127,7 +129,7 @@ func TestScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
 
-	CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after a minute")
@@ -137,7 +139,7 @@ func TestScaler(t *testing.T) {
 	testScaleDown(t, kc, sbQueue)
 
 	// cleanup
-	DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 	cleanupServiceBusQueue(t, sbQueueManager)
 }
 
@@ -174,7 +176,7 @@ func createQueue(t *testing.T, sbQueueManager *servicebus.QueueManager) {
 	assert.NoErrorf(t, err, "cannot create service bus queue - %s", err)
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, templateValues) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
@@ -185,7 +187,7 @@ func getTemplateData() (templateData, []string) {
 		TriggerAuthName:  triggerAuthName,
 		ScaledObjectName: scaledObjectName,
 		QueueName:        queueName,
-	}, []string{secretTemplate, deploymentTemplate, triggerAuthTemplate, scaledObjectTemplate}
+	}, templateValues{"secretTemplate": secretTemplate, "deploymentTemplate": deploymentTemplate, "triggerAuthTemplate": triggerAuthTemplate, "scaledObjectTemplate": scaledObjectTemplate}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, sbQueue *servicebus.Queue) {

--- a/tests/scalers_go/azure_service_bus_topic/azure_service_bus_topic_test.go
+++ b/tests/scalers_go/azure_service_bus_topic/azure_service_bus_topic_test.go
@@ -48,6 +48,7 @@ type templateData struct {
 	TopicName        string
 	SubscriptionName string
 }
+type templateValues map[string]string
 
 const (
 	secretTemplate = `
@@ -130,7 +131,7 @@ func TestScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
 
-	CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after a minute")
@@ -140,7 +141,7 @@ func TestScaler(t *testing.T) {
 	testScaleDown(t, kc, sbSubscription)
 
 	// cleanup
-	DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 	cleanupServiceBusTopic(t, sbTopicManager)
 }
 
@@ -188,19 +189,24 @@ func createTopicAndSubscription(t *testing.T, sbNamespace *servicebus.Namespace,
 	assert.NoErrorf(t, err, "cannot create subscription for topic - %s", err)
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, templateValues) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
-		TestNamespace:    testNamespace,
-		SecretName:       secretName,
-		Connection:       base64ConnectionString,
-		DeploymentName:   deploymentName,
-		TriggerAuthName:  triggerAuthName,
-		ScaledObjectName: scaledObjectName,
-		TopicName:        topicName,
-		SubscriptionName: subscriptionName,
-	}, []string{secretTemplate, deploymentTemplate, triggerAuthTemplate, scaledObjectTemplate}
+			TestNamespace:    testNamespace,
+			SecretName:       secretName,
+			Connection:       base64ConnectionString,
+			DeploymentName:   deploymentName,
+			TriggerAuthName:  triggerAuthName,
+			ScaledObjectName: scaledObjectName,
+			TopicName:        topicName,
+			SubscriptionName: subscriptionName,
+		}, templateValues{
+			"secretTemplate":       secretTemplate,
+			"deploymentTemplate":   deploymentTemplate,
+			"triggerAuthTemplate":  triggerAuthTemplate,
+			"scaledObjectTemplate": scaledObjectTemplate,
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, sbTopic *servicebus.Topic) {

--- a/tests/scalers_go/azure_workload_identity/azure_workload_identity_test.go
+++ b/tests/scalers_go/azure_workload_identity/azure_workload_identity_test.go
@@ -44,6 +44,8 @@ type templateData struct {
 	QueueName           string
 }
 
+type templateValues map[string]string
+
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -113,7 +115,7 @@ func TestScaler(t *testing.T) {
 	data, templates := getTemplateData()
 	data.ServiceBusNamespace = sbNamespace.Name
 
-	CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after a minute")
@@ -123,7 +125,7 @@ func TestScaler(t *testing.T) {
 	testScaleDown(t, kc, sbQueue)
 
 	// cleanup
-	DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 	cleanupServiceBusQueue(t, sbQueueManager)
 }
 
@@ -160,14 +162,14 @@ func createQueue(t *testing.T, sbQueueManager *servicebus.QueueManager) {
 	assert.NoErrorf(t, err, "cannot create service bus queue - %s", err)
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, templateValues) {
 	return templateData{
 		TestNamespace:    testNamespace,
 		DeploymentName:   deploymentName,
 		TriggerAuthName:  triggerAuthName,
 		ScaledObjectName: scaledObjectName,
 		QueueName:        queueName,
-	}, []string{deploymentTemplate, triggerAuthTemplate, scaledObjectTemplate}
+	}, templateValues{"deploymentTemplate": deploymentTemplate, "triggerAuthTemplate": triggerAuthTemplate, "scaledObjectTemplate": scaledObjectTemplate}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, sbQueue *servicebus.Queue) {

--- a/tests/scalers_go/cron/cron_test.go
+++ b/tests/scalers_go/cron/cron_test.go
@@ -37,6 +37,8 @@ type templateData struct {
 	EndMin           string
 }
 
+type templateValues map[string]string
+
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -97,7 +99,7 @@ func TestScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
 
-	CreateKubernetesResources(t, kc, testNamespace, data, templates...)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
 		"replica count should be 1 after a minute")
@@ -107,17 +109,20 @@ func TestScaler(t *testing.T) {
 	testScaleDown(t, kc)
 
 	// cleanup
-	DeleteKubernetesResources(t, kc, testNamespace, data, templates...)
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, []string) {
+func getTemplateData() (templateData, map[string]string) {
 	return templateData{
-		TestNamespace:    testNamespace,
-		DeploymentName:   deploymentName,
-		ScaledObjectName: scaledObjectName,
-		StartMin:         strconv.Itoa(start),
-		EndMin:           strconv.Itoa(end),
-	}, []string{deploymentTemplate, scaledObjectTemplate}
+			TestNamespace:    testNamespace,
+			DeploymentName:   deploymentName,
+			ScaledObjectName: scaledObjectName,
+			StartMin:         strconv.Itoa(start),
+			EndMin:           strconv.Itoa(end),
+		}, templateValues{
+			"deploymentTemplate":   deploymentTemplate,
+			"scaledObjectTemplate": scaledObjectTemplate,
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {


### PR DESCRIPTION
Added a variable for template name in /tests/helper/helpers.go to clarify any erroneous template file developer is applying.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added

Fixes #3192 