### PR TITLE
h|i|k|l*: Reference ScaledObject's/ScaledJob's name in the scalers log

### DIFF
--- a/pkg/scalers/huawei_cloudeye_scaler.go
+++ b/pkg/scalers/huawei_cloudeye_scaler.go
@@ -10,10 +10,10 @@ import (
 	"github.com/Huawei/gophercloud/auth/aksk"
 	"github.com/Huawei/gophercloud/openstack"
 	"github.com/Huawei/gophercloud/openstack/ces/v1/metricdata"
+	"github.com/go-logr/logr"
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
@@ -29,6 +29,7 @@ const (
 type huaweiCloudeyeScaler struct {
 	metricType v2beta2.MetricTargetType
 	metadata   *huaweiCloudeyeMetadata
+	logger     logr.Logger
 }
 
 type huaweiCloudeyeMetadata struct {
@@ -70,8 +71,6 @@ type huaweiAuthorizationMetadata struct {
 	SecretKey string // Secret key
 }
 
-var cloudeyeLog = logf.Log.WithName("huawei_cloudeye_scaler")
-
 // NewHuaweiCloudeyeScaler creates a new huaweiCloudeyeScaler
 func NewHuaweiCloudeyeScaler(config *ScalerConfig) (Scaler, error) {
 	metricType, err := GetMetricTargetType(config)
@@ -79,7 +78,9 @@ func NewHuaweiCloudeyeScaler(config *ScalerConfig) (Scaler, error) {
 		return nil, fmt.Errorf("error getting scaler metric type: %s", err)
 	}
 
-	meta, err := parseHuaweiCloudeyeMetadata(config)
+	logger := InitializeLogger(config, "huawei_cloudeye_scaler")
+
+	meta, err := parseHuaweiCloudeyeMetadata(config, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing Cloudeye metadata: %s", err)
 	}
@@ -87,10 +88,11 @@ func NewHuaweiCloudeyeScaler(config *ScalerConfig) (Scaler, error) {
 	return &huaweiCloudeyeScaler{
 		metricType: metricType,
 		metadata:   meta,
+		logger:     logger,
 	}, nil
 }
 
-func parseHuaweiCloudeyeMetadata(config *ScalerConfig) (*huaweiCloudeyeMetadata, error) {
+func parseHuaweiCloudeyeMetadata(config *ScalerConfig, logger logr.Logger) (*huaweiCloudeyeMetadata, error) {
 	meta := huaweiCloudeyeMetadata{}
 
 	meta.metricCollectionTime = defaultCloudeyeMetricCollectionTime
@@ -124,7 +126,7 @@ func parseHuaweiCloudeyeMetadata(config *ScalerConfig) (*huaweiCloudeyeMetadata,
 	if val, ok := config.TriggerMetadata["targetMetricValue"]; ok && val != "" {
 		targetMetricValue, err := strconv.ParseFloat(val, 64)
 		if err != nil {
-			cloudeyeLog.Error(err, "Error parsing targetMetricValue metadata")
+			logger.Error(err, "Error parsing targetMetricValue metadata")
 		} else {
 			meta.targetMetricValue = targetMetricValue
 		}
@@ -136,7 +138,7 @@ func parseHuaweiCloudeyeMetadata(config *ScalerConfig) (*huaweiCloudeyeMetadata,
 	if val, ok := config.TriggerMetadata["activationTargetMetricValue"]; ok && val != "" {
 		activationTargetMetricValue, err := strconv.ParseFloat(val, 64)
 		if err != nil {
-			cloudeyeLog.Error(err, "Error parsing activationTargetMetricValue metadata")
+			logger.Error(err, "Error parsing activationTargetMetricValue metadata")
 		}
 		meta.activationTargetMetricValue = activationTargetMetricValue
 	}
@@ -144,9 +146,9 @@ func parseHuaweiCloudeyeMetadata(config *ScalerConfig) (*huaweiCloudeyeMetadata,
 	if val, ok := config.TriggerMetadata["minMetricValue"]; ok && val != "" {
 		minMetricValue, err := strconv.ParseFloat(val, 64)
 		if err != nil {
-			cloudeyeLog.Error(err, "Error parsing minMetricValue metadata")
+			logger.Error(err, "Error parsing minMetricValue metadata")
 		} else {
-			cloudeyeLog.Error(err, "minMetricValue is deprecated and will be removed in next versions, please use activationTargetMetricValue instead")
+			logger.Error(err, "minMetricValue is deprecated and will be removed in next versions, please use activationTargetMetricValue instead")
 			meta.activationTargetMetricValue = minMetricValue
 		}
 	} else {
@@ -156,7 +158,7 @@ func parseHuaweiCloudeyeMetadata(config *ScalerConfig) (*huaweiCloudeyeMetadata,
 	if val, ok := config.TriggerMetadata["metricCollectionTime"]; ok && val != "" {
 		metricCollectionTime, err := strconv.Atoi(val)
 		if err != nil {
-			cloudeyeLog.Error(err, "Error parsing metricCollectionTime metadata")
+			logger.Error(err, "Error parsing metricCollectionTime metadata")
 		} else {
 			meta.metricCollectionTime = int64(metricCollectionTime)
 		}
@@ -169,7 +171,7 @@ func parseHuaweiCloudeyeMetadata(config *ScalerConfig) (*huaweiCloudeyeMetadata,
 	if val, ok := config.TriggerMetadata["metricPeriod"]; ok && val != "" {
 		_, err := strconv.Atoi(val)
 		if err != nil {
-			cloudeyeLog.Error(err, "Error parsing metricPeriod metadata")
+			logger.Error(err, "Error parsing metricPeriod metadata")
 		} else {
 			meta.metricPeriod = val
 		}
@@ -239,11 +241,11 @@ func gethuaweiAuthorization(authParams map[string]string) (huaweiAuthorizationMe
 	return meta, nil
 }
 
-func (h *huaweiCloudeyeScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
-	metricValue, err := h.GetCloudeyeMetrics()
+func (s *huaweiCloudeyeScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
+	metricValue, err := s.GetCloudeyeMetrics()
 
 	if err != nil {
-		cloudeyeLog.Error(err, "Error getting metric value")
+		s.logger.Error(err, "Error getting metric value")
 		return []external_metrics.ExternalMetricValue{}, err
 	}
 
@@ -251,55 +253,55 @@ func (h *huaweiCloudeyeScaler) GetMetrics(ctx context.Context, metricName string
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-func (h *huaweiCloudeyeScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
+func (s *huaweiCloudeyeScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	externalMetric := &v2beta2.ExternalMetricSource{
 		Metric: v2beta2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(h.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("huawei-cloudeye-%s", h.metadata.metricsName))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("huawei-cloudeye-%s", s.metadata.metricsName))),
 		},
-		Target: GetMetricTargetMili(h.metricType, h.metadata.targetMetricValue),
+		Target: GetMetricTargetMili(s.metricType, s.metadata.targetMetricValue),
 	}
 	metricSpec := v2beta2.MetricSpec{External: externalMetric, Type: externalMetricType}
 	return []v2beta2.MetricSpec{metricSpec}
 }
 
-func (h *huaweiCloudeyeScaler) IsActive(ctx context.Context) (bool, error) {
-	val, err := h.GetCloudeyeMetrics()
+func (s *huaweiCloudeyeScaler) IsActive(ctx context.Context) (bool, error) {
+	val, err := s.GetCloudeyeMetrics()
 
 	if err != nil {
 		return false, err
 	}
 
-	return val > h.metadata.activationTargetMetricValue, nil
+	return val > s.metadata.activationTargetMetricValue, nil
 }
 
-func (h *huaweiCloudeyeScaler) Close(context.Context) error {
+func (s *huaweiCloudeyeScaler) Close(context.Context) error {
 	return nil
 }
 
-func (h *huaweiCloudeyeScaler) GetCloudeyeMetrics() (float64, error) {
+func (s *huaweiCloudeyeScaler) GetCloudeyeMetrics() (float64, error) {
 	options := aksk.AKSKOptions{
-		IdentityEndpoint: h.metadata.huaweiAuthorization.IdentityEndpoint,
-		ProjectID:        h.metadata.huaweiAuthorization.ProjectID,
-		AccessKey:        h.metadata.huaweiAuthorization.AccessKey,
-		SecretKey:        h.metadata.huaweiAuthorization.SecretKey,
-		Region:           h.metadata.huaweiAuthorization.Region,
-		Domain:           h.metadata.huaweiAuthorization.Domain,
-		DomainID:         h.metadata.huaweiAuthorization.DomainID,
-		Cloud:            h.metadata.huaweiAuthorization.Cloud,
+		IdentityEndpoint: s.metadata.huaweiAuthorization.IdentityEndpoint,
+		ProjectID:        s.metadata.huaweiAuthorization.ProjectID,
+		AccessKey:        s.metadata.huaweiAuthorization.AccessKey,
+		SecretKey:        s.metadata.huaweiAuthorization.SecretKey,
+		Region:           s.metadata.huaweiAuthorization.Region,
+		Domain:           s.metadata.huaweiAuthorization.Domain,
+		DomainID:         s.metadata.huaweiAuthorization.DomainID,
+		Cloud:            s.metadata.huaweiAuthorization.Cloud,
 	}
 
 	provider, err := openstack.AuthenticatedClient(options)
 	if err != nil {
-		cloudeyeLog.Error(err, "Failed to get the provider")
+		s.logger.Error(err, "Failed to get the provider")
 		return -1, err
 	}
 	sc, err := openstack.NewCESV1(provider, gophercloud.EndpointOpts{})
 
 	if err != nil {
-		cloudeyeLog.Error(err, "get ces client failed")
+		s.logger.Error(err, "get ces client failed")
 		if ue, ok := err.(*gophercloud.UnifiedError); ok {
-			cloudeyeLog.Info("ErrCode:", ue.ErrorCode())
-			cloudeyeLog.Info("Message:", ue.Message())
+			s.logger.Info("ErrCode:", ue.ErrorCode())
+			s.logger.Info("Message:", ue.Message())
 		}
 		return -1, err
 	}
@@ -307,38 +309,38 @@ func (h *huaweiCloudeyeScaler) GetCloudeyeMetrics() (float64, error) {
 	opts := metricdata.BatchQueryOpts{
 		Metrics: []metricdata.Metric{
 			{
-				Namespace: h.metadata.namespace,
+				Namespace: s.metadata.namespace,
 				Dimensions: []map[string]string{
 					{
-						"name":  h.metadata.dimensionName,
-						"value": h.metadata.dimensionValue,
+						"name":  s.metadata.dimensionName,
+						"value": s.metadata.dimensionValue,
 					},
 				},
-				MetricName: h.metadata.metricsName,
+				MetricName: s.metadata.metricsName,
 			},
 		},
-		From:   time.Now().Truncate(time.Minute).Add(time.Second*-1*time.Duration(h.metadata.metricCollectionTime)).UnixNano() / 1e6,
+		From:   time.Now().Truncate(time.Minute).Add(time.Second*-1*time.Duration(s.metadata.metricCollectionTime)).UnixNano() / 1e6,
 		To:     time.Now().Truncate(time.Minute).UnixNano() / 1e6,
-		Period: h.metadata.metricPeriod,
-		Filter: h.metadata.metricFilter,
+		Period: s.metadata.metricPeriod,
+		Filter: s.metadata.metricFilter,
 	}
 
 	metricdatas, err := metricdata.BatchQuery(sc, opts).ExtractMetricDatas()
 	if err != nil {
-		cloudeyeLog.Error(err, "query metrics failed")
+		s.logger.Error(err, "query metrics failed")
 		if ue, ok := err.(*gophercloud.UnifiedError); ok {
-			cloudeyeLog.Info("ErrCode:", ue.ErrorCode())
-			cloudeyeLog.Info("Message:", ue.Message())
+			s.logger.Info("ErrCode:", ue.ErrorCode())
+			s.logger.Info("Message:", ue.Message())
 		}
 		return -1, err
 	}
 
-	cloudeyeLog.V(1).Info("Received Metric Data", "data", metricdatas)
+	s.logger.V(1).Info("Received Metric Data", "data", metricdatas)
 
 	var metricValue float64
 
 	if metricdatas[0].Datapoints != nil && len(metricdatas[0].Datapoints) > 0 {
-		v, ok := metricdatas[0].Datapoints[0][h.metadata.metricFilter].(float64)
+		v, ok := metricdatas[0].Datapoints[0][s.metadata.metricFilter].(float64)
 		if ok {
 			metricValue = v
 		} else {

--- a/pkg/scalers/huawei_cloudeye_scaler_test.go
+++ b/pkg/scalers/huawei_cloudeye_scaler_test.go
@@ -3,6 +3,8 @@ package scalers
 import (
 	"context"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 var (
@@ -158,7 +160,7 @@ var huaweiCloudeyeMetricIdentifiers = []huaweiCloudeyeMetricIdentifier{
 
 func TestHuaweiCloudeyeParseMetadata(t *testing.T) {
 	for _, testData := range testHuaweiCloudeyeMetadata {
-		_, err := parseHuaweiCloudeyeMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
+		_, err := parseHuaweiCloudeyeMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams}, logr.Discard())
 		if err != nil && !testData.isError {
 			t.Errorf("%s: Expected success but got error %s", testData.comment, err)
 		}
@@ -170,11 +172,11 @@ func TestHuaweiCloudeyeParseMetadata(t *testing.T) {
 
 func TestHuaweiCloudeyeGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range huaweiCloudeyeMetricIdentifiers {
-		meta, err := parseHuaweiCloudeyeMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, ScalerIndex: testData.scalerIndex})
+		meta, err := parseHuaweiCloudeyeMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, ScalerIndex: testData.scalerIndex}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockHuaweiCloudeyeScaler := huaweiCloudeyeScaler{"", meta}
+		mockHuaweiCloudeyeScaler := huaweiCloudeyeScaler{"", meta, logr.Discard()}
 
 		metricSpec := mockHuaweiCloudeyeScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name

--- a/pkg/scalers/ibmmq_scaler.go
+++ b/pkg/scalers/ibmmq_scaler.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -30,6 +31,7 @@ type IBMMQScaler struct {
 	metricType         v2beta2.MetricTargetType
 	metadata           *IBMMQMetadata
 	defaultHTTPTimeout time.Duration
+	logger             logr.Logger
 }
 
 // IBMMQMetadata Metadata used by KEDA to query IBM MQ queue depth and scale
@@ -76,6 +78,7 @@ func NewIBMMQScaler(config *ScalerConfig) (Scaler, error) {
 		metricType:         metricType,
 		metadata:           meta,
 		defaultHTTPTimeout: config.GlobalHTTPTimeout,
+		logger:             InitializeLogger(config, "ibm_mq_scaler"),
 	}, nil
 }
 

--- a/pkg/scalers/influxdb_scaler_test.go
+++ b/pkg/scalers/influxdb_scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 )
 
@@ -72,7 +73,7 @@ func TestInfluxDBGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockInfluxDBScaler := influxDBScaler{influxdb2.NewClient("https://influxdata.com", "myToken"), "", meta}
+		mockInfluxDBScaler := influxDBScaler{influxdb2.NewClient("https://influxdata.com", "myToken"), "", meta, logr.Discard()}
 
 		metricSpec := mockInfluxDBScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 type parseKafkaMetadataTestData struct {
@@ -131,7 +133,7 @@ var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
 
 func TestGetBrokers(t *testing.T) {
 	for _, testData := range parseKafkaMetadataTestDataset {
-		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams})
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -155,7 +157,7 @@ func TestGetBrokers(t *testing.T) {
 			t.Errorf("Expected offsetResetPolicy %s but got %s\n", testData.offsetResetPolicy, meta.offsetResetPolicy)
 		}
 
-		meta, err = parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithoutAuthParams})
+		meta, err = parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithoutAuthParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -186,7 +188,7 @@ func TestGetBrokers(t *testing.T) {
 
 func TestKafkaAuthParams(t *testing.T) {
 	for _, testData := range parseKafkaAuthParamsTestDataset {
-		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams})
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -216,11 +218,11 @@ func TestKafkaAuthParams(t *testing.T) {
 
 func TestKafkaGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range kafkaMetricIdentifiers {
-		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: validWithAuthParams, ScalerIndex: testData.scalerIndex})
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: validWithAuthParams, ScalerIndex: testData.scalerIndex}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockKafkaScaler := kafkaScaler{"", meta, nil, nil}
+		mockKafkaScaler := kafkaScaler{"", meta, nil, nil, logr.Discard()}
 
 		metricSpec := mockKafkaScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -22,6 +23,7 @@ type liiklusScaler struct {
 	metadata   *liiklusMetadata
 	connection *grpc.ClientConn
 	client     liiklus_service.LiiklusServiceClient
+	logger     logr.Logger
 }
 
 type liiklusMetadata struct {
@@ -68,6 +70,7 @@ func NewLiiklusScaler(config *ScalerConfig) (Scaler, error) {
 		client:     c,
 		metricType: metricType,
 		metadata:   lm,
+		logger:     InitializeLogger(config, "liiklus_scaler"),
 	}
 	return &scaler, nil
 }

--- a/pkg/scalers/liiklus_scaler_test.go
+++ b/pkg/scalers/liiklus_scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 
@@ -173,7 +174,7 @@ func TestLiiklusGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockLiiklusScaler := liiklusScaler{"", meta, nil, nil}
+		mockLiiklusScaler := liiklusScaler{"", meta, nil, nil, logr.Discard()}
 
 		metricSpec := mockLiiklusScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #3419
