### PR TITLE
Fixed issue #3782 (job duplication in azure pipelines)

### DIFF
--- a/pkg/scalers/azure_pipelines_scaler_test.go
+++ b/pkg/scalers/azure_pipelines_scaler_test.go
@@ -199,13 +199,17 @@ func TestAzurePipelinesMatchedAgent(t *testing.T) {
 		httpClient: http.DefaultClient,
 	}
 
-	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
+	err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
 
 	if err != nil {
 		t.Fail()
 	}
 
-	if queuelen < 1 {
+	if mockAzurePipelinesScaler.count > 1 {
+		t.Fail()
+	}
+
+	if mockAzurePipelinesScaler.count < 1 {
 		t.Fail()
 	}
 }
@@ -239,13 +243,17 @@ func TestAzurePipelinesMatchedDemandAgent(t *testing.T) {
 		httpClient: http.DefaultClient,
 	}
 
-	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
+	err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
 
 	if err != nil {
 		t.Fail()
 	}
 
-	if queuelen < 1 {
+	if mockAzurePipelinesScaler.count > 1 {
+		t.Fail()
+	}
+
+	if mockAzurePipelinesScaler.count < 1 {
 		t.Fail()
 	}
 }
@@ -263,13 +271,13 @@ func TestAzurePipelinesNonMatchedDemandAgent(t *testing.T) {
 		httpClient: http.DefaultClient,
 	}
 
-	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
+	err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.TODO())
 
 	if err != nil {
 		t.Fail()
 	}
 
-	if queuelen > 0 {
+	if mockAzurePipelinesScaler.count > 0 {
 		t.Fail()
 	}
 }

--- a/pkg/scalers/octopus_tentacle_scaler.go
+++ b/pkg/scalers/octopus_tentacle_scaler.go
@@ -1,0 +1,1 @@
+package scalers

--- a/pkg/scalers/octopus_tentacle_scaler.go
+++ b/pkg/scalers/octopus_tentacle_scaler.go
@@ -1,1 +1,0 @@
-package scalers


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

An active register of jobs has been created so that jobs do not get initiated more than once for a single scaler.

### Checklist

- [x ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x ] Tests have been added
- [x ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #
https://github.com/kedacore/keda/issues/3782
<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
