### PR TITLE
chore: Add `enhancement` to label for stale bot to ignore

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,7 @@ exemptLabels:
   - security
   - Epic
   - dependencies
+  - enhancement
 
 # Label to use when marking an issue as stale
 staleLabel: stale


### PR DESCRIPTION
Add `enhancement` to label for stale bot to ignore.

I've thought of adding `bug` as well but didn't proceed given we want to auto-close bugs where reporters are not getting rid of the stale poke given it might not be relevant anymore.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))