### PR TITLE
feat: publish e2e test result as artifacts

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -185,3 +185,9 @@ jobs:
           name: ${{ env.E2E_CHECK_NAME }}
           conclusion: failure
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-logs
+          path: '*.log'

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -32,3 +32,9 @@ jobs:
       - name: Delete all e2e related namespaces
         if: ${{ always() }}
         run: make e2e-test-clean
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-logs
+          path: '*.log'

--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -42,3 +42,9 @@ jobs:
 
       - name: Run smoke test
         run: make smoke-test
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-logs
+          path: '*.log'


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #3867

