### PR TITLE
Fix/ListAllExternalMetrics change to return api-resource types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General:** Add explicit seccompProfile type to securityContext config ([#3561](https://github.com/kedacore/keda/issues/3561))
 - **General:** Add `Min` column to ScaledJob visualization ([#3689](https://github.com/kedacore/keda/issues/3689))
 - **General:** Add support to use pod identities for authentication in Azure Key Vault ([#3813](https://github.com/kedacore/keda/issues/3813)
-- **General:** ListAllExternalMetrics change to return api-resource type. ([#1797](https://github.com/kedacore/keda/issues/1797)
 - **Apache Kafka Scaler:** SASL/OAuthbearer Implementation ([#3681](https://github.com/kedacore/keda/issues/3681))
 - **Azure AD Pod Identity Authentication:** Improve error messages to emphasize problems around the integration with aad-pod-identity itself ([#3610](https://github.com/kedacore/keda/issues/3610))
 - **Azure Pipelines Scaler:** Improved speed of profiling large set of Job Requests from Azure Pipelines ([#3702](https://github.com/kedacore/keda/issues/3702))
@@ -65,6 +64,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General:** Provide patch for CVE-2022-3172 vulnerability ([#3690](https://github.com/kedacore/keda/issues/3690))
 - **General:** Respect optional parameter inside envs for ScaledJobs ([#3568](https://github.com/kedacore/keda/issues/3568))
+- **General:** ListAllExternalMetrics change to return api-resource type. ([#1797](https://github.com/kedacore/keda/issues/1797)
 - **Azure Blob Scaler** Store forgotten logger ([#3811](https://github.com/kedacore/keda/issues/3811))
 - **Prometheus Scaler:** Treat Inf the same as Null result ([#3644](https://github.com/kedacore/keda/issues/3644))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General:** Add explicit seccompProfile type to securityContext config ([#3561](https://github.com/kedacore/keda/issues/3561))
 - **General:** Add `Min` column to ScaledJob visualization ([#3689](https://github.com/kedacore/keda/issues/3689))
 - **General:** Add support to use pod identities for authentication in Azure Key Vault ([#3813](https://github.com/kedacore/keda/issues/3813)
+- **General:** ListAllExternalMetrics change to return api-resource type. ([#1797](https://github.com/kedacore/keda/issues/1797)
 - **Apache Kafka Scaler:** SASL/OAuthbearer Implementation ([#3681](https://github.com/kedacore/keda/issues/3681))
 - **Azure AD Pod Identity Authentication:** Improve error messages to emphasize problems around the integration with aad-pod-identity itself ([#3610](https://github.com/kedacore/keda/issues/3610))
 - **Azure Pipelines Scaler:** Improved speed of profiling large set of Job Requests from Azure Pipelines ([#3702](https://github.com/kedacore/keda/issues/3702))

--- a/adapter/main.go
+++ b/adapter/main.go
@@ -149,10 +149,8 @@ func (a *Adapter) makeProvider(ctx context.Context, globalHTTPTimeout time.Durat
 
 func runScaledObjectController(ctx context.Context, mgr manager.Manager, scaleHandler scaling.ScaleHandler, logger logr.Logger, externalMetricsInfo *[]provider.ExternalMetricInfo, externalMetricsInfoLock *sync.RWMutex, maxConcurrentReconciles int, stopCh chan<- struct{}) error {
 	if err := (&kedacontrollers.MetricsScaledObjectReconciler{
-		Client:                  mgr.GetClient(),
-		ScaleHandler:            scaleHandler,
-		ExternalMetricsInfo:     externalMetricsInfo,
-		ExternalMetricsInfoLock: externalMetricsInfoLock,
+		Client:       mgr.GetClient(),
+		ScaleHandler: scaleHandler,
 	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}); err != nil {
 		return err
 	}

--- a/controllers/keda/metrics_adapter_controller.go
+++ b/controllers/keda/metrics_adapter_controller.go
@@ -18,8 +18,6 @@ package keda
 
 import (
 	"context"
-	"sync"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -37,10 +35,6 @@ type MetricsScaledObjectReconciler struct {
 	ScaleHandler            scaling.ScaleHandler
 	MaxConcurrentReconciles int
 }
-
-var (
-	scaledObjectsMetricsLock = &sync.Mutex{}
-)
 
 func (r *MetricsScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -38,12 +38,10 @@ import (
 
 // KedaProvider implements External Metrics Provider
 type KedaProvider struct {
-	client                  client.Client
-	scaleHandler            scaling.ScaleHandler
-	watchedNamespace        string
-	ctx                     context.Context
-	externalMetricsInfo     *[]provider.ExternalMetricInfo
-	externalMetricsInfoLock *sync.RWMutex
+	client           client.Client
+	scaleHandler     scaling.ScaleHandler
+	watchedNamespace string
+	ctx              context.Context
 }
 
 var (
@@ -54,12 +52,10 @@ var (
 // NewProvider returns an instance of KedaProvider
 func NewProvider(ctx context.Context, adapterLogger logr.Logger, scaleHandler scaling.ScaleHandler, client client.Client, watchedNamespace string, externalMetricsInfo *[]provider.ExternalMetricInfo, externalMetricsInfoLock *sync.RWMutex) provider.MetricsProvider {
 	provider := &KedaProvider{
-		client:                  client,
-		scaleHandler:            scaleHandler,
-		watchedNamespace:        watchedNamespace,
-		ctx:                     ctx,
-		externalMetricsInfo:     externalMetricsInfo,
-		externalMetricsInfoLock: externalMetricsInfoLock,
+		client:           client,
+		scaleHandler:     scaleHandler,
+		watchedNamespace: watchedNamespace,
+		ctx:              ctx,
 	}
 	logger = adapterLogger.WithName("provider")
 	logger.Info("starting")

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,9 +19,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"strings"
-	"sync"
-
 	"github.com/go-logr/logr"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,6 +27,7 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+	"strings"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	prommetrics "github.com/kedacore/keda/v2/pkg/metrics"
@@ -50,7 +48,7 @@ var (
 )
 
 // NewProvider returns an instance of KedaProvider
-func NewProvider(ctx context.Context, adapterLogger logr.Logger, scaleHandler scaling.ScaleHandler, client client.Client, watchedNamespace string, externalMetricsInfo *[]provider.ExternalMetricInfo, externalMetricsInfoLock *sync.RWMutex) provider.MetricsProvider {
+func NewProvider(ctx context.Context, adapterLogger logr.Logger, scaleHandler scaling.ScaleHandler, client client.Client, watchedNamespace string) provider.MetricsProvider {
 	provider := &KedaProvider{
 		client:           client,
 		scaleHandler:     scaleHandler,

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -156,11 +156,11 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 // ListAllExternalMetrics returns the supported external metrics for this provider
 func (p *KedaProvider) ListAllExternalMetrics() []provider.ExternalMetricInfo {
 	logger.V(1).Info("KEDA Metrics Server received request for list of all provided external metrics names")
-
-	p.externalMetricsInfoLock.RLock()
-	defer p.externalMetricsInfoLock.RUnlock()
-	externalMetricsInfo := *p.externalMetricsInfo
-
+	externalMetricsInfo := make([]provider.ExternalMetricInfo, 0, 1)
+	info := provider.ExternalMetricInfo{
+		Metric: "scaledobjects",
+	}
+	externalMetricsInfo = append(externalMetricsInfo, info)
 	return externalMetricsInfo
 }
 


### PR DESCRIPTION
ListAllExternalMetrics change to return api-resource types, delete externalMetricsInfo code.

### Checklist

- [✓] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [✓] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Relates to #1797
