### PR TITLE
fix: Reference ScaledObject's/ScaledJob's name in the scalers log

### DIFF
--- a/pkg/scalers/azure_data_explorer_scaler.go
+++ b/pkg/scalers/azure_data_explorer_scaler.go
@@ -38,6 +38,7 @@ type azureDataExplorerScaler struct {
 	client     *kusto.Client
 	name       string
 	namespace  string
+	logger     logr.Logger
 }
 
 const adxName = "azure-data-explorer"
@@ -66,6 +67,7 @@ func NewAzureDataExplorerScaler(ctx context.Context, config *ScalerConfig) (Scal
 		client:     client,
 		name:       config.ScalableObjectName,
 		namespace:  config.ScalableObjectNamespace,
+		logger:     logger,
 	}, nil
 }
 

--- a/pkg/scalers/azure_data_explorer_scaler_test.go
+++ b/pkg/scalers/azure_data_explorer_scaler_test.go
@@ -178,6 +178,7 @@ func TestDataExplorerGetMetricSpecForScaling(t *testing.T) {
 			client:    nil,
 			name:      "mock_scaled_object",
 			namespace: "mock_namespace",
+			logger:    logr.Discard(),
 		}
 
 		metricSpec := mockDataExplorerScaler.GetMetricSpecForScaling(context.Background())


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Fixing outstanding issues introduced by this change.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #3419
