### PR TITLE
Fix: panic in datadog scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ To learn more about our roadmap, we recommend reading [this document](ROADMAP.md
 ### Fixes
 
 - **General:** Metrics endpoint returns correct HPA values ([#3554](https://github.com/kedacore/keda/issues/3554))
+- **Datadog Scaler:** Fix: panic in datadog scaler ([#3448](https://github.com/kedacore/keda/issues/3448))
 
 ### Deprecations
 

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -286,7 +286,7 @@ func (s *datadogScaler) getQueryResult(ctx context.Context) (float64, error) {
 	points := series[0].GetPointlist()
 
 	index := len(points) - 1
-	if len(points) == 0 || len(points[index]) < 2 {
+	if len(points) == 0 || len(points[index]) < 2 || points[index][1] == nil {
 		if !s.metadata.useFiller {
 			return 0, fmt.Errorf("no Datadog metrics returned for the given time window")
 		}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

In getQueryResult(), check if the last point as a value before dereferencing it.

~~In the datadog scaler, returns the value of the last point with a value instead of the value of the last point.
This fixes a panic when the last point has a nil value when we try to dereference it.~~

~~Also moves duplicated code used when no metric can be found to a dedicated function.~~

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixe #3448

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
