### PR TITLE
Add option to get queueURL from env for aws SQS scaler

### DIFF
--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -116,7 +116,11 @@ func parseAwsSqsQueueMetadata(config *ScalerConfig, logger logr.Logger) (*awsSqs
 	if val, ok := config.TriggerMetadata["queueURL"]; ok && val != "" {
 		meta.queueURL = val
 	} else if val, ok := config.TriggerMetadata["queueURLFromEnv"]; ok && val != "" {
-		meta.queueURL = config.ResolvedEnv[val]
+		if val, ok := config.ResolvedEnv[val]; ok && val != "" {
+			meta.queueURL = val
+		} else {
+			return nil, fmt.Errorf("queueURLFromEnv `%s` env variable value is empty", config.TriggerMetadata["queueURLFromEnv"])
+		}
 	} else {
 		return nil, fmt.Errorf("no queueURL given")
 	}

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -116,7 +116,7 @@ func parseAwsSqsQueueMetadata(config *ScalerConfig, logger logr.Logger) (*awsSqs
 	if val, ok := config.TriggerMetadata["queueURL"]; ok && val != "" {
 		meta.queueURL = val
 	} else if val, ok := config.TriggerMetadata["queueURLFromEnv"]; ok && val != "" {
-		meta.queueURL = config.ResolvedEnv[config.TriggerMetadata["queueURLFromEnv"]]
+		meta.queueURL = config.ResolvedEnv[val]
 	} else {
 		return nil, fmt.Errorf("no queueURL given")
 	}

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -115,6 +115,8 @@ func parseAwsSqsQueueMetadata(config *ScalerConfig, logger logr.Logger) (*awsSqs
 
 	if val, ok := config.TriggerMetadata["queueURL"]; ok && val != "" {
 		meta.queueURL = val
+	} else if val, ok := config.TriggerMetadata["queueURLFromEnv"]; ok && val != "" {
+		meta.queueURL = config.ResolvedEnv[config.TriggerMetadata["queueURLFromEnv"]]
 	} else {
 		return nil, fmt.Errorf("no queueURL given")
 	}

--- a/pkg/scalers/aws_sqs_queue_scaler_test.go
+++ b/pkg/scalers/aws_sqs_queue_scaler_test.go
@@ -28,6 +28,12 @@ const (
 	testAWSSQSBadDataQueueURL = "https://sqs.eu-west-1.amazonaws.com/account_id/BadData"
 )
 
+var testSQSResolvedEnv = map[string]string{
+	"awsAccessKeyId":     testAWSSQSAccessKeyID,
+	"awsSecretAccessKey": testAWSSQSSecretAccessKey,
+	"QUEUE_URL":          testAWSSQSProperQueueURL,
+}
+
 var testAWSSQSAuthentication = map[string]string{
 	"awsAccessKeyId":     testAWSSQSAccessKeyID,
 	"awsSecretAccessKey": testAWSSQSSecretAccessKey,
@@ -240,6 +246,19 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		testAWSSQSAuthentication,
 		false,
 		"properly formed queue and region"},
+	{map[string]string{
+		"queueURLFromEnv": "QUEUE_URL",
+		"queueLength":     "1",
+		"awsRegion":       "eu-west-1"},
+		testSQSResolvedEnv,
+		false,
+		"properly formed queue loaded from env"},
+	{map[string]string{
+		"queueLength": "1",
+		"awsRegion":   "eu-west-1"},
+		testSQSResolvedEnv,
+		true,
+		"missing queue url from both queueURL and queueURLFromEnv"},
 }
 
 var awsSQSMetricIdentifiers = []awsSQSMetricIdentifier{

--- a/pkg/scalers/aws_sqs_queue_scaler_test.go
+++ b/pkg/scalers/aws_sqs_queue_scaler_test.go
@@ -28,10 +28,10 @@ const (
 	testAWSSQSBadDataQueueURL = "https://sqs.eu-west-1.amazonaws.com/account_id/BadData"
 )
 
-var testSQSResolvedEnv = map[string]string{
-	"awsAccessKeyId":     testAWSSQSAccessKeyID,
-	"awsSecretAccessKey": testAWSSQSSecretAccessKey,
-	"QUEUE_URL":          testAWSSQSProperQueueURL,
+var testAWSSQSEmptyResolvedEnv = map[string]string{}
+
+var testAWSSQSResolvedEnv = map[string]string{
+	"QUEUE_URL": testAWSSQSProperQueueURL,
 }
 
 var testAWSSQSAuthentication = map[string]string{
@@ -40,10 +40,11 @@ var testAWSSQSAuthentication = map[string]string{
 }
 
 type parseAWSSQSMetadataTestData struct {
-	metadata   map[string]string
-	authParams map[string]string
-	isError    bool
-	comment    string
+	metadata    map[string]string
+	authParams  map[string]string
+	resolvedEnv map[string]string
+	isError     bool
+	comment     string
 }
 
 type awsSQSMetricIdentifier struct {
@@ -80,6 +81,7 @@ func (m *mockSqs) GetQueueAttributes(input *sqs.GetQueueAttributesInput) (*sqs.G
 var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 	{map[string]string{},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"metadata empty"},
 	{map[string]string{
@@ -87,6 +89,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"queueLength": "1",
 		"awsRegion":   "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue and region"},
 	{map[string]string{
@@ -94,6 +97,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"queueLength": "1",
 		"awsRegion":   "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"improperly formed queue, missing queueName"},
 	{map[string]string{
@@ -101,6 +105,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"queueLength": "1",
 		"awsRegion":   "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"improperly formed queue, missing path"},
 	{map[string]string{
@@ -108,6 +113,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"queueLength": "1",
 		"awsRegion":   ""},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"properly formed queue, empty region"},
 	{map[string]string{
@@ -115,6 +121,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"queueLength": "1",
 		"awsRegion":   "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue, integer queueLength"},
 	{map[string]string{
@@ -122,6 +129,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"queueLength": "a",
 		"awsRegion":   "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue, invalid queueLength"},
 	{map[string]string{
@@ -130,6 +138,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"activationQueueLength": "1",
 		"awsRegion":             "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue, integer activationQueueLength"},
 	{map[string]string{
@@ -138,6 +147,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"activationQueueLength": "a",
 		"awsRegion":             "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue, invalid activationQueueLength"},
 	{map[string]string{
@@ -148,6 +158,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 			"awsAccessKeyId":     testAWSSQSAccessKeyID,
 			"awsSecretAccessKey": testAWSSQSSecretAccessKey,
 		},
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"with AWS static credentials from TriggerAuthentication"},
 	{map[string]string{
@@ -159,6 +170,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 			"awsSecretAccessKey": testAWSSQSSecretAccessKey,
 			"awsSessionToken":    testAWSSQSSessionToken,
 		},
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"with AWS temporary credentials from TriggerAuthentication"},
 	{map[string]string{
@@ -169,6 +181,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 			"awsAccessKeyId":     "",
 			"awsSecretAccessKey": testAWSSQSSecretAccessKey,
 		},
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"with AWS static credentials from TriggerAuthentication, missing Access Key Id"},
 	{map[string]string{
@@ -179,6 +192,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 			"awsAccessKeyId":     testAWSSQSAccessKeyID,
 			"awsSecretAccessKey": "",
 		},
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"with AWS temporary credentials from TriggerAuthentication, missing Secret Access Key"},
 	{map[string]string{
@@ -190,6 +204,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 			"awsSecretAccessKey": testAWSSQSSecretAccessKey,
 			"awsSessionToken":    testAWSSQSSessionToken,
 		},
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"with AWS temporary credentials from TriggerAuthentication, missing Access Key Id"},
 	{map[string]string{
@@ -201,6 +216,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 			"awsSecretAccessKey": "",
 			"awsSessionToken":    testAWSSQSSessionToken,
 		},
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"with AWS static credentials from TriggerAuthentication, missing Secret Access Key"},
 	{map[string]string{
@@ -210,6 +226,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		map[string]string{
 			"awsRoleArn": testAWSSQSRoleArn,
 		},
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"with AWS Role from TriggerAuthentication"},
 	{map[string]string{
@@ -221,6 +238,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 			"awsAccessKeyId":     "",
 			"awsSecretAccessKey": "",
 		},
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"with AWS Role assigned on KEDA operator itself"},
 	{map[string]string{
@@ -228,6 +246,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"queueLength": "1",
 		"awsRegion":   "eu-west-1"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue and region"},
 	{map[string]string{
@@ -236,6 +255,7 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"awsRegion":       "eu-west-1",
 		"scaleOnInFlight": "false"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue and region"},
 	{map[string]string{
@@ -244,21 +264,34 @@ var testAWSSQSMetadata = []parseAWSSQSMetadataTestData{
 		"awsRegion":       "eu-west-1",
 		"scaleOnInFlight": "true"},
 		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		false,
 		"properly formed queue and region"},
 	{map[string]string{
 		"queueURLFromEnv": "QUEUE_URL",
 		"queueLength":     "1",
 		"awsRegion":       "eu-west-1"},
-		testSQSResolvedEnv,
+		testAWSSQSAuthentication,
+		testAWSSQSResolvedEnv,
 		false,
 		"properly formed queue loaded from env"},
 	{map[string]string{
 		"queueLength": "1",
 		"awsRegion":   "eu-west-1"},
-		testSQSResolvedEnv,
+		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
 		true,
 		"missing queue url from both queueURL and queueURLFromEnv"},
+	{map[string]string{
+		"queueURLFromEnv": "QUEUE_URL",
+		"queueLength":     "1",
+		"awsRegion":       "eu-west-1"},
+		testAWSSQSAuthentication,
+		map[string]string{
+			"QUEUE_URL": "",
+		},
+		true,
+		"empty QUEUE_URL env value"},
 }
 
 var awsSQSMetricIdentifiers = []awsSQSMetricIdentifier{
@@ -274,7 +307,7 @@ var awsSQSGetMetricTestData = []*awsSqsQueueMetadata{
 
 func TestSQSParseMetadata(t *testing.T) {
 	for _, testData := range testAWSSQSMetadata {
-		_, err := parseAwsSqsQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testAWSSQSAuthentication, AuthParams: testData.authParams}, logr.Discard())
+		_, err := parseAwsSqsQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testData.resolvedEnv, AuthParams: testData.authParams}, logr.Discard())
 		if err != nil && !testData.isError {
 			t.Errorf("Expected success because %s got error, %s", testData.comment, err)
 		}
@@ -287,7 +320,7 @@ func TestSQSParseMetadata(t *testing.T) {
 func TestAWSSQSGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range awsSQSMetricIdentifiers {
 		ctx := context.Background()
-		meta, err := parseAwsSqsQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testAWSSQSAuthentication, AuthParams: testData.metadataTestData.authParams, ScalerIndex: testData.scalerIndex}, logr.Discard())
+		meta, err := parseAwsSqsQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testData.metadataTestData.resolvedEnv, AuthParams: testData.metadataTestData.authParams, ScalerIndex: testData.scalerIndex}, logr.Discard())
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}


### PR DESCRIPTION
Add `queueURLFromEnv` as additional trigger metadata to allow loading the queueURL from env variables.

It would be useful to be able to set the queueURL to load from env variables, especially when having multiple deployment environment. This way if using kustomize, the queueURL could be defined in a configmap and loaded as env variable, rather than patching  the manifest. This for example would be similar to the `addressFromEnv` in the redis-lists scaler.



Signed-off-by: Fahdi Kanavati <fk128@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
https://github.com/kedacore/keda-docs/pull/902