### PR TITLE
feat(scaler): support cloudID and apiKey in elasticsearch scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **AWS Scalers**: Add setting AWS endpoint url. ([#3337](https://github.com/kedacore/keda/issues/3337))
 - **Azure Service Bus Scaler**: Add support for Shared Access Signature (SAS) tokens for authentication. ([#2920](https://github.com/kedacore/keda/issues/2920))
 - **Azure Service Bus Scaler:** Support regex usage in queueName / subscriptionName parameters. ([#1624](https://github.com/kedacore/keda/issues/1624))
+- **ElasticSearch Scaler**: Support for ElasticSearch Service on Elastic Cloud ([#3785]https://github.com/kedacore/keda/issues/3785)
 - **Selenium Grid Scaler:** Allow setting url trigger parameter from TriggerAuthentication/ClusterTriggerAuthentication ([#3752](https://github.com/kedacore/keda/pull/3752))
 
 ### Improvements

--- a/pkg/scalers/elasticsearch_scaler_test.go
+++ b/pkg/scalers/elasticsearch_scaler_test.go
@@ -33,10 +33,22 @@ type elasticsearchMetricIdentifier struct {
 
 var testCases = []parseElasticsearchMetadataTestData{
 	{
-		name:          "no addresses given",
+		name:          "must provide either endpoint addresses or cloud config",
 		metadata:      map[string]string{},
 		authParams:    map[string]string{},
-		expectedError: errors.New("no addresses given"),
+		expectedError: errors.New("must provide either endpoint addresses or cloud config"),
+	},
+	{
+		name:          "no apiKey given",
+		metadata:      map[string]string{"cloudID": "my-cluster:xxxxxxxxxxx"},
+		authParams:    map[string]string{},
+		expectedError: errors.New("no apiKey given"),
+	},
+	{
+		name:          "can't provide endpoint addresses and cloud config at the same time",
+		metadata:      map[string]string{"addresses": "http://localhost:9200", "cloudID": "my-cluster:xxxxxxxxxxx"},
+		authParams:    map[string]string{"username": "admin", "apiKey": "xxxxxxxxx"},
+		expectedError: errors.New("can't provide endpoint addresses and cloud config at the same time"),
 	},
 	{
 		name:          "no index given",
@@ -447,6 +459,10 @@ func TestElasticsearchGetMetricSpecForScaling(t *testing.T) {
 			AuthParams:      testData.metadataTestData.authParams,
 			ScalerIndex:     testData.scalerIndex,
 		})
+		if testData.metadataTestData.expectedError != nil {
+			assert.Equal(t, err, testData.metadataTestData.expectedError)
+			continue
+		}
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}


### PR DESCRIPTION
- Support providing `cloudID` and `apiKey` in Elasticsearch scaler enabling it to be used with ElasticSearch Service on Elastic Cloud.
- Add test case for missing `apiKey` parameters.
- Add test case for mutual exclusion between providing endpoint `addresses` and `cloudID`.
- Add test case for providing neither `addresses` nor `cloudID`.
- Fix `TestElasticsearchGetMetricSpecForScaling`, `testCase[7]` used as input returns a parsing error that was not being checked.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) (if applicable) https://github.com/kedacore/keda-docs/pull/966
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)


Relates to https://github.com/kedacore/keda/issues/3785
