### PR TITLE
chore: move Prometheus related metrics to `prommetrics` package

### DIFF
--- a/adapter/main.go
+++ b/adapter/main.go
@@ -44,7 +44,7 @@ import (
 	generatedopenapi "github.com/kedacore/keda/v2/adapter/generated/openapi"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kedacontrollers "github.com/kedacore/keda/v2/controllers/keda"
-	prommetrics "github.com/kedacore/keda/v2/pkg/metrics"
+	"github.com/kedacore/keda/v2/pkg/prommetrics"
 	kedaprovider "github.com/kedacore/keda/v2/pkg/provider"
 	"github.com/kedacore/keda/v2/pkg/scaling"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"

--- a/controllers/keda/scaledjob_finalizer.go
+++ b/controllers/keda/scaledjob_finalizer.go
@@ -50,7 +50,7 @@ func (r *ScaledJobReconciler) finalizeScaledJob(ctx context.Context, logger logr
 			return err
 		}
 
-		r.updateMetricsOnDelete(namespacedName)
+		r.updatePromMetricsOnDelete(namespacedName)
 	}
 
 	logger.Info("Successfully finalized ScaledJob")

--- a/controllers/keda/scaledobject_finalizer.go
+++ b/controllers/keda/scaledobject_finalizer.go
@@ -79,7 +79,7 @@ func (r *ScaledObjectReconciler) finalizeScaledObject(ctx context.Context, logge
 			return err
 		}
 
-		r.updateMetricsOnDelete(namespacedName)
+		r.updatePromMetricsOnDelete(namespacedName)
 	}
 
 	logger.Info("Successfully finalized ScaledObject")

--- a/controllers/keda/util/finalizer.go
+++ b/controllers/keda/util/finalizer.go
@@ -20,7 +20,7 @@ const (
 type authenticationReconciler interface {
 	client.Client
 	record.EventRecorder
-	UpdateMetricsOnDelete(string)
+	UpdatePromMetricsOnDelete(string)
 }
 
 func EnsureAuthenticationResourceFinalizer(ctx context.Context, logger logr.Logger, reconciler authenticationReconciler, authResource client.Object) error {
@@ -64,7 +64,7 @@ func FinalizeAuthenticationResource(ctx context.Context, logger logr.Logger, rec
 			return err
 		}
 
-		reconciler.UpdateMetricsOnDelete(namespacedName)
+		reconciler.UpdatePromMetricsOnDelete(namespacedName)
 	}
 
 	logger.Info(fmt.Sprintf("Successfully finalized %s", authResourceType))

--- a/pkg/prommetrics/adapter_prommetrics.go
+++ b/pkg/prommetrics/adapter_prommetrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package prommetrics
 
 import (
 	"log"

--- a/pkg/prommetrics/operator_prommetrics.go
+++ b/pkg/prommetrics/operator_prommetrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package prommetrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/prommetrics/prommetrics.go
+++ b/pkg/prommetrics/prommetrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package prommetrics
 
 // Server an HTTP serving instance to track metrics
 type Server interface {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-	prommetrics "github.com/kedacore/keda/v2/pkg/metrics"
+	"github.com/kedacore/keda/v2/pkg/prommetrics"
 	"github.com/kedacore/keda/v2/pkg/scaling"
 )
 

--- a/tests/internals/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/internals/prometheus_metrics/prometheus_metrics_test.go
@@ -15,7 +15,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kedacore/keda/v2/pkg/metrics"
+	"github.com/kedacore/keda/v2/pkg/prommetrics"
 	. "github.com/kedacore/keda/v2/tests/helper"
 )
 
@@ -336,7 +336,7 @@ func getOperatorMetricsManually(t *testing.T, kc *kubernetes.Clientset) (map[str
 		if namespace == "" {
 			namespace = "default"
 		}
-		crTotals[metrics.ClusterTriggerAuthenticationResource][namespace]++
+		crTotals[prommetrics.ClusterTriggerAuthenticationResource][namespace]++
 	}
 
 	for _, namespace := range namespaceList.Items {
@@ -348,7 +348,7 @@ func getOperatorMetricsManually(t *testing.T, kc *kubernetes.Clientset) (map[str
 		scaledObjectList, err := kedaKc.ScaledObjects(namespace.Name).List(context.Background(), v1.ListOptions{})
 		assert.NoErrorf(t, err, "failed to list scaledObjects in namespace - %s with err - %s", namespace.Name, err)
 
-		crTotals[metrics.ScaledObjectResource][namespaceName] = len(scaledObjectList.Items)
+		crTotals[prommetrics.ScaledObjectResource][namespaceName] = len(scaledObjectList.Items)
 		for _, scaledObject := range scaledObjectList.Items {
 			for _, trigger := range scaledObject.Spec.Triggers {
 				triggerTotals[trigger.Type]++
@@ -358,7 +358,7 @@ func getOperatorMetricsManually(t *testing.T, kc *kubernetes.Clientset) (map[str
 		scaledJobList, err := kedaKc.ScaledJobs(namespace.Name).List(context.Background(), v1.ListOptions{})
 		assert.NoErrorf(t, err, "failed to list scaledJobs in namespace - %s with err - %s", namespace.Name, err)
 
-		crTotals[metrics.ScaledJobResource][namespaceName] = len(scaledJobList.Items)
+		crTotals[prommetrics.ScaledJobResource][namespaceName] = len(scaledJobList.Items)
 		for _, scaledJob := range scaledJobList.Items {
 			for _, trigger := range scaledJob.Spec.Triggers {
 				triggerTotals[trigger.Type]++
@@ -368,7 +368,7 @@ func getOperatorMetricsManually(t *testing.T, kc *kubernetes.Clientset) (map[str
 		triggerAuthList, err := kedaKc.TriggerAuthentications(namespace.Name).List(context.Background(), v1.ListOptions{})
 		assert.NoErrorf(t, err, "failed to list triggerAuthentications in namespace - %s with err - %s", namespace.Name, err)
 
-		crTotals[metrics.TriggerAuthenticationResource][namespaceName] = len(triggerAuthList.Items)
+		crTotals[prommetrics.TriggerAuthenticationResource][namespaceName] = len(triggerAuthList.Items)
 	}
 
 	return triggerTotals, crTotals


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

KEDA operates on many types of metrics, this has became confusing in the source code. Thus moving Prometheus related stuff from `metrics` package to `prommetrics` and bunch of renames of functions/properties.

Just source code chores, no functionality changes in this PR.

### Checklist


- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #3719 
