### PR TITLE
Apache Pulsar: add support for bearer token and basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,8 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Metrics API Scaler:** Add unsafeSsl paramater to skip certificate validation when connecting over HTTPS ([#3728](https://github.com/kedacore/keda/discussions/3728))
 - **NATS Scalers:** Support HTTPS protocol in NATS Scalers ([#3805](https://github.com/kedacore/keda/issues/3805))
 - **Prometheus Scaler:** Introduce skipping of certificate check for unsigned certs ([#2310](https://github.com/kedacore/keda/issues/2310))
-- **Pulsar Scaler:** Add support for partitioned topics ([#3833](https://github.com/kedacore/keda/issues/3833))
 - **Pulsar Scaler:** Add support for bearer token and basic auth ([#3844](https://github.com/kedacore/keda/issues/3844))
+- **Pulsar Scaler:** Add support for partitioned topics ([#3833](https://github.com/kedacore/keda/issues/3833))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **NATS Scalers:** Support HTTPS protocol in NATS Scalers ([#3805](https://github.com/kedacore/keda/issues/3805))
 - **Prometheus Scaler:** Introduce skipping of certificate check for unsigned certs ([#2310](https://github.com/kedacore/keda/issues/2310))
 - **Pulsar Scaler:** Add support for partitioned topics ([#3833](https://github.com/kedacore/keda/issues/3833))
+- **Pulsar Scaler:** Add support for bearer token and basic auth ([#3844](https://github.com/kedacore/keda/issues/3844))
 
 ### Fixes
 

--- a/pkg/scalers/loki_scaler.go
+++ b/pkg/scalers/loki_scaler.go
@@ -207,7 +207,7 @@ func (s *lokiScaler) ExecuteLokiQuery(ctx context.Context) (float64, error) {
 	}
 
 	if s.metadata.lokiAuth != nil && s.metadata.lokiAuth.EnableBearerAuth {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.metadata.lokiAuth.BearerToken))
+		req.Header.Add("Authorization", authentication.GetBearerToken(s.metadata.lokiAuth))
 	} else if s.metadata.lokiAuth != nil && s.metadata.lokiAuth.EnableBasicAuth {
 		req.SetBasicAuth(s.metadata.lokiAuth.Username, s.metadata.lokiAuth.Password)
 	}

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -234,7 +234,7 @@ func (s *prometheusScaler) ExecutePromQuery(ctx context.Context) (float64, error
 	}
 
 	if s.metadata.prometheusAuth != nil && s.metadata.prometheusAuth.EnableBearerAuth {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.metadata.prometheusAuth.BearerToken))
+		req.Header.Add("Authorization", authentication.GetBearerToken(s.metadata.prometheusAuth))
 	} else if s.metadata.prometheusAuth != nil && s.metadata.prometheusAuth.EnableBasicAuth {
 		req.SetBasicAuth(s.metadata.prometheusAuth.Username, s.metadata.prometheusAuth.Password)
 	}

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	"github.com/kedacore/keda/v2/pkg/scalers/authentication"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
@@ -32,11 +33,7 @@ type pulsarMetadata struct {
 	msgBacklogThreshold           int64
 	activationMsgBacklogThreshold int64
 
-	// TLS
-	enableTLS bool
-	cert      string
-	key       string
-	ca        string
+	pulsarAuth *authentication.AuthMeta
 
 	statsURL    string
 	metricName  string
@@ -49,6 +46,7 @@ const (
 	defaultMsgBacklogThreshold = 10
 	enable                     = "enable"
 	stringTrue                 = "true"
+	pulsarAuthModeHeader       = "X-Pulsar-Auth-Method-Name"
 )
 
 type pulsarSubscription struct {
@@ -105,12 +103,22 @@ func NewPulsarScaler(config *ScalerConfig) (Scaler, error) {
 
 	client := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
 
-	if pulsarMetadata.enableTLS {
-		config, err := kedautil.NewTLSConfig(pulsarMetadata.cert, pulsarMetadata.key, pulsarMetadata.ca)
+	if pulsarMetadata.pulsarAuth.CA != "" || pulsarMetadata.pulsarAuth.EnableTLS {
+		config, err := authentication.NewTLSConfig(pulsarMetadata.pulsarAuth)
 		if err != nil {
 			return nil, err
 		}
 		client.Transport = &http.Transport{TLSClientConfig: config}
+	}
+
+	if pulsarMetadata.pulsarAuth.EnableBearerAuth || pulsarMetadata.pulsarAuth.EnableBasicAuth {
+		// The pulsar broker redirects HTTP calls to other brokers and expects the Authorization header
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) != 0 && via[0].Response.StatusCode == http.StatusTemporaryRedirect {
+				addAuthHeaders(req, &pulsarMetadata)
+			}
+			return nil
+		}
 	}
 
 	return &pulsarScaler{
@@ -176,25 +184,21 @@ func parsePulsarMetadata(config *ScalerConfig) (pulsarMetadata, error) {
 		}
 		meta.msgBacklogThreshold = t
 	}
-
-	meta.enableTLS = false
-	if val, ok := config.TriggerMetadata["tls"]; ok {
-		val = strings.TrimSpace(val)
-
-		if val == enable {
-			cert := config.AuthParams["cert"]
-			key := config.AuthParams["key"]
-			if key == "" || cert == "" {
-				return meta, errors.New("must be provided cert and key")
+	// For backwards compatibility, we need to map "tls: enable" to
+	if tls, ok := config.TriggerMetadata["tls"]; ok {
+		if tls == enable && (config.AuthParams["cert"] != "" || config.AuthParams["key"] != "") {
+			if authModes, authModesOk := config.TriggerMetadata[authentication.AuthModesKey]; authModesOk {
+				config.TriggerMetadata[authentication.AuthModesKey] = fmt.Sprintf("%s,%s", authModes, authentication.TLSAuthType)
+			} else {
+				config.TriggerMetadata[authentication.AuthModesKey] = string(authentication.TLSAuthType)
 			}
-			meta.ca = config.AuthParams["ca"]
-			meta.cert = cert
-			meta.key = key
-			meta.enableTLS = true
-		} else {
-			return meta, fmt.Errorf("err incorrect value for TLS given: %s", val)
 		}
 	}
+	auth, err := authentication.GetAuthConfigs(config.TriggerMetadata, config.AuthParams)
+	if err != nil {
+		return meta, fmt.Errorf("error parsing %s: %s", msgBacklogMetricName, err)
+	}
+	meta.pulsarAuth = auth
 	meta.scalerIndex = config.ScalerIndex
 	return meta, nil
 }
@@ -206,6 +210,8 @@ func (s *pulsarScaler) GetStats(ctx context.Context) (*pulsarStats, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error requesting stats from url: %s", err)
 	}
+
+	addAuthHeaders(req, &s.metadata)
 
 	res, err := s.client.Do(req)
 	if res == nil || err != nil {
@@ -297,4 +303,20 @@ func (s *pulsarScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec 
 func (s *pulsarScaler) Close(context.Context) error {
 	s.client = nil
 	return nil
+}
+
+// addAuthHeaders add the relevant headers used by Pulsar to authenticate and authorize http requests
+func addAuthHeaders(req *http.Request, metadata *pulsarMetadata) {
+	switch {
+	case metadata.pulsarAuth.EnableBearerAuth:
+		req.Header.Add("Authorization", authentication.GetBearerToken(metadata.pulsarAuth))
+		req.Header.Add(pulsarAuthModeHeader, "token")
+	case metadata.pulsarAuth.EnableBasicAuth:
+		req.SetBasicAuth(metadata.pulsarAuth.Username, metadata.pulsarAuth.Password)
+		req.Header.Add(pulsarAuthModeHeader, "basic")
+	case metadata.pulsarAuth.EnableTLS:
+		// When BearerAuth or BasicAuth are also configured, let them take precedence for the purposes of
+		// the authMode header.
+		req.Header.Add(pulsarAuthModeHeader, "tls")
+	}
 }

--- a/tests/scalers/pulsar/helper/helper.go
+++ b/tests/scalers/pulsar/helper/helper.go
@@ -35,6 +35,17 @@ type templateData struct {
 	MsgBacklog          int
 }
 
+const authSecretTemplate = `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.TestName}}
+  namespace: {{.TestName}}
+data:
+  key.pub: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnkggprp2GTl/2oQgLvnspbH0Lxthhmw3O3qpcx1FVUcJeD1JlUsuK6rO8uexfY/3JuZffzEm5busJB/5zuXQqO52ph8xDRiEeHOuFY0RKv8DAfpss+oG8Ou/LdHPYCbbyjbJXK/iVE/rUhicp7n6udv2/AaqJj/9535Qo49Q+3S/fbWqhNR6r84+Q+KTHtfwuoLsE4AbZ+g7FRpnyH3iYDxC4ISr1zIJiv4o41cwglaho/cOqCpBFwRHYyZTgeEIf9+7bjTPbpPThFztxO6DOAw73ikU7iT3T0H6hgpQqKa79kw1R8PAfeTYvkeQ4juQwlYmyGePTb9F4LZ+0w7a8wIDAQAB
+  token.jwt: ZXlKaGJHY2lPaUpTVXpJMU5pSjkuZXlKemRXSWlPaUpoWkcxcGJpSjkubEg2TEVqcDU3Y2pFc2xhdWV2Z1ZKV1NTa19IaThFLVZGb29EZHVxUHRiQ1Q0U0NJQlluV0YtRlA5NzBMVUMxRzFWWnZFMmJFZGlkNGd3SzhKY3RnVHNMNGJTV2V5SW4yVVBNTnNnaDVGemhWQkQ4SXVaRnFLTXktLUZnUmtKWFZzWldrbUFwNW5yamU3MEZaRkJLME1uV0licWxSZ2Y2UUZKR2Vxd1FXbzlZV0RCOUh5cTRYR0oxUGx1SGR4T282eTJjVm1Ib3c2SFV3R0dfSDZfTmk0eTNBaU0zWEhvNlNvMkEtRGU5cGRBX3d6MHQzemFyXzhBNFJNeXdTYmtXYldNSVEwUnN5bEZhSk80SzYzT0lTRG5IQkp0TUNJTUNjNlo1WDFKYWt2eUdKek9FTVNQeDZRM1hXWG1MOFFDNjBrcG1xQkd0dXV4XzZlbWFSaHZTcDlB
+`
+
 const pulsarStatefulsetTemplate = `
 apiVersion: apps/v1
 kind: StatefulSet
@@ -58,6 +69,10 @@ spec:
       - name: pulsar
         image: apachepulsar/pulsar:{{.ApachePulsarVersion}}
         imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: auth-data
+          mountPath: "/bin/pulsar"
+          readOnly: true
         readinessProbe:
           tcpSocket:
             port: 8080
@@ -71,10 +86,26 @@ spec:
         env:
         - name: PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect
           value: "true"
+        - name: brokerDeleteInactiveTopicsEnabled
+          value: "false"
+        - name: authenticationEnabled
+          value: "true"
+        - name: authenticationProviders
+          value: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
+        - name: PULSAR_PREFIX_tokenPublicKey
+          value: "/bin/pulsar/key.pub"
+        - name: brokerClientAuthenticationPlugin
+          value: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
+        - name: brokerClientAuthenticationParameters
+          value: "file:///bin/pulsar/token.jwt"
         command:
         - sh
         - -c
-        args: ["bin/apply-config-from-env.py conf/client.conf && bin/apply-config-from-env.py conf/standalone.conf && bin/pulsar standalone -nfw -nss"]
+        args: ["bin/apply-config-from-env.py conf/client.conf && bin/apply-config-from-env.py conf/standalone.conf && exec bin/pulsar standalone -nfw -nss"]
+      volumes:
+      - name: auth-data
+        secret:
+          secretName: {{.TestName}}
 `
 
 const pulsarServiceTemplate = `
@@ -111,11 +142,19 @@ spec:
       - name: pulsar-topic-init
         image: apachepulsar/pulsar:{{.ApachePulsarVersion}}
         imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: auth-data
+          mountPath: "/pulsar/auth"
+          readOnly: true
         command:
         - sh
         - -c
-        args: ["bin/pulsar-admin --admin-url http://{{.TestName}}.{{.TestName}}:8080 topics {{ if .NumPartitions }} create-partitioned-topic -p {{.NumPartitions}} {{ else }} create {{ end }} persistent://public/default/keda"]
+        args: ["bin/pulsar-admin --admin-url http://{{.TestName}}.{{.TestName}}:8080 --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken --auth-params file:///pulsar/auth/token.jwt topics {{ if .NumPartitions }} create-partitioned-topic -p {{.NumPartitions}} {{ else }} create {{ end }} persistent://public/default/keda"]
       restartPolicy: Never
+      volumes:
+      - name: auth-data
+        secret:
+          secretName: {{.TestName}}
   backoffLimit: 4
 `
 
@@ -138,13 +177,20 @@ spec:
     spec:
       containers:
         - name: pulsar-consumer
-          image: ghcr.io/pulsar-sigs/pulsar-client:v0.3.1
+          image: apachepulsar/pulsar:{{.ApachePulsarVersion}}
           imagePullPolicy: IfNotPresent
-          readinessProbe:
-            tcpSocket:
-              port: 9494
-          args: ["consumer","--broker","pulsar://{{.TestName}}.{{.TestName}}:6650","--topic","persistent://public/default/keda","--subscription-name","keda","--consume-time","200"]
-
+          volumeMounts:
+          - name: auth-data
+            mountPath: "/pulsar/auth"
+            readOnly: true
+          command:
+          - sh
+          - -c
+          args: ["bin/pulsar-perf consume --service-url pulsar://{{.TestName}}.{{.TestName}}:6650 --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken --auth-params file:///pulsar/auth/token.jwt --receiver-queue-size 1 --subscription-type Shared --rate 1 --subscriptions keda persistent://public/default/keda"]
+      volumes:
+      - name: auth-data
+        secret:
+          secretName: {{.TestName}}
 `
 
 const scaledObjectTemplate = `
@@ -168,8 +214,24 @@ spec:
         adminURL: http://{{.TestName}}.{{.TestName}}:8080
         topic:  persistent://public/default/keda
         isPartitionedTopic: {{ if .NumPartitions }} "true" {{else}} "false" {{end}}
+        authModes: "bearer"
         subscription: keda
+      authenticationRef:
+        name: {{.TestName}}
           `
+
+const authenticationRefTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{.TestName}}
+  namespace: {{.TestName}}
+spec:
+  secretTargetRef:
+    - parameter: bearerToken
+      name: {{.TestName}}
+      key: token.jwt
+`
 
 const topicPublishJobTemplate = `
 apiVersion: batch/v1
@@ -203,7 +265,7 @@ func TestScalerWithConfig(t *testing.T, testName string, numPartitions int) {
 	helper.CreateKubernetesResources(t, kc, testName, data, templates)
 
 	assert.True(t, helper.WaitForStatefulsetReplicaReadyCount(t, kc, testName, testName, 1, 300, 1),
-		"replica count should be 1 after 5 minute")
+		"replica count should be 1 within 5 minutes")
 
 	helper.KubectlApplyWithTemplate(t, data, "topicInitJobTemplate", topicInitJobTemplate)
 
@@ -214,7 +276,7 @@ func TestScalerWithConfig(t *testing.T, testName string, numPartitions int) {
 
 	// run consumer for create subscription
 	assert.True(t, helper.WaitForDeploymentReplicaReadyCount(t, kc, getConsumerDeploymentName(testName), testName, 1, 300, 1),
-		"replica count should be 1 after 5 minute")
+		"replica count should be 1 within 5 minutes")
 
 	helper.KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
@@ -247,6 +309,8 @@ func getTemplateData(testName string, numPartitions int) (templateData, []helper
 		}, []helper.Template{
 			{Name: "statefulsetTemplate", Config: pulsarStatefulsetTemplate},
 			{Name: "serviceTemplate", Config: pulsarServiceTemplate},
+			{Name: "authenticationRefTemplate", Config: authenticationRefTemplate},
+			{Name: "secretTemplate", Config: authSecretTemplate},
 		}
 }
 
@@ -262,14 +326,14 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	data.MessageCount = 100
 	helper.KubectlApplyWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
 	assert.True(t, helper.WaitForDeploymentReplicaReadyCount(t, kc, getConsumerDeploymentName(data.TestName), data.TestName, 5, 300, 1),
-		"replica count should be 5 after 5 minute")
+		"replica count should be 5 within 5 minute")
 }
 
 func testScaleDown(t *testing.T, kc *kubernetes.Clientset, testName string) {
 	t.Log("--- testing scale down ---")
 	// Check if deployment scale down to 0 after 5 minutes
 	assert.True(t, helper.WaitForDeploymentReplicaReadyCount(t, kc, getConsumerDeploymentName(testName), testName, 0, 300, 1),
-		"Replica count should be 0 after 5 minutes")
+		"Replica count should be 0 within 5 minutes")
 }
 
 func getConsumerDeploymentName(testName string) string {

--- a/tests/scalers/pulsar/helper/helper.go
+++ b/tests/scalers/pulsar/helper/helper.go
@@ -246,11 +246,19 @@ spec:
       - name: pulsar-producer
         image: apachepulsar/pulsar:{{.ApachePulsarVersion}}
         imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: auth-data
+          mountPath: "/pulsar/auth"
+          readOnly: true
         command:
         - sh
         - -c
-        args: ["bin/pulsar-perf produce --admin-url http://{{.TestName}}.{{.TestName}}:8080 --service-url pulsar://{{.TestName}}.{{.TestName}}:6650 --num-messages {{.MessageCount}} {{ if .NumPartitions }} --partitions {{.NumPartitions}} {{ end }} persistent://public/default/keda"]
+        args: ["bin/pulsar-perf produce --admin-url http://{{.TestName}}.{{.TestName}}:8080 --service-url pulsar://{{.TestName}}.{{.TestName}}:6650 --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken --auth-params file:///pulsar/auth/token.jwt --num-messages {{.MessageCount}} {{ if .NumPartitions }} --partitions {{.NumPartitions}} {{ end }} --batch-max-messages 1 persistent://public/default/keda"]
       restartPolicy: Never
+      volumes:
+      - name: auth-data
+        secret:
+          secretName: {{.TestName}}
   backoffLimit: 4
 `
 


### PR DESCRIPTION
Signed-off-by: Michael Marshall <mmarshall@apache.org>

### Modifications

This PR adds support for both bearer tokens and basic authentication (and authorization) with Apache Pulsar. In order to reduce duplicate code, there are some backwards compatible changes made to TLS authentication. 

Note that because Apache Pulsar redirects HTTP calls using the 307 response code, it is necessary to re-add the authorization header. This PR includes that change. It is also important to add the `X-Pulsar-Auth-Method-Name` header to make authentication calls efficient on the broker.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes https://github.com/kedacore/keda/issues/3844

Relates to https://github.com/kedacore/keda-docs/pull/977
