### PR TITLE
g*: Reference ScaledObject's/ScaledJob's name in the scalers log

### DIFF
--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -3,6 +3,8 @@ package scalers
 import (
 	"context"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 var testPubSubResolvedEnv = map[string]string{
@@ -68,7 +70,7 @@ var gcpSubscriptionNameTests = []gcpPubSubSubscription{
 
 func TestPubSubParseMetadata(t *testing.T) {
 	for _, testData := range testPubSubMetadata {
-		_, err := parsePubSubMetadata(&ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testPubSubResolvedEnv})
+		_, err := parsePubSubMetadata(&ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testPubSubResolvedEnv}, logr.Discard())
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -80,11 +82,11 @@ func TestPubSubParseMetadata(t *testing.T) {
 
 func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range gcpPubSubMetricIdentifiers {
-		meta, err := parsePubSubMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, ScalerIndex: testData.scalerIndex})
+		meta, err := parsePubSubMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, ScalerIndex: testData.scalerIndex}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockGcpPubSubScaler := pubsubScaler{nil, "", meta}
+		mockGcpPubSubScaler := pubsubScaler{nil, "", meta, logr.Discard()}
 
 		metricSpec := mockGcpPubSubScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name
@@ -96,11 +98,11 @@ func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
 
 func TestGcpPubSubSubscriptionName(t *testing.T) {
 	for _, testData := range gcpSubscriptionNameTests {
-		meta, err := parsePubSubMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, ScalerIndex: testData.scalerIndex})
+		meta, err := parsePubSubMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, ScalerIndex: testData.scalerIndex}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockGcpPubSubScaler := pubsubScaler{nil, "", meta}
+		mockGcpPubSubScaler := pubsubScaler{nil, "", meta, logr.Discard()}
 		subscriptionID, projectID := getSubscriptionData(&mockGcpPubSubScaler)
 
 		if subscriptionID != testData.name || projectID != testData.projectID {

--- a/pkg/scalers/gcp_stackdriver_scaler_test.go
+++ b/pkg/scalers/gcp_stackdriver_scaler_test.go
@@ -3,6 +3,8 @@ package scalers
 import (
 	"context"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 var testStackdriverResolvedEnv = map[string]string{
@@ -60,7 +62,7 @@ var gcpStackdriverMetricIdentifiers = []gcpStackdriverMetricIdentifier{
 
 func TestStackdriverParseMetadata(t *testing.T) {
 	for _, testData := range testStackdriverMetadata {
-		_, err := parseStackdriverMetadata(&ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testStackdriverResolvedEnv})
+		_, err := parseStackdriverMetadata(&ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testStackdriverResolvedEnv}, logr.Discard())
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -72,11 +74,11 @@ func TestStackdriverParseMetadata(t *testing.T) {
 
 func TestGcpStackdriverGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range gcpStackdriverMetricIdentifiers {
-		meta, err := parseStackdriverMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testStackdriverResolvedEnv, ScalerIndex: testData.scalerIndex})
+		meta, err := parseStackdriverMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testStackdriverResolvedEnv, ScalerIndex: testData.scalerIndex}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockGcpStackdriverScaler := stackdriverScaler{nil, "", meta}
+		mockGcpStackdriverScaler := stackdriverScaler{nil, "", meta, logr.Discard()}
 
 		metricSpec := mockGcpStackdriverScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name

--- a/pkg/scalers/gcp_storage_scaler_test.go
+++ b/pkg/scalers/gcp_storage_scaler_test.go
@@ -3,6 +3,8 @@ package scalers
 import (
 	"context"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 var testGcsResolvedEnv = map[string]string{
@@ -50,7 +52,7 @@ var gcpGcsMetricIdentifiers = []gcpGcsMetricIdentifier{
 
 func TestGcsParseMetadata(t *testing.T) {
 	for _, testData := range testGcsMetadata {
-		_, err := parseGcsMetadata(&ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testGcsResolvedEnv})
+		_, err := parseGcsMetadata(&ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testGcsResolvedEnv}, logr.Discard())
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -62,11 +64,11 @@ func TestGcsParseMetadata(t *testing.T) {
 
 func TestGcsGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range gcpGcsMetricIdentifiers {
-		meta, err := parseGcsMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testGcsResolvedEnv, ScalerIndex: testData.scalerIndex})
+		meta, err := parseGcsMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testGcsResolvedEnv, ScalerIndex: testData.scalerIndex}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockGcsScaler := gcsScaler{nil, nil, "", meta}
+		mockGcsScaler := gcsScaler{nil, nil, "", meta, logr.Discard()}
 
 		metricSpec := mockGcsScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #3419
