### PR TITLE
chore: fix deprecations and linting

### DIFF
--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -142,7 +142,7 @@ func initScaleClient(mgr manager.Manager, clientset *discovery.DiscoveryClient) 
 	)
 }
 
-//  Reconcile performs reconciliation on the identified ScaledObject resource based on the request information passed, returns the result and an error (if any).
+// Reconcile performs reconciliation on the identified ScaledObject resource based on the request information passed, returns the result and an error (if any).
 func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx)
 

--- a/pkg/scalers/azure/azure_aad_podidentity.go
+++ b/pkg/scalers/azure/azure_aad_podidentity.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -42,7 +42,7 @@ func GetAzureADPodIdentityToken(ctx context.Context, httpClient util.HTTPDoer, i
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return token, err
 	}

--- a/pkg/scalers/azure_log_analytics_scaler.go
+++ b/pkg/scalers/azure_log_analytics_scaler.go
@@ -23,7 +23,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -625,7 +625,7 @@ func (s *azureLogAnalyticsScaler) runHTTP(request *http.Request, caller string) 
 	defer resp.Body.Close()
 	s.httpClient.CloseIdleConnections()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("error reading %s response body: Inner Error: %v", caller, err)
 	}

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -210,7 +210,7 @@ func getAzurePipelineRequest(ctx context.Context, url string, metadata *azurePip
 		return []byte{}, err
 	}
 
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/scalers/elasticsearch_scaler.go
+++ b/pkg/scalers/elasticsearch_scaler.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -204,7 +204,7 @@ func (s *elasticsearchScaler) getQueryResult(ctx context.Context) (float64, erro
 	}
 
 	defer res.Body.Close()
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/scalers/graphite_scaler.go
+++ b/pkg/scalers/graphite_scaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	url_pkg "net/url"
 	"strconv"
@@ -191,7 +191,7 @@ func (s *graphiteScaler) executeGrapQuery(ctx context.Context) (float64, error) 
 		return -1, err
 	}
 
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/scalers/ibmmq_scaler.go
+++ b/pkg/scalers/ibmmq_scaler.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -200,7 +200,7 @@ func (s *IBMMQScaler) getQueueDepthViaHTTP(ctx context.Context) (int64, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, fmt.Errorf("failed to ready body of request: %s", err)
 	}

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	neturl "net/url"
 	"strconv"
@@ -232,7 +232,7 @@ func (s *metricsAPIScaler) getMetricValue(ctx context.Context) (float64, error) 
 		return 0, errors.New(msg)
 	}
 
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/scalers/openstack/keystone_authentication.go
+++ b/pkg/scalers/openstack/keystone_authentication.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -289,7 +289,7 @@ func (keystone *KeystoneAuthRequest) getToken(ctx context.Context) (string, erro
 		return resp.Header["X-Subject-Token"][0], nil
 	}
 
-	errBody, err := ioutil.ReadAll(resp.Body)
+	errBody, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return "", err
@@ -338,7 +338,7 @@ func (keystone *KeystoneAuthRequest) getCatalog(ctx context.Context, token strin
 		return keystoneCatalog.Catalog, nil
 	}
 
-	errBody, err := ioutil.ReadAll(resp.Body)
+	errBody, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return nil, err

--- a/pkg/scalers/openstack_metrics_scaler.go
+++ b/pkg/scalers/openstack_metrics_scaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -331,7 +331,7 @@ func (s *openstackMetricScaler) readOpenstackMetrics(ctx context.Context) (float
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		bodyError, readError := ioutil.ReadAll(resp.Body)
+		bodyError, readError := io.ReadAll(resp.Body)
 
 		if readError != nil {
 			s.logger.Error(readError, "Request failed with code: %s for URL: %s", resp.StatusCode, s.metadata.metricsURL)
@@ -342,7 +342,7 @@ func (s *openstackMetricScaler) readOpenstackMetrics(ctx context.Context) (float
 	}
 
 	m := measureResult{}
-	body, errConvertJSON := ioutil.ReadAll(resp.Body)
+	body, errConvertJSON := io.ReadAll(resp.Body)
 
 	if errConvertJSON != nil {
 		s.logger.Error(errConvertJSON, "Failed to convert Body format response to json")

--- a/pkg/scalers/openstack_swift_scaler.go
+++ b/pkg/scalers/openstack_swift_scaler.go
@@ -3,7 +3,7 @@ package scalers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -114,7 +114,7 @@ func (s *openstackSwiftScaler) getOpenstackSwiftContainerObjectCount(ctx context
 
 	defer resp.Body.Close()
 
-	body, readError := ioutil.ReadAll(resp.Body)
+	body, readError := io.ReadAll(resp.Body)
 
 	if readError != nil {
 		s.logger.Error(readError, "could not read response body from Swift API")

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	url_pkg "net/url"
 	"strconv"
@@ -235,7 +235,7 @@ func (s *prometheusScaler) ExecutePromQuery(ctx context.Context) (float64, error
 		return -1, err
 	}
 
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -211,7 +211,7 @@ func (s *pulsarScaler) GetStats(ctx context.Context) (*pulsarStats, error) {
 
 	switch res.StatusCode {
 	case 200:
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, fmt.Errorf("error requesting stats from url: %s", err)
 		}

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -443,7 +443,7 @@ func getJSON(s *rabbitMQScaler, url string) (queueInfo, error) {
 		return result, err
 	}
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	return result, fmt.Errorf("error requesting rabbitMQ API status: %s, response: %s, from: %s", r.Status, body, url)
 }
 

--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"strconv"
@@ -210,7 +210,7 @@ func (s *seleniumGridScaler) getSessionsCount(ctx context.Context, logger logr.L
 	}
 
 	defer res.Body.Close()
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/scalers/solace_scaler.go
+++ b/pkg/scalers/solace_scaler.go
@@ -112,7 +112,7 @@ type solaceSEMPMetadata struct {
 	ResponseCode int `json:"responseCode"`
 }
 
-//	Constructor for SolaceScaler
+// Constructor for SolaceScaler
 func NewSolaceScaler(config *ScalerConfig) (Scaler, error) {
 	// Create HTTP Client
 	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
@@ -139,7 +139,7 @@ func NewSolaceScaler(config *ScalerConfig) (Scaler, error) {
 	}, nil
 }
 
-//	Called by constructor
+// Called by constructor
 func parseSolaceMetadata(config *ScalerConfig) (*SolaceMetadata, error) {
 	meta := SolaceMetadata{}
 	//	GET THE SEMP API ENDPOINT
@@ -263,14 +263,14 @@ func getSolaceSempCredentials(config *ScalerConfig) (u string, p string, err err
 	return u, p, nil
 }
 
-//	INTERFACE METHOD
-//	DEFINE METRIC FOR SCALING
-//	CURRENT SUPPORTED METRICS ARE:
-//	- QUEUE MESSAGE COUNT (msgCount)
-//	- QUEUE SPOOL USAGE   (msgSpoolUsage in MBytes)
-//	METRIC IDENTIFIER HAS THE SIGNATURE:
-//	- solace-[Queue_Name]-[metric_type]
-//	e.g. solace-QUEUE1-msgCount
+// INTERFACE METHOD
+// DEFINE METRIC FOR SCALING
+// CURRENT SUPPORTED METRICS ARE:
+// - QUEUE MESSAGE COUNT (msgCount)
+// - QUEUE SPOOL USAGE   (msgSpoolUsage in MBytes)
+// METRIC IDENTIFIER HAS THE SIGNATURE:
+// - solace-[Queue_Name]-[metric_type]
+// e.g. solace-QUEUE1-msgCount
 func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2beta2.MetricSpec {
 	var metricSpecList []v2beta2.MetricSpec
 	// Message Count Target Spec
@@ -300,7 +300,7 @@ func (s *SolaceScaler) GetMetricSpecForScaling(context.Context) []v2beta2.Metric
 	return metricSpecList
 }
 
-//	returns SolaceMetricValues struct populated from broker  SEMP endpoint
+// returns SolaceMetricValues struct populated from broker  SEMP endpoint
 func (s *SolaceScaler) getSolaceQueueMetricsFromSEMP(ctx context.Context) (SolaceMetricValues, error) {
 	var scaledMetricEndpointURL = s.metadata.endpointURL
 	var httpClient = s.httpClient
@@ -345,9 +345,9 @@ func (s *SolaceScaler) getSolaceQueueMetricsFromSEMP(ctx context.Context) (Solac
 	return metricValues, nil
 }
 
-//	INTERFACE METHOD
-//	Call SEMP API to retrieve metrics
-//	returns value for named metric
+// INTERFACE METHOD
+// Call SEMP API to retrieve metrics
+// returns value for named metric
 func (s *SolaceScaler) GetMetrics(ctx context.Context, metricName string, metricSelector labels.Selector) ([]external_metrics.ExternalMetricValue, error) {
 	var metricValues, mv SolaceMetricValues
 	var mve error
@@ -372,9 +372,9 @@ func (s *SolaceScaler) GetMetrics(ctx context.Context, metricName string, metric
 	return append([]external_metrics.ExternalMetricValue{}, metric), nil
 }
 
-//	INTERFACE METHOD
-//	Call SEMP API to retrieve metrics
-//	IsActive returns true if queue messageCount > 0 || msgSpoolUsage > 0
+// INTERFACE METHOD
+// Call SEMP API to retrieve metrics
+// IsActive returns true if queue messageCount > 0 || msgSpoolUsage > 0
 func (s *SolaceScaler) IsActive(ctx context.Context) (bool, error) {
 	metricValues, err := s.getSolaceQueueMetricsFromSEMP(ctx)
 	if err != nil {

--- a/pkg/scaling/resolver/hashicorpvault_handler.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler.go
@@ -19,7 +19,7 @@ package resolver
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/go-logr/logr"
 	vaultapi "github.com/hashicorp/vault/api"
@@ -112,7 +112,7 @@ func (vh *HashicorpVaultHandler) token(client *vaultapi.Client) (string, error) 
 		}
 
 		// Get the JWT from POD
-		jwt, err := ioutil.ReadFile(vh.vault.Credential.ServiceAccount)
+		jwt, err := os.ReadFile(vh.vault.Credential.ServiceAccount)
 		if err != nil {
 			return token, err
 		}

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/go-logr/logr"
@@ -250,7 +249,7 @@ func getClusterObjectNamespace() (string, error) {
 		clusterObjectNamespaceCache = &env
 		return env, nil
 	}
-	data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", err
 	}

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -406,7 +405,7 @@ func KubectlApplyWithTemplate(t *testing.T, data interface{}, templateName strin
 	tmpl, err := template.New("kubernetes resource template").Parse(config)
 	assert.NoErrorf(t, err, "cannot parse template - %s", err)
 
-	tempFile, err := ioutil.TempFile("", templateName)
+	tempFile, err := os.CreateTemp("", templateName)
 	assert.NoErrorf(t, err, "cannot create temp file - %s", err)
 
 	defer os.Remove(tempFile.Name())
@@ -433,7 +432,7 @@ func KubectlDeleteWithTemplate(t *testing.T, data interface{}, templateName, con
 	tmpl, err := template.New("kubernetes resource template").Parse(config)
 	assert.NoErrorf(t, err, "cannot parse template - %s", err)
 
-	tempFile, err := ioutil.TempFile("", templateName)
+	tempFile, err := os.CreateTemp("", templateName)
 	assert.NoErrorf(t, err, "cannot delete temp file - %s", err)
 
 	defer os.Remove(tempFile.Name())


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
with `golangci-lint version 1.48.0` there can be discovered additional problems in the repo, some linting problems and some deprecations, such as:
```
SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


