### PR TITLE
feat: add seccompProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+- **General:** Add explicit seccompProfile type to securityContext config ([#3561](https://github.com/kedacore/keda/issues/3561))
 
 ### Fixes
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,6 +68,8 @@ spec:
               - ALL
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
       terminationGracePeriodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -70,8 +70,10 @@ spec:
               drop:
               - ALL
             allowPrivilegeEscalation: false
-            ## Metrics server needs to write the self-signed cert so it's not possible set this
+            ## Metrics server needs to write the self-signed cert. See FAQ for discussion of options.
             # readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
       nodeSelector:
         kubernetes.io/os: linux
       volumes:


### PR DESCRIPTION
Add/update securityContext configs:
* seccompProfile.type RuntimeDefault is needed for compliance with restricted policies in Kubernetes 1.19+
* Updated comment in metrics Deployment regarding readOnlyRootFilesystem

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] N/A - Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) => https://github.com/kedacore/charts/pull/307
- [x] N/A - A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #3561 
