### PR TITLE
Improved scaling speed of AzDO pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General:** Add explicit seccompProfile type to securityContext config ([#3561](https://github.com/kedacore/keda/issues/3561))
 - **General:** Add `Min` column to ScaledJob visualization ([#3689](https://github.com/kedacore/keda/issues/3689))
 - **Azure AD Pod Identity Authentication:** Improve error messages to emphasize problems around the integration with aad-pod-identity itself ([#3610](https://github.com/kedacore/keda/issues/3610))
+- **Azure Pipelines Scaler:** Improved speed of profiling large set of Job Requests from Azure Pipelines ([#3702](https://github.com/kedacore/keda/issues/3702))
 - **Prometheus Scaler:** Introduce skipping of certificate check for unsigned certs ([#2310](https://github.com/kedacore/keda/issues/2310))
 
 ### Fixes

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -28,19 +28,19 @@ type JobRequests struct {
 }
 
 type JobRequest struct {
-	RequestId     int       `json:"requestId"`
-	QueueTime     time.Time `json:"queueTime"`
+	RequestID int       `json:"requestId"`
+	QueueTime time.Time `json:"queueTime"`
 	AssignTime    time.Time `json:"assignTime,omitempty"`
 	ReceiveTime   time.Time `json:"receiveTime,omitempty"`
 	LockedUntil   time.Time `json:"lockedUntil,omitempty"`
-	ServiceOwner  string    `json:"serviceOwner"`
-	HostId        string    `json:"hostId"`
-	Result        *string   `json:"result"`
-	ScopeId       string    `json:"scopeId"`
-	PlanType      string    `json:"planType"`
-	PlanId        string    `json:"planId"`
-	JobId         string    `json:"jobId"`
-	Demands       []string  `json:"demands"`
+	ServiceOwner string  `json:"serviceOwner"`
+	HostID       string  `json:"hostId"`
+	Result   *string `json:"result"`
+	ScopeID  string  `json:"scopeId"`
+	PlanType string `json:"planType"`
+	PlanID  string   `json:"planId"`
+	JobID   string   `json:"jobId"`
+	Demands []string `json:"demands"`
 	ReservedAgent *struct {
 		Links struct {
 			Self struct {
@@ -50,7 +50,7 @@ type JobRequest struct {
 				Href string `json:"href"`
 			} `json:"web"`
 		} `json:"_links"`
-		Id                int    `json:"id"`
+		ID                int    `json:"id"`
 		Name              string `json:"name"`
 		Version           string `json:"version"`
 		OsDescription     string `json:"osDescription"`
@@ -68,7 +68,7 @@ type JobRequest struct {
 				Href string `json:"href"`
 			} `json:"self"`
 		} `json:"_links"`
-		Id   int    `json:"id"`
+		ID   int    `json:"id"`
 		Name string `json:"name"`
 	} `json:"definition"`
 	Owner struct {
@@ -80,15 +80,15 @@ type JobRequest struct {
 				Href string `json:"href"`
 			} `json:"self"`
 		} `json:"_links"`
-		Id   int    `json:"id"`
+		ID   int    `json:"id"`
 		Name string `json:"name"`
 	} `json:"owner"`
 	Data struct {
 		ParallelismTag string `json:"ParallelismTag"`
 		IsScheduledKey string `json:"IsScheduledKey"`
 	} `json:"data"`
-	PoolId          int    `json:"poolId"`
-	OrchestrationId string `json:"orchestrationId"`
+	PoolID          int    `json:"poolId"`
+	OrchestrationID string `json:"orchestrationId"`
 	Priority        int    `json:"priority"`
 	MatchedAgents   *[]struct {
 		Links struct {
@@ -99,7 +99,7 @@ type JobRequest struct {
 				Href string `json:"href"`
 			} `json:"web"`
 		} `json:"_links"`
-		Id                int    `json:"id"`
+		ID                int    `json:"id"`
 		Name              string `json:"name"`
 		Version           string `json:"version"`
 		Enabled           bool   `json:"enabled"`

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -28,19 +28,19 @@ type JobRequests struct {
 }
 
 type JobRequest struct {
-	RequestID int       `json:"requestId"`
-	QueueTime time.Time `json:"queueTime"`
+	RequestID     int       `json:"requestId"`
+	QueueTime     time.Time `json:"queueTime"`
 	AssignTime    time.Time `json:"assignTime,omitempty"`
 	ReceiveTime   time.Time `json:"receiveTime,omitempty"`
 	LockedUntil   time.Time `json:"lockedUntil,omitempty"`
-	ServiceOwner string  `json:"serviceOwner"`
-	HostID       string  `json:"hostId"`
-	Result   *string `json:"result"`
-	ScopeID  string  `json:"scopeId"`
-	PlanType string `json:"planType"`
-	PlanID  string   `json:"planId"`
-	JobID   string   `json:"jobId"`
-	Demands []string `json:"demands"`
+	ServiceOwner  string    `json:"serviceOwner"`
+	HostID        string    `json:"hostId"`
+	Result        *string   `json:"result"`
+	ScopeID       string    `json:"scopeId"`
+	PlanType      string    `json:"planType"`
+	PlanID        string    `json:"planId"`
+	JobID         string    `json:"jobId"`
+	Demands       []string  `json:"demands"`
 	ReservedAgent *struct {
 		Links struct {
 			Self struct {

--- a/pkg/scalers/azure_pipelines_scaler_test.go
+++ b/pkg/scalers/azure_pipelines_scaler_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const loadCount = 1000 // the size of the pretend pool completed of job requests
+
 type parseAzurePipelinesMetadataTestData struct {
 	testName    string
 	metadata    map[string]string
@@ -39,6 +41,9 @@ var testAzurePipelinesMetadata = []parseAzurePipelinesMetadataTestData{
 	// activationTargetPipelinesQueueLength malformed
 	{"all properly formed", map[string]string{"organizationURLFromEnv": "AZP_URL", "personalAccessTokenFromEnv": "AZP_TOKEN", "poolID": "1", "targetPipelinesQueueLength": "1", "activationTargetPipelinesQueueLength": "A"}, true, testAzurePipelinesResolvedEnv, map[string]string{}},
 }
+
+var testJobRequestResponse = `{"count":2,"value":[{"requestId":890659,"queueTime":"2022-09-28T11:19:49.89Z","assignTime":"2022-09-28T11:20:29.5033333Z","receiveTime":"2022-09-28T11:20:32.0530499Z","lockedUntil":"2022-09-28T11:30:32.07Z","serviceOwner":"xxx","hostId":"xxx","scopeId":"xxx","planType":"Build","planId":"xxx","jobId":"xxx","demands":["kubectl","Agent.Version -gtVersion 2.182.1"],"reservedAgent":{"_links":{"self":{"href":"https://dev.azure.com/FOO/_apis/distributedtask/pools/44/agents/11735"},"web":{"href":"https://dev.azure.com/FOO/_settings/agentpools?view=jobs&poolId=44&agentId=11735"}},"id":11735,"name":"kube-scaledjob-5nlph-kzpgf","version":"2.210.1","osDescription":"Linux 5.4.0-1089-azure #94~18.04.1-Ubuntu SMP Fri Aug 5 12:34:50 UTC 2022","enabled":true,"status":"online","provisioningState":"Provisioned","accessPoint":"CodexAccessMapping"},"definition":{"_links":{"web":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_build/definition?definitionId=4869"},"self":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_apis/build/Definitions/4869"}},"id":4869,"name":"base - main"},"owner":{"_links":{"web":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_build/results?buildId=673584"},"self":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_apis/build/Builds/673584"}},"id":673584,"name":"20220928.2"},"data":{"ParallelismTag":"Private","IsScheduledKey":"False"},"poolId":44,"orchestrationId":"5c5c8ec9-786f-4e97-99d4-a29279befba3.build.__default","priority":0},{"requestId":890663,"queueTime":"2022-09-28T11:20:22.4633333Z","serviceOwner":"00025394-6065-48ca-87d9-7f5672854ef7","hostId":"41a18c7d-df5e-4032-a4df-d533b56bd2de","scopeId":"02696e26-a35b-424c-86b8-1f54e1b0b4b7","planType":"Build","planId":"b718cfed-493c-46be-a650-88fe762f75aa","jobId":"15b95994-59ec-5502-695d-0b93722883bd","demands":["dotnet60","java","Agent.Version -gtVersion 2.182.1"],"matchedAgents":[{"_links":{"self":{"href":"https://dev.azure.com/FOO/_apis/distributedtask/pools/44/agents/1755"},"web":{"href":"https://dev.azure.com/FOO/_settings/agentpools?view=jobs&poolId=44&agentId=1755"}},"id":1755,"name":"dotnet60-keda-template","version":"2.210.1","enabled":true,"status":"offline","provisioningState":"Provisioned"},{"_links":{"self":{"href":"https://dev.azure.com/FOO/_apis/distributedtask/pools/44/agents/11732"},"web":{"href":"https://dev.azure.com/FOO/_settings/agentpools?view=jobs&poolId=44&agentId=11732"}},"id":11732,"name":"dotnet60-scaledjob-5dsgc-pkqvm","version":"2.210.1","enabled":true,"status":"online","provisioningState":"Provisioned"},{"_links":{"self":{"href":"https://dev.azure.com/FOO/_apis/distributedtask/pools/44/agents/11733"},"web":{"href":"https://dev.azure.com/FOO/_settings/agentpools?view=jobs&poolId=44&agentId=11733"}},"id":11733,"name":"dotnet60-scaledjob-zgqnp-8h4z4","version":"2.210.1","enabled":true,"status":"online","provisioningState":"Provisioned"},{"_links":{"self":{"href":"https://dev.azure.com/FOO/_apis/distributedtask/pools/44/agents/11734"},"web":{"href":"https://dev.azure.com/FOO/_settings/agentpools?view=jobs&poolId=44&agentId=11734"}},"id":11734,"name":"dotnet60-scaledjob-wr65c-ff2cv","version":"2.210.1","enabled":true,"status":"online","provisioningState":"Provisioned"}],"definition":{"_links":{"web":{"href":"https://FOO.visualstudio.com/02696e26-a35b-424c-86b8-1f54e1b0b4b7/_build/definition?definitionId=3129"},"self":{"href":"https://FOO.visualstudio.com/02696e26-a35b-424c-86b8-1f54e1b0b4b7/_apis/build/Definitions/3129"}},"id":3129,"name":"Other Build CI"},"owner":{"_links":{"web":{"href":"https://FOO.visualstudio.com/02696e26-a35b-424c-86b8-1f54e1b0b4b7/_build/results?buildId=673585"},"self":{"href":"https://FOO.visualstudio.com/02696e26-a35b-424c-86b8-1f54e1b0b4b7/_apis/build/Builds/673585"}},"id":673585,"name":"20220928.11"},"data":{"ParallelismTag":"Private","IsScheduledKey":"False"},"poolId":44,"orchestrationId":"b718cfed-493c-46be-a650-88fe762f75aa.buildtest.build_and_test.__default","priority":0}]}`
+var deadJob = `{"requestId":890659,"result":"succeeded","queueTime":"2022-09-28T11:19:49.89Z","assignTime":"2022-09-28T11:20:29.5033333Z","receiveTime":"2022-09-28T11:20:32.0530499Z","lockedUntil":"2022-09-28T11:30:32.07Z","serviceOwner":"xxx","hostId":"xxx","scopeId":"xxx","planType":"Build","planId":"xxx","jobId":"xxx","demands":["kubectl","Agent.Version -gtVersion 2.182.1"],"reservedAgent":{"_links":{"self":{"href":"https://dev.azure.com/FOO/_apis/distributedtask/pools/44/agents/11735"},"web":{"href":"https://dev.azure.com/FOO/_settings/agentpools?view=jobs&poolId=44&agentId=11735"}},"id":11735,"name":"kube-scaledjob-5nlph-kzpgf","version":"2.210.1","osDescription":"Linux 5.4.0-1089-azure #94~18.04.1-Ubuntu SMP Fri Aug 5 12:34:50 UTC 2022","enabled":true,"status":"online","provisioningState":"Provisioned","accessPoint":"CodexAccessMapping"},"definition":{"_links":{"web":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_build/definition?definitionId=4869"},"self":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_apis/build/Definitions/4869"}},"id":4869,"name":"base - main"},"owner":{"_links":{"web":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_build/results?buildId=673584"},"self":{"href":"https://dev.azure.com/FOO/1858395a-257e-4efd-bbc5-eb618128452b/_apis/build/Builds/673584"}},"id":673584,"name":"20220928.2"},"data":{"ParallelismTag":"Private","IsScheduledKey":"False"},"poolId":44,"orchestrationId":"5c5c8ec9-786f-4e97-99d4-a29279befba3.build.__default","priority":0}`
 
 func TestParseAzurePipelinesMetadata(t *testing.T) {
 	for _, testData := range testAzurePipelinesMetadata {
@@ -173,7 +178,7 @@ func getMatchedAgentMetaData(url string) *azurePipelinesMetadata {
 	meta := azurePipelinesMetadata{}
 	meta.organizationName = "testOrg"
 	meta.organizationURL = url
-	meta.parent = "test-keda-template"
+	meta.parent = "dotnet60-keda-template"
 	meta.personalAccessToken = "testPAT"
 	meta.poolID = 1
 	meta.targetPipelinesQueueLength = 1
@@ -182,11 +187,9 @@ func getMatchedAgentMetaData(url string) *azurePipelinesMetadata {
 }
 
 func TestAzurePipelinesMatchedAgent(t *testing.T) {
-	var response = `{"count":1,"value":[{"demands":["Agent.Version -gtVersion 2.144.0"],"matchedAgents":[{"id":1,"name":"test-keda-template"}]}]}`
-
 	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(response))
+		_, _ = w.Write(buildLoadJson())
 	}))
 
 	meta := getMatchedAgentMetaData(apiStub.URL)
@@ -205,12 +208,13 @@ func TestAzurePipelinesMatchedAgent(t *testing.T) {
 	if queuelen < 1 {
 		t.Fail()
 	}
+
 }
 
 func getDemandJobMetaData(url string) *azurePipelinesMetadata {
 	meta := getMatchedAgentMetaData(url)
 	meta.parent = ""
-	meta.demands = "testDemand,kubernetes"
+	meta.demands = "dotnet60,java"
 
 	return meta
 }
@@ -224,11 +228,9 @@ func getMismatchDemandJobMetaData(url string) *azurePipelinesMetadata {
 }
 
 func TestAzurePipelinesMatchedDemandAgent(t *testing.T) {
-	var response = `{"count":1,"value":[{"demands":["Agent.Version -gtVersion 2.144.0", "testDemand", "kubernetes"],"matchedAgents":[{"id":1,"name":"test-keda-template"}]}]}`
-
 	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(response))
+		_, _ = w.Write(buildLoadJson())
 	}))
 
 	meta := getDemandJobMetaData(apiStub.URL)
@@ -247,14 +249,13 @@ func TestAzurePipelinesMatchedDemandAgent(t *testing.T) {
 	if queuelen < 1 {
 		t.Fail()
 	}
+
 }
 
 func TestAzurePipelinesNonMatchedDemandAgent(t *testing.T) {
-	var response = `{"count":1,"value":[{"demands":["Agent.Version -gtVersion 2.144.0", "testDemand", "kubernetes"],"matchedAgents":[{"id":1,"name":"test-keda-template"}]}]}`
-
 	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(response))
+		_, _ = w.Write(buildLoadJson())
 	}))
 
 	meta := getMismatchDemandJobMetaData(apiStub.URL)
@@ -273,4 +274,16 @@ func TestAzurePipelinesNonMatchedDemandAgent(t *testing.T) {
 	if queuelen > 0 {
 		t.Fail()
 	}
+
+}
+
+func buildLoadJson() []byte {
+	output := testJobRequestResponse[0 : len(testJobRequestResponse)-2]
+	for i := 1; i < loadCount; i++ {
+		output = output + "," + deadJob
+	}
+
+	output = output + "]}"
+
+	return []byte(output)
 }

--- a/pkg/scalers/azure_pipelines_scaler_test.go
+++ b/pkg/scalers/azure_pipelines_scaler_test.go
@@ -189,7 +189,7 @@ func getMatchedAgentMetaData(url string) *azurePipelinesMetadata {
 func TestAzurePipelinesMatchedAgent(t *testing.T) {
 	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(buildLoadJson())
+		_, _ = w.Write(buildLoadJSON())
 	}))
 
 	meta := getMatchedAgentMetaData(apiStub.URL)
@@ -208,7 +208,6 @@ func TestAzurePipelinesMatchedAgent(t *testing.T) {
 	if queuelen < 1 {
 		t.Fail()
 	}
-
 }
 
 func getDemandJobMetaData(url string) *azurePipelinesMetadata {
@@ -230,7 +229,7 @@ func getMismatchDemandJobMetaData(url string) *azurePipelinesMetadata {
 func TestAzurePipelinesMatchedDemandAgent(t *testing.T) {
 	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(buildLoadJson())
+		_, _ = w.Write(buildLoadJSON())
 	}))
 
 	meta := getDemandJobMetaData(apiStub.URL)
@@ -249,13 +248,12 @@ func TestAzurePipelinesMatchedDemandAgent(t *testing.T) {
 	if queuelen < 1 {
 		t.Fail()
 	}
-
 }
 
 func TestAzurePipelinesNonMatchedDemandAgent(t *testing.T) {
 	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(buildLoadJson())
+		_, _ = w.Write(buildLoadJSON())
 	}))
 
 	meta := getMismatchDemandJobMetaData(apiStub.URL)
@@ -274,16 +272,15 @@ func TestAzurePipelinesNonMatchedDemandAgent(t *testing.T) {
 	if queuelen > 0 {
 		t.Fail()
 	}
-
 }
 
-func buildLoadJson() []byte {
+func buildLoadJSON() []byte {
 	output := testJobRequestResponse[0 : len(testJobRequestResponse)-2]
 	for i := 1; i < loadCount; i++ {
 		output = output + "," + deadJob
 	}
 
-	output = output + "]}"
+	output += "]}"
 
 	return []byte(output)
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

azure_pipelines_scalar.go has been modified to use a struct for the ADO JobRequest API to remove reliance on interface{} and a pre-run step has been introduced to remove previously completed jobs so only working jobs getting analysed for scaling

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

Issue (#3702)
<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
