### PR TITLE
fix(azure blob scaler): initialize logger #3811

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General:** Provide patch for CVE-2022-3172 vulnerability ([#3690](https://github.com/kedacore/keda/issues/3690))
 - **General:** Respect optional parameter inside envs for ScaledJobs ([#3568](https://github.com/kedacore/keda/issues/3568))
+- **Azure Blob Scaler** Store forgotten logger ([#3811](https://github.com/kedacore/keda/issues/3811))
 
 ### Deprecations
 

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -68,6 +68,7 @@ func NewAzureBlobScaler(config *ScalerConfig) (Scaler, error) {
 		metadata:    meta,
 		podIdentity: podIdentity,
 		httpClient:  kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false),
+		logger:      logger,
 	}, nil
 }
 
@@ -190,7 +191,7 @@ func (s *azureBlobScaler) IsActive(ctx context.Context) (bool, error) {
 	)
 
 	if err != nil {
-		s.logger.Error(err, "error)")
+		s.logger.Error(err, "error")
 		return false, err
 	}
 


### PR DESCRIPTION
The logger in Azure blob scaler was initialized but not saved. Thus, when logging an error, the logger segfaulted.

In addition, a very minor improvement of the log message which caused the segfault.

Note: I am not a GO developer and I have not tested it locally. 

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #3811

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
