### PR TITLE
fix: Remove unnecessary TLS Config

### DIFF
--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -52,9 +52,6 @@ func decryptClientKey(clientKey, clientKeyPassword string) ([]byte, error) {
 // and CA certificate. If clientKeyPassword is not empty the provided password will be used to
 // decrypt the given key. If none are appropriate, a nil *tls.Config is returned.
 func NewTLSConfigWithPassword(clientCert, clientKey, clientKeyPassword, caCert string) (*tls.Config, error) {
-	// skipVerify := true is a hack to avoid the CodeQL error related with allowing insecure certificates in production environments.
-	// Skipping this validation is necessary and intended in our use case in order to be able to trust in the CA.
-	skipVerify := true
 	valid := false
 
 	config := &tls.Config{}
@@ -81,7 +78,6 @@ func NewTLSConfigWithPassword(clientCert, clientKey, clientKeyPassword, caCert s
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM([]byte(caCert))
 		config.RootCAs = caCertPool
-		config.InsecureSkipVerify = skipVerify
 		valid = true
 	}
 

--- a/tests/scalers/pulsar/README.md
+++ b/tests/scalers/pulsar/README.md
@@ -1,0 +1,43 @@
+# Apache Pulsar Integration Tests TLS Configuration
+
+In order to ensure the Apache Pulsar scaler correctly works with self-signed certificates, both tests are run using self-signed certs.
+
+The Subject Alternative Name on the certs is the service name that points to the broker. Since keda runs in another namespace, it is qualified by namespace.
+
+## Core assumptions
+
+Here are the assumptions under which the certificates will work:
+
+First, we need to establish the DNS names. Those are defined by the service, and will be `testName.testName`. Here are the test names:
+* pulsar-partitioned-topic-test
+* pulsar-non-partitioned-topic-test
+
+Second, we must only run a single broker so that `serviceName` points only to a single broker and there are not any redirects. Given that the tests are using the standalone pulsar, it already has to be a single instance, so this assumption holds.
+
+## Creating the self-signed certs
+
+Generate the relevant artifacts using the following steps.
+
+1. Generate a self-signed keystore. It has a long expiration to simplify test management.
+    ```shell
+    keytool \
+      -keystore server.jks  -storepass protected  -deststoretype pkcs12 \
+      -genkeypair -keyalg RSA -validity 36500 \
+      -dname "CN=pulsar.apache.org,O=pulsar,OU=pulsar" \
+      -ext "SAN=DNS:pulsar-partitioned-topic-test.pulsar-partitioned-topic-test,DNS:pulsar-non-partitioned-topic-test.pulsar-non-partitioned-topic-test"
+    ```
+2. Extract the public key. This will be used by the client and the server. (Requires entering the password: `protected`.)
+   ```shell
+   openssl pkcs12 -in server.jks -nokeys -out servercert.pem
+   ```
+3. Extract the private key for use by the server. (Requires entering the password: `protected`.)
+   ```shell
+   openssl pkcs12 -in server.jks -nodes -nocerts -out serverkey.pem
+   ```
+4. base64 encode `servercert.jks` and `serverkey.pem` and place them in the secret to be used in the tests. On MacOS, run:
+    ```shell
+    cat servercert.pem | base64 | pbcopy
+    ```
+    ```shell
+    cat serverkey.pem | base64 | pbcopy
+    ```

--- a/tests/scalers/pulsar/helper/helper.go
+++ b/tests/scalers/pulsar/helper/helper.go
@@ -44,6 +44,8 @@ metadata:
 data:
   key.pub: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnkggprp2GTl/2oQgLvnspbH0Lxthhmw3O3qpcx1FVUcJeD1JlUsuK6rO8uexfY/3JuZffzEm5busJB/5zuXQqO52ph8xDRiEeHOuFY0RKv8DAfpss+oG8Ou/LdHPYCbbyjbJXK/iVE/rUhicp7n6udv2/AaqJj/9535Qo49Q+3S/fbWqhNR6r84+Q+KTHtfwuoLsE4AbZ+g7FRpnyH3iYDxC4ISr1zIJiv4o41cwglaho/cOqCpBFwRHYyZTgeEIf9+7bjTPbpPThFztxO6DOAw73ikU7iT3T0H6hgpQqKa79kw1R8PAfeTYvkeQ4juQwlYmyGePTb9F4LZ+0w7a8wIDAQAB
   token.jwt: ZXlKaGJHY2lPaUpTVXpJMU5pSjkuZXlKemRXSWlPaUpoWkcxcGJpSjkubEg2TEVqcDU3Y2pFc2xhdWV2Z1ZKV1NTa19IaThFLVZGb29EZHVxUHRiQ1Q0U0NJQlluV0YtRlA5NzBMVUMxRzFWWnZFMmJFZGlkNGd3SzhKY3RnVHNMNGJTV2V5SW4yVVBNTnNnaDVGemhWQkQ4SXVaRnFLTXktLUZnUmtKWFZzWldrbUFwNW5yamU3MEZaRkJLME1uV0licWxSZ2Y2UUZKR2Vxd1FXbzlZV0RCOUh5cTRYR0oxUGx1SGR4T282eTJjVm1Ib3c2SFV3R0dfSDZfTmk0eTNBaU0zWEhvNlNvMkEtRGU5cGRBX3d6MHQzemFyXzhBNFJNeXdTYmtXYldNSVEwUnN5bEZhSk80SzYzT0lTRG5IQkp0TUNJTUNjNlo1WDFKYWt2eUdKek9FTVNQeDZRM1hXWG1MOFFDNjBrcG1xQkd0dXV4XzZlbWFSaHZTcDlB
+  tls.crt: QmFnIEF0dHJpYnV0ZXMKICAgIGZyaWVuZGx5TmFtZTogbXlrZXkKICAgIGxvY2FsS2V5SUQ6IDU0IDY5IDZEIDY1IDIwIDMxIDM2IDM2IDM4IDM4IDMyIDM4IDM3IDMwIDMxIDMzIDMxIDMzIApzdWJqZWN0PS9PVT1wdWxzYXIvTz1wdWxzYXIvQ049cHVsc2FyLmFwYWNoZS5vcmcKaXNzdWVyPS9PVT1wdWxzYXIvTz1wdWxzYXIvQ049cHVsc2FyLmFwYWNoZS5vcmcKLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzekNDQXB1Z0F3SUJBZ0lJU1p5aFpQbzhCcVV3RFFZSktvWklodmNOQVFFTEJRQXdQakVQTUEwR0ExVUUKQ3hNR2NIVnNjMkZ5TVE4d0RRWURWUVFLRXdad2RXeHpZWEl4R2pBWUJnTlZCQU1URVhCMWJITmhjaTVoY0dGagphR1V1YjNKbk1DQVhEVEl5TVRFeE9UQXpNekUwTVZvWUR6SXhNakl4TURJMk1ETXpNVFF4V2pBK01ROHdEUVlEClZRUUxFd1p3ZFd4ellYSXhEekFOQmdOVkJBb1RCbkIxYkhOaGNqRWFNQmdHQTFVRUF4TVJjSFZzYzJGeUxtRncKWVdOb1pTNXZjbWN3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLQW9JQkFRQ3BKckZ1Mm55QQp5d3BzZDRFZURCWlNMN24xamdoUzlrRFIvMkVYU1VGMGE1M1czeG13ckRKNUR0azBCQ0wrUnNlb2J0SXRTUnpFCk9Cd1lOTFl1RmxLNHVRbTdWRk1ic3FWbTJ0c2h6bXRpRzNCQ3l6K2kzdXpEWTloakVPUjVjbzJDVDlmc0lydE0KR1N0eitGMmNHbjI2WTJMZFZRVDNQNXpoUXhXZFVydSs0cTZicFZmQ25tdnltVG9QTS9aMmVnYnBiVGllbWphYwpiS3Uya0pMZTF3bmxmcFVmWlBHa0dGQy9uTUlVUWJjblpSNG5tU3dtVGJobm8vZGRpNGI5VHhCTUNZWW45K3lICmo5ZmcvaTBTeEZ3VzB2NjVmNjJjdnNNZi8rOGd5NlVBUHF2SzYxK1ZaSy81TWQyYlpBS3N4RkUyS0k0emQ4MzcKTCt0USsvVU5HOHozQWdNQkFBR2pnYkl3Z2E4d0hRWURWUjBPQkJZRUZQM05oMHJzdHVLQ2VEQjRrR1JSSnQ4QgpXVllCTUlHTkJnTlZIUkVFZ1lVd2dZS0NPM0IxYkhOaGNpMXdZWEowYVhScGIyNWxaQzEwYjNCcFl5MTBaWE4wCkxuQjFiSE5oY2kxd1lYSjBhWFJwYjI1bFpDMTBiM0JwWXkxMFpYTjBna053ZFd4ellYSXRibTl1TFhCaGNuUnAKZEdsdmJtVmtMWFJ2Y0dsakxYUmxjM1F1Y0hWc2MyRnlMVzV2Ymkxd1lYSjBhWFJwYjI1bFpDMTBiM0JwWXkxMApaWE4wTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBY1A3OStvN2E0VGZBY2EzamtQZFV6eFdGN1FKMytoVXJzCnRaMlpGNFpLSXhTa2Y2MmlNaFdJM1B0TG1qRDVLT2t6RFFua092VXk2bVdncVd5Q2tWdHF1TE1iT1p3TXJkZysKQ01JbmRNR2NDUi9lbkk1dzg4TzdnZzZIQkZ5RHNqRjh1RnZYbGMrRU9Nc3lyTWU3cUFQTlI4cVQyV0Eyd0djcQpsMjQvQkwxRFl1YWlsTi9hNU9nSDZENHh2OHhNaGlRcWJHZnBlUE8wY2YrT0hET0FURDExOGhSck1RQXlpWWs0CjJzNHBTOFAvRUFpaHdOdXhwb3VLWmFEUnAxa2hIZmlycUVNQUozTmtkOURsMXpRdmFRK2RPVXJ3ZWJpV2FkR3UKakx5ZVFWbEFhK0NVajNKWUVrS25ST0JXdmc4Y1Nvd0dYVTRBTDZxbXZLNTlIVkFBSHg4TgotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+  tls.key: QmFnIEF0dHJpYnV0ZXMKICAgIGZyaWVuZGx5TmFtZTogbXlrZXkKICAgIGxvY2FsS2V5SUQ6IDU0IDY5IDZEIDY1IDIwIDMxIDM2IDM2IDM4IDM4IDMyIDM4IDM3IDMwIDMxIDMzIDMxIDMzIApLZXkgQXR0cmlidXRlczogPE5vIEF0dHJpYnV0ZXM+Ci0tLS0tQkVHSU4gUFJJVkFURSBLRVktLS0tLQpNSUlFdlFJQkFEQU5CZ2txaGtpRzl3MEJBUUVGQUFTQ0JLY3dnZ1NqQWdFQUFvSUJBUUNwSnJGdTJueUF5d3BzCmQ0RWVEQlpTTDduMWpnaFM5a0RSLzJFWFNVRjBhNTNXM3htd3JESjVEdGswQkNMK1JzZW9idEl0U1J6RU9Cd1kKTkxZdUZsSzR1UW03VkZNYnNxVm0ydHNoem10aUczQkN5eitpM3V6RFk5aGpFT1I1Y28yQ1Q5ZnNJcnRNR1N0egorRjJjR24yNlkyTGRWUVQzUDV6aFF4V2RVcnUrNHE2YnBWZkNubXZ5bVRvUE0vWjJlZ2JwYlRpZW1qYWNiS3UyCmtKTGUxd25sZnBVZlpQR2tHRkMvbk1JVVFiY25aUjRubVN3bVRiaG5vL2RkaTRiOVR4Qk1DWVluOSt5SGo5ZmcKL2kwU3hGd1cwdjY1ZjYyY3ZzTWYvKzhneTZVQVBxdks2MStWWksvNU1kMmJaQUtzeEZFMktJNHpkODM3TCt0UQorL1VORzh6M0FnTUJBQUVDZ2dFQUNXYTdwT0FpM0Z1c25DTzJPdS9NQzh4WVJ4UWFWVllYZXpSNDluemRWUFdvClE2bUp1WDZRblpiY0xwNXVQWGk4bnhsdHVCT2d0QzAwTG9vN2QrdEl0TGlnR0ZmUytLNmdyOHRKTTZOUDU1ZUQKMFVxUG9tTkdnSU9ib3NIdEdPenJmWXNuZ3BuWmxCeXdCQldSU2x4VWtaZjFoanl6OW5RRUthYjdYQStkbkxuUQpTcGdXZncrRHZlc2JlYWMrM2lIV2FaUnBoOWMwUklRQVZ1UHozODhFbTQwSVQwdVlURnliSDF0bU5sdG8rVDlpCkgzenNBWU9mS2ZKeFh4OXd6SWI4d2JOc3ZnSFVhSm1XNGNlRmFkbnd1YktFMU5RZ3ZYaXlXRVQ3Q1cvdjBDRnoKSHgvU2l2elpqQlJ0UjVhOEF5NnNHVHdmNE03Nm9kNE1hcit6M011azdRS0JnUUMyY2tiRHJHd0hhQXJCaDg4egp5S2pqeHAyekxLMzY4dnhmazJrRDBkTUg1bmdmc2J4TlRNRDdIRENjbitUSExvVzNGNWdsYitldW5tMksycHFUClNHUHlIVGl3S2twNjVJSGRTZzBUNk5HbDVrRS85SktCZWpQM3I0VlcwVHZ3M2R6N1ZvWHVsVmpsTGoxNUkxWU8KY0NvT3djczVTTHlvMGY3R2FiTWcyMHhEUXdLQmdRRHRXRUZ3d29hc2pKcjBCN1pBRWRBZGN2R1ptUmFSNnJZUAoxKzdTdHFXN0xzNkdSZG5lRkpTZStzZmIwUmM2Nm91WjRwQmRsYlZ4bGpkSHJlNTJaYkR3cVpXcHQrc05MTE5zCkxHL29VOGFhempGK0ovMnZCdTBQblYybkUxMy9RcWhONmpvWjVsU2k2YjFmTzEyVFpSSlp5MlIxRTBzZTZxbjUKR09VT2ZqM0NQUUtCZ0JqdzBFbXBoVzhSd3Y2bjBTUjBGdHBrYVdSNEJDU2RHUEQ3MXN4RjM4Smh1Q1FsQ09mTQpTVWxLbGo2akFRUlZrTVB4dnNQSFkzV1VoTWNKa1QzM0ZHcWhvZ0U3RnNscitYREYwYm5hQnViVjdpK1BBSVFnCnIzLzVoNUhSc283LzFWaXFnRTZZTGZuT2MycmU4TUd5aFoxVTBySTNCa3RSd2JGZis3UFBKc0svQW9HQVZxUkYKSDFpanVSR0s3MUp4WVdvZlF1RFcrVzg5SWY5QWZ3QWdtcU02Vk41OVhkN1o3WXd0eE90ZlVncytJNi9EVG1XNgp0YThWRVdYNHdCM3FVeVpFTlZaeTRBWFh0SE9BL0Jnc3NlOERMVGZnTVdGLzVnanRPU29GS2h5VHo3OFJtWC9MCnZmQ3JMTjJPMTlqZ0RCSjFaSG92TGQzaEttUVhzR3M2RXRSYXp6RUNnWUVBazBuT3lmbWd2YVVrMHZSTWJnRmEKVmIzUFdNNG0rMG5sbU4wdnpxSHBPbi9SRDc2MlZlT0cxNnNCOFpFKzVlOWFVVWxxTnUxL3M4blByajhDbGhweApmc0RkQnJKZnBHbjBJUGdKNUF4R3F1WEFEOFl3WmpodFp5RVR5bVRlRm9YemNyNVZWaC90cC9HVmlIOXB4VDhGCktKVm1ybWpiMm1HUjBHallNM2dhVGlJPQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
 `
 
 const pulsarStatefulsetTemplate = `
@@ -71,7 +73,7 @@ spec:
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: auth-data
-          mountPath: "/bin/pulsar"
+          mountPath: "/pulsar/secrets"
           readOnly: true
         readinessProbe:
           tcpSocket:
@@ -80,12 +82,13 @@ spec:
         - name: pulsar
           containerPort: 6650
           protocol: TCP
-        - name: admin
+        - name: http
           containerPort: 8080
           protocol: TCP
+        - name: https
+          containerPort: 8443
+          protocol: TCP
         env:
-        - name: PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect
-          value: "true"
         - name: brokerDeleteInactiveTopicsEnabled
           value: "false"
         - name: authenticationEnabled
@@ -93,11 +96,17 @@ spec:
         - name: authenticationProviders
           value: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
         - name: PULSAR_PREFIX_tokenPublicKey
-          value: "/bin/pulsar/key.pub"
+          value: "/pulsar/secrets/key.pub"
         - name: brokerClientAuthenticationPlugin
           value: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
         - name: brokerClientAuthenticationParameters
-          value: "file:///bin/pulsar/token.jwt"
+          value: "file:///pulsar/secrets/token.jwt"
+        - name: PULSAR_PREFIX_webServicePortTls
+          value: "8443"
+        - name: tlsKeyFilePath
+          value: "/pulsar/secrets/tls.key"
+        - name: tlsCertificateFilePath
+          value: "/pulsar/secrets/tls.crt"
         command:
         - sh
         - -c
@@ -116,10 +125,15 @@ metadata:
   namespace: {{.TestName}}
 spec:
   type: ClusterIP
+  clusterIP: None
   ports:
   - name: http
     port: 8080
     targetPort: 8080
+    protocol: TCP
+  - name: https
+    port: 8443
+    targetPort: 8443
     protocol: TCP
   - name: pulsar
     port: 6650
@@ -211,7 +225,7 @@ spec:
       metadata:
         msgBacklog: "{{.MsgBacklog}}"
         activationMsgBacklogThreshold: "5"
-        adminURL: http://{{.TestName}}.{{.TestName}}:8080
+        adminURL: https://{{.TestName}}.{{.TestName}}:8443
         topic:  persistent://public/default/keda
         isPartitionedTopic: {{ if .NumPartitions }} "true" {{else}} "false" {{end}}
         authModes: "bearer"
@@ -231,6 +245,9 @@ spec:
     - parameter: bearerToken
       name: {{.TestName}}
       key: token.jwt
+    - parameter: ca
+      name: {{.TestName}}
+      key: tls.crt
 `
 
 const topicPublishJobTemplate = `


### PR DESCRIPTION
Signed-off-by: Michael Marshall <mmarshall@apache.org>

It is incorrect to override the default for `InsecureSkipVerify`. There are many parts of the code base use the default value for `InsecureSkipVerify` without testing TLS, so I did not add any tests and I did not make it configurable. I did manually verify the correctness of the change.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added (there isn't test coverage)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)