### PR TITLE
fix(e2e tests): Extend time to deploy KEDA

### DIFF
--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -15,7 +15,7 @@ counter=0
 executed_count=0
 
 function run_setup {
-    go test -v -tags e2e utils/setup_test.go
+    go test -v -tags e2e -timeout 15m utils/setup_test.go
 }
 
 function run_tests {


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Lately e2e tests need more time to deploy KEDA and [sometimes the deployment fails](https://github.com/kedacore/keda/actions/runs/3393845930/jobs/5641816280#step:7:153), producing fails on all the other tests, this PR extends the KEDA setup timeout

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

