### PR TITLE
fix(nats-jetstream): correctly count messages that should be redelivered (waiting for ack) towards keda value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General:** Respect optional parameter inside envs for ScaledJobs ([#3568](https://github.com/kedacore/keda/issues/3568))
 - **Azure Blob Scaler** Store forgotten logger ([#3811](https://github.com/kedacore/keda/issues/3811))
 - **Prometheus Scaler:** Treat Inf the same as Null result ([#3644](https://github.com/kedacore/keda/issues/3644))
+- **NATS Jetstream:** Correctly count messages that should be redelivered (waiting for ack) towards keda value ([#3787](https://github.com/kedacore/keda/issues/3787))
 
 ### Deprecations
 

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -195,7 +195,7 @@ func (s *natsJetStreamScaler) getMaxMsgLag() int64 {
 
 	for _, consumer := range s.stream.Consumers {
 		if consumer.Name == consumerName {
-			return int64(consumer.NumPending)
+			return int64(consumer.NumPending + consumer.NumAckPending)
 		}
 	}
 	return s.stream.State.LastSequence


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Until now, the keda nats jetstream scaler did only use the `num_pending` value returned by the nats monitoring endpoint for a specifc consumer. The problem was that messages that should be re-delivered (retried) are not returned as part of the `num_pending` counter but they are in a separate counter called `num_ack_pending`.
This PR use the sum of these two counter to determine the value that should be used by keda instead of only the `num_pending` value.

This fixes two problems:
- Keda would never scale up a deployment/job based on a consumer if this consumer only has messages that are waiting for a retry.
- Keda would scale down deployment/job too fast because when a consumer pulls a message from nats, it decrements immediatly the `num_pending` counter and increment the `num_ack_pending` counter. Keda would then think that there is no work to be done and scale down the deployment/job that are still processing the messages (after a cooldown time if setup).

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #3787

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
