### PR TITLE
chore: Use golang version as tag for build-tools and bump it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ IMAGE_REPO     ?= kedacore
 IMAGE_CONTROLLER = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda$(SUFFIX):$(VERSION)
 IMAGE_ADAPTER    = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda-metrics-apiserver$(SUFFIX):$(VERSION)
 
-IMAGE_BUILD_TOOLS = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/build-tools:main
+BUILD_TOOLS_GO_VERSION = 1.17.12
+IMAGE_BUILD_TOOLS = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/build-tools:$(BUILD_TOOLS_GO_VERSION)
 
 ARCH       ?=amd64
 CGO        ?=0
@@ -311,11 +312,11 @@ help: ## Display this help.
 
 .PHONY: docker-build-tools
 docker-build-tools: ## Build build-tools image
-	docker build -f tools/build-tools.Dockerfile -t $(IMAGE_BUILD_TOOLS) .
+	docker build -f tools/build-tools.Dockerfile -t $(IMAGE_BUILD_TOOLS) --build-arg GO_VERSION=$(BUILD_TOOLS_GO_VERSION) .
 
 .PHONY: publish-build-tools
 publish-build-tools: ## Build and push multi-arch Docker image for build-tools.
-	docker buildx build --push --platform=${BUILD_PLATFORMS} -f tools/build-tools.Dockerfile  -t ${IMAGE_BUILD_TOOLS} .
+	docker buildx build --push --platform=${BUILD_PLATFORMS} -f tools/build-tools.Dockerfile -t ${IMAGE_BUILD_TOOLS} --build-arg GO_VERSION=$(BUILD_TOOLS_GO_VERSION) .
 
 .PHONY: docker-build-dev-containers
 docker-build-dev-containers: ## Build dev-containers image

--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -24,10 +24,8 @@ RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent soft
     apt-get install -y docker-ce-cli
 
 # Install golang
-RUN GO_VERSION=1.17.9 && \
-    curl -LO https://golang.org/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz && \
-    ARCH=$(dpkg --print-architecture) && if [ ${ARCH} == "amd64" ]; then go_sha256="9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6" ; elif [ ${ARCH} == "arm64" ]; then go_sha256="44dcdcd4f0fa6f83c15ef70b31580f1e3f95895c2f11a00e36c440c3554b6ad5" ; fi && \
-    echo "$go_sha256 go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" | sha256sum -c - && \
+ARG GO_VERSION
+RUN curl -LO https://golang.org/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz && \
     tar -C /usr/local -xvzf go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz && \
     rm -rf go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

This PR bumps golang version for build-tools and bump it to golang 1.17.12.

Note: to make the process easier, I have removed the checksum validation because I can't recover it dynamically so I need to pass another build args. I think that this could be acceptable because this is only for tooling and not for prod images, but if we consider it as a requirement, I can pass ARM and AMD checksums as build args too.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

