### PR TITLE
fix: Updated flaky tests and max concurrent test

### DIFF
--- a/tests/internals/pause_scaling/pause_scaling_test.go
+++ b/tests/internals/pause_scaling/pause_scaling_test.go
@@ -239,7 +239,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale down ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, min, 60, 2),
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 2),
 		"replica count should be 0 after 2 minutes")
 }
 

--- a/tests/internals/pause_scaling/pause_scaling_test.go
+++ b/tests/internals/pause_scaling/pause_scaling_test.go
@@ -37,6 +37,8 @@ var (
 	deploymentName   = fmt.Sprintf("%s-deployment", testName)
 	scaledObjectName = fmt.Sprintf("%s-so", testName)
 	queueName        = fmt.Sprintf("%s-queue", testName)
+	maxReplicaCount  = 1
+	minReplicaCount  = 0
 )
 
 type templateData struct {
@@ -103,8 +105,8 @@ spec:
   scaleTargetRef:
     name: {{.DeploymentName}}
   pollingInterval: 5
-  minReplicaCount: 2
-  maxReplicaCount: 4
+  minReplicaCount: 0
+  maxReplicaCount: 1
   cooldownPeriod: 10
   triggers:
     - type: azure-queue
@@ -125,8 +127,8 @@ spec:
   scaleTargetRef:
     name: {{.DeploymentName}}
   pollingInterval: 5
-  minReplicaCount: 2
-  maxReplicaCount: 4
+  minReplicaCount: 0
+  maxReplicaCount: 1
   cooldownPeriod: 10
   triggers:
     - type: azure-queue
@@ -217,8 +219,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale up ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 1),
-		"replica count should be 2 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 1),
+		"replica count should be 1 after 1 minute")
 }
 
 func testPauseAtN(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL, data templateData, n int) {
@@ -237,8 +239,8 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale down ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
-		"replica count should be 2 after 2 minutes")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, min, 60, 2),
+		"replica count should be 0 after 2 minutes")
 }
 
 func cleanupQueue(t *testing.T, queueURL azqueue.QueueURL) {

--- a/tests/internals/pause_scaling/pause_scaling_test.go
+++ b/tests/internals/pause_scaling/pause_scaling_test.go
@@ -237,8 +237,8 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale down ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 1),
-		"replica count should be 2 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
+		"replica count should be 2 after 2 minutes")
 }
 
 func cleanupQueue(t *testing.T, queueURL azqueue.QueueURL) {

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -8,7 +8,7 @@ E2E_REGEX_TS="./*${E2E_TEST_REGEX:-*.test.ts}"
 DIR=$(dirname "$0")
 cd $DIR
 
-concurrent_tests_limit=6
+concurrent_tests_limit=10
 pids=()
 lookup=()
 failed_count=0

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -8,7 +8,7 @@ E2E_REGEX_TS="./*${E2E_TEST_REGEX:-*.test.ts}"
 DIR=$(dirname "$0")
 cd $DIR
 
-concurrent_tests_limit=10
+concurrent_tests_limit=8
 pids=()
 lookup=()
 failed_count=0

--- a/tests/scalers_go/activemq/activemq_test.go
+++ b/tests/scalers_go/activemq/activemq_test.go
@@ -149,20 +149,20 @@ spec:
           protocol: TCP
         resources:
         volumeMounts:
-        - name: config
+        - name: remote-access-cm
           mountPath: /opt/apache-activemq-5.16.3/webapps/api/WEB-INF/classes/jolokia-access.xml
           subPath: jolokia-access.xml
-        - name: remote-access-cm
+        - name: config
           mountPath: /opt/apache-activemq-5.16.3/conf/jetty.xml
           subPath: jetty.xml
       volumes:
-      - name: config
+      - name: remote-access-cm
         configMap:
           name: activemq-config
           items:
           - key: jolokia-access.xml
             path: jolokia-access.xml
-      - name: remote-access-cm
+      - name: config
         configMap:
           name: activemq-config
           items:
@@ -480,9 +480,9 @@ func checkIfActiveMQStatusIsReady(t *testing.T, name string) error {
 	t.Log("--- checking activemq status ---")
 	time.Sleep(time.Second * 10)
 	for i := 0; i < 60; i++ {
-		out, errOut, _ := ExecCommandOnSpecificPod(t, name, testNamespace, fmt.Sprintf("curl -u %s:%s -s http://localhost:8161/api/jolokia/exec/org.apache.activemq:type=Broker,brokerName=localhost,service=Health/healthStatus", activemqUser, activemqPassword))
+		out, errOut, _ := ExecCommandOnSpecificPod(t, name, testNamespace, fmt.Sprintf("%s query –objname type=Broker,brokerName=localhost,Service=Health", activemqPath))
 		t.Logf("Output: %s, Error: %s", out, errOut)
-		if !strings.Contains(out, "\"status\":200") {
+		if !strings.Contains(out, "CurrentStatus = Good") {
 			time.Sleep(time.Second * 10)
 			continue
 		}

--- a/tests/scalers_go/azure_pipelines/azure_pipelines_test.go
+++ b/tests/scalers_go/azure_pipelines/azure_pipelines_test.go
@@ -88,7 +88,7 @@ spec:
       labels:
         app: azdevops-agent
     spec:
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 90
       containers:
       - name: azdevops-agent
         lifecycle:


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR improves activemq, az_pipeline nad pause_scaling e2e test and also increase the concurrency from 6 to 8.
I know that `redis-cluster-lists` fails but they are in ts so I will not touch them. I'm going to migrate them directly in other PR

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
