### PR TITLE
c|d|e*: Reference ScaledObject's/ScaledJob's name in the scalers log

### DIFF
--- a/pkg/scalers/cpu_memory_scaler_test.go
+++ b/pkg/scalers/cpu_memory_scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
@@ -40,7 +41,7 @@ func TestCPUMemoryParseMetadata(t *testing.T) {
 			TriggerMetadata: testData.metadata,
 			MetricType:      testData.metricType,
 		}
-		_, err := parseResourceMetadata(config)
+		_, err := parseResourceMetadata(config, logr.Discard())
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -118,7 +119,7 @@ func TestCronGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockCronScaler := cronScaler{"", meta}
+		mockCronScaler := cronScaler{"", meta, logr.Discard()}
 
 		metricSpec := mockCronScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 )
 
@@ -96,7 +97,7 @@ var testDatadogMetadata = []datadogAuthMetadataTestData{
 
 func TestDatadogScalerAuthParams(t *testing.T) {
 	for _, testData := range testDatadogMetadata {
-		_, err := parseDatadogMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams, MetricType: testData.metricType})
+		_, err := parseDatadogMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams, MetricType: testData.metricType}, logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -114,7 +115,7 @@ var datadogMetricIdentifiers = []datadogMetricIdentifier{
 
 func TestDatadogGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range datadogMetricIdentifiers {
-		meta, err := parseDatadogMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, ScalerIndex: testData.scalerIndex, MetricType: testData.metadataTestData.metricType})
+		meta, err := parseDatadogMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, ScalerIndex: testData.scalerIndex, MetricType: testData.metadataTestData.metricType}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #3419
