### PR TITLE
Metrics api unsafessl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **GCP Storage Scaler:** Add prefix and delimiter support ([#3756](https://github.com/kedacore/keda/issues/3756))
 - **Prometheus Scaler:** Introduce skipping of certificate check for unsigned certs ([#2310](https://github.com/kedacore/keda/issues/2310))
 - **Event Hubs Scaler:** Support Azure Active Direcotry Pod & Workload Identity for Storage Blobs ([#3569](https://github.com/kedacore/keda/issues/3569))
+- **Metrics API Scaler:** Add unsafeSsl paramater to skil certificate validation when connecting over HTTPS ([#3728](https://github.com/kedacore/keda/discussions/3728))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **GCP Storage Scaler:** Add prefix and delimiter support ([#3756](https://github.com/kedacore/keda/issues/3756))
 - **Prometheus Scaler:** Introduce skipping of certificate check for unsigned certs ([#2310](https://github.com/kedacore/keda/issues/2310))
 - **Event Hubs Scaler:** Support Azure Active Direcotry Pod & Workload Identity for Storage Blobs ([#3569](https://github.com/kedacore/keda/issues/3569))
-- **Metrics API Scaler:** Add unsafeSsl paramater to skil certificate validation when connecting over HTTPS ([#3728](https://github.com/kedacore/keda/discussions/3728))
+- **Metrics API Scaler:** Add unsafeSsl paramater to skip certificate validation when connecting over HTTPS ([#3728](https://github.com/kedacore/keda/discussions/3728))
 
 ### Fixes
 

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -33,6 +33,7 @@ type metricsAPIScalerMetadata struct {
 	activationTargetValue float64
 	url                   string
 	valueLocation         string
+	unsafeSsl             bool
 
 	// apiKeyAuth
 	enableAPIKeyAuth bool
@@ -76,14 +77,13 @@ func NewMetricsAPIScaler(config *ScalerConfig) (Scaler, error) {
 		return nil, fmt.Errorf("error parsing metric API metadata: %s", err)
 	}
 
-	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
+	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, meta.unsafeSsl)
 
 	if meta.enableTLS || len(meta.ca) > 0 {
 		config, err := kedautil.NewTLSConfig(meta.cert, meta.key, meta.ca)
 		if err != nil {
 			return nil, err
 		}
-
 		httpClient.Transport = &http.Transport{TLSClientConfig: config}
 	}
 
@@ -98,6 +98,16 @@ func NewMetricsAPIScaler(config *ScalerConfig) (Scaler, error) {
 func parseMetricsAPIMetadata(config *ScalerConfig) (*metricsAPIScalerMetadata, error) {
 	meta := metricsAPIScalerMetadata{}
 	meta.scalerIndex = config.ScalerIndex
+	var err error
+
+	if val, ok := config.TriggerMetadata["unsafeSsl"]; ok {
+		meta.unsafeSsl, err = strconv.ParseBool(val)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing unsafeSsl: %s", err)
+		}
+	} else {
+		meta.unsafeSsl = false
+	}
 
 	if val, ok := config.TriggerMetadata["targetValue"]; ok {
 		targetValue, err := strconv.ParseFloat(val, 64)

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -98,15 +98,14 @@ func NewMetricsAPIScaler(config *ScalerConfig) (Scaler, error) {
 func parseMetricsAPIMetadata(config *ScalerConfig) (*metricsAPIScalerMetadata, error) {
 	meta := metricsAPIScalerMetadata{}
 	meta.scalerIndex = config.ScalerIndex
-	var err error
 
+	meta.unsafeSsl = false
 	if val, ok := config.TriggerMetadata["unsafeSsl"]; ok {
-		meta.unsafeSsl, err = strconv.ParseBool(val)
+		unsafeSsl, err := strconv.ParseBool(val)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing unsafeSsl: %s", err)
 		}
-	} else {
-		meta.unsafeSsl = false
+		meta.unsafeSsl = unsafeSsl
 	}
 
 	if val, ok := config.TriggerMetadata["targetValue"]; ok {

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -67,6 +67,10 @@ var testMetricsAPIAuthMetadata = []metricAPIAuthMetadataTestData{
 	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "authMode": "bearer"}, map[string]string{"token": "bearerTokenValue"}, false},
 	// fail bearerAuth without token
 	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "authMode": "bearer"}, map[string]string{}, true},
+	// success unsafeSsl true
+	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "unsafeSsl": "true"}, map[string]string{}, false},
+	// success unsafeSsl false
+	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "unsafeSsl": "false"}, map[string]string{}, false},
 }
 
 func TestParseMetricsAPIMetadata(t *testing.T) {

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -71,6 +71,8 @@ var testMetricsAPIAuthMetadata = []metricAPIAuthMetadataTestData{
 	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "unsafeSsl": "true"}, map[string]string{}, false},
 	// success unsafeSsl false
 	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "unsafeSsl": "false"}, map[string]string{}, false},
+	// failed unsafeSsl non bool
+	{map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "unsafeSsl": "yes"}, map[string]string{}, true},
 }
 
 func TestParseMetricsAPIMetadata(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add unsafeSsl paramater to skil certificate validation when connecting over HTTPS

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #3728 
Fixes https://github.com/kedacore/keda/issues/3821
<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->

[Relates to #972](https://github.com/kedacore/keda-docs/pull/972)
