### PR TITLE
fix: Corrected error statement spelling

### DIFF
--- a/pkg/scalers/authentication/authentication_helpers.go
+++ b/pkg/scalers/authentication/authentication_helpers.go
@@ -39,7 +39,7 @@ func GetAuthConfigs(triggerMetadata, authParams map[string]string) (out *AuthMet
 				return nil, errors.New("no bearer token provided")
 			}
 			if out.EnableBasicAuth {
-				return nil, errors.New("beare and basic authentication can not be set both")
+				return nil, errors.New("both bearer and basic authentication can not be set")
 			}
 
 			out.BearerToken = authParams["bearerToken"]
@@ -49,7 +49,7 @@ func GetAuthConfigs(triggerMetadata, authParams map[string]string) (out *AuthMet
 				return nil, errors.New("no username given")
 			}
 			if out.EnableBearerAuth {
-				return nil, errors.New("beare and basic authentication can not be set both")
+				return nil, errors.New("both bearer and basic authentication can not be set")
 			}
 
 			out.Username = authParams["username"]
@@ -70,7 +70,7 @@ func GetAuthConfigs(triggerMetadata, authParams map[string]string) (out *AuthMet
 			out.Key = authParams["key"]
 			out.EnableTLS = true
 		default:
-			return nil, fmt.Errorf("err incorrect value for authMode is given: %s", t)
+			return nil, fmt.Errorf("incorrect value for authMode is given: %s", t)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Neelanjan Manna <neelanjan.manna@harness.io>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
- Corrects bearer spelling
- Improves grammar of error statements
- Removes unnecessary err word from error statement

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

