### PR TITLE
reword(rabbitmq): make condition match error string

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -201,11 +201,11 @@ func parseRabbitMQMetadata(config *ScalerConfig) (*rabbitMQMetadata, error) {
 		return nil, err
 	}
 
-	if meta.useRegex && meta.protocol == amqpProtocol {
+	if meta.useRegex && meta.protocol != httpProtocol {
 		return nil, fmt.Errorf("configure only useRegex with http protocol")
 	}
 
-	if meta.excludeUnacknowledged && meta.protocol == amqpProtocol {
+	if meta.excludeUnacknowledged && meta.protocol != httpProtocol {
 		return nil, fmt.Errorf("configure excludeUnacknowledged=true with http protocol only")
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Reword a conditional statement in the RabbitMQ Scaler to match the error message that is returned when evaluating to true.

Translated in a sentence, the conditional statement would match "if excludeUnacknowledged is set and the protocol used is equal to amqp" instead of "if excludeUnacknowledged is set and the protocol used is different then http"


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
