### PR TITLE
fix(rabbitmq): Parse vhost correctly if it's provided in the host url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 
 - **General:** Metrics endpoint returns correct HPA values ([#3554](https://github.com/kedacore/keda/issues/3554))
 - **Datadog Scaler:** Fix: panic in datadog scaler ([#3448](https://github.com/kedacore/keda/issues/3448))
+- **RabbitMQ Scaler:** Parse vhost correctly if it's provided in the host url ([#3602](https://github.com/kedacore/keda/issues/3602))
 
 ### Deprecations
 

--- a/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
@@ -32,8 +32,8 @@ var (
 	queueName        = "hello"
 	user             = fmt.Sprintf("%s-user", testName)
 	password         = fmt.Sprintf("%s-password", testName)
-	vhost            = fmt.Sprintf("%s-vhost", testName)
-	connectionString = fmt.Sprintf("amqp://%s:%s@rabbitmq.%s.svc.cluster.local/%s", user, password, rmqNamespace, vhost)
+	vhost            = "/"
+	connectionString = fmt.Sprintf("amqp://%s:%s@rabbitmq.%s.svc.cluster.local", user, password, rmqNamespace)
 	messageCount     = 100
 )
 

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
@@ -32,9 +32,9 @@ var (
 	queueName            = "hello"
 	user                 = fmt.Sprintf("%s-user", testName)
 	password             = fmt.Sprintf("%s-password", testName)
-	vhost                = fmt.Sprintf("%s-vhost", testName)
-	connectionString     = fmt.Sprintf("amqp://%s:%s@rabbitmq.%s.svc.cluster.local/%s", user, password, rmqNamespace, vhost)
-	httpConnectionString = fmt.Sprintf("http://%s:%s@rabbitmq.%s.svc.cluster.local/%s", user, password, rmqNamespace, vhost)
+	vhost                = "/"
+	connectionString     = fmt.Sprintf("amqp://%s:%s@rabbitmq.%s.svc.cluster.local/", user, password, rmqNamespace)
+	httpConnectionString = fmt.Sprintf("http://%s:%s@rabbitmq.%s.svc.cluster.local/", user, password, rmqNamespace)
 	messageCount         = 100
 )
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

After [this PR](https://github.com/kedacore/keda/pull/2591), the parsing of the `vHost` from the url changed. With this PR we restore that behaviour and add 2 extra e2e test to ensure that these changes works with and without `vHost` on `amqp` and `http`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)


Fixes https://github.com/kedacore/keda/issues/3602

