### PR TITLE
feat: Provide support for explicitly pausing autoscaling of ScaledJobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - [v1.2.0](#v120)
 - [v1.1.0](#v110)
 - [v1.0.0](#v100)
+- **General:** Introduce autoscaling is paused annotation for ScaledJobs ([#3303](https://github.com/kedacore/keda/issues/3303))
 
 ### New
 

--- a/apis/keda/v1alpha1/scaledjob_types.go
+++ b/apis/keda/v1alpha1/scaledjob_types.go
@@ -73,6 +73,8 @@ type ScaledJobStatus struct {
 	LastActiveTime *metav1.Time `json:"lastActiveTime,omitempty"`
 	// +optional
 	Conditions Conditions `json:"conditions,omitempty"`
+	// +optional
+	Paused string `json:"isPaused,omitempty"`
 }
 
 // ScaledJobList contains a list of ScaledJob

--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -7743,6 +7743,8 @@ spec:
               lastActiveTime:
                 format: date-time
                 type: string
+              Paused:
+                type: string
             type: object
         type: object
     served: true

--- a/controllers/keda/util/predicate.go
+++ b/controllers/keda/util/predicate.go
@@ -9,6 +9,8 @@ import (
 
 const PausedReplicasAnnotation = "autoscaling.keda.sh/paused-replicas"
 
+const Paused = "autoscaling.keda.sh/paused"
+
 type PausedReplicasPredicate struct {
 	predicate.Funcs
 }
@@ -59,5 +61,25 @@ func (ScaleObjectReadyConditionPredicate) Update(e event.UpdateEvent) bool {
 		return true
 	}
 
+	return false
+}
+type PausedPredicate struct {
+	predicate.Funcs
+}
+func (PausedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	newAnnotations := e.ObjectNew.GetAnnotations()
+	oldAnnotations := e.ObjectOld.GetAnnotations()
+	if newAnnotations != nil && oldAnnotations != nil {
+		if newVal, ok1 := newAnnotations[Paused]; ok1 {
+			if oldVal, ok2 := oldAnnotations[Paused]; ok2 {
+				return newVal != oldVal
+			}
+			return true
+		}
+	}
 	return false
 }

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -428,3 +428,10 @@ func min(x, y int64) int64 {
 	}
 	return x
 }
+//check if scaledJob has Paused annotation, if it does, pause the scaledjob
+func (e *scaleExecutor) Pause(ctx context.Context, logger logr.Logger, scaledJob *kedav1alpha1.ScaledJob) error {
+	if scaledJob.Annotations["scaledjob.keda.sh/paused"] == "true" {
+		return e.client.Status().Update(ctx, scaledJob)
+	}
+	return nil
+}


### PR DESCRIPTION
Introduce paused annotation for scaledJobs 
### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #3303 


