### PR TITLE
chore: install az-cli using pip in build-tools

### DIFF
--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -10,18 +10,11 @@ RUN apt-add-repository ppa:git-core/ppa && \
 # Use Bash instead of Dash
 RUN ln -sf bash /bin/sh
 
-# Install azure-cli
-RUN apt-get install apt-transport-https lsb-release dirmngr -y && \
-    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | \
-        tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
-    AZ_REPO=$(lsb_release -cs) && \
-    echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
-        tee /etc/apt/sources.list.d/azure-cli.list && \
-    apt-key --keyring /etc/apt/trusted.gpg.d/Microsoft.gpg adv \
-        --keyserver keyserver.ubuntu.com \
-        --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF && \
-    apt-get update && \
-    apt-get install -y azure-cli
+# Install python3
+RUN apt install -y python3 python3-pip
+
+# Install azure-cli (using pip)
+RUN python3 -m pip install azure.cli
 
 # Install docker
 RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release && \


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Sadly, az-cli doesn't support ARM64 if we use deb package, so this PR changes it to install az-cli by python3 pip
![image](https://user-images.githubusercontent.com/36899226/178321773-19d4d023-e46b-4289-a62d-24722e1c761b.png)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

