### PR TITLE
feat: Allow specifying Selenium Grid URL as secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Provide Prometheus metric with indication of total number of triggers per trigger type in `ScaledJob`/`ScaledObject`. ([#3663](https://github.com/kedacore/keda/issues/3663))
 - **Azure Service Bus Scaler**: Add support for Shared Access Signature (SAS) tokens for authentication. ([#2920](https://github.com/kedacore/keda/issues/2920))
 - **Azure Service Bus Scaler:** Support regex usage in queueName / subscriptionName parameters. ([#1624](https://github.com/kedacore/keda/issues/1624))
-- **Selenium Grid Scaler:** Allow setting url trigger parameter from TriggerAuthentication/ClusterTriggerAuthentication
+- **Selenium Grid Scaler:** Allow setting url trigger parameter from TriggerAuthentication/ClusterTriggerAuthentication ([#3752](https://github.com/kedacore/keda/pull/3752))
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Provide Prometheus metric with indication of total number of triggers per trigger type in `ScaledJob`/`ScaledObject`. ([#3663](https://github.com/kedacore/keda/issues/3663))
 - **Azure Service Bus Scaler**: Add support for Shared Access Signature (SAS) tokens for authentication. ([#2920](https://github.com/kedacore/keda/issues/2920))
 - **Azure Service Bus Scaler:** Support regex usage in queueName / subscriptionName parameters. ([#1624](https://github.com/kedacore/keda/issues/1624))
+- **Selenium Grid Scaler:** Allow setting url trigger parameter from TriggerAuthentication/ClusterTriggerAuthentication
 
 ### Improvements
 

--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -101,7 +101,9 @@ func parseSeleniumGridScalerMetadata(config *ScalerConfig) (*seleniumGridScalerM
 		targetValue: 1,
 	}
 
-	if val, ok := config.TriggerMetadata["url"]; ok {
+	if val, ok := config.AuthParams["url"]; ok {
+		meta.url = val
+	} else if val, ok := config.TriggerMetadata["url"]; ok {
 		meta.url = val
 	} else {
 		return nil, fmt.Errorf("no selenium grid url given in metadata")

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -404,6 +404,28 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "valid url in AuthParams, browsername, and sessionbrowsername should return metadata",
+			args: args{
+				config: &ScalerConfig{
+					AuthParams: map[string]string{
+						"url": "http://user:password@selenium-hub:4444/graphql",
+					},
+					TriggerMetadata: map[string]string{
+						"browserName":        "MicrosoftEdge",
+						"sessionBrowserName": "msedge",
+					},
+				},
+			},
+			wantErr: false,
+			want: &seleniumGridScalerMetadata{
+				url:                "http://user:password@selenium-hub:4444/graphql",
+				browserName:        "MicrosoftEdge",
+				sessionBrowserName: "msedge",
+				targetValue:        1,
+				browserVersion:     "latest",
+			},
+		},
+		{
 			name: "valid url and browsername should return metadata",
 			args: args{
 				config: &ScalerConfig{


### PR DESCRIPTION
This allows specifying the GraphQL URL used by the Selenium Grid Scaler to be specified in a TriggerAuthentication resource and thus pulled from a secret store. We are using Selenium Grid's basic authentication and needed to specify a username/password as part of the URL.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda-docs/pull/959