### PR TITLE
Node is no longer needed in build tools image

### DIFF
--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -36,10 +36,6 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
     chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl && \
     rm kubectl.sha256
 
-# Install node
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
-    apt-get install -y nodejs
-
 # Install operator-sdk
 RUN RELEASE_VERSION=v1.0.1 && \
     curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && \


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

One leftover from the migration.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #2737 
