### PR TITLE
chore: e2e - extend timeout for cassandra & activemq tests

### DIFF
--- a/tests/scalers_go/activemq/activemq_test.go
+++ b/tests/scalers_go/activemq/activemq_test.go
@@ -479,7 +479,7 @@ func setupActiveMQ(t *testing.T, kc *kubernetes.Clientset) {
 func checkIfActiveMQStatusIsReady(t *testing.T, name string) error {
 	t.Log("--- checking activemq status ---")
 	time.Sleep(time.Second * 10)
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 60; i++ {
 		out, errOut, _ := ExecCommandOnSpecificPod(t, name, testNamespace, fmt.Sprintf("curl -u %s:%s -s http://localhost:8161/api/jolokia/exec/org.apache.activemq:type=Broker,brokerName=localhost,service=Health/healthStatus", activemqUser, activemqPassword))
 		t.Logf("Output: %s, Error: %s", out, errOut)
 		if !strings.Contains(out, "\"status\":200") {

--- a/tests/scalers_go/cassandra/cassandra_test.go
+++ b/tests/scalers_go/cassandra/cassandra_test.go
@@ -268,7 +268,7 @@ func setupCassandra(t *testing.T, kc *kubernetes.Clientset) {
 func checkIfCassandraStatusIsReady(t *testing.T, name string) error {
 	t.Log("--- checking cassandra status ---")
 	time.Sleep(time.Second * 10)
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 60; i++ {
 		out, errOut, _ := ExecCommandOnSpecificPod(t, name, testNamespace, "nodetool status")
 		t.Logf("Output: %s, Error: %s", out, errOut)
 		if !strings.Contains(out, "UN ") {


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

