### PR TITLE
e2e: Make order of applying / deleting templates consistent.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -130,10 +130,6 @@ type templateData struct {
     ...
 }
 
-// templateValues consists of templates and their names
-type templateValues map[string] string
-
-
 func TestScaler(t *testing.T) {
     setupTest(t)
 
@@ -158,12 +154,15 @@ func setupTest(t *testing.T) {
     assert.NoErrorf(t, err, "error while installing redis - %s", err)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
     return templateData{
         // Populate fields required in YAML templates
         ...
         ...
-    }, templateValues{"deploymentTemplate":deploymentTemplate,  "scaledObjectTemplate":scaledObjectTemplate}
+    }, []Template{
+        {Name: "deploymentTemplate", Config: deploymentTemplate},
+        {Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+    }
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/internals/custom_hpa_name/custom_hpa_name_test.go
+++ b/tests/internals/custom_hpa_name/custom_hpa_name_test.go
@@ -24,8 +24,6 @@ type templateData struct {
 	CustomHpaName    string
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -128,7 +126,10 @@ func test(t *testing.T, testName string, firstHpaName string, firstSOTemplate st
 	// Create kubernetes resources
 	kc := GetKubernetesClient(t)
 	data := getTemplateData(testNamespace, deploymentName, scaledObjectName, customHpaName)
-	templates := templateValues{"deploymentTemplate": deploymentTemplate, "firstSOTemplate": firstSOTemplate}
+	templates := []Template{
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "firstSOTemplate", Config: firstSOTemplate},
+	}
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
@@ -137,7 +138,7 @@ func test(t *testing.T, testName string, firstHpaName string, firstSOTemplate st
 	assert.Equal(t, firstHpaName, hpa.Name)
 
 	t.Log("--- change hpa name ---")
-	templatesCustomName := templateValues{"secondSOTemplate": secondSOTemplate}
+	templatesCustomName := []Template{{Name: "secondSOTemplate", Config: secondSOTemplate}}
 	KubectlApplyMultipleWithTemplate(t, data, templatesCustomName)
 
 	t.Logf("--- validate new hpa is with %s name ---", secondHpaDescription)

--- a/tests/internals/idle_replicas/idle_replicas_test.go
+++ b/tests/internals/idle_replicas/idle_replicas_test.go
@@ -30,7 +30,6 @@ type templateData struct {
 	ScaledObjectName        string
 	MonitoredDeploymentName string
 }
-type templateValues map[string]string
 
 const (
 	monitoredDeploymentTemplate = `
@@ -125,16 +124,17 @@ func TestScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			DeploymentName:          deploymentName,
 			ScaledObjectName:        scaledObjectName,
 			MonitoredDeploymentName: monitoredDeploymentName,
-		}, templateValues{
-			"deploymentTemplate":          deploymentTemplate,
-			"monitoredDeploymentTemplate": monitoredDeploymentTemplate,
-			"scaledObjectTemplate":        scaledObjectTemplate}
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/internals/min_replica_sj/min_replica_sj_test.go
+++ b/tests/internals/min_replica_sj/min_replica_sj_test.go
@@ -37,7 +37,6 @@ type templateData struct {
 	MetricThreshold, MetricValue     int
 	MinReplicaCount, MaxReplicaCount int
 }
-type templateValues map[string]string
 
 const (
 	serviceTemplate = `
@@ -173,7 +172,7 @@ func testMinReplicaCountWithMetricValueGreaterMaxReplicaCountScalesOnlyToMaxRepl
 		"job count should be %d after %d iterations", data.MaxReplicaCount, iterationCount)
 }
 
-func getTemplateData(minReplicaCount int, maxReplicaCount int, metricValue int) (templateData, templateValues) {
+func getTemplateData(minReplicaCount int, maxReplicaCount int, metricValue int) (templateData, []Template) {
 	return templateData{
 			TestNamespace:   testNamespace,
 			ServiceName:     serviceName,
@@ -183,8 +182,9 @@ func getTemplateData(minReplicaCount int, maxReplicaCount int, metricValue int) 
 			MetricValue:     metricValue,
 			MinReplicaCount: minReplicaCount,
 			MaxReplicaCount: maxReplicaCount,
-		}, templateValues{
-			"scalerTemplate":    scalerTemplate,
-			"serviceTemplate":   serviceTemplate,
-			"scaledJobTemplate": scaledJobTemplate}
+		}, []Template{
+			{Name: "scalerTemplate", Config: scalerTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "scaledJobTemplate", Config: scaledJobTemplate},
+		}
 }

--- a/tests/internals/pause_scaling/pause_scaling_test.go
+++ b/tests/internals/pause_scaling/pause_scaling_test.go
@@ -35,7 +35,6 @@ type templateData struct {
 	MonitoredDeploymentName string
 	PausedReplicaCount      int
 }
-type templateValues map[string]string
 
 const (
 	monitoredDeploymentTemplate = `
@@ -151,17 +150,18 @@ func TestScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			DeploymentName:          deploymentName,
 			ScaledObjectName:        scaledObjectName,
 			MonitoredDeploymentName: monitoredDeploymentName,
 			PausedReplicaCount:      0,
-		}, templateValues{
-			"deploymentTemplate":            deploymentTemplate,
-			"monitoredDeploymentTemplate":   monitoredDeploymentTemplate,
-			"scaledObjectAnnotatedTemplate": scaledObjectAnnotatedTemplate}
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
+			{Name: "scaledObjectAnnotatedTemplate", Config: scaledObjectAnnotatedTemplate},
+		}
 }
 
 func testPauseAt0(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/internals/restore_original/restore_original_test.go
+++ b/tests/internals/restore_original/restore_original_test.go
@@ -30,7 +30,6 @@ type templateData struct {
 	ScaledObjectName        string
 	MonitoredDeploymentName string
 }
-type templateValues map[string]string
 
 const (
 	monitoredDeploymentTemplate = `
@@ -123,15 +122,15 @@ func TestScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			DeploymentName:          deploymentName,
 			ScaledObjectName:        scaledObjectName,
 			MonitoredDeploymentName: monitoredDeploymentName,
-		}, templateValues{
-			"deploymentTemplate":          deploymentTemplate,
-			"monitoredDeploymentTemplate": monitoredDeploymentTemplate,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
 		}
 }
 

--- a/tests/internals/subresource_scale/subresource_scale_test.go
+++ b/tests/internals/subresource_scale/subresource_scale_test.go
@@ -35,8 +35,6 @@ type templateData struct {
 	ScaledObjectName        string
 }
 
-type templateValues map[string]string
-
 const (
 	monitoredDeploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -181,16 +179,17 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be 0 after 1 minute")
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			MonitoredDeploymentName: monitoredDeploymentName,
 			ArgoRolloutName:         argoRolloutName,
 			ScaledObjectName:        scaledObjectName,
-		}, templateValues{
-			"monitoredDeploymentTemplate": monitoredDeploymentTemplate,
-			"argoRolloutTemplate":         argoRolloutTemplate,
-			"scaledObjectTemplate":        scaledObjectTemplate}
+		}, []Template{
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
+			{Name: "argoRolloutTemplate", Config: argoRolloutTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func waitForArgoRolloutReplicaCount(t *testing.T, name, namespace string, target int) bool {

--- a/tests/internals/value_metric_type/value_metric_type_test.go
+++ b/tests/internals/value_metric_type/value_metric_type_test.go
@@ -31,7 +31,6 @@ type templateData struct {
 	MonitoredDeploymentName string
 	MetricType              string
 }
-type templateValues map[string]string
 
 const (
 	monitoredDeploymentTemplate = `
@@ -126,15 +125,15 @@ func TestScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			DeploymentName:          deploymentName,
 			ScaledObjectName:        scaledObjectName,
 			MonitoredDeploymentName: monitoredDeploymentName,
-		}, templateValues{
-			"deploymentTemplate":          deploymentTemplate,
-			"monitoredDeploymentTemplate": monitoredDeploymentTemplate,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
 		}
 }
 

--- a/tests/scalers/activemq/activemq_test.go
+++ b/tests/scalers/activemq/activemq_test.go
@@ -53,8 +53,6 @@ type templateData struct {
 	ActiveMQDestination    string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -514,7 +512,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:          testNamespace,
 			DeploymentName:         deploymentName,
@@ -525,13 +523,13 @@ func getTemplateData() (templateData, map[string]string) {
 			ActiveMQConf:           activemqConf,
 			ActiveMQHome:           activemqHome,
 			ActiveMQDestination:    activemqDestination,
-		}, templateValues{
-			"secretTemplate":                secretTemplate,
-			"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-			"activemqServiceTemplate":       activemqServiceTemplate,
-			"activemqConfigTemplate":        activemqConfigTemplate,
-			"activemqSteatefulTemplate":     activemqSteatefulTemplate,
-			"deploymentTemplate":            deploymentTemplate,
-			"scaledObjectTemplate":          scaledObjectTemplate,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "activemqServiceTemplate", Config: activemqServiceTemplate},
+			{Name: "activemqConfigTemplate", Config: activemqConfigTemplate},
+			{Name: "activemqSteatefulTemplate", Config: activemqSteatefulTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }

--- a/tests/scalers/aws_cloudwatch/aws_cloudwatch_test.go
+++ b/tests/scalers/aws_cloudwatch/aws_cloudwatch_test.go
@@ -41,7 +41,6 @@ type templateData struct {
 	CloudWatchMetricDimensionName  string
 	CloudWatchMetricDimensionValue string
 }
-type templateValues map[string]string
 
 const (
 	secretTemplate = `apiVersion: v1
@@ -221,7 +220,7 @@ func createCloudWatchClient() *cloudwatch.CloudWatch {
 	})
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:                  testNamespace,
 			DeploymentName:                 deploymentName,
@@ -234,8 +233,10 @@ func getTemplateData() (templateData, templateValues) {
 			CloudWatchMetricNamespace:      cloudwatchMetricNamespace,
 			CloudWatchMetricDimensionName:  cloudwatchMetricDimensionName,
 			CloudWatchMetricDimensionValue: cloudwatchMetricDimensionValue,
-		}, templateValues{"secretTemplate": secretTemplate,
-			"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-			"deploymentTemplate":            deploymentTemplate,
-			"scaledObjectTemplate":          scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
+++ b/tests/scalers/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
@@ -40,7 +40,6 @@ type templateData struct {
 	CloudWatchMetricNamespace  string
 	CloudwatchMetricExpression string
 }
-type templateValues map[string]string
 
 const (
 	secretTemplate = `apiVersion: v1
@@ -220,7 +219,7 @@ func createCloudWatchClient() *cloudwatch.CloudWatch {
 	})
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:              testNamespace,
 			DeploymentName:             deploymentName,
@@ -232,8 +231,10 @@ func getTemplateData() (templateData, templateValues) {
 			CloudWatchMetricName:       cloudwatchMetricName,
 			CloudWatchMetricNamespace:  cloudwatchMetricNamespace,
 			CloudwatchMetricExpression: cloudwatchMetricExpression,
-		}, templateValues{"secretTemplate": secretTemplate,
-			"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-			"deploymentTemplate":            deploymentTemplate,
-			"scaledObjectTemplate":          scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/aws_dynamodb/aws_dynamodb_test.go
+++ b/tests/scalers/aws_dynamodb/aws_dynamodb_test.go
@@ -44,8 +44,6 @@ type templateData struct {
 	ExpressionAttributeValues string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -266,18 +264,23 @@ func createDynamoDBClient() *dynamodb.DynamoDB {
 	})
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
-		TestNamespace:             testNamespace,
-		DeploymentName:            deploymentName,
-		ScaledObjectName:          scaledObjectName,
-		SecretName:                secretName,
-		AwsAccessKeyID:            base64.StdEncoding.EncodeToString([]byte(awsAccessKeyID)),
-		AwsSecretAccessKey:        base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
-		AwsRegion:                 awsRegion,
-		DynamoDBTableName:         dynamoDBTableName,
-		ExpressionAttributeNames:  expressionAttributeNames,
-		KeyConditionExpression:    keyConditionExpression,
-		ExpressionAttributeValues: expressionAttributeValues,
-	}, templateValues{"secretTemplate": secretTemplate, "triggerAuthenticationTemplate": triggerAuthenticationTemplate, "deploymentTemplate": deploymentTemplate, "scaledObjectTemplate": scaledObjectTemplate}
+			TestNamespace:             testNamespace,
+			DeploymentName:            deploymentName,
+			ScaledObjectName:          scaledObjectName,
+			SecretName:                secretName,
+			AwsAccessKeyID:            base64.StdEncoding.EncodeToString([]byte(awsAccessKeyID)),
+			AwsSecretAccessKey:        base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
+			AwsRegion:                 awsRegion,
+			DynamoDBTableName:         dynamoDBTableName,
+			ExpressionAttributeNames:  expressionAttributeNames,
+			KeyConditionExpression:    keyConditionExpression,
+			ExpressionAttributeValues: expressionAttributeValues,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/aws_dynamodb_streams/aws_dynamodb_streams_test.go
+++ b/tests/scalers/aws_dynamodb_streams/aws_dynamodb_streams_test.go
@@ -62,8 +62,6 @@ type templateData struct {
 	ActivationShardCount int64
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -247,7 +245,7 @@ func getDynamoDBStreamShardCount(dbs dynamodbstreamsiface.DynamoDBStreamsAPI, st
 	return int64(len(des.StreamDescription.Shards)), nil
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64AwsAccessKey := base64.StdEncoding.EncodeToString([]byte(awsAccessKey))
 	base64AwsSecretKey := base64.StdEncoding.EncodeToString([]byte(awsSecretKey))
 
@@ -262,11 +260,12 @@ func getTemplateData() (templateData, templateValues) {
 			ScaledObjectName: scaledObjectName,
 			TableName:        tableName,
 			ShardCount:       int64(shardCount),
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"triggerAuthTemplate":  triggerAuthTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/scalers/aws_kinesis_stream/aws_kinesis_stream_test.go
+++ b/tests/scalers/aws_kinesis_stream/aws_kinesis_stream_test.go
@@ -40,8 +40,6 @@ type templateData struct {
 	KinesisStream      string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -239,15 +237,20 @@ func createKinesisClient() *kinesis.Kinesis {
 	})
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
-		TestNamespace:      testNamespace,
-		DeploymentName:     deploymentName,
-		ScaledObjectName:   scaledObjectName,
-		SecretName:         secretName,
-		AwsAccessKeyID:     base64.StdEncoding.EncodeToString([]byte(awsAccessKeyID)),
-		AwsSecretAccessKey: base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
-		AwsRegion:          awsRegion,
-		KinesisStream:      kinesisStreamName,
-	}, templateValues{"secretTemplate": secretTemplate, "triggerAuthenticationTemplate": triggerAuthenticationTemplate, "deploymentTemplate": deploymentTemplate, "scaledObjectTemplate": scaledObjectTemplate}
+			TestNamespace:      testNamespace,
+			DeploymentName:     deploymentName,
+			ScaledObjectName:   scaledObjectName,
+			SecretName:         secretName,
+			AwsAccessKeyID:     base64.StdEncoding.EncodeToString([]byte(awsAccessKeyID)),
+			AwsSecretAccessKey: base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
+			AwsRegion:          awsRegion,
+			KinesisStream:      kinesisStreamName,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/aws_sqs_queue/aws_sqs_queue_test.go
+++ b/tests/scalers/aws_sqs_queue/aws_sqs_queue_test.go
@@ -39,8 +39,6 @@ type templateData struct {
 	SqsQueue           string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -220,15 +218,20 @@ func createSqsClient() *sqs.SQS {
 	})
 }
 
-func getTemplateData(sqsQueue string) (templateData, templateValues) {
+func getTemplateData(sqsQueue string) (templateData, []Template) {
 	return templateData{
-		TestNamespace:      testNamespace,
-		DeploymentName:     deploymentName,
-		ScaledObjectName:   scaledObjectName,
-		SecretName:         secretName,
-		AwsAccessKeyID:     base64.StdEncoding.EncodeToString([]byte(awsAccessKeyID)),
-		AwsSecretAccessKey: base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
-		AwsRegion:          awsRegion,
-		SqsQueue:           sqsQueue,
-	}, templateValues{"secretTemplate": secretTemplate, "triggerAuthenticationTemplate": triggerAuthenticationTemplate, "deploymentTemplate": deploymentTemplate, "scaledObjectTemplate": scaledObjectTemplate}
+			TestNamespace:      testNamespace,
+			DeploymentName:     deploymentName,
+			ScaledObjectName:   scaledObjectName,
+			SecretName:         secretName,
+			AwsAccessKeyID:     base64.StdEncoding.EncodeToString([]byte(awsAccessKeyID)),
+			AwsSecretAccessKey: base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
+			AwsRegion:          awsRegion,
+			SqsQueue:           sqsQueue,
+		}, []Template{
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/azure_application_insights/azure_application_insights_test.go
+++ b/tests/scalers/azure_application_insights/azure_application_insights_test.go
@@ -60,8 +60,6 @@ type templateData struct {
 	MaxReplicaCount               string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -216,7 +214,7 @@ func setMetricValue(client appinsights.TelemetryClient, value float64, stopCh <-
 	}
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ClientSecret := base64.StdEncoding.EncodeToString([]byte(azureADSecret))
 	base64ClientID := base64.StdEncoding.EncodeToString([]byte(azureADClientID))
 	base64TenantID := base64.StdEncoding.EncodeToString([]byte(azureADTenantID))
@@ -236,9 +234,10 @@ func getTemplateData() (templateData, templateValues) {
 			ApplicationInsightsRole:       appInsightsRole,
 			MinReplicaCount:               fmt.Sprintf("%v", minReplicaCount),
 			MaxReplicaCount:               fmt.Sprintf("%v", maxReplicaCount),
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"triggerAuthTemplate":  triggerAuthTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/azure_blob/azure_blob_test.go
+++ b/tests/scalers/azure_blob/azure_blob_test.go
@@ -47,7 +47,6 @@ type templateData struct {
 	ScaledObjectName string
 	ContainerName    string
 }
-type templateValues map[string]string
 
 const (
 	secretTemplate = `
@@ -168,7 +167,7 @@ func createContainer(t *testing.T) azblob.ContainerURL {
 	return containerURL
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
@@ -178,10 +177,11 @@ func getTemplateData() (templateData, templateValues) {
 			DeploymentName:   deploymentName,
 			ScaledObjectName: scaledObjectName,
 			ContainerName:    containerName,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, containerURL azblob.ContainerURL) {

--- a/tests/scalers/azure_data_explorer/azure_data_explorer_test.go
+++ b/tests/scalers/azure_data_explorer/azure_data_explorer_test.go
@@ -57,8 +57,6 @@ type templateData struct {
 	ScaleMetricValue     int
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -160,8 +158,8 @@ func TestScaler(t *testing.T) {
 	testScaleDown(t, kc, data)
 
 	// cleanup
-	templates["triggerAuthTemplate"] = triggerAuthTemplate
-	templates["scaledObjectTemplate"] = scaledObjectTemplate
+	templates = append(templates, Template{Name: "triggerAuthTemplate", Config: triggerAuthTemplate})
+	templates = append(templates, Template{Name: "scaledObjectTemplate", Config: scaledObjectTemplate})
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
@@ -195,7 +193,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 1 minute", scaleInReplicaCount)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ClientSecret := base64.StdEncoding.EncodeToString([]byte(azureADSecret))
 
 	return templateData{
@@ -210,7 +208,8 @@ func getTemplateData() (templateData, templateValues) {
 			DataExplorerDB:       dataExplorerDB,
 			DataExplorerEndpoint: dataExplorerEndpoint,
 			ScaleReplicaCount:    scaleInReplicaCount,
-		}, templateValues{
-			"secretTemplate":     secretTemplate,
-			"deploymentTemplate": deploymentTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+		}
 }

--- a/tests/scalers/azure_log_analytics/azure_log_analytics_test.go
+++ b/tests/scalers/azure_log_analytics/azure_log_analytics_test.go
@@ -49,8 +49,6 @@ type templateData struct {
 	QueryX, QueryY          int
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -149,8 +147,8 @@ func TestScaler(t *testing.T) {
 	testScaleDown(t, kc, data)
 
 	// cleanup
-	templates["triggerAuthTemplate"] = triggerAuthTemplate
-	templates["scaledObjectTemplate"] = scaledObjectTemplate
+	templates = append(templates, Template{Name: "triggerAuthTemplate", Config: triggerAuthTemplate})
+	templates = append(templates, Template{Name: "scaledObjectTemplate", Config: scaledObjectTemplate})
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
@@ -186,7 +184,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be 0 after 1 minute")
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ClientSecret := base64.StdEncoding.EncodeToString([]byte(azureADSecret))
 
 	return templateData{
@@ -199,7 +197,8 @@ func getTemplateData() (templateData, templateValues) {
 			AzureADSecret:           base64ClientSecret,
 			AzureADTenantID:         azureADTenantID,
 			LogAnalyticsWorkspaceID: logAnalyticsWorkspaceID,
-		}, templateValues{
-			"secretTemplate":     secretTemplate,
-			"deploymentTemplate": deploymentTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+		}
 }

--- a/tests/scalers/azure_pipelines/azure_pipelines_test.go
+++ b/tests/scalers/azure_pipelines/azure_pipelines_test.go
@@ -57,7 +57,6 @@ type templateData struct {
 	PoolName         string
 	PoolID           string
 }
-type templateValues map[string]string
 
 const (
 	secretTemplate = `
@@ -268,7 +267,7 @@ func clearAllBuilds(t *testing.T, connection *azuredevops.Connection) {
 	}
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64Pat := base64.StdEncoding.EncodeToString([]byte(personalAccessToken))
 
 	return templateData{
@@ -282,10 +281,11 @@ func getTemplateData() (templateData, templateValues) {
 			URL:              organizationURL,
 			PoolName:         poolName,
 			PoolID:           poolID,
-		}, templateValues{
-			"secretTemplate":             secretTemplate,
-			"deploymentTemplate":         deploymentTemplate,
-			"poolIdscaledObjectTemplate": poolIdscaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "poolIdscaledObjectTemplate", Config: poolIdscaledObjectTemplate},
+		}
 }
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, connection *azuredevops.Connection) {

--- a/tests/scalers/azure_queue/azure_queue_test.go
+++ b/tests/scalers/azure_queue/azure_queue_test.go
@@ -47,7 +47,6 @@ type templateData struct {
 	ScaledObjectName string
 	QueueName        string
 }
-type templateValues map[string]string
 
 const (
 	secretTemplate = `
@@ -160,7 +159,7 @@ func createQueue(t *testing.T) (azqueue.QueueURL, azqueue.MessagesURL) {
 	return queueURL, messageURL
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
@@ -170,10 +169,11 @@ func getTemplateData() (templateData, templateValues) {
 			DeploymentName:   deploymentName,
 			ScaledObjectName: scaledObjectName,
 			QueueName:        queueName,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {

--- a/tests/scalers/azure_service_bus_queue/azure_service_bus_queue_test.go
+++ b/tests/scalers/azure_service_bus_queue/azure_service_bus_queue_test.go
@@ -47,8 +47,6 @@ type templateData struct {
 	QueueName        string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -178,18 +176,23 @@ func createQueue(t *testing.T, sbQueueManager *servicebus.QueueManager) {
 	assert.NoErrorf(t, err, "cannot create service bus queue - %s", err)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
-		TestNamespace:    testNamespace,
-		SecretName:       secretName,
-		Connection:       base64ConnectionString,
-		DeploymentName:   deploymentName,
-		TriggerAuthName:  triggerAuthName,
-		ScaledObjectName: scaledObjectName,
-		QueueName:        queueName,
-	}, templateValues{"secretTemplate": secretTemplate, "deploymentTemplate": deploymentTemplate, "triggerAuthTemplate": triggerAuthTemplate, "scaledObjectTemplate": scaledObjectTemplate}
+			TestNamespace:    testNamespace,
+			SecretName:       secretName,
+			Connection:       base64ConnectionString,
+			DeploymentName:   deploymentName,
+			TriggerAuthName:  triggerAuthName,
+			ScaledObjectName: scaledObjectName,
+			QueueName:        queueName,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, sbQueue *servicebus.Queue) {

--- a/tests/scalers/azure_service_bus_topic/azure_service_bus_topic_test.go
+++ b/tests/scalers/azure_service_bus_topic/azure_service_bus_topic_test.go
@@ -48,7 +48,6 @@ type templateData struct {
 	TopicName        string
 	SubscriptionName string
 }
-type templateValues map[string]string
 
 const (
 	secretTemplate = `
@@ -191,7 +190,7 @@ func createTopicAndSubscription(t *testing.T, sbNamespace *servicebus.Namespace,
 	assert.NoErrorf(t, err, "cannot create subscription for topic - %s", err)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
@@ -203,11 +202,11 @@ func getTemplateData() (templateData, templateValues) {
 			ScaledObjectName: scaledObjectName,
 			TopicName:        topicName,
 			SubscriptionName: subscriptionName,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"triggerAuthTemplate":  triggerAuthTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }
 

--- a/tests/scalers/cassandra/cassandra_test.go
+++ b/tests/scalers/cassandra/cassandra_test.go
@@ -53,8 +53,6 @@ type templateData struct {
 	CassandraTableName      string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -321,7 +319,7 @@ func getCassandraInsertCmd(insertDataTemplate string) (string, error) {
 	return result, err
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			DeploymentName:          deploymentName,
@@ -330,13 +328,13 @@ func getTemplateData() (templateData, map[string]string) {
 			CassandraPasswordBase64: base64.StdEncoding.EncodeToString([]byte(cassandraPassword)),
 			CassandraKeyspace:       cassandraKeyspace,
 			CassandraTableName:      cassandraTableName,
-		}, templateValues{
-			"secretTemplate":                    secretTemplate,
-			"triggerAuthenticationTemplate":     triggerAuthenticationTemplate,
-			"serviceTemplate":                   serviceTemplate,
-			"cassandraDeploymentTemplate":       cassandraDeploymentTemplate,
-			"cassandraClientDeploymentTemplate": cassandraClientDeploymentTemplate,
-			"deploymentTemplate":                deploymentTemplate,
-			"scaledObjectTemplate":              scaledObjectTemplate,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "cassandraDeploymentTemplate", Config: cassandraDeploymentTemplate},
+			{Name: "cassandraClientDeploymentTemplate", Config: cassandraClientDeploymentTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -26,8 +26,6 @@ type templateData struct {
 	ScaledObjectName string
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -132,7 +130,7 @@ func TestCpuScaler(t *testing.T) {
 	t.Log("--- testing scale up ---")
 	t.Log("--- applying job ---")
 
-	templateTriggerJob := templateValues{"triggerJobTemplate": triggerJob}
+	templateTriggerJob := []Template{{Name: "triggerJobTemplate", Config: triggerJob}}
 	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 180, 1),
@@ -150,14 +148,14 @@ func TestCpuScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData(testNamespace string, deploymentName string, scaledObjectName string) (templateData, map[string]string) {
+func getTemplateData(testNamespace string, deploymentName string, scaledObjectName string) (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			DeploymentName:   deploymentName,
 			ScaledObjectName: scaledObjectName,
-		}, templateValues{
-			"deploymentTemplate":   deploymentTemplate,
-			"serviceTemplate":      serviceTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }

--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -37,8 +37,6 @@ type templateData struct {
 	EndMin           string
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -112,16 +110,16 @@ func TestScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			DeploymentName:   deploymentName,
 			ScaledObjectName: scaledObjectName,
 			StartMin:         strconv.Itoa(start),
 			EndMin:           strconv.Itoa(end),
-		}, templateValues{
-			"deploymentTemplate":   deploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }
 

--- a/tests/scalers/datadog/datadog_test.go
+++ b/tests/scalers/datadog/datadog_test.go
@@ -59,8 +59,6 @@ type templateData struct {
 	MaxReplicaCount         string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -310,7 +308,7 @@ func installDatadog(t *testing.T) {
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			DeploymentName:          deploymentName,
@@ -326,13 +324,13 @@ func getTemplateData() (templateData, map[string]string) {
 			KuberneteClusterName:    kuberneteClusterName,
 			MinReplicaCount:         fmt.Sprintf("%v", minReplicaCount),
 			MaxReplicaCount:         fmt.Sprintf("%v", maxReplicaCount),
-		}, templateValues{
-			"secretTemplate":                secretTemplate,
-			"configTemplate":                configTemplate,
-			"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-			"serviceTemplate":               serviceTemplate,
-			"deploymentTemplate":            deploymentTemplate,
-			"monitoredDeploymentTemplate":   monitoredDeploymentTemplate,
-			"scaledObjectTemplate":          scaledObjectTemplate,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "configTemplate", Config: configTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }

--- a/tests/scalers/elasticsearch/elasticsearch_test.go
+++ b/tests/scalers/elasticsearch/elasticsearch_test.go
@@ -49,8 +49,6 @@ type templateData struct {
 	SearchTemplateName    string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -368,7 +366,7 @@ func getElasticsearchDoc() (interface{}, error) {
 	return result, err
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:         testNamespace,
 			DeploymentName:        deploymentName,
@@ -378,12 +376,12 @@ func getTemplateData() (templateData, map[string]string) {
 			ElasticPasswordBase64: base64.StdEncoding.EncodeToString([]byte(password)),
 			IndexName:             indexName,
 			SearchTemplateName:    searchTemplateName,
-		}, templateValues{
-			"secretTemplate":                  secretTemplate,
-			"triggerAuthenticationTemplate":   triggerAuthenticationTemplate,
-			"serviceTemplate":                 serviceTemplate,
-			"elasticsearchDeploymentTemplate": elasticsearchDeploymentTemplate,
-			"deploymentTemplate":              deploymentTemplate,
-			"scaledObjectTemplate":            scaledObjectTemplate,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "elasticsearchDeploymentTemplate", Config: elasticsearchDeploymentTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }

--- a/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
+++ b/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
@@ -35,7 +35,6 @@ type templateData struct {
 	ScaledJobName                string
 	MetricThreshold, MetricValue int
 }
-type templateValues map[string]string
 
 const (
 	serviceTemplate = `
@@ -131,7 +130,7 @@ func TestScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:   testNamespace,
 			ServiceName:     serviceName,
@@ -139,10 +138,11 @@ func getTemplateData() (templateData, templateValues) {
 			ScaledJobName:   scaledJobName,
 			MetricThreshold: 10,
 			MetricValue:     0,
-		}, templateValues{
-			"scalerTemplate":    scalerTemplate,
-			"serviceTemplate":   serviceTemplate,
-			"scaledJobTemplate": scaledJobTemplate}
+		}, []Template{
+			{Name: "scalerTemplate", Config: scalerTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "scaledJobTemplate", Config: scaledJobTemplate},
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/scalers/external_scaler_so/external_scaler_so_test.go
+++ b/tests/scalers/external_scaler_so/external_scaler_so_test.go
@@ -37,7 +37,6 @@ type templateData struct {
 	ScaledObjectName             string
 	MetricThreshold, MetricValue int
 }
-type templateValues map[string]string
 
 const (
 	serviceTemplate = `
@@ -147,7 +146,7 @@ func TestScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			ServiceName:      serviceName,
@@ -156,11 +155,12 @@ func getTemplateData() (templateData, templateValues) {
 			ScaledObjectName: scaledObjectName,
 			MetricThreshold:  10,
 			MetricValue:      0,
-		}, templateValues{
-			"scalerTemplate":       scalerTemplate,
-			"serviceTemplate":      serviceTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "scalerTemplate", Config: scalerTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/scalers/gcp_pubsub/gcp_pubsub_test.go
+++ b/tests/scalers/gcp_pubsub/gcp_pubsub_test.go
@@ -57,8 +57,6 @@ type templateData struct {
 	ActivationThreshold int
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -236,7 +234,7 @@ func cleanupPubsub(t *testing.T) {
 	_, _ = ExecuteCommand(fmt.Sprintf("%sgcloud pubsub topics delete %s", gsPrefix, topicID))
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64GcpCreds := base64.StdEncoding.EncodeToString([]byte(gcpKey))
 
 	return templateData{
@@ -249,11 +247,12 @@ func getTemplateData() (templateData, templateValues) {
 			SubscriptionName:    subscriptionName,
 			MaxReplicaCount:     maxReplicaCount,
 			ActivationThreshold: activationThreshold,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
-			"gcpSdkTemplate":       gcpSdkTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+			{Name: "gcpSdkTemplate", Config: gcpSdkTemplate},
+		}
 }
 
 func publishMessages(t *testing.T, count int) {

--- a/tests/scalers/gcp_stackdriver/gcp_stackdriver_test.go
+++ b/tests/scalers/gcp_stackdriver/gcp_stackdriver_test.go
@@ -60,8 +60,6 @@ type templateData struct {
 	ActivationThreshold int
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -242,7 +240,7 @@ func cleanupPubsub(t *testing.T) {
 	_, _ = ExecuteCommand(fmt.Sprintf("%sgcloud pubsub topics delete %s", gsPrefix, topicID))
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64GcpCreds := base64.StdEncoding.EncodeToString([]byte(gcpKey))
 
 	return templateData{
@@ -257,11 +255,12 @@ func getTemplateData() (templateData, templateValues) {
 			SubscriptionName:    subscriptionName,
 			MaxReplicaCount:     maxReplicaCount,
 			ActivationThreshold: activationThreshold,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
-			"gcpSdkTemplate":       gcpSdkTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+			{Name: "gcpSdkTemplate", Config: gcpSdkTemplate},
+		}
 }
 
 func publishMessages(t *testing.T, count int) {

--- a/tests/scalers/gcp_storage/gcp_storage_test.go
+++ b/tests/scalers/gcp_storage/gcp_storage_test.go
@@ -48,8 +48,6 @@ type templateData struct {
 	ActivationThreshold int
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -203,7 +201,7 @@ func cleanupBucket(t *testing.T) {
 	_, _ = ExecuteCommand(fmt.Sprintf("%sgsutil -m rm -r gs://%s", gsPrefix, bucketName))
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64GcpCreds := base64.StdEncoding.EncodeToString([]byte(gcpKey))
 
 	return templateData{
@@ -215,11 +213,12 @@ func getTemplateData() (templateData, templateValues) {
 			BucketName:          bucketName,
 			MaxReplicaCount:     maxReplicaCount,
 			ActivationThreshold: activationThreshold,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
-			"gcpSdkTemplate":       gcpSdkTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+			{Name: "gcpSdkTemplate", Config: gcpSdkTemplate},
+		}
 }
 
 func uploadFiles(t *testing.T, prefix string, count int) {

--- a/tests/scalers/influxdb/influxdb_test.go
+++ b/tests/scalers/influxdb/influxdb_test.go
@@ -51,8 +51,6 @@ type templateData struct {
 	OrgName                    string
 }
 
-type templateValues map[string]string
-
 const (
 	influxdbStatefulsetTemplate = `
 apiVersion: apps/v1
@@ -248,7 +246,7 @@ func TestScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
 
-	CreateKubernetesResources(t, kc, testNamespace, data, templateValues{"influxdbStatefulsetTemplate": influxdbStatefulsetTemplate})
+	CreateKubernetesResources(t, kc, testNamespace, data, []Template{{Name: "influxdbStatefulsetTemplate", Config: influxdbStatefulsetTemplate}})
 
 	assert.True(t, WaitForStatefulsetReplicaReadyCount(t, kc, influxdbStatefulsetName, testNamespace, 1, 60, 1),
 		"replica count should be 0 after a minute")
@@ -282,7 +280,7 @@ func runWriteJob(t *testing.T, kc *kubernetes.Clientset) templateData {
 	return data
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:              testNamespace,
 			InfluxdbStatefulsetName:    influxdbStatefulsetName,
@@ -294,14 +292,14 @@ func getTemplateData() (templateData, templateValues) {
 			BasicDeploymentIntName:     basicDeploymentIntName,
 			AuthToken:                  authToken,
 			OrgName:                    orgName,
-		}, templateValues{
-			"influxdbStatefulsetTemplate":    influxdbStatefulsetTemplate,
-			"scaledObjectTemplateFloat":      scaledObjectTemplateFloat,
-			"scaledObjectTemplateInt":        scaledObjectTemplateInt,
-			"scaledObjectActivationTemplate": scaledObjectActivationTemplate,
-			"basicDeploymentFloatTemplate":   basicDeploymentFloatTemplate,
-			"basicDeploymentIntTemplate":     basicDeploymentIntTemplate,
-			"influxdbWriteJobTemplate":       influxdbWriteJobTemplate,
+		}, []Template{
+			{Name: "influxdbStatefulsetTemplate", Config: influxdbStatefulsetTemplate},
+			{Name: "scaledObjectTemplateFloat", Config: scaledObjectTemplateFloat},
+			{Name: "scaledObjectTemplateInt", Config: scaledObjectTemplateInt},
+			{Name: "scaledObjectActivationTemplate", Config: scaledObjectActivationTemplate},
+			{Name: "basicDeploymentFloatTemplate", Config: basicDeploymentFloatTemplate},
+			{Name: "basicDeploymentIntTemplate", Config: basicDeploymentIntTemplate},
+			{Name: "influxdbWriteJobTemplate", Config: influxdbWriteJobTemplate},
 		}
 }
 

--- a/tests/scalers/kafka/kafka_test.go
+++ b/tests/scalers/kafka/kafka_test.go
@@ -57,8 +57,6 @@ type templateData struct {
 	ScaleToZeroOnInvalid string
 }
 
-type templateValues map[string]string
-
 const (
 	singleDeploymentTemplate = `
 apiVersion: apps/v1
@@ -463,7 +461,7 @@ func addCluster(t *testing.T, data templateData) {
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			DeploymentName:   deploymentName,
@@ -475,7 +473,7 @@ func getTemplateData() (templateData, map[string]string) {
 			Topic2Name:       topic2,
 			ResetPolicy:      "",
 			ScaledObjectName: scaledObjectName,
-		}, templateValues{
-			"kafkaClientTemplate": kafkaClientTemplate,
+		}, []Template{
+			{Name: "kafkaClientTemplate", Config: kafkaClientTemplate},
 		}
 }

--- a/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
+++ b/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
@@ -31,8 +31,6 @@ type templateData struct {
 	ScaledObjectName        string
 }
 
-type templateValues map[string]string
-
 const (
 	monitoredDeploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -153,11 +151,15 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be 0 after 1 minute")
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
-		TestNamespace:           testNamespace,
-		MonitoredDeploymentName: monitoredDeploymentName,
-		SutDeploymentName:       sutDeploymentName,
-		ScaledObjectName:        scaledObjectName,
-	}, templateValues{"monitoredDeploymentTemplate": monitoredDeploymentTemplate, "sutDeploymentTemplate": sutDeploymentTemplate, "scaledObjectTemplate": scaledObjectTemplate}
+			TestNamespace:           testNamespace,
+			MonitoredDeploymentName: monitoredDeploymentName,
+			SutDeploymentName:       sutDeploymentName,
+			ScaledObjectName:        scaledObjectName,
+		}, []Template{
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
+			{Name: "sutDeploymentTemplate", Config: sutDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/metrics_api/metrics_api_test.go
+++ b/tests/scalers/metrics_api/metrics_api_test.go
@@ -48,8 +48,6 @@ type templateData struct {
 	MaxReplicaCount             string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `apiVersion: v1
 kind: Secret
@@ -233,7 +231,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:               testNamespace,
 			DeploymentName:              deploymentName,
@@ -246,12 +244,12 @@ func getTemplateData() (templateData, map[string]string) {
 			MinReplicaCount:             fmt.Sprintf("%v", minReplicaCount),
 			MaxReplicaCount:             fmt.Sprintf("%v", maxReplicaCount),
 			MetricValue:                 0,
-		}, templateValues{
-			"secretTemplate":                  secretTemplate,
-			"metricsServerdeploymentTemplate": metricsServerdeploymentTemplate,
-			"serviceTemplate":                 serviceTemplate,
-			"triggerAuthenticationTemplate":   triggerAuthenticationTemplate,
-			"deploymentTemplate":              deploymentTemplate,
-			"scaledObjectTemplate":            scaledObjectTemplate,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "metricsServerdeploymentTemplate", Config: metricsServerdeploymentTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }

--- a/tests/scalers/mongodb/mongodb_test.go
+++ b/tests/scalers/mongodb/mongodb_test.go
@@ -47,8 +47,6 @@ type templateData struct {
 	Database, Collection         string
 }
 
-type templateValues map[string]string
-
 const (
 	mongoTemplate = `
 apiVersion: apps/v1
@@ -174,7 +172,7 @@ func TestScaler(t *testing.T) {
 	cleanupMongo(t, kc)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	connectionString := fmt.Sprintf("mongodb://%s:%s@mongodb-svc.%s.svc.cluster.local:27017/%s",
 		mongoUser, mongoPassword, mongoNamespace, mongoDBName)
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
@@ -189,10 +187,11 @@ func getTemplateData() (templateData, templateValues) {
 			Collection:       mongoCollection,
 			Connection:       connectionString,
 			Base64Connection: base64ConnectionString,
-		}, templateValues{
-			"secretTemplate":      secretTemplate,
-			"triggerAuthTemplate": triggerAuthTemplate,
-			"scaledJobTemplate":   scaledJobTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledJobTemplate", Config: scaledJobTemplate},
+		}
 }
 
 func setupMongo(t *testing.T, kc *kubernetes.Clientset) string {

--- a/tests/scalers/mysql/mysql_test.go
+++ b/tests/scalers/mysql/mysql_test.go
@@ -48,8 +48,6 @@ type templateData struct {
 	ItemsToWrite          int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -246,7 +244,7 @@ func TestMySQLScaler(t *testing.T) {
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func setupMySQL(t *testing.T, kc *kubernetes.Clientset, data templateData, templates templateValues) {
+func setupMySQL(t *testing.T, kc *kubernetes.Clientset, data templateData, templates []Template) {
 	// Deploy mysql
 	KubectlApplyWithTemplate(t, data, "mysqlDeploymentTemplate", mysqlDeploymentTemplate)
 	KubectlApplyWithTemplate(t, data, "mysqlServiceTemplate", mysqlServiceTemplate)
@@ -297,7 +295,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
 		"Replica count should be 0 after 5 minutes")
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64MySQLConnectionString := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s@tcp(mysql.%s.svc.cluster.local:3306)/%s", mySQLUsername, mySQLPassword, testNamespace, mySQLDatabase)))
 	return templateData{
 			TestNamespace:         testNamespace,
@@ -310,10 +308,10 @@ func getTemplateData() (templateData, templateValues) {
 			MySQLRootPassword:     mySQLRootPassword,
 			MySQLConnectionString: base64MySQLConnectionString,
 			ItemsToWrite:          0,
-		}, templateValues{
-			"deploymentTemplate":   deploymentTemplate,
-			"secretTemplate":       secretTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
-			"triggerAuthTemplate":  triggerAuthTemplate,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
 		}
 }

--- a/tests/scalers/nats_jetstream/nats_helper.go
+++ b/tests/scalers/nats_jetstream/nats_helper.go
@@ -11,8 +11,6 @@ import (
 	"github.com/kedacore/keda/v2/tests/helper"
 )
 
-type templateValues map[string]string
-
 type templateData struct {
 	NatsNamespace string
 	TestNamespace string
@@ -196,10 +194,7 @@ func InstallServerWithJetStream(t *testing.T, kc *k8s.Clientset, namespace strin
 		NatsNamespace: namespace,
 	}
 
-	natsServerTemplateValue := templateValues{
-		"natsServerTemplate": natsServerTemplate,
-	}
-	helper.KubectlApplyMultipleWithTemplate(t, data, natsServerTemplateValue)
+	helper.KubectlApplyWithTemplate(t, data, "natsServerTemplate", natsServerTemplate)
 }
 
 // RemoveServer will remove the NATS server and delete the namespace.
@@ -207,10 +202,8 @@ func RemoveServer(t *testing.T, kc *k8s.Clientset, namespace string) {
 	data := templateData{
 		NatsNamespace: namespace,
 	}
-	natsServerTemplateValue := templateValues{
-		"natsServerTemplate": natsServerTemplate,
-	}
-	helper.KubectlApplyMultipleWithTemplate(t, data, natsServerTemplateValue)
+
+	helper.KubectlDeleteWithTemplate(t, data, "natsServerTemplate", natsServerTemplate)
 	helper.DeleteNamespace(t, kc, namespace)
 }
 
@@ -220,8 +213,6 @@ func InstallStreamAndConsumer(t *testing.T, kc *k8s.Clientset, namespace, natsAd
 		TestNamespace: namespace,
 		NatsAddress:   natsAddress,
 	}
-	streamAndConsumerJob := templateValues{
-		"streamAndConsumerTemplate": streamAndConsumerTemplate,
-	}
-	helper.KubectlApplyMultipleWithTemplate(t, data, streamAndConsumerJob)
+
+	helper.KubectlApplyWithTemplate(t, data, "streamAndConsumerTemplate", streamAndConsumerTemplate)
 }

--- a/tests/scalers/new_relic/new_relic_test.go
+++ b/tests/scalers/new_relic/new_relic_test.go
@@ -59,7 +59,6 @@ type templateData struct {
 	MinReplicaCount         string
 	MaxReplicaCount         string
 }
-type templateValues map[string]string
 
 const (
 	secretTemplate = `apiVersion: v1
@@ -272,7 +271,7 @@ func installNewRelic(t *testing.T) {
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:           testNamespace,
 			DeploymentName:          deploymentName,
@@ -288,11 +287,12 @@ func getTemplateData() (templateData, templateValues) {
 			DeploymentReplicas:      fmt.Sprintf("%v", deploymentReplicas),
 			NewRelicAccountID:       newRelicAccountID,
 			NewRelicAPIKey:          base64.StdEncoding.EncodeToString([]byte(newRelicAPIKey)),
-		}, templateValues{
-			"secretTemplate":                secretTemplate,
-			"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-			"serviceTemplate":               serviceTemplate,
-			"monitoredDeploymentTemplate":   monitoredDeploymentTemplate,
-			"deploymentTemplate":            deploymentTemplate,
-			"scaledObjectTemplate":          scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }

--- a/tests/scalers/openstack_swift/openstack_swift_test.go
+++ b/tests/scalers/openstack_swift/openstack_swift_test.go
@@ -68,8 +68,6 @@ type templateData struct {
 	MaxReplicaCount           int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -206,7 +204,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset, client *gophercloud.S
 		"replica count should be %d after 5 minutes", minReplicaCount)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:             testNamespace,
 			DeploymentName:            deploymentName,
@@ -220,10 +218,10 @@ func getTemplateData() (templateData, map[string]string) {
 			Container:                 containerName,
 			MinReplicaCount:           minReplicaCount,
 			MaxReplicaCount:           maxReplicaCount,
-		}, templateValues{
-			"deploymentTemplate":   deploymentTemplate,
-			"secretTemplate":       secretTemplate,
-			"triggerAuthTemplate":  triggerAuthTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}
 }

--- a/tests/scalers/postgresql/postgresql_test.go
+++ b/tests/scalers/postgresql/postgresql_test.go
@@ -54,8 +54,6 @@ type templateData struct {
 	MaxReplicaCount                  int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -282,16 +280,14 @@ func TestPostreSQLScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	templateTriggerJob := templateValues{"lowLevelRecordsJobTemplate": lowLevelRecordsJobTemplate}
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "lowLevelRecordsJobTemplate", lowLevelRecordsJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale up ---")
-	templateTriggerJob := templateValues{"insertRecordsJobTemplate": insertRecordsJobTemplate}
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -319,18 +315,18 @@ var data = templateData{
 	PostgreSQLConnectionStringBase64: base64.StdEncoding.EncodeToString([]byte(postgreSQLConnectionString)),
 }
 
-func getPostgreSQLTemplateData() (templateData, map[string]string) {
-	return data, templateValues{
-		"postgreSQLStatefulSetTemplate": postgreSQLStatefulSetTemplate,
-		"postgreSQLServiceTemplate":     postgreSQLServiceTemplate,
+func getPostgreSQLTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "postgreSQLStatefulSetTemplate", Config: postgreSQLStatefulSetTemplate},
+		{Name: "postgreSQLServiceTemplate", Config: postgreSQLServiceTemplate},
 	}
 }
 
-func getTemplateData() (templateData, map[string]string) {
-	return data, templateValues{
-		"secretTemplate":                secretTemplate,
-		"deploymentTemplate":            deploymentTemplate,
-		"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-		"scaledObjectTemplate":          scaledObjectTemplate,
+func getTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "secretTemplate", Config: secretTemplate},
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 	}
 }

--- a/tests/scalers/prometheus/prometheus_helper.go
+++ b/tests/scalers/prometheus/prometheus_helper.go
@@ -12,21 +12,19 @@ import (
 	"github.com/kedacore/keda/v2/tests/helper"
 )
 
-type templateValues map[string]string
-
 type templateData struct {
 	Namespace            string
 	PrometheusServerName string
 }
 
 var (
-	prometheusTemplates = templateValues{
-		"prometheusServerServiceAccountTemplate":     prometheusServerServiceAccountTemplate,
-		"standaloneRedisServiceTemplate":             prometheusServerConfigMapTemplate,
-		"prometheusServerClusterRoleTemplate":        prometheusServerClusterRoleTemplate,
-		"prometheusServerClusterRoleBindingTemplate": prometheusServerClusterRoleBindingTemplate,
-		"prometheusServerDeploymentTemplate":         prometheusServerDeploymentTemplate,
-		"prometheusServerServiceTemplate":            prometheusServerServiceTemplate,
+	prometheusTemplates = []helper.Template{
+		{Name: "prometheusServerServiceAccountTemplate", Config: prometheusServerServiceAccountTemplate},
+		{Name: "standaloneRedisServiceTemplate", Config: prometheusServerConfigMapTemplate},
+		{Name: "prometheusServerClusterRoleTemplate", Config: prometheusServerClusterRoleTemplate},
+		{Name: "prometheusServerClusterRoleBindingTemplate", Config: prometheusServerClusterRoleBindingTemplate},
+		{Name: "prometheusServerDeploymentTemplate", Config: prometheusServerDeploymentTemplate},
+		{Name: "prometheusServerServiceTemplate", Config: prometheusServerServiceTemplate},
 	}
 )
 

--- a/tests/scalers/pulsar/pulsar_test.go
+++ b/tests/scalers/pulsar/pulsar_test.go
@@ -177,9 +177,7 @@ spec:
     app: pulsar
 `
 
-type templateValues map[string]string
-
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:          testNamespace,
 			StatefulSetName:        statefulSetName,
@@ -190,9 +188,9 @@ func getTemplateData() (templateData, templateValues) {
 			MinReplicaCount:        minReplicaCount,
 			MaxReplicaCount:        maxReplicaCount,
 			MsgBacklog:             msgBacklog,
-		}, templateValues{
-			"statefulsetTemplate": statefulsetTemplate,
-			"serviceTemplate":     serviceTemplate,
+		}, []Template{
+			{Name: "statefulsetTemplate", Config: statefulsetTemplate},
+			{Name: "serviceTemplate", Config: serviceTemplate},
 		}
 }
 

--- a/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
@@ -70,7 +70,6 @@ type templateData struct {
 	QueueName                    string
 	Connection, Base64Connection string
 }
-type templateValues map[string]string
 
 func TestScaler(t *testing.T) {
 	// setup
@@ -96,7 +95,7 @@ func TestScaler(t *testing.T) {
 	RMQUninstall(t, kc, rmqNamespace, user, password, vhost)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			DeploymentName:   deploymentName,
@@ -105,9 +104,10 @@ func getTemplateData() (templateData, templateValues) {
 			QueueName:        queueName,
 			Connection:       connectionString,
 			Base64Connection: base64.StdEncoding.EncodeToString([]byte(connectionString)),
-		}, templateValues{
-			"deploymentTemplate":   RMQTargetDeploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "deploymentTemplate", Config: RMQTargetDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
@@ -71,7 +71,6 @@ type templateData struct {
 	QueueName                    string
 	Connection, Base64Connection string
 }
-type templateValues map[string]string
 
 func TestScaler(t *testing.T) {
 	// setup
@@ -95,7 +94,7 @@ func TestScaler(t *testing.T) {
 	RMQUninstall(t, kc, rmqNamespace, user, password, vhost)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			DeploymentName:   deploymentName,
@@ -104,9 +103,10 @@ func getTemplateData() (templateData, templateValues) {
 			QueueName:        queueName,
 			Connection:       connectionString,
 			Base64Connection: base64.StdEncoding.EncodeToString([]byte(httpConnectionString)),
-		}, templateValues{
-			"deploymentTemplate":   RMQTargetDeploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "deploymentTemplate", Config: RMQTargetDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_regex/rabbitmq_queue_http_regex_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_regex/rabbitmq_queue_http_regex_test.go
@@ -74,7 +74,6 @@ type templateData struct {
 	QueueName                    string
 	Connection, Base64Connection string
 }
-type templateValues map[string]string
 
 func TestScaler(t *testing.T) {
 	// setup
@@ -98,7 +97,7 @@ func TestScaler(t *testing.T) {
 	RMQUninstall(t, kc, rmqNamespace, user, password, vhost)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			DeploymentName:   deploymentName,
@@ -107,9 +106,10 @@ func getTemplateData() (templateData, templateValues) {
 			QueueName:        queueRegex,
 			Connection:       connectionString,
 			Base64Connection: base64.StdEncoding.EncodeToString([]byte(httpConnectionString)),
-		}, templateValues{
-			"deploymentTemplate":   RMQTargetDeploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "deploymentTemplate", Config: RMQTargetDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_regex_vhost/rabbitmq_queue_http_regex_vhost_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_regex_vhost/rabbitmq_queue_http_regex_vhost_test.go
@@ -79,7 +79,6 @@ type templateData struct {
 	QueueName                    string
 	Connection, Base64Connection string
 }
-type templateValues map[string]string
 
 func TestScaler(t *testing.T) {
 	// setup
@@ -106,7 +105,7 @@ func TestScaler(t *testing.T) {
 	RMQUninstall(t, kc, rmqNamespace, user, password, vhost)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:    testNamespace,
 			DeploymentName:   deploymentName,
@@ -115,9 +114,10 @@ func getTemplateData() (templateData, templateValues) {
 			QueueName:        queueRegex,
 			Connection:       connectionString,
 			Base64Connection: base64.StdEncoding.EncodeToString([]byte(httpConnectionString)),
-		}, templateValues{
-			"deploymentTemplate":   RMQTargetDeploymentTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "deploymentTemplate", Config: RMQTargetDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/scalers/redis/helper/helper.go
+++ b/tests/scalers/redis/helper/helper.go
@@ -13,8 +13,6 @@ import (
 	"github.com/kedacore/keda/v2/tests/helper"
 )
 
-type templateValues map[string]string
-
 type templateData struct {
 	Namespace     string
 	RedisName     string
@@ -22,18 +20,18 @@ type templateData struct {
 }
 
 var (
-	redisStandaloneTemplates = templateValues{
-		"standaloneRedisTemplate":        standaloneRedisTemplate,
-		"standaloneRedisServiceTemplate": standaloneRedisServiceTemplate,
+	redisStandaloneTemplates = []helper.Template{
+		{Name: "standaloneRedisTemplate", Config: standaloneRedisTemplate},
+		{Name: "standaloneRedisServiceTemplate", Config: standaloneRedisServiceTemplate},
 	}
 
-	redisClusterTemplates = templateValues{
-		"clusterRedisSecretTemplate":          clusterRedisSecretTemplate,
-		"clusterRedisConfig1Template":         clusterRedisConfig1Template,
-		"clusterRedisConfig2Template":         clusterRedisConfig2Template,
-		"clusterRedisHeadlessServiceTemplate": clusterRedisHeadlessServiceTemplate,
-		"clusterRedisServiceTemplate":         clusterRedisServiceTemplate,
-		"clusterRedisStatefulSetTemplate":     clusterRedisStatefulSetTemplate,
+	redisClusterTemplates = []helper.Template{
+		{Name: "clusterRedisSecretTemplate", Config: clusterRedisSecretTemplate},
+		{Name: "clusterRedisConfig1Template", Config: clusterRedisConfig1Template},
+		{Name: "clusterRedisConfig2Template", Config: clusterRedisConfig2Template},
+		{Name: "clusterRedisHeadlessServiceTemplate", Config: clusterRedisHeadlessServiceTemplate},
+		{Name: "clusterRedisServiceTemplate", Config: clusterRedisServiceTemplate},
+		{Name: "clusterRedisStatefulSetTemplate", Config: clusterRedisStatefulSetTemplate},
 	}
 )
 

--- a/tests/scalers/redis/redis_cluster_streams/redis_cluster_streams_test.go
+++ b/tests/scalers/redis/redis_cluster_streams/redis_cluster_streams_test.go
@@ -53,8 +53,6 @@ type templateData struct {
 	ItemsToWrite              int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -193,8 +191,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale up ---")
-	templateTriggerJob := templateValues{"insertJobTemplate": insertJobTemplate}
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -223,11 +220,11 @@ var data = templateData{
 	ItemsToWrite:              100,
 }
 
-func getTemplateData() (templateData, map[string]string) {
-	return data, templateValues{
-		"secretTemplate":                secretTemplate,
-		"deploymentTemplate":            deploymentTemplate,
-		"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-		"scaledObjectTemplate":          scaledObjectTemplate,
+func getTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "secretTemplate", Config: secretTemplate},
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 	}
 }

--- a/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
+++ b/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
@@ -55,8 +55,6 @@ type templateData struct {
 	ItemsToWrite              int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -198,18 +196,15 @@ func TestScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	templateTriggerJob := templateValues{"insertJobTemplate": insertJobTemplate}
-	data.ItemsToWrite = 5
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale up ---")
-	templateTriggerJob := templateValues{"insertJobTemplate": insertJobTemplate}
 	data.ItemsToWrite = 200
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -239,11 +234,11 @@ var data = templateData{
 	ItemsToWrite:              0,
 }
 
-func getTemplateData() (templateData, map[string]string) {
-	return data, templateValues{
-		"secretTemplate":                secretTemplate,
-		"deploymentTemplate":            deploymentTemplate,
-		"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-		"scaledObjectTemplate":          scaledObjectTemplate,
+func getTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "secretTemplate", Config: secretTemplate},
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 	}
 }

--- a/tests/scalers/redis/redis_sentinel_streams/redis_sentinel_streams_test.go
+++ b/tests/scalers/redis/redis_sentinel_streams/redis_sentinel_streams_test.go
@@ -53,8 +53,6 @@ type templateData struct {
 	ItemsToWrite              int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -207,8 +205,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale up ---")
-	templateTriggerJob := templateValues{"insertJobTemplate": insertJobTemplate}
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -237,11 +234,11 @@ var data = templateData{
 	ItemsToWrite:              100,
 }
 
-func getTemplateData() (templateData, map[string]string) {
-	return data, templateValues{
-		"secretTemplate":                secretTemplate,
-		"deploymentTemplate":            deploymentTemplate,
-		"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-		"scaledObjectTemplate":          scaledObjectTemplate,
+func getTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "secretTemplate", Config: secretTemplate},
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 	}
 }

--- a/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
+++ b/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
@@ -54,8 +54,6 @@ type templateData struct {
 	ItemsToWrite              int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -186,18 +184,16 @@ func TestScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	templateTriggerJob := templateValues{"insertJobTemplate": insertJobTemplate}
 	data.ItemsToWrite = 5
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale up ---")
-	templateTriggerJob := templateValues{"insertJobTemplate": insertJobTemplate}
 	data.ItemsToWrite = 200
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -226,11 +222,11 @@ var data = templateData{
 	ItemsToWrite:              0,
 }
 
-func getTemplateData() (templateData, map[string]string) {
-	return data, templateValues{
-		"secretTemplate":                secretTemplate,
-		"deploymentTemplate":            deploymentTemplate,
-		"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-		"scaledObjectTemplate":          scaledObjectTemplate,
+func getTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "secretTemplate", Config: secretTemplate},
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 	}
 }

--- a/tests/scalers/redis/redis_standalone_streams/redis_standalone_streams_test.go
+++ b/tests/scalers/redis/redis_standalone_streams/redis_standalone_streams_test.go
@@ -54,8 +54,6 @@ type templateData struct {
 	ItemsToWrite              int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -187,9 +185,8 @@ func TestScaler(t *testing.T) {
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale up ---")
-	templateTriggerJob := templateValues{"insertJobTemplate": insertJobTemplate}
 	data.ItemsToWrite = 20
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -218,11 +215,11 @@ var data = templateData{
 	ItemsToWrite:              0,
 }
 
-func getTemplateData() (templateData, map[string]string) {
-	return data, templateValues{
-		"secretTemplate":                secretTemplate,
-		"deploymentTemplate":            deploymentTemplate,
-		"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-		"scaledObjectTemplate":          scaledObjectTemplate,
+func getTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "secretTemplate", Config: secretTemplate},
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 	}
 }

--- a/tests/scalers/selenium/selenium_test.go
+++ b/tests/scalers/selenium/selenium_test.go
@@ -52,8 +52,6 @@ type templateData struct {
 	MaxReplicaCount       int
 }
 
-type templateValues map[string]string
-
 const (
 	eventBusConfigTemplate = `
 apiVersion: v1
@@ -520,7 +518,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be %s after 3 minutes", minReplicaCount)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:         testNamespace,
 			ChromeDeploymentName:  chromeDeploymentName,
@@ -533,18 +531,18 @@ func getTemplateData() (templateData, map[string]string) {
 			ScaledObjectName:      scaledObjectName,
 			MinReplicaCount:       minReplicaCount,
 			MaxReplicaCount:       maxReplicaCount,
-		}, templateValues{
-			"eventBusConfigTemplate":        eventBusConfigTemplate,
-			"hubDeploymentTemplate":         hubDeploymentTemplate,
-			"hubServiceTemplate":            hubServiceTemplate,
-			"chromeNodeServiceTemplate":     chromeNodeServiceTemplate,
-			"chromeNodeDeploymentTemplate":  chromeNodeDeploymentTemplate,
-			"chromeScaledObjectTemplate":    chromeScaledObjectTemplate,
-			"firefoxNodeServiceTemplate":    firefoxNodeServiceTemplate,
-			"firefoxNodeDeploymentTemplate": firefoxNodeDeploymentTemplate,
-			"firefoxScaledObjectTemplate":   firefoxScaledObjectTemplate,
-			"edgeNodeServiceTemplate":       edgeNodeServiceTemplate,
-			"edgeNodeDeploymentTemplate":    edgeNodeDeploymentTemplate,
-			"edgeScaledObjectTemplate":      edgeScaledObjectTemplate,
+		}, []Template{
+			{Name: "eventBusConfigTemplate", Config: eventBusConfigTemplate},
+			{Name: "hubDeploymentTemplate", Config: hubDeploymentTemplate},
+			{Name: "hubServiceTemplate", Config: hubServiceTemplate},
+			{Name: "chromeNodeServiceTemplate", Config: chromeNodeServiceTemplate},
+			{Name: "chromeNodeDeploymentTemplate", Config: chromeNodeDeploymentTemplate},
+			{Name: "chromeScaledObjectTemplate", Config: chromeScaledObjectTemplate},
+			{Name: "firefoxNodeServiceTemplate", Config: firefoxNodeServiceTemplate},
+			{Name: "firefoxNodeDeploymentTemplate", Config: firefoxNodeDeploymentTemplate},
+			{Name: "firefoxScaledObjectTemplate", Config: firefoxScaledObjectTemplate},
+			{Name: "edgeNodeServiceTemplate", Config: edgeNodeServiceTemplate},
+			{Name: "edgeNodeDeploymentTemplate", Config: edgeNodeDeploymentTemplate},
+			{Name: "edgeScaledObjectTemplate", Config: edgeScaledObjectTemplate},
 		}
 }

--- a/tests/scalers/solace/solace_test.go
+++ b/tests/scalers/solace/solace_test.go
@@ -43,8 +43,6 @@ type templateData struct {
 	MaxReplicaCount           int
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -224,7 +222,7 @@ func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 }
 
-func getTemplateData() (templateData, map[string]string) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
 			TestNamespace:             testNamespace,
 			DeploymentName:            deploymentName,
@@ -234,10 +232,10 @@ func getTemplateData() (templateData, map[string]string) {
 			SecretName:                secretName,
 			MinReplicaCount:           minReplicaCount,
 			MaxReplicaCount:           maxReplicaCount,
-		}, templateValues{
-			"secretTemplate":                secretTemplate,
-			"deploymentTemplate":            deploymentTemplate,
-			"triggerAuthenticationTemplate": triggerAuthenticationTemplate,
-			"helperTemplate":                helperTemplate,
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "helperTemplate", Config: helperTemplate},
 		}
 }

--- a/tests/secret-providers/azure_keyvault/azure_keyvault_test.go
+++ b/tests/secret-providers/azure_keyvault/azure_keyvault_test.go
@@ -58,8 +58,6 @@ type templateData struct {
 	AzureADTenantID  string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -197,7 +195,7 @@ func createQueue(t *testing.T) (azqueue.QueueURL, azqueue.MessagesURL) {
 	return queueURL, messageURL
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 	base64ClientSecret := base64.StdEncoding.EncodeToString([]byte(azureADSecret))
 
@@ -213,11 +211,12 @@ func getTemplateData() (templateData, templateValues) {
 			AzureADClientID:  azureADClientID,
 			AzureADSecret:    base64ClientSecret,
 			AzureADTenantID:  azureADTenantID,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"triggerAuthTemplate":  triggerAuthTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {

--- a/tests/secret-providers/azure_workload_identity/azure_workload_identity_test.go
+++ b/tests/secret-providers/azure_workload_identity/azure_workload_identity_test.go
@@ -44,8 +44,6 @@ type templateData struct {
 	QueueName           string
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -162,14 +160,18 @@ func createQueue(t *testing.T, sbQueueManager *servicebus.QueueManager) {
 	assert.NoErrorf(t, err, "cannot create service bus queue - %s", err)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
-		TestNamespace:    testNamespace,
-		DeploymentName:   deploymentName,
-		TriggerAuthName:  triggerAuthName,
-		ScaledObjectName: scaledObjectName,
-		QueueName:        queueName,
-	}, templateValues{"deploymentTemplate": deploymentTemplate, "triggerAuthTemplate": triggerAuthTemplate, "scaledObjectTemplate": scaledObjectTemplate}
+			TestNamespace:    testNamespace,
+			DeploymentName:   deploymentName,
+			TriggerAuthName:  triggerAuthName,
+			ScaledObjectName: scaledObjectName,
+			QueueName:        queueName,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, sbQueue *servicebus.Queue) {

--- a/tests/secret-providers/azure_workload_identity_user_assigned/azure_workload_identity_user_assigned_test.go
+++ b/tests/secret-providers/azure_workload_identity_user_assigned/azure_workload_identity_user_assigned_test.go
@@ -46,8 +46,6 @@ type templateData struct {
 	QueueName           string
 }
 
-type templateValues map[string]string
-
 const (
 	deploymentTemplate = `
 apiVersion: apps/v1
@@ -178,15 +176,19 @@ func createQueue(t *testing.T, sbQueueManager *servicebus.QueueManager) {
 	assert.NoErrorf(t, err, "cannot create service bus queue - %s", err)
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	return templateData{
-		TestNamespace:    testNamespace,
-		DeploymentName:   deploymentName,
-		TriggerAuthName:  triggerAuthName,
-		IdentityID:       azureADClientID,
-		ScaledObjectName: scaledObjectName,
-		QueueName:        queueName,
-	}, templateValues{"deploymentTemplate": deploymentTemplate, "triggerAuthTemplate": triggerAuthTemplate, "scaledObjectTemplate": scaledObjectTemplate}
+			TestNamespace:    testNamespace,
+			DeploymentName:   deploymentName,
+			TriggerAuthName:  triggerAuthName,
+			IdentityID:       azureADClientID,
+			ScaledObjectName: scaledObjectName,
+			QueueName:        queueName,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaleUpWithIncorrectIdentity(t *testing.T, kc *kubernetes.Clientset, sbQueue *servicebus.Queue) {

--- a/tests/secret-providers/trigger_auth_secret/trigger_auth_secret_test.go
+++ b/tests/secret-providers/trigger_auth_secret/trigger_auth_secret_test.go
@@ -50,8 +50,6 @@ type templateData struct {
 	QueueName        string
 }
 
-type templateValues map[string]string
-
 const (
 	secretTemplate = `
 apiVersion: v1
@@ -175,7 +173,7 @@ func createQueue(t *testing.T) (azqueue.QueueURL, azqueue.MessagesURL) {
 	return queueURL, messageURL
 }
 
-func getTemplateData() (templateData, templateValues) {
+func getTemplateData() (templateData, []Template) {
 	base64ConnectionString := base64.StdEncoding.EncodeToString([]byte(connectionString))
 
 	return templateData{
@@ -186,11 +184,12 @@ func getTemplateData() (templateData, templateValues) {
 			TriggerAuthName:  triggerAuthName,
 			ScaledObjectName: scaledObjectName,
 			QueueName:        queueName,
-		}, templateValues{
-			"secretTemplate":       secretTemplate,
-			"deploymentTemplate":   deploymentTemplate,
-			"triggerAuthTemplate":  triggerAuthTemplate,
-			"scaledObjectTemplate": scaledObjectTemplate}
+		}, []Template{
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
 }
 
 func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {


### PR DESCRIPTION
Signed-off-by: Vighnesh Shenoy <vshenoy@microsoft.com>

Earlier, the apply / delete functions for Kubernetes templates were using maps. Iteration order is not guaranteed for maps in Go. So, which template would get applied / deleted first would be run dependent. This matters in cases where one template is dependent on other (ex - SO depends on target deployment). This leads to noise in the KEDA pod logs with errors that are unrelated to test failures themselves.

Sorry for the large PR.
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
