### PR TITLE
add trigger name as a label in Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### New
 
+- **General**: Expand Prometheus metric with label "ScalerName" to distinguish different triggers. The scaleName is defined per Trigger.Name ([#3588](https://github.com/kedacore/keda/issues/3588)
 - **General:** Introduce new Loki Scaler ([#3699](https://github.com/kedacore/keda/issues/3699))
 - **General**: Add ratelimitting parameters to keda manager to allow override of client defaults ([#3730](https://github.com/kedacore/keda/issues/2920))
 - **General**: Provide Prometheus metric with indication of total number of triggers per trigger type in `ScaledJob`/`ScaledObject`. ([#3663](https://github.com/kedacore/keda/issues/3663))

--- a/pkg/metrics/adapter_prom_metrics.go
+++ b/pkg/metrics/adapter_prom_metrics.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	metricLabels      = []string{"namespace", "metric", "scaledObject", "scaler", "scalerIndex"}
+	metricLabels      = []string{"namespace", "metric", "scaledObject", "scaler", "scalerIndex", "scalerName"}
 	scalerErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "keda_metrics_adapter",
@@ -100,21 +100,21 @@ func (metricsServer PrometheusMetricServer) NewServer(address string, pattern st
 }
 
 // RecordHPAScalerMetric create a measurement of the external metric used by the HPA
-func (metricsServer PrometheusMetricServer) RecordHPAScalerMetric(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
-	scalerMetricsValue.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
+func (metricsServer PrometheusMetricServer) RecordHPAScalerMetric(namespace string, scaledObject string, scaler string, scalerIndex int, scalerName string, metric string, value float64) {
+	scalerMetricsValue.With(getLabels(namespace, scaledObject, scaler, scalerIndex, scalerName, metric)).Set(value)
 }
 
 // RecordHPAScalerError counts the number of errors occurred in trying get an external metric used by the HPA
-func (metricsServer PrometheusMetricServer) RecordHPAScalerError(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, err error) {
+func (metricsServer PrometheusMetricServer) RecordHPAScalerError(namespace string, scaledObject string, scaler string, scalerIndex int, scalerName string, metric string, err error) {
 	if err != nil {
-		scalerErrors.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Inc()
+		scalerErrors.With(getLabels(namespace, scaledObject, scaler, scalerIndex, scalerName, metric)).Inc()
 		// scaledObjectErrors.With(prometheus.Labels{"namespace": namespace, "scaledObject": scaledObject}).Inc()
 		metricsServer.RecordScalerObjectError(namespace, scaledObject, err)
 		scalerErrorsTotal.With(prometheus.Labels{}).Inc()
 		return
 	}
 	// initialize metric with 0 if not already set
-	_, errscaler := scalerErrors.GetMetricWith(getLabels(namespace, scaledObject, scaler, scalerIndex, metric))
+	_, errscaler := scalerErrors.GetMetricWith(getLabels(namespace, scaledObject, scaler, scalerIndex, scalerName, metric))
 	if errscaler != nil {
 		log.Fatalf("Unable to write to serve custom metrics: %v", errscaler)
 	}
@@ -135,6 +135,6 @@ func (metricsServer PrometheusMetricServer) RecordScalerObjectError(namespace st
 	}
 }
 
-func getLabels(namespace string, scaledObject string, scaler string, scalerIndex int, metric string) prometheus.Labels {
-	return prometheus.Labels{"namespace": namespace, "scaledObject": scaledObject, "scaler": scaler, "scalerIndex": strconv.Itoa(scalerIndex), "metric": metric}
+func getLabels(namespace string, scaledObject string, scaler string, scalerIndex int, scalerName string, metric string) prometheus.Labels {
+	return prometheus.Labels{"namespace": namespace, "scaledObject": scaledObject, "scaler": scaler, "scalerIndex": strconv.Itoa(scalerIndex), "scalerName": scalerName, "metric": metric}
 }

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -42,14 +42,23 @@ type ScalersCache struct {
 }
 
 type ScalerBuilder struct {
-	Scaler  scalers.Scaler
-	Factory func() (scalers.Scaler, error)
+	Scaler      scalers.Scaler
+	TriggerName string
+	Factory     func() (scalers.Scaler, error)
 }
 
-func (c *ScalersCache) GetScalers() []scalers.Scaler {
-	result := make([]scalers.Scaler, 0, len(c.Scalers))
+type ScalerPair struct {
+	Scaler      scalers.Scaler
+	TriggerName string
+}
+
+func (c *ScalersCache) GetScalers() []ScalerPair {
+	result := make([]ScalerPair, 0, len(c.Scalers))
 	for _, s := range c.Scalers {
-		result = append(result, s.Scaler)
+		result = append(result, ScalerPair{
+			Scaler:      s.Scaler,
+			TriggerName: s.TriggerName,
+		})
 	}
 	return result
 }

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -339,8 +339,9 @@ func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alp
 		}
 
 		result = append(result, cache.ScalerBuilder{
-			Scaler:  scaler,
-			Factory: factory,
+			Scaler:      scaler,
+			TriggerName: trigger.Name,
+			Factory:     factory,
 		})
 	}
 


### PR DESCRIPTION
This PR is used to resolve https://github.com/kedacore/keda/issues/3588
* use the existing Trigger.Name field as the scalerName
* add scalerName to prometheus metric as a label to facilitate the grafana dashboard display

see below: 
![image](https://user-images.githubusercontent.com/17263036/189028330-81b6a5b0-b6fe-40d9-8164-6908faa31770.png)
