### PR TITLE
chore: e2e - delete namespace before creating a new one

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -174,6 +174,7 @@ func GetKubernetesClient(t *testing.T) *kubernetes.Clientset {
 
 // Creates a new namespace. If it already exists, make sure it is deleted first.
 func CreateNamespace(t *testing.T, kc *kubernetes.Clientset, nsName string) {
+	DeleteNamespace(t, kc, nsName)
 	WaitForNamespaceDeletion(t, kc, nsName)
 
 	t.Logf("Creating namespace - %s", nsName)
@@ -194,6 +195,9 @@ func DeleteNamespace(t *testing.T, kc *kubernetes.Clientset, nsName string) {
 	err := KubeClient.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{
 		GracePeriodSeconds: &period,
 	})
+	if errors.IsNotFound(err) {
+		err = nil
+	}
 	assert.NoErrorf(t, err, "cannot delete kubernetes namespace - %s", err)
 }
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

in  `CreateNamespace()` we are waiting for a namespace deletion, shouldn't we as a precaution actually try to delete the namespace before? So we now that we are using clean namespace.

@JorTurFer @v-shenoy let me know what you think about this, if you don't think it is a good idea, I am completely ok to close this one :)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
