### PR TITLE
triggerName is part of Prometheus metrics

### DIFF
--- a/controllers/keda/hpa_test.go
+++ b/controllers/keda/hpa_test.go
@@ -133,8 +133,8 @@ func setupTest(health map[string]v1alpha1.HealthStatus, scaler *mock_scalers.Moc
 	scalersCache := cache.ScalersCache{
 		Scalers: []cache.ScalerBuilder{{
 			Scaler: scaler,
-			Factory: func() (scalers.Scaler, error) {
-				return scaler, nil
+			Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+				return scaler, &scalers.ScalerConfig{}, nil
 			},
 		}},
 		Logger:   logr.Discard(),

--- a/pkg/prommetrics/adapter_prommetrics.go
+++ b/pkg/prommetrics/adapter_prommetrics.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	metricLabels      = []string{"namespace", "metric", "scaledObject", "scaler", "scalerIndex", "scalerName"}
+	metricLabels      = []string{"namespace", "metric", "scaledObject", "scaler", "scalerIndex"}
 	scalerErrorsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "keda_metrics_adapter",
@@ -100,21 +100,21 @@ func (metricsServer PrometheusMetricServer) NewServer(address string, pattern st
 }
 
 // RecordHPAScalerMetric create a measurement of the external metric used by the HPA
-func (metricsServer PrometheusMetricServer) RecordHPAScalerMetric(namespace string, scaledObject string, scaler string, scalerIndex int, scalerName string, metric string, value float64) {
-	scalerMetricsValue.With(getLabels(namespace, scaledObject, scaler, scalerIndex, scalerName, metric)).Set(value)
+func (metricsServer PrometheusMetricServer) RecordHPAScalerMetric(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
+	scalerMetricsValue.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
 }
 
 // RecordHPAScalerError counts the number of errors occurred in trying get an external metric used by the HPA
-func (metricsServer PrometheusMetricServer) RecordHPAScalerError(namespace string, scaledObject string, scaler string, scalerIndex int, scalerName string, metric string, err error) {
+func (metricsServer PrometheusMetricServer) RecordHPAScalerError(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, err error) {
 	if err != nil {
-		scalerErrors.With(getLabels(namespace, scaledObject, scaler, scalerIndex, scalerName, metric)).Inc()
+		scalerErrors.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Inc()
 		// scaledObjectErrors.With(prometheus.Labels{"namespace": namespace, "scaledObject": scaledObject}).Inc()
 		metricsServer.RecordScalerObjectError(namespace, scaledObject, err)
 		scalerErrorsTotal.With(prometheus.Labels{}).Inc()
 		return
 	}
 	// initialize metric with 0 if not already set
-	_, errscaler := scalerErrors.GetMetricWith(getLabels(namespace, scaledObject, scaler, scalerIndex, scalerName, metric))
+	_, errscaler := scalerErrors.GetMetricWith(getLabels(namespace, scaledObject, scaler, scalerIndex, metric))
 	if errscaler != nil {
 		log.Fatalf("Unable to write to serve custom metrics: %v", errscaler)
 	}
@@ -135,6 +135,6 @@ func (metricsServer PrometheusMetricServer) RecordScalerObjectError(namespace st
 	}
 }
 
-func getLabels(namespace string, scaledObject string, scaler string, scalerIndex int, scalerName string, metric string) prometheus.Labels {
-	return prometheus.Labels{"namespace": namespace, "scaledObject": scaledObject, "scaler": scaler, "scalerIndex": strconv.Itoa(scalerIndex), "scalerName": scalerName, "metric": metric}
+func getLabels(namespace string, scaledObject string, scaler string, scalerIndex int, metric string) prometheus.Labels {
+	return prometheus.Labels{"namespace": namespace, "scaledObject": scaledObject, "scaler": scaler, "scalerIndex": strconv.Itoa(scalerIndex), "metric": metric}
 }

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -78,6 +78,9 @@ type ScalerConfig struct {
 	// The timeout to be used on all HTTP requests from the controller
 	GlobalHTTPTimeout time.Duration
 
+	// Name of the trigger
+	TriggerName string
+
 	// TriggerMetadata
 	TriggerMetadata map[string]string
 

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -73,8 +73,8 @@ func TestIsScaledJobActive(t *testing.T) {
 	scaledJobSingle := createScaledObject(0, 100, "") // testing default = max
 	scalerSingle := []ScalerBuilder{{
 		Scaler: createScaler(ctrl, int64(20), int64(2), true, metricName),
-		Factory: func() (scalers.Scaler, error) {
-			return createScaler(ctrl, int64(20), int64(2), true, metricName), nil
+		Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+			return createScaler(ctrl, int64(20), int64(2), true, metricName), &scalers.ScalerConfig{}, nil
 		},
 	}}
 
@@ -93,8 +93,8 @@ func TestIsScaledJobActive(t *testing.T) {
 	// Non-Active trigger only
 	scalerSingle = []ScalerBuilder{{
 		Scaler: createScaler(ctrl, int64(0), int64(2), false, metricName),
-		Factory: func() (scalers.Scaler, error) {
-			return createScaler(ctrl, int64(0), int64(2), false, metricName), nil
+		Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+			return createScaler(ctrl, int64(0), int64(2), false, metricName), &scalers.ScalerConfig{}, nil
 		},
 	}}
 
@@ -123,23 +123,23 @@ func TestIsScaledJobActive(t *testing.T) {
 		scaledJob := createScaledObject(scalerTestData.MinReplicaCount, scalerTestData.MaxReplicaCount, scalerTestData.MultipleScalersCalculation)
 		scalersToTest := []ScalerBuilder{{
 			Scaler: createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive, scalerTestData.MetricName), nil
+			Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+				return createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive, scalerTestData.MetricName), &scalers.ScalerConfig{}, nil
 			},
 		}, {
 			Scaler: createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive, scalerTestData.MetricName), nil
+			Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+				return createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive, scalerTestData.MetricName), &scalers.ScalerConfig{}, nil
 			},
 		}, {
 			Scaler: createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive, scalerTestData.MetricName), nil
+			Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+				return createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive, scalerTestData.MetricName), &scalers.ScalerConfig{}, nil
 			},
 		}, {
 			Scaler: createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, error) {
-				return createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive, scalerTestData.MetricName), nil
+			Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+				return createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive, scalerTestData.MetricName), &scalers.ScalerConfig{}, nil
 			},
 		}}
 
@@ -167,8 +167,8 @@ func TestIsScaledJobActiveIfQueueEmptyButMinReplicaCountGreaterZero(t *testing.T
 	scaledJobSingle := createScaledObject(1, 100, "") // testing default = max
 	scalerSingle := []ScalerBuilder{{
 		Scaler: createScaler(ctrl, int64(0), int64(1), true, metricName),
-		Factory: func() (scalers.Scaler, error) {
-			return createScaler(ctrl, int64(0), int64(1), true, metricName), nil
+		Factory: func() (scalers.Scaler, *scalers.ScalerConfig, error) {
+			return createScaler(ctrl, int64(0), int64(1), true, metricName), &scalers.ScalerConfig{}, nil
 		},
 	}}
 

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -39,13 +39,13 @@ func TestCheckScaledObjectScalersWithError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	recorder := record.NewFakeRecorder(1)
 
-	factory := func() (scalers.Scaler, error) {
+	factory := func() (scalers.Scaler, *scalers.ScalerConfig, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
 		scaler.EXPECT().IsActive(gomock.Any()).Return(false, errors.New("some error"))
 		scaler.EXPECT().Close(gomock.Any())
-		return scaler, nil
+		return scaler, &scalers.ScalerConfig{}, nil
 	}
-	scaler, err := factory()
+	scaler, _, err := factory()
 	assert.Nil(t, err)
 
 	scaledObject := kedav1alpha1.ScaledObject{
@@ -82,23 +82,23 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 
 	metricsSpecs := []v2.MetricSpec{createMetricSpec(1)}
 
-	activeFactory := func() (scalers.Scaler, error) {
+	activeFactory := func() (scalers.Scaler, *scalers.ScalerConfig, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
 		scaler.EXPECT().IsActive(gomock.Any()).Return(true, nil)
 		scaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Times(2).Return(metricsSpecs)
 		scaler.EXPECT().Close(gomock.Any())
-		return scaler, nil
+		return scaler, &scalers.ScalerConfig{}, nil
 	}
-	activeScaler, err := activeFactory()
+	activeScaler, _, err := activeFactory()
 	assert.Nil(t, err)
 
-	failingFactory := func() (scalers.Scaler, error) {
+	failingFactory := func() (scalers.Scaler, *scalers.ScalerConfig, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
 		scaler.EXPECT().IsActive(gomock.Any()).Return(false, errors.New("some error"))
 		scaler.EXPECT().Close(gomock.Any())
-		return scaler, nil
+		return scaler, &scalers.ScalerConfig{}, nil
 	}
-	failingScaler, err := failingFactory()
+	failingScaler, _, err := failingFactory()
 	assert.Nil(t, err)
 
 	scaledObject := &kedav1alpha1.ScaledObject{


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

Reverting part of the implementation done in #3650. Internally reuses `ScalerConfig` for the `triggerName`, also the name is visible in Prometheus metrics under label `scaler`.

Also checking uniqueness of `triggerName` in a ScaledObject.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #3650 #3588
