### PR TITLE
make propagationPolicy configurable during job rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 ### Deprecations
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+- **ScaledJob**: `rolloutStrategy` is deprecated in favor of `rollout.strategy` ([#2910](https://github.com/kedacore/keda/issues/2910))
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 - **General:** Add support to customize HPA name ([3057](https://github.com/kedacore/keda/issues/3057))
 - **General:** Basic setup for migrating e2e tests to Go. ([#2737](https://github.com/kedacore/keda/issues/2737))
 - **General:** Introduce new AWS DynamoDB Streams Scaler ([#3124](https://github.com/kedacore/keda/issues/3124))
+- **General:** Make propagation policy for ScaledJob rollout configurable ([#2910](https://github.com/kedacore/keda/issues/2910))
 - **General:** Support for Azure AD Workload Identity as a pod identity provider. ([#2487](https://github.com/kedacore/keda/issues/2487)|[#2656](https://github.com/kedacore/keda/issues/2656))
 - **General:** Support for permission segregation when using Azure AD Pod / Workload Identity. ([#2656](https://github.com/kedacore/keda/issues/2656))
 
@@ -52,7 +53,6 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 - **Prometheus Scaler:** Add ignoreNullValues to return error when prometheus return null in values ([#3065](https://github.com/kedacore/keda/issues/3065))
 - **Selenium Grid Scaler:** Edge active sessions not being properly counted ([#2709](https://github.com/kedacore/keda/issues/2709))
 - **Selenium Grid Scaler:** Max Sessions implementation issue ([#3061](https://github.com/kedacore/keda/issues/3061))
-- **ScaledJob:** Make propagation policy for rollout configurable ([#2910](https://github.com/kedacore/keda/issues/2910)
 ### Fixes
 
 - **General:** Refactor adapter startup to ensure proper log initilization. ([2316](https://github.com/kedacore/keda/issues/2316))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 - **Prometheus Scaler:** Add ignoreNullValues to return error when prometheus return null in values ([#3065](https://github.com/kedacore/keda/issues/3065))
 - **Selenium Grid Scaler:** Edge active sessions not being properly counted ([#2709](https://github.com/kedacore/keda/issues/2709))
 - **Selenium Grid Scaler:** Max Sessions implementation issue ([#3061](https://github.com/kedacore/keda/issues/3061))
-
+- **ScaledJob:** Make propagation policy for rollout configurable ([#2910](https://github.com/kedacore/keda/issues/2910)
 ### Fixes
 
 - **General:** Refactor adapter startup to ensure proper log initilization. ([2316](https://github.com/kedacore/keda/issues/2316))

--- a/apis/keda/v1alpha1/scaledjob_types.go
+++ b/apis/keda/v1alpha1/scaledjob_types.go
@@ -53,6 +53,8 @@ type ScaledJobSpec struct {
 	// +optional
 	RolloutStrategy string `json:"rolloutStrategy,omitempty"`
 	// +optional
+	Rollout Rollout `json:"rollout,omitempty"`
+	// +optional
 	EnvSourceContainerName string `json:"envSourceContainerName,omitempty"`
 	// +optional
 	MaxReplicaCount *int32 `json:"maxReplicaCount,omitempty"`
@@ -91,6 +93,15 @@ type ScalingStrategy struct {
 	PendingPodConditions []string `json:"pendingPodConditions,omitempty"`
 	// +optional
 	MultipleScalersCalculation string `json:"multipleScalersCalculation,omitempty"`
+}
+
+// Rollout defines the strategy for job rollouts
+// +optional
+type Rollout struct {
+	// +optional
+	Strategy string `json:"strategy,omitempty"`
+	// +optional
+	PropagationPolicy string `json:"propagationPolicy,omitempty"`
 }
 
 func init() {

--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -7595,6 +7595,14 @@ spec:
               pollingInterval:
                 format: int32
                 type: integer
+              rollout:
+                description: Rollout defines the strategy for job rollouts
+                properties:
+                  propagationPolicy:
+                    type: string
+                  strategy:
+                    type: string
+                type: object
               rolloutStrategy:
                 type: string
               scalingStrategy:


### PR DESCRIPTION
Signed-off-by: Jonas Bentz <jonas.bentz@sap.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR allows to configure the kubernetes propagation policy during job scaled roll out. 
In some usecases (see Issue https://github.com/kedacore/keda/issues/2910) its required to use foreground propagation instead of background propagation during rollout. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #2910

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to # https://github.com/kedacore/keda-docs/pull/804
