### PR TITLE
chore: Add a concurrency group for arm-smoke-tests

### DIFF
--- a/.github/workflows/template-arm64-smoke-tests.yml
+++ b/.github/workflows/template-arm64-smoke-tests.yml
@@ -6,8 +6,8 @@ on:
 jobs:
   smoke-tests-ARM64:
     name: ARM64
-    uses: kedacore/keda/.github/workflows/template-smoke-tests.yml@main
     concurrency: arm-smoke-tests
+    uses: kedacore/keda/.github/workflows/template-smoke-tests.yml@main    
     with:
       runs-on: ARM64
       kubernetesVersion: v1.25

--- a/.github/workflows/template-arm64-smoke-tests.yml
+++ b/.github/workflows/template-arm64-smoke-tests.yml
@@ -7,6 +7,7 @@ jobs:
   smoke-tests-ARM64:
     name: ARM64
     uses: kedacore/keda/.github/workflows/template-smoke-tests.yml@main
+    concurrency: arm-smoke-tests
     with:
       runs-on: ARM64
       kubernetesVersion: v1.25


### PR DESCRIPTION
Signed-off-by: Jorge Turrado Ferrero <Jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

We have multiple ARM runners, but all of them run in the same machine, reusing the same Kind clusters, because we use the underlying docker engine with the same kubectl, I guess that we can improve this in the future, using different kind clusters and different kubectl (e.g: running in containers) but for the moment we can't.

This PR adds a concurrency group to avoid multiple smoke test executions running concurrently in ARM machines

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
