### PR TITLE
feat: add trivy scanner for code and images

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -171,6 +171,30 @@ jobs:
       - name: Run smoke test
         run: make arm-smoke-test
 
+  trivy-scan:
+    name: Trivy scan code
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run Trivy vulnerability scanner in repo mode
+      uses: aquasecurity/trivy-action@0.5.0
+      with:
+        scan-type: 'fs'
+        ignore-unfixed: false
+        format: 'sarif'
+        output: 'code.sarif'
+        exit-code: 1
+        skip-dirs: tests # Remove this once the ts files are removed
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      if: always()
+      with:
+        sarif_file: 'code.sarif'
+
   trivy-scan-metrics-server:
     name: Trivy scan metrics server image - ${{ matrix.name }}
     needs: build

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -170,3 +170,59 @@ jobs:
 
       - name: Run smoke test
         run: make arm-smoke-test
+
+  trivy-scan-metrics-server:
+    name: Trivy scan metrics server image - ${{ matrix.name }}
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+       matrix:
+        include:
+        - runner: ARM64
+          name: arm64
+        - runner: ubuntu-latest
+          name: amd64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Trivy on metrics-server
+        uses: aquasecurity/trivy-action@0.5.0
+        with:
+          scan-type: 'image'
+          image-ref: ghcr.io/kedacore/keda-metrics-apiserver:main
+          format: 'sarif'
+          output: 'metrics-server.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'metrics-server.sarif'
+
+  trivy-scan-keda:
+    name: Trivy scan keda image - ${{ matrix.name }}
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    strategy:
+       matrix:
+        include:
+        - runner: ARM64
+          name: arm64
+        - runner: ubuntu-latest
+          name: amd64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Trivy on operator
+        uses: aquasecurity/trivy-action@0.5.0
+        with:
+          scan-type: 'image'
+          image-ref: ghcr.io/kedacore/keda:main
+          format: 'sarif'
+          output: 'keda.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'keda.sarif'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -263,3 +263,19 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+
+  trivy-scanner:
+    name: Trivy Scan
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run Trivy vulnerability scanner in repo mode
+      uses: aquasecurity/trivy-action@0.5.0
+      with:
+        scan-type: 'fs'
+        ignore-unfixed: false
+        format: 'table'
+        exit-code: 1
+        skip-dirs: tests # Remove this once the ts files are removed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,7 @@ We have a few preventive measures in place to detect security vulnerabilities:
   - Images are scanned in every pull request (PR) to detect new vulnerabilities.
   - Published images on GitHub Container Registry are monitored to detect new vulnerabilities so we can ship patches
 - [Whitesource Bolt for GitHub](https://www.whitesourcesoftware.com/free-developer-tools/bolt/) helps us with identifying vulnerabilities in our dependencies to raise awareness.
+- [Trivy](https://aquasecurity.github.io/trivy/latest/) helps us with identifying vulnerabilities in our dependencies and docker images to raise awareness.
 - [GitHub's security features](https://github.com/features/security) are constantly monitoring our repo and dependencies:
   - All pull requests (PRs) are using CodeQL to scan our source code for vulnerabilities
   - Dependabot will automatically identify vulnerabilities based on GitHub Advisory Database and open PRs with patches

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ We have a few preventive measures in place to detect security vulnerabilities:
   - Images are scanned in every pull request (PR) to detect new vulnerabilities.
   - Published images on GitHub Container Registry are monitored to detect new vulnerabilities so we can ship patches
 - [Whitesource Bolt for GitHub](https://www.whitesourcesoftware.com/free-developer-tools/bolt/) helps us with identifying vulnerabilities in our dependencies to raise awareness.
-- [Trivy](https://aquasecurity.github.io/trivy/latest/) helps us with identifying vulnerabilities in our dependencies and docker images to raise awareness.
+- [Trivy](https://aquasecurity.github.io/trivy/latest/) helps us with identifying vulnerabilities in our dependencies and docker images to raise awareness as part of our CI.
 - [GitHub's security features](https://github.com/features/security) are constantly monitoring our repo and dependencies:
   - All pull requests (PRs) are using CodeQL to scan our source code for vulnerabilities
   - Dependabot will automatically identify vulnerabilities based on GitHub Advisory Database and open PRs with patches


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

This PR enables [Trivy](https://aquasecurity.github.io/trivy/v0.29.2/) as an analyzer to check the code and the build images.
- On every PR Trivy will be executed checking the code and exposing the results as a table, in case of detected vulnerabilities, the CI will fail. 
- On every push to `main`, after the image generation, both images are analyzed for each arch to detect vulnerabilities and the results will be pushed to GitHub as security alerts

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
Relates to https://github.com/kedacore/keda/issues/1040
