### PR TITLE
fix(datadog): ensure that returns the same element that has been checked

### DIFF
--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -283,7 +283,8 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 
 	points := series[0].GetPointlist()
 
-	if len(points) == 0 || len(points[0]) < 2 {
+	index := len(points) - 1
+	if len(points) == 0 || len(points[index]) < 2 {
 		if !s.metadata.useFiller {
 			return 0, fmt.Errorf("no Datadog metrics returned for the given time window")
 		}
@@ -291,7 +292,6 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 	}
 
 	// Return the last point from the series
-	index := len(points) - 1
 	return *points[index][1], nil
 }
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@docplanner.com>

If we receive more than 1 point, we are checking that the first one has the correct amount of elements and return an error if not, but after that, we access to the last point, so potentially we are not checking the amount of elements for the latest point if get more than 1 point.

This PR changes the behavior to ensure we access to the same point we have checked

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)


Fixes https://github.com/kedacore/keda/issues/3448

