### PR TITLE
fix: Cron Scaler e2e test works during min 59

### DIFF
--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -25,8 +25,8 @@ var (
 	scaledObjectName = fmt.Sprintf("%s-so", testName)
 
 	now   = time.Now().Local()
-	start = (now.Minute() + 1)
-	end   = (start + 1)
+	start = (now.Minute() + 1) % 60
+	end   = (start + 1) % 60
 )
 
 type templateData struct {


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Before this fix, if we execute the e2e test at XX:59, the generated cron expressions are 60 * * * * and 61 * * * * which are incorrect, this PR ensures that cron's minutes are between 0 and 59

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

