### PR TITLE
chore: remove fossa test 

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,8 +1,6 @@
-name: Scanning with FOSSA
+name: FOSSA
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
 
 jobs:
@@ -14,9 +12,8 @@ jobs:
         with:
           go-version: 1.17
       - run: go version
-      - uses: nelonoel/branch-name@v1.0.1
       - uses: fossas/fossa-action@main
         name: Scanning with FOSSA
         with:
-          api-key: 9e722f2c8904586d61f97f0bf05a99e4
-          branch: ${{ env.BRANCH_NAME }}
+          api-key: 9e722f2c8904586d61f97f0bf05a99e4 # This is a public key only for pushing, it's safe here
+          branch: main

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -14,8 +14,9 @@ jobs:
         with:
           go-version: 1.17
       - run: go version
+      - uses: nelonoel/branch-name@v1.0.1
       - uses: fossas/fossa-action@main
         name: Scanning with FOSSA
         with:
           api-key: 9e722f2c8904586d61f97f0bf05a99e4
-          branch: main
+          branch: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,6 +1,8 @@
-name: FOSSA
+name: Scanning with FOSSA
 on:
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
 
 jobs:
@@ -15,10 +17,5 @@ jobs:
       - uses: fossas/fossa-action@main
         name: Scanning with FOSSA
         with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
+          api-key: 9e722f2c8904586d61f97f0bf05a99e4
           branch: main
-      - uses: fossas/fossa-action@main
-        name: Testing with FOSSA
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          run-tests: true


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

FOSSA pushes the analysis status to the repository using a different check:
![image](https://user-images.githubusercontent.com/36899226/179073781-95a1784c-dfbf-46f8-afb6-c14affc1fca1.png)


Using fossa test it's not necessary and avoid the requirement of having a secret

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

