### PR TITLE
chore: Add extra path to build tools CI

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -6,6 +6,8 @@ on:
       - v1
     paths:
       - 'tools/**'
+      - 'Makefile'
+
 jobs:
   validate:
     name: Validate


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

Golang version for build-tools is set in `Makefile` now, so we need to add it to the triggering paths for the CI that generates the image

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

