### PR TITLE
Add etcd scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Disable response compression for k8s restAPI in client-go ([#3863](https://github.com/kedacore/keda/issues/3863)). Kubernetes issue for reference (https://github.com/kubernetes/kubernetes/issues/112296)
 - **General**: Expand Prometheus metric with label "ScalerName" to distinguish different triggers. The scaleName is defined per Trigger.Name ([#3588](https://github.com/kedacore/keda/issues/3588))
 - **General:** Introduce new Loki Scaler ([#3699](https://github.com/kedacore/keda/issues/3699))
+- **General:** Introduce new Etcd Scaler ([#3880](https://github.com/kedacore/keda/issues/3880))
 - **General**: Introduce rate-limitting parameters to KEDA manager to allow override of client defaults ([#3730](https://github.com/kedacore/keda/issues/3730))
 - **General**: Provide off-the-shelf Grafana dashboard for application autoscaling ([Docs](https://keda.sh/docs/2.9/operate/prometheus/) | [#3911](https://github.com/kedacore/keda/issues/3911))
 - **General**: Provide Prometheus metric with indication of total number of custom resources per namespace for each custom resource type (CRD). ([#2637](https://github.com/kedacore/keda/issues/2637)|[#2638](https://github.com/kedacore/keda/issues/2638)|[#2639](https://github.com/kedacore/keda/issues/2639))

--- a/pkg/scalers/etcd_scaler.go
+++ b/pkg/scalers/etcd_scaler.go
@@ -1,0 +1,305 @@
+package scalers
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	v2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+)
+
+const (
+	endpoints                          = "endpoints"
+	watchKey                           = "watchKey"
+	value                              = "value"
+	activationValue                    = "activationValue"
+	watchProgressNotifyInterval        = "watchProgressNotifyInterval"
+	etcdMetricType                     = "External"
+	etcdTLSEnable                      = "enable"
+	etcdTLSDisable                     = "disable"
+	defaultWatchProgressNotifyInterval = 600
+)
+
+type etcdScaler struct {
+	metricType v2.MetricTargetType
+	metadata   *etcdMetadata
+	client     *clientv3.Client
+	logger     logr.Logger
+}
+
+type etcdMetadata struct {
+	endpoints                   []string
+	watchKey                    string
+	value                       float64
+	activationValue             float64
+	watchProgressNotifyInterval int
+	scalerIndex                 int
+	// TLS
+	enableTLS   bool
+	cert        string
+	key         string
+	keyPassword string
+	ca          string
+}
+
+// NewEtcdScaler creates a new etcdScaler
+func NewEtcdScaler(config *ScalerConfig) (Scaler, error) {
+	metricType, err := GetMetricTargetType(config)
+	if err != nil {
+		return nil, fmt.Errorf("error getting scaler metric type: %s", err)
+	}
+
+	meta, parseErr := parseEtcdMetadata(config)
+	if parseErr != nil {
+		return nil, fmt.Errorf("error parsing kubernetes workload metadata: %s", parseErr)
+	}
+
+	cli, err := getEtcdClients(meta)
+	if err != nil {
+		return nil, err
+	}
+	return &etcdScaler{
+		metricType: metricType,
+		metadata:   meta,
+		client:     cli,
+		logger:     InitializeLogger(config, "etcd_scaler"),
+	}, nil
+}
+
+func parseEtcdAuthParams(config *ScalerConfig, meta *etcdMetadata) error {
+	meta.enableTLS = false
+	if val, ok := config.AuthParams["tls"]; ok {
+		val = strings.TrimSpace(val)
+		if val == etcdTLSEnable {
+			certGiven := config.AuthParams["cert"] != ""
+			keyGiven := config.AuthParams["key"] != ""
+			if certGiven && !keyGiven {
+				return errors.New("key must be provided with cert")
+			}
+			if keyGiven && !certGiven {
+				return errors.New("cert must be provided with key")
+			}
+			meta.ca = config.AuthParams["ca"]
+			meta.cert = config.AuthParams["cert"]
+			meta.key = config.AuthParams["key"]
+			if value, found := config.AuthParams["keyPassword"]; found {
+				meta.keyPassword = value
+			} else {
+				meta.keyPassword = ""
+			}
+			meta.enableTLS = true
+		} else if val != etcdTLSDisable {
+			return fmt.Errorf("err incorrect value for TLS given: %s", val)
+		}
+	}
+
+	return nil
+}
+
+func parseEtcdMetadata(config *ScalerConfig) (*etcdMetadata, error) {
+	meta := &etcdMetadata{}
+	var err error
+	meta.endpoints = strings.Split(config.TriggerMetadata[endpoints], ",")
+	if len(meta.endpoints) == 0 || meta.endpoints[0] == "" {
+		return nil, fmt.Errorf("endpoints required")
+	}
+
+	meta.watchKey = config.TriggerMetadata[watchKey]
+	if len(meta.watchKey) == 0 {
+		return nil, fmt.Errorf("watchKey required")
+	}
+
+	meta.value, err = strconv.ParseFloat(config.TriggerMetadata[value], 64)
+	if err != nil || meta.value <= 0 {
+		return nil, fmt.Errorf("value must be a float greater than 0")
+	}
+
+	meta.activationValue = 0
+	if val, ok := config.TriggerMetadata[activationValue]; ok {
+		meta.activationValue, err = strconv.ParseFloat(val, 64)
+		if err != nil {
+			return nil, fmt.Errorf("activationValue must be a float")
+		}
+	}
+
+	meta.watchProgressNotifyInterval = defaultWatchProgressNotifyInterval
+	if val, ok := config.TriggerMetadata[watchProgressNotifyInterval]; ok {
+		meta.watchProgressNotifyInterval, err = strconv.Atoi(val)
+		if err != nil || meta.watchProgressNotifyInterval <= 0 {
+			return nil, fmt.Errorf("watchProgressNotifyInterval must be a int greater than 0")
+		}
+	}
+
+	if err = parseEtcdAuthParams(config, meta); err != nil {
+		return meta, err
+	}
+
+	meta.scalerIndex = config.ScalerIndex
+	return meta, nil
+}
+
+func getEtcdClients(metadata *etcdMetadata) (*clientv3.Client, error) {
+	var tlsConfig *tls.Config
+	var err error
+	if metadata.enableTLS {
+		tlsConfig, err = kedautil.NewTLSConfigWithPassword(metadata.cert, metadata.key, metadata.keyPassword, metadata.ca)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   metadata.endpoints,
+		DialTimeout: 5 * time.Second,
+		TLS:         tlsConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to etcd server: %s", err)
+	}
+
+	return cli, nil
+}
+
+// IsActive determines if we need to scale from zero
+func (s *etcdScaler) IsActive(ctx context.Context) (bool, error) {
+	v, err := s.getMetricValue(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	return v > s.metadata.activationValue, nil
+}
+
+// Close closes the etcd client
+func (s *etcdScaler) Close(context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+// GetMetrics returns value for a supported metric and an error if there is a problem getting the metric
+func (s *etcdScaler) GetMetrics(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, error) {
+	v, err := s.getMetricValue(ctx)
+	if err != nil {
+		return []external_metrics.ExternalMetricValue{}, fmt.Errorf("error getting metric value: %s", err)
+	}
+
+	metric := GenerateMetricInMili(metricName, v)
+	return append([]external_metrics.ExternalMetricValue{}, metric), nil
+}
+
+// GetMetricSpecForScaling returns the metric spec for the HPA.
+func (s *etcdScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("etcd-%s", s.metadata.watchKey))),
+		},
+		Target: GetMetricTargetMili(s.metricType, s.metadata.value),
+	}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: etcdMetricType}
+	return []v2.MetricSpec{metricSpec}
+}
+
+func (s *etcdScaler) Run(ctx context.Context, active chan<- bool) {
+	defer close(active)
+
+	// It's possible for the watch to get terminated anytime, we need to run this in a retry loop
+	runWithWatch := func() {
+		s.logger.Info("run watch", "watchKey", s.metadata.watchKey, "endpoints", s.metadata.endpoints)
+		subCtx, cancel := context.WithCancel(ctx)
+		subCtx = clientv3.WithRequireLeader(subCtx)
+		rch := s.client.Watch(subCtx, s.metadata.watchKey, clientv3.WithProgressNotify())
+
+		// rewatch to another etcd server when the network is isolated from the current etcd server.
+		progress := make(chan bool)
+		defer close(progress)
+		go func() {
+			for {
+				select {
+				case <-progress:
+				case <-subCtx.Done():
+					return
+				case <-time.After(time.Duration(s.metadata.watchProgressNotifyInterval) * 2 * time.Second):
+					s.logger.Info("no watch progress notification in the interval", "watchKey", s.metadata.watchKey, "endpoints", s.metadata.endpoints)
+					cancel()
+					return
+				}
+			}
+		}()
+
+		for wresp := range rch {
+			progress <- wresp.IsProgressNotify()
+
+			// rewatch to another etcd server when there is an error form the current etcd server, such as 'no leader','required revision has been compacted'
+			if wresp.Err() != nil {
+				s.logger.Error(wresp.Err(), "an error occurred in the watch process", "watchKey", s.metadata.watchKey, "endpoints", s.metadata.endpoints)
+				cancel()
+				return
+			}
+
+			for _, ev := range wresp.Events {
+				v, err := strconv.ParseFloat(string(ev.Kv.Value), 64)
+				if err != nil {
+					s.logger.Error(err, "etcdValue invalid will be treated as 0")
+					v = 0
+				}
+				active <- v > s.metadata.activationValue
+			}
+		}
+	}
+
+	// retry on error from runWithWatch() starting by 2 sec backing off * 2 with a max of 1 minute
+	retryDuration := time.Second * 2
+	// the caller of this function needs to ensure that they call Stop() on the resulting
+	// timer, to release background resources.
+	retryBackoff := func() *time.Timer {
+		tmr := time.NewTimer(retryDuration)
+		retryDuration *= 2
+		if retryDuration > time.Minute*1 {
+			retryDuration = time.Minute * 1
+		}
+		return tmr
+	}
+
+	// start the first runWithWatch without delay
+	runWithWatch()
+
+	for {
+		backoffTimer := retryBackoff()
+		select {
+		case <-ctx.Done():
+			backoffTimer.Stop()
+			return
+		case <-backoffTimer.C:
+			backoffTimer.Stop()
+			runWithWatch()
+		}
+	}
+}
+
+func (s *etcdScaler) getMetricValue(ctx context.Context) (float64, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	resp, err := s.client.Get(ctx, s.metadata.watchKey)
+	if err != nil {
+		return 0, err
+	}
+	if resp.Kvs == nil {
+		return 0, fmt.Errorf("watchKey %s doesn't exist", s.metadata.watchKey)
+	}
+	v, err := strconv.ParseFloat(string(resp.Kvs[0].Value), 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
+}

--- a/pkg/scalers/etcd_scaler_test.go
+++ b/pkg/scalers/etcd_scaler_test.go
@@ -1,0 +1,136 @@
+package scalers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+type parseEtcdMetadataTestData struct {
+	metadata  map[string]string
+	endpoints []string
+	isError   bool
+}
+
+type parseEtcdAuthParamsTestData struct {
+	authParams map[string]string
+	isError    bool
+	enableTLS  bool
+}
+
+type etcdMetricIdentifier struct {
+	metadataTestData *parseEtcdMetadataTestData
+	scalerIndex      int
+	name             string
+}
+
+// A complete valid metadata example for reference
+var validEtcdMetadata = map[string]string{
+	"endpoints":                   "172.0.0.1:2379,172.0.0.2:2379,172.0.0.3:2379",
+	"watchKey":                    "length",
+	"value":                       "5.5",
+	"activationValue":             "0.5",
+	"watchProgressNotifyInterval": "600",
+}
+
+var parseEtcdMetadataTestDataset = []parseEtcdMetadataTestData{
+	// success
+	{map[string]string{"endpoints": "172.0.0.1:2379,172.0.0.2:2379,172.0.0.3:2379", "watchKey": "length", "value": "5.5", "activationValue": "0.5", "watchProgressNotifyInterval": "600"}, []string{"172.0.0.1:2379", "172.0.0.2:2379", "172.0.0.3:2379"}, false},
+	// success
+	{map[string]string{"endpoints": "172.0.0.1:2379", "watchKey": "var", "value": "5.5", "activationValue": "0.5", "watchProgressNotifyInterval": "600"}, []string{"172.0.0.1:2379"}, false},
+	// failure, endpoints missed
+	{map[string]string{"endpoints": "", "watchKey": "length", "value": "5", "activationValue": "0", "watchProgressNotifyInterval": "600"}, []string{""}, true},
+	// failure, watchKey missed
+	{map[string]string{"endpoints": "172.0.0.1:2379", "watchKey": "", "value": "5", "activationValue": "0", "watchProgressNotifyInterval": "600"}, []string{"172.0.0.1:2379"}, true},
+	// failure, value invalid
+	{map[string]string{"endpoints": "172.0.0.1:2379", "watchKey": "length", "value": "a", "activationValue": "0", "watchProgressNotifyInterval": "600"}, []string{"172.0.0.1:2379"}, true},
+	// failure, activationValue invalid
+	{map[string]string{"endpoints": "172.0.0.1:2379", "watchKey": "length", "value": "5", "activationValue": "b", "watchProgressNotifyInterval": "600"}, []string{"172.0.0.1:2379"}, true},
+	// failure, watchProgressNotifyInterval invalid
+	{map[string]string{"endpoints": "172.0.0.1:2379", "watchKey": "length", "value": "5", "activationValue": "0", "watchProgressNotifyInterval": "0"}, []string{"172.0.0.1:2379"}, true},
+}
+
+var parseEtcdAuthParamsTestDataset = []parseEtcdAuthParamsTestData{
+	// success, TLS only
+	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	// success, TLS cert/key and assumed public CA
+	{map[string]string{"tls": "enable", "cert": "ceert", "key": "keey"}, false, true},
+	// success, TLS cert/key + key password and assumed public CA
+	{map[string]string{"tls": "enable", "cert": "ceert", "key": "keey", "keyPassword": "keeyPassword"}, false, true},
+	// success, TLS CA only
+	{map[string]string{"tls": "enable", "ca": "caaa"}, false, true},
+	// failure, TLS missing cert
+	{map[string]string{"tls": "enable", "ca": "caaa", "key": "keey"}, true, false},
+	// failure, TLS missing key
+	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert"}, true, false},
+	// failure, TLS invalid
+	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+}
+
+var etcdMetricIdentifiers = []etcdMetricIdentifier{
+	{&parseEtcdMetadataTestDataset[0], 0, "s0-etcd-length"},
+	{&parseEtcdMetadataTestDataset[1], 1, "s1-etcd-var"},
+}
+
+func TestParseEtcdMetadata(t *testing.T) {
+	for _, testData := range parseEtcdMetadataTestDataset {
+		meta, err := parseEtcdMetadata(&ScalerConfig{TriggerMetadata: testData.metadata})
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+		if err == nil && !reflect.DeepEqual(meta.endpoints, testData.endpoints) {
+			t.Errorf("Expected  %v but got %v\n", testData.endpoints, meta.endpoints)
+		}
+	}
+}
+
+func TestParseEtcdAuthParams(t *testing.T) {
+	for _, testData := range parseEtcdAuthParamsTestDataset {
+		meta, err := parseEtcdMetadata(&ScalerConfig{TriggerMetadata: validEtcdMetadata, AuthParams: testData.authParams})
+
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+		if meta.enableTLS != testData.enableTLS {
+			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
+		}
+		if meta.enableTLS {
+			if meta.ca != testData.authParams["ca"] {
+				t.Errorf("Expected ca to be set to %v but got %v\n", testData.authParams["ca"], meta.enableTLS)
+			}
+			if meta.cert != testData.authParams["cert"] {
+				t.Errorf("Expected cert to be set to %v but got %v\n", testData.authParams["cert"], meta.cert)
+			}
+			if meta.key != testData.authParams["key"] {
+				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["key"], meta.key)
+			}
+			if meta.keyPassword != testData.authParams["keyPassword"] {
+				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["keyPassword"], meta.key)
+			}
+		}
+	}
+}
+
+func TestEtcdGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range etcdMetricIdentifiers {
+		meta, err := parseEtcdMetadata(&ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ScalerIndex: testData.scalerIndex})
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+		mockEtcdScaler := etcdScaler{"", meta, nil, logr.Logger{}}
+
+		metricSpec := mockEtcdScaler.GetMetricSpecForScaling(context.Background())
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
+		}
+	}
+}

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -561,6 +561,8 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 		return scalers.NewDatadogScaler(ctx, config)
 	case "elasticsearch":
 		return scalers.NewElasticsearchScaler(config)
+	case "etcd":
+		return scalers.NewEtcdScaler(config)
 	case "external":
 		return scalers.NewExternalScaler(config)
 	// TODO: use other way for test.

--- a/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
+++ b/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
@@ -1,0 +1,182 @@
+//go:build e2e
+// +build e2e
+
+package etcd_cluster_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
+	etcd "github.com/kedacore/keda/v2/tests/scalers/etcd/helper"
+)
+
+const (
+	testName = "etcd-test"
+)
+
+var (
+	testNamespace    = fmt.Sprintf("%s-ns", testName)
+	scaledObjectName = fmt.Sprintf("%s-so", testName)
+	deploymentName   = fmt.Sprintf("%s-deployment", testName)
+	jobName          = fmt.Sprintf("%s-job", testName)
+)
+
+type templateData struct {
+	TestNamespace    string
+	DeploymentName   string
+	JobName          string
+	ScaledObjectName string
+	EtcdName         string
+}
+
+const (
+	deploymentTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.DeploymentName}}
+  namespace: {{.TestNamespace}}
+spec:
+  selector:
+    matchLabels:
+      app: {{.DeploymentName}}
+  replicas: 0
+  template:
+    metadata:
+      labels:
+        app: {{.DeploymentName}}
+    spec:
+      containers:
+      - name: my-app
+        image: nginx
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+`
+	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 30
+  cooldownPeriod: 5
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: keda-hpa-etcd-scaledobject
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  triggers:
+    - type: etcd
+      metadata:
+        endpoints: {{.EtcdName}}-0.etcd-headless.{{.TestNamespace}}:2379,{{.EtcdName}}-1.etcd-headless.{{.TestNamespace}}:2379,{{.EtcdName}}-2.etcd-headless.{{.TestNamespace}}:2379
+        watchKey: var
+        value: '1.5'
+        watchProgressNotifyInterval: '10'
+`
+	insertJobTemplate = `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.JobName}}
+  namespace: {{.TestNamespace}}
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+      - name: etcd
+        image: gcr.io/etcd-development/etcd:v3.4.20
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - "/usr/local/bin/etcdctl put var 9 --endpoints=http://{{.EtcdName}}-0.etcd-headless.{{.TestNamespace}}:2380,http://{{.EtcdName}}-1.etcd-headless.{{.TestNamespace}}:2380,http://{{.EtcdName}}-2.etcd-headless.{{.TestNamespace}}:2380"
+      restartPolicy: Never
+  backoffLimit: 4
+`
+	deleteJobTemplate = `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.JobName}}
+  namespace: {{.TestNamespace}}
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+      - name: etcd
+        image: gcr.io/etcd-development/etcd:v3.4.20
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - "/usr/local/bin/etcdctl put var 0 --endpoints=http://{{.EtcdName}}-0.etcd-headless.{{.TestNamespace}}:2380,http://{{.EtcdName}}-1.etcd-headless.{{.TestNamespace}}:2380,http://{{.EtcdName}}-2.etcd-headless.{{.TestNamespace}}:2380"
+      restartPolicy: Never
+  backoffLimit: 4
+`
+)
+
+func TestScaler(t *testing.T) {
+	// setup
+	t.Log("--- setting up ---")
+	// Create kubernetes resources
+	kc := GetKubernetesClient(t)
+
+	// Create kubernetes resources for testing
+	data, templates := getTemplateData()
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
+
+	// Create Etcd Cluster
+	etcd.InstallCluster(t, kc, testName, testNamespace)
+
+	testActivation(t, kc, data)
+	testScaleIn(t, kc, data)
+	testScaleOut(t, kc)
+
+	// cleanup
+	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
+}
+
+func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing activation ---")
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 10)
+}
+
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
+	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 6, 60, 3),
+		"replica count should be %d after 3 minutes", 6)
+}
+
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
+	KubectlApplyWithTemplate(t, data, "deleteJobTemplate", deleteJobTemplate)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 3),
+		"replica count should be %d after 3 minutes", 0)
+}
+
+var data = templateData{
+	TestNamespace:    testNamespace,
+	DeploymentName:   deploymentName,
+	ScaledObjectName: scaledObjectName,
+	JobName:          jobName,
+	EtcdName:         testName,
+}
+
+func getTemplateData() (templateData, []Template) {
+	return data, []Template{
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+	}
+}

--- a/tests/scalers/etcd/helper/helper.go
+++ b/tests/scalers/etcd/helper/helper.go
@@ -1,0 +1,145 @@
+//go:build e2e
+// +build e2e
+
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kedacore/keda/v2/tests/helper"
+)
+
+type templateData struct {
+	Namespace string
+	EtcdName  string
+}
+
+const (
+	statefulSetTemplate = `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: {{.EtcdName}}
+  name: {{.EtcdName}}
+  namespace: {{.Namespace}}
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: {{.EtcdName}}
+  serviceName: etcd-headless
+  template:
+    metadata:
+      labels:
+        app: {{.EtcdName}}
+      name: {{.EtcdName}}
+    spec:
+      containers:
+        - env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          image: gcr.io/etcd-development/etcd:v3.4.20
+          command:
+          - sh
+          - -c
+          - "/usr/local/bin/etcd --name $MY_POD_NAME \
+            --data-dir /etcd-data \
+            --listen-client-urls http://$MY_POD_IP:2379 \
+            --advertise-client-urls http://$MY_POD_IP:2379 \
+            --listen-peer-urls http://$MY_POD_IP:2380 \
+            --initial-advertise-peer-urls http://$MY_POD_IP:2380 \
+            --initial-cluster {{.EtcdName}}-0=http://{{.EtcdName}}-0.etcd-headless.{{.Namespace}}:2380,{{.EtcdName}}-1=http://{{.EtcdName}}-1.etcd-headless.{{.Namespace}}:2380,{{.EtcdName}}-2=http://{{.EtcdName}}-2.etcd-headless.{{.Namespace}}:2380 \
+            --initial-cluster-token tkn \
+            --initial-cluster-state new \
+            --experimental-watch-progress-notify-interval 10s \
+			--log-level info \
+            --logger zap \
+            --log-outputs stderr"
+          imagePullPolicy: IfNotPresent
+          name: etcd
+          ports:
+          - containerPort: 2380
+            name: peer
+            protocol: TCP
+          - containerPort: 2379
+            name: client
+            protocol: TCP
+          resources:
+            requests:
+              memory: "0.5Gi"
+              cpu: "500m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          volumeMounts:
+          - mountPath: /etcd-data
+            name: cache-volume
+      volumes:
+      - name: cache-volume
+        emptyDir: {}
+`
+	headlessServiceTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{.EtcdName}}
+  name: etcd-headless
+  namespace: {{.Namespace}}
+spec:
+  clusterIP: None
+  ports:
+  - name: infra-etcd-cluster-2379
+    port: 2379
+    protocol: TCP
+    targetPort: 2379
+  - name: infra-etcd-cluster-2380
+    port: 2380
+    protocol: TCP
+    targetPort: 2380
+  selector:
+    app: {{.EtcdName}}
+  type: ClusterIP
+`
+	serviceTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{.EtcdName}}
+  name: etcd-svc
+  namespace: {{.Namespace}}
+spec:
+  ports:
+  - name: etcd-cluster
+    port: 2379
+    targetPort: 2379
+  selector:
+    app: {{.EtcdName}}
+  sessionAffinity: None
+  type: NodePort
+`
+)
+
+var etcdClusterTemplates = []helper.Template{
+	{Name: "statefulSetTemplate", Config: statefulSetTemplate},
+	{Name: "headlessServiceTemplate", Config: headlessServiceTemplate},
+	{Name: "serviceTemplate", Config: serviceTemplate},
+}
+
+func InstallCluster(t *testing.T, kc *kubernetes.Clientset, name, namespace string) {
+	var data = templateData{
+		Namespace: namespace,
+		EtcdName:  name,
+	}
+	helper.KubectlApplyMultipleWithTemplate(t, data, etcdClusterTemplates)
+	assert.True(t, helper.WaitForStatefulsetReplicaReadyCount(t, kc, name, namespace, 2, 60, 3),
+		"etcd-cluster should be up")
+}


### PR DESCRIPTION
Signed-off-by: ytz [1020560484@qq.com](mailto:1020560484@qq.com)

Hi, I'm a software engineer from Huawei Cloud. Thanks to KEDA for providing us with a flexible scaling project that can scale applications from zero. We find that when the pollingInterval parameter is set to a small value, the scaler will frequently pull metrics from the event source, which leads to an increase in the system load.  So by watching the an etcd key, a passively received push mode,  the scaler can activate applications with lower load usage than frequent pull mode. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/3880
Relates to kedacore/keda-docs#914
