### PR TITLE
chore: Use scale in/out instead of up/down as we do horizontal scaling

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -91,7 +91,7 @@ To have fully operational KEDA we need to deploy Metrics Server first.
    ```bash
    make deploy
    ```
-2. Scale down `keda-operator` Deployment
+2. Scale in `keda-operator` Deployment
    ```bash
    kubectl scale deployment/keda-operator --replicas=0 -n keda
    ```
@@ -148,7 +148,7 @@ Follow these instructions if you want to debug the KEDA operator using VS Code.
    ```bash
    make deploy
    ```
-3. Scale down `keda-operator` Deployment
+3. Scale in `keda-operator` Deployment
    ```bash
    kubectl scale deployment/keda-operator --replicas=0 -n keda
    ```

--- a/CREATE-NEW-SCALER.md
+++ b/CREATE-NEW-SCALER.md
@@ -94,5 +94,5 @@ Scalers are created and cached until the ScaledObject is modified, or `.IsActive
 ## Note
 The scaler code is embedded into the two separate binaries comprising KEDA, the operator and the custom metrics server component. The metrics server must be occasionally rebuilt published and deployed to k8s for it to have the same code as your operator.
 
-GetMetricSpecForScaling() is executed by the operator for the purposes of scaling up to and down to 0 replicas.
+GetMetricSpecForScaling() is executed by the operator for the purposes of scaling out and in to 0 replicas.
 GetMetrics() is executed by the custom metrics server in response to a calls against the external metrics api, whether by the HPA loop or by curl

--- a/config/crd/bases/keda.sh_scaledobjects.yaml
+++ b/config/crd/bases/keda.sh_scaledobjects.yaml
@@ -82,7 +82,7 @@ spec:
                         properties:
                           scaleDown:
                             description: scaleDown is scaling policy for scaling Down.
-                              If not set, the default value is to allow to scale down
+                              If not set, the default value is to allow to scale in
                               to minReplicas pods, with a 300 second stabilization
                               window (i.e., the highest recommendation for the last
                               300sec is used).
@@ -132,8 +132,8 @@ spec:
                                   StabilizationWindowSeconds must be greater than
                                   or equal to zero and less than or equal to 3600
                                   (one hour). If not set, use the default values:
-                                  - For scale up: 0 (i.e. no stabilization is done).
-                                  - For scale down: 300 (i.e. the stabilization window
+                                  - For scale out: 0 (i.e. no stabilization is done).
+                                  - For scale in: 300 (i.e. the stabilization window
                                   is 300 seconds long).'
                                 format: int32
                                 type: integer
@@ -189,8 +189,8 @@ spec:
                                   StabilizationWindowSeconds must be greater than
                                   or equal to zero and less than or equal to 3600
                                   (one hour). If not set, use the default values:
-                                  - For scale up: 0 (i.e. no stabilization is done).
-                                  - For scale down: 300 (i.e. the stabilization window
+                                  - For scale out: 0 (i.e. no stabilization is done).
+                                  - For scale in: 300 (i.e. the stabilization window
                                   is 300 seconds long).'
                                 format: int32
                                 type: integer

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -190,7 +190,7 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 			// AND
 			// there is no minimum configured or minimum is set to ZERO
 
-			// Try to scale the deployment down, HPA will handle other scale down operations
+			// Try to scale the deployment down, HPA will handle other scale in operations
 			e.scaleToZeroOrIdle(ctx, logger, scaledObject, currentScale)
 		case currentReplicas < minReplicas && scaledObject.Spec.IdleReplicaCount == nil:
 			// there are no active triggers
@@ -257,7 +257,7 @@ func (e *scaleExecutor) scaleToZeroOrIdle(ctx context.Context, logger logr.Logge
 	// In this case we will ignore the cooldown period and scale it down
 	if scaledObject.Status.LastActiveTime == nil ||
 		scaledObject.Status.LastActiveTime.Add(cooldownPeriod).Before(time.Now()) {
-		// or last time a trigger was active was > cooldown period, so scale down.
+		// or last time a trigger was active was > cooldown period, so scale in.
 
 		idleValue, scaleToReplicas := getIdleOrMinimumReplicaCount(scaledObject)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -151,7 +151,7 @@ func TestScaler(t *testing.T) {
 
     CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
-    testScaleUp(t)
+    testScaleOut(t)
 
     // Ensure that this gets run. Using defer is necessary
     DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -178,9 +178,9 @@ func getTemplateData() (templateData, []Template) {
     }
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-    t.Log("--- testing scale up ---")
-    // Use Go Redis Library to add stuff to redis to trigger scale up.
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+    t.Log("--- testing scale out ---")
+    // Use Go Redis Library to add stuff to redis to trigger scale out.
     ...
     ...
     // Sleep / poll for replica count using helper method.

--- a/tests/internals/idle_replicas/idle_replicas_test.go
+++ b/tests/internals/idle_replicas/idle_replicas_test.go
@@ -116,9 +116,9 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	// till min replica count
-	testScaleUp(t, kc)
+	testScaleOut(t, kc)
 	// back to idle replica count
-	testScaleDown(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -137,8 +137,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 
 	t.Log("--- scale to min replicas ---")
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 2, testNamespace)
@@ -151,8 +151,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be 4 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	t.Log("--- scale to idle replicas ---")
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 0, testNamespace)

--- a/tests/internals/pause_scaling/pause_scaling_test.go
+++ b/tests/internals/pause_scaling/pause_scaling_test.go
@@ -142,9 +142,9 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testPauseAt0(t, kc)
-	testScaleUp(t, kc, data)
+	testScaleOut(t, kc, data)
 	testPauseAtN(t, kc, data, 5)
-	testScaleDown(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -171,8 +171,8 @@ func testPauseAt0(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 1),
@@ -190,8 +190,8 @@ func testPauseAtN(t *testing.T, kc *kubernetes.Clientset, data templateData, n i
 		"replica count should be %d after 1 minute", n)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 2),

--- a/tests/internals/subresource_scale/subresource_scale_test.go
+++ b/tests/internals/subresource_scale/subresource_scale_test.go
@@ -125,8 +125,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -151,8 +151,8 @@ func cleanupArgo(t *testing.T, kc *kubernetes.Clientset) {
 	DeleteNamespace(t, kc, argoNamespace)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)
@@ -165,8 +165,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be 10 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)

--- a/tests/internals/value_metric_type/value_metric_type_test.go
+++ b/tests/internals/value_metric_type/value_metric_type_test.go
@@ -148,7 +148,7 @@ func testScaleByAverageValue(t *testing.T, kc *kubernetes.Clientset, data templa
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	// Metric Value = 8, DesiredAverageMetricValue = 2
-	// should scale down to 8/2 = 4 replicas, irrespective of current replicas
+	// should scale in to 8/2 = 4 replicas, irrespective of current replicas
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
 		"replica count should be 4 after 1 minute")
 

--- a/tests/scalers/activemq/activemq_test.go
+++ b/tests/scalers/activemq/activemq_test.go
@@ -460,8 +460,8 @@ func TestActiveMQScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc)
-	testScaleUp(t, kc)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -496,16 +496,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 	_, _, err := ExecCommandOnSpecificPod(t, activemqPodName, testNamespace, fmt.Sprintf("%s producer --destination %s --messageCount 900", activemqPath, activemqDestination))
 	assert.NoErrorf(t, err, "cannot enqueue messages - %s", err)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	_, _, err := ExecCommandOnSpecificPod(t, activemqPodName, testNamespace, fmt.Sprintf("%s consumer --destination %s --messageCount 1000", activemqPath, activemqDestination))
 	assert.NoErrorf(t, err, "cannot enqueue messages - %s", err)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),

--- a/tests/scalers/artemis/artemis_test.go
+++ b/tests/scalers/artemis/artemis_test.go
@@ -313,8 +313,8 @@ func TestArtemisScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -327,16 +327,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "triggerJobTemplate", producerJob)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/aws/aws_cloudwatch/aws_cloudwatch_test.go
+++ b/tests/scalers/aws/aws_cloudwatch/aws_cloudwatch_test.go
@@ -156,8 +156,8 @@ func TestCloudWatchScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, cloudwatchClient)
-	testScaleUp(t, kc, cloudwatchClient)
-	testScaleDown(t, kc, cloudwatchClient)
+	testScaleOut(t, kc, cloudwatchClient)
+	testScaleIn(t, kc, cloudwatchClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -172,16 +172,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cl
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
+	t.Log("--- testing scale out ---")
 	setCloudWatchCustomMetric(t, cloudwatchClient, 10)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
+	t.Log("--- testing scale in ---")
 
 	setCloudWatchCustomMetric(t, cloudwatchClient, 0)
 

--- a/tests/scalers/aws/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
@@ -155,8 +155,8 @@ func TestCloudWatchExpressionScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, cloudwatchClient)
-	testScaleUp(t, kc, cloudwatchClient)
-	testScaleDown(t, kc, cloudwatchClient)
+	testScaleOut(t, kc, cloudwatchClient)
+	testScaleIn(t, kc, cloudwatchClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -171,16 +171,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cl
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
+	t.Log("--- testing scale out ---")
 	setCloudWatchCustomMetric(t, cloudwatchClient, 10)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
+	t.Log("--- testing scale in ---")
 
 	setCloudWatchCustomMetric(t, cloudwatchClient, 0)
 

--- a/tests/scalers/aws/aws_cloudwatch_pod_identity/aws_cloudwatch_pod_identity_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_pod_identity/aws_cloudwatch_pod_identity_test.go
@@ -143,8 +143,8 @@ func TestCloudWatchScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, cloudwatchClient)
-	testScaleUp(t, kc, cloudwatchClient)
-	testScaleDown(t, kc, cloudwatchClient)
+	testScaleOut(t, kc, cloudwatchClient)
+	testScaleIn(t, kc, cloudwatchClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -159,16 +159,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cl
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
+	t.Log("--- testing scale out ---")
 	setCloudWatchCustomMetric(t, cloudwatchClient, 10)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, cloudwatchClient *cloudwatch.CloudWatch) {
+	t.Log("--- testing scale in ---")
 
 	setCloudWatchCustomMetric(t, cloudwatchClient, 0)
 

--- a/tests/scalers/aws/aws_dynamodb/aws_dynamodb_test.go
+++ b/tests/scalers/aws/aws_dynamodb/aws_dynamodb_test.go
@@ -155,8 +155,8 @@ func TestDynamoDBScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, dynamodbClient)
-	testScaleUp(t, kc, dynamodbClient)
-	testScaleDown(t, kc, dynamodbClient)
+	testScaleOut(t, kc, dynamodbClient)
+	testScaleIn(t, kc, dynamodbClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -169,15 +169,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dyna
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
+	t.Log("--- testing scale out ---")
 	addMessages(t, dynamodbClient, 6)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
+	t.Log("--- testing scale in ---")
 
 	for i := 0; i < 6; i++ {
 		_, err := dynamodbClient.DeleteItemWithContext(context.Background(), &dynamodb.DeleteItemInput{

--- a/tests/scalers/aws/aws_dynamodb_pod_identity/aws_dynamodb_pod_identity_test.go
+++ b/tests/scalers/aws/aws_dynamodb_pod_identity/aws_dynamodb_pod_identity_test.go
@@ -142,8 +142,8 @@ func TestDynamoDBScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, dynamodbClient)
-	testScaleUp(t, kc, dynamodbClient)
-	testScaleDown(t, kc, dynamodbClient)
+	testScaleOut(t, kc, dynamodbClient)
+	testScaleIn(t, kc, dynamodbClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -156,15 +156,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dyna
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
+	t.Log("--- testing scale out ---")
 	addMessages(t, dynamodbClient, 6)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, dynamodbClient *dynamodb.DynamoDB) {
+	t.Log("--- testing scale in ---")
 
 	for i := 0; i < 6; i++ {
 		_, err := dynamodbClient.DeleteItemWithContext(context.Background(), &dynamodb.DeleteItemInput{

--- a/tests/scalers/aws/aws_dynamodb_streams/aws_dynamodb_streams_test.go
+++ b/tests/scalers/aws/aws_dynamodb_streams/aws_dynamodb_streams_test.go
@@ -168,8 +168,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data, shardCount)
-	testScaleDown(t, kc, data, shardCount)
+	testScaleOut(t, kc, data, shardCount)
+	testScaleIn(t, kc, data, shardCount)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -275,27 +275,27 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
-	t.Log("--- testing scale up ---")
-	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale up to 1
-	t.Log("replicas should scale up to 1")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
+	t.Log("--- testing scale out ---")
+	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale out to 1
+	t.Log("replicas should scale out to 1")
 	data.ShardCount = shardCount
 	data.ActivationShardCount = int64(activationShardCount)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 180, 1),
 		"replica count should increase to 1")
 
-	// Deploy scalerObject with its shardCount = 1 and check if replicas scale up to 2 (maxReplicaCount)
-	t.Log("then, replicas should scale up to 2")
+	// Deploy scalerObject with its shardCount = 1 and check if replicas scale out to 2 (maxReplicaCount)
+	t.Log("then, replicas should scale out to 2")
 	data.ShardCount = 1
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 180, 1),
 		"replica count should increase to 2")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
-	t.Log("--- testing scale down ---")
-	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale down to 1
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
+	t.Log("--- testing scale in ---")
+	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale in to 1
 	data.ShardCount = shardCount
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 330, 1),

--- a/tests/scalers/aws/aws_dynamodb_streams_pod_identity/aws_dynamodb_streams_pod_identity_test.go
+++ b/tests/scalers/aws/aws_dynamodb_streams_pod_identity/aws_dynamodb_streams_pod_identity_test.go
@@ -152,8 +152,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data, shardCount)
-	testScaleDown(t, kc, data, shardCount)
+	testScaleOut(t, kc, data, shardCount)
+	testScaleIn(t, kc, data, shardCount)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -258,27 +258,27 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
-	t.Log("--- testing scale up ---")
-	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale up to 1
-	t.Log("replicas should scale up to 1")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
+	t.Log("--- testing scale out ---")
+	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale out to 1
+	t.Log("replicas should scale out to 1")
 	data.ShardCount = shardCount
 	data.ActivationShardCount = int64(activationShardCount)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 180, 1),
 		"replica count should increase to 1")
 
-	// Deploy scalerObject with its shardCount = 1 and check if replicas scale up to 2 (maxReplicaCount)
-	t.Log("then, replicas should scale up to 2")
+	// Deploy scalerObject with its shardCount = 1 and check if replicas scale out to 2 (maxReplicaCount)
+	t.Log("then, replicas should scale out to 2")
 	data.ShardCount = 1
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 180, 1),
 		"replica count should increase to 2")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
-	t.Log("--- testing scale down ---")
-	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale down to 1
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData, shardCount int64) {
+	t.Log("--- testing scale in ---")
+	// Deploy scalerObject with its target shardCount = the current dynamodb streams shard count and check if replicas scale in to 1
 	data.ShardCount = shardCount
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 330, 1),

--- a/tests/scalers/aws/aws_kinesis_stream/aws_kinesis_stream_test.go
+++ b/tests/scalers/aws/aws_kinesis_stream/aws_kinesis_stream_test.go
@@ -150,8 +150,8 @@ func TestKiensisScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, kinesisClient)
-	testScaleUp(t, kc, kinesisClient)
-	testScaleDown(t, kc, kinesisClient)
+	testScaleOut(t, kc, kinesisClient)
+	testScaleIn(t, kc, kinesisClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -164,15 +164,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kines
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
+	t.Log("--- testing scale out ---")
 	updateShardCount(t, kinesisClient, 6)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
+	t.Log("--- testing scale in ---")
 	updateShardCount(t, kinesisClient, 3)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),

--- a/tests/scalers/aws/aws_kinesis_stream_pod_identity/aws_kinesis_stream_pod_identity_test.go
+++ b/tests/scalers/aws/aws_kinesis_stream_pod_identity/aws_kinesis_stream_pod_identity_test.go
@@ -137,8 +137,8 @@ func TestKiensisScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, kinesisClient)
-	testScaleUp(t, kc, kinesisClient)
-	testScaleDown(t, kc, kinesisClient)
+	testScaleOut(t, kc, kinesisClient)
+	testScaleIn(t, kc, kinesisClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -151,15 +151,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kines
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
+	t.Log("--- testing scale out ---")
 	updateShardCount(t, kinesisClient, 6)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, kinesisClient *kinesis.Kinesis) {
+	t.Log("--- testing scale in ---")
 	updateShardCount(t, kinesisClient, 3)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),

--- a/tests/scalers/aws/aws_sqs_queue/aws_sqs_queue_test.go
+++ b/tests/scalers/aws/aws_sqs_queue/aws_sqs_queue_test.go
@@ -144,8 +144,8 @@ func TestSqsScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, sqsClient, queue.QueueUrl)
-	testScaleUp(t, kc, sqsClient, queue.QueueUrl)
-	testScaleDown(t, kc, sqsClient, queue.QueueUrl)
+	testScaleOut(t, kc, sqsClient, queue.QueueUrl)
+	testScaleIn(t, kc, sqsClient, queue.QueueUrl)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -158,15 +158,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
+	t.Log("--- testing scale out ---")
 	addMessages(t, sqsClient, queueURL, 6)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 180, 1),
 		"replica count should be 2 after 3 minutes")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
+	t.Log("--- testing scale in ---")
 	_, err := sqsClient.PurgeQueueWithContext(context.Background(), &sqs.PurgeQueueInput{
 		QueueUrl: queueURL,
 	})

--- a/tests/scalers/aws/aws_sqs_queue_pod_identity/aws_sqs_queue_pod_identity_test.go
+++ b/tests/scalers/aws/aws_sqs_queue_pod_identity/aws_sqs_queue_pod_identity_test.go
@@ -131,8 +131,8 @@ func TestSqsScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, sqsClient, queue.QueueUrl)
-	testScaleUp(t, kc, sqsClient, queue.QueueUrl)
-	testScaleDown(t, kc, sqsClient, queue.QueueUrl)
+	testScaleOut(t, kc, sqsClient, queue.QueueUrl)
+	testScaleIn(t, kc, sqsClient, queue.QueueUrl)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -145,15 +145,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
+	t.Log("--- testing scale out ---")
 	addMessages(t, sqsClient, queueURL, 6)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 180, 1),
 		"replica count should be 2 after 3 minutes")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, sqsClient *sqs.SQS, queueURL *string) {
+	t.Log("--- testing scale in ---")
 	_, err := sqsClient.PurgeQueueWithContext(context.Background(), &sqs.PurgeQueueInput{
 		QueueUrl: queueURL,
 	})

--- a/tests/scalers/azure/azure_application_insights/azure_application_insights_test.go
+++ b/tests/scalers/azure/azure_application_insights/azure_application_insights_test.go
@@ -167,8 +167,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, client)
-	testScaleUp(t, kc, client)
-	testScaleDown(t, kc, client)
+	testScaleOut(t, kc, client)
+	testScaleIn(t, kc, client)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -182,8 +182,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, client appinsights.T
 	close(stopCh)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client appinsights.TelemetryClient) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, client appinsights.TelemetryClient) {
+	t.Log("--- testing scale out ---")
 	stopCh := make(chan struct{})
 	go setMetricValue(client, 100, stopCh)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 5),
@@ -191,8 +191,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client appinsights.Tele
 	close(stopCh)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, client appinsights.TelemetryClient) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, client appinsights.TelemetryClient) {
+	t.Log("--- testing scale in ---")
 	stopCh := make(chan struct{})
 	go setMetricValue(client, 0, stopCh)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 5),

--- a/tests/scalers/azure/azure_blob/azure_blob_test.go
+++ b/tests/scalers/azure/azure_blob/azure_blob_test.go
@@ -141,8 +141,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, containerURL)
-	testScaleUp(t, kc, containerURL)
-	testScaleDown(t, kc, containerURL)
+	testScaleOut(t, kc, containerURL)
+	testScaleIn(t, kc, containerURL)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -190,15 +190,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, containerURL azblob.
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, containerURL azblob.ContainerURL) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, containerURL azblob.ContainerURL) {
+	t.Log("--- testing scale out ---")
 	addFiles(t, containerURL, 10)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 1),
 		"replica count should be 2 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, containerURL azblob.ContainerURL) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, containerURL azblob.ContainerURL) {
+	t.Log("--- testing scale in ---")
 
 	for i := 0; i < 10; i++ {
 		blobName := fmt.Sprintf("blob-%d", i)

--- a/tests/scalers/azure/azure_data_explorer/azure_data_explorer_test.go
+++ b/tests/scalers/azure/azure_data_explorer/azure_data_explorer_test.go
@@ -154,8 +154,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	templates = append(templates, Template{Name: "triggerAuthTemplate", Config: triggerAuthTemplate})
@@ -173,8 +173,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, scaleInReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	data.ScaleMetricValue = scaleOutMetricValue
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
@@ -183,8 +183,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 1 minute", scaleOutReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 	data.ScaleMetricValue = scaleInMetricValue
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)

--- a/tests/scalers/azure/azure_event_hub_blob_metadata/azure_event_hub_blob_metadata_test.go
+++ b/tests/scalers/azure/azure_event_hub_blob_metadata/azure_event_hub_blob_metadata_test.go
@@ -177,8 +177,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, client)
-	testScaleUp(t, kc, client)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, client)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -258,16 +258,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, client *eventhub.Hub
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *eventhub.Hub) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, client *eventhub.Hub) {
+	t.Log("--- testing scale out ---")
 	addEvents(t, client, 8)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")

--- a/tests/scalers/azure/azure_event_hub_go_sdk/azure_event_hub_go_sdk_test.go
+++ b/tests/scalers/azure/azure_event_hub_go_sdk/azure_event_hub_go_sdk_test.go
@@ -177,8 +177,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, client)
-	testScaleUp(t, kc, client)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, client)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -258,16 +258,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, client *eventhub.Hub
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *eventhub.Hub) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, client *eventhub.Hub) {
+	t.Log("--- testing scale out ---")
 	addEvents(t, client, 8)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")

--- a/tests/scalers/azure/azure_log_analytics/azure_log_analytics_test.go
+++ b/tests/scalers/azure/azure_log_analytics/azure_log_analytics_test.go
@@ -143,8 +143,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	templates = append(templates, Template{Name: "triggerAuthTemplate", Config: triggerAuthTemplate})
@@ -163,8 +163,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	data.QueryX = 10
 	data.QueryY = 1
 
@@ -174,8 +174,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be 2 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 	data.QueryX = 0
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)

--- a/tests/scalers/azure/azure_pipelines/azure_pipelines_test.go
+++ b/tests/scalers/azure/azure_pipelines/azure_pipelines_test.go
@@ -180,14 +180,14 @@ func TestScaler(t *testing.T) {
 
 	// test scaling poolId
 	testActivation(t, kc, connection)
-	testScaleUp(t, kc, connection)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, connection)
+	testScaleIn(t, kc)
 
 	// test scaling PoolName
 	KubectlApplyWithTemplate(t, data, "poolNamescaledObjectTemplate", poolNamescaledObjectTemplate)
 	testActivation(t, kc, connection)
-	testScaleUp(t, kc, connection)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, connection)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -294,15 +294,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, connection *azuredev
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, connection *azuredevops.Connection) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, connection *azuredevops.Connection) {
+	t.Log("--- testing scale out ---")
 	queueBuild(t, connection)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 1),
 		"replica count should be 2 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 5),
 		"pod count should be 0 after 1 minute")
 }

--- a/tests/scalers/azure/azure_queue/azure_queue_test.go
+++ b/tests/scalers/azure/azure_queue/azure_queue_test.go
@@ -131,8 +131,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, messageURL)
-	testScaleUp(t, kc, messageURL)
-	testScaleDown(t, kc, messageURL)
+	testScaleOut(t, kc, messageURL)
+	testScaleIn(t, kc, messageURL)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -183,16 +183,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.M
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale out ---")
 	addMessages(t, messageURL, 5)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale in ---")
 	_, err := messageURL.Clear(context.Background())
 	assert.NoErrorf(t, err, "cannot clear queue - %s", err)
 

--- a/tests/scalers/azure/azure_service_bus_queue/azure_service_bus_queue_test.go
+++ b/tests/scalers/azure/azure_service_bus_queue/azure_service_bus_queue_test.go
@@ -135,8 +135,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, client)
-	testScaleUp(t, kc, client)
-	testScaleDown(t, kc, adminClient)
+	testScaleOut(t, kc, client)
+	testScaleIn(t, kc, adminClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -185,16 +185,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, client *azservicebus
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
+	t.Log("--- testing scale out ---")
 	addMessages(t, client, 10)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
+	t.Log("--- testing scale in ---")
 
 	_, err := adminClient.DeleteQueue(context.Background(), queueName, nil)
 	assert.NoErrorf(t, err, "cannot delete the queue - %s", err)

--- a/tests/scalers/azure/azure_service_bus_topic/azure_service_bus_topic_test.go
+++ b/tests/scalers/azure/azure_service_bus_topic/azure_service_bus_topic_test.go
@@ -138,8 +138,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, client)
-	testScaleUp(t, kc, client)
-	testScaleDown(t, kc, adminClient)
+	testScaleOut(t, kc, client)
+	testScaleIn(t, kc, adminClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -191,16 +191,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, client *azservicebus
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
+	t.Log("--- testing scale out ---")
 	addMessages(t, client, 10)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
+	t.Log("--- testing scale in ---")
 
 	_, err := adminClient.DeleteTopic(context.Background(), topicName, nil)
 	assert.NoErrorf(t, err, "cannot delete the topic - %s", err)

--- a/tests/scalers/azure/azure_service_bus_topic_regex/azure_service_bus_topic_regex_test.go
+++ b/tests/scalers/azure/azure_service_bus_topic_regex/azure_service_bus_topic_regex_test.go
@@ -212,7 +212,7 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func testScale(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client, data templateData) {
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 
 	// send messages to subscription 1
 	addMessages(t, client, fmt.Sprintf("%s-1", subscriptionPrefix), 2)

--- a/tests/scalers/cassandra/cassandra_test.go
+++ b/tests/scalers/cassandra/cassandra_test.go
@@ -238,8 +238,8 @@ func TestCassandraScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc)
-	testScaleUp(t, kc)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -288,8 +288,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 	result, err := getCassandraInsertCmd(insertDataTemplateB)
 	assert.NoErrorf(t, err, "cannot parse log - %s", err)
 	out, errOut, _ := ExecCommandOnSpecificPod(t, "cassandra-client-0", testNamespace, fmt.Sprintf("bash cqlsh -u %s -p %s %s.%s --execute=\"%s\"", cassandraUsername, cassandraPassword, deploymentName, testNamespace, result))
@@ -299,8 +299,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	out, errOut, _ := ExecCommandOnSpecificPod(t, "cassandra-client-0", testNamespace, fmt.Sprintf("bash cqlsh -u %s -p %s %s.%s --execute=\"%s\"", cassandraUsername, cassandraPassword, deploymentName, testNamespace, truncateData))
 	t.Logf("Output: %s, Error: %s", out, errOut)

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -127,16 +127,16 @@ func TestCpuScaler(t *testing.T) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"Replica count should start out as 1")
 
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	t.Log("--- applying job ---")
 
 	templateTriggerJob := []Template{{Name: "triggerJobTemplate", Config: triggerJob}}
 	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 180, 1),
-		"Replica count should scale up in next 3 minutes")
+		"Replica count should scale out in next 3 minutes")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	t.Log("--- deleting job ---")
 
 	KubectlDeleteMultipleWithTemplate(t, data, templateTriggerJob)

--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -103,8 +103,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 1 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -123,14 +123,14 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 2),
 		"replica count should be 4 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
 		"replica count should be 1 after 1 minute")
 }

--- a/tests/scalers/datadog/datadog_test.go
+++ b/tests/scalers/datadog/datadog_test.go
@@ -263,8 +263,8 @@ func TestDatadogScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -277,16 +277,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "heavyLoadTemplate", heavyLoadTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 	KubectlDeleteWithTemplate(t, data, "lightLoadTemplate", lightLoadTemplate)
 	KubectlDeleteWithTemplate(t, data, "heavyLoadTemplate", heavyLoadTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),

--- a/tests/scalers/elasticsearch/elasticsearch_test.go
+++ b/tests/scalers/elasticsearch/elasticsearch_test.go
@@ -308,8 +308,8 @@ func TestElasticsearchScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc)
-	testScaleUp(t, kc)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -332,16 +332,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 	addElements(t, 5)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
+++ b/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
@@ -123,8 +123,8 @@ func TestScaler(t *testing.T) {
 		"job count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -145,8 +145,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 
 	t.Log("scaling to max replicas")
 	data.MetricValue = data.MetricThreshold * 3
@@ -156,8 +156,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"job count should be 3 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 
 	t.Log("scaling to idle replicas")
 	data.MetricValue = 0

--- a/tests/scalers/external_scaler_so/external_scaler_so_test.go
+++ b/tests/scalers/external_scaler_so/external_scaler_so_test.go
@@ -139,8 +139,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -163,8 +163,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 
 	t.Log("scaling to min replicas")
 	data.MetricValue = data.MetricThreshold
@@ -181,8 +181,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be 2 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 
 	t.Log("scaling to idle replicas")
 	data.MetricValue = 0

--- a/tests/scalers/gcp_pubsub/gcp_pubsub_test.go
+++ b/tests/scalers/gcp_pubsub/gcp_pubsub_test.go
@@ -187,8 +187,8 @@ func TestScaler(t *testing.T) {
 		if createPubsub(t) == nil {
 			// test scaling
 			testActivation(t, kc)
-			testScaleUp(t, kc)
-			testScaleDown(t, kc)
+			testScaleOut(t, kc)
+			testScaleIn(t, kc)
 
 			// cleanup
 			t.Log("--- cleanup ---")
@@ -275,23 +275,23 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 240)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 
 	publishMessages(t, 20-activationThreshold)
 
-	t.Log("--- waiting for replicas to scale up ---")
+	t.Log("--- waiting for replicas to scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 30, 10),
 		fmt.Sprintf("replica count should be %d after five minutes", maxReplicaCount))
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	cmd := fmt.Sprintf("%sgcloud pubsub subscriptions seek %s --time=-P1S", gsPrefix, subscriptionID)
 	_, err := ExecuteCommand(cmd)
 	assert.NoErrorf(t, err, "cannot reset subscription position - %s", err)
 
-	t.Log("--- waiting for replicas to scale down to zero ---")
+	t.Log("--- waiting for replicas to scale in to zero ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
 		"replica count should be 0 after five minute")
 }

--- a/tests/scalers/gcp_stackdriver/gcp_stackdriver_test.go
+++ b/tests/scalers/gcp_stackdriver/gcp_stackdriver_test.go
@@ -193,8 +193,8 @@ func TestScaler(t *testing.T) {
 		if createPubsub(t) == nil {
 			// test scaling
 			testActivation(t, kc)
-			testScaleUp(t, kc)
-			testScaleDown(t, kc)
+			testScaleOut(t, kc)
+			testScaleIn(t, kc)
 
 			// cleanup
 			t.Log("--- cleanup ---")
@@ -283,23 +283,23 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 240)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 
 	publishMessages(t, 20-activationThreshold)
 
-	t.Log("--- waiting for replicas to scale up ---")
+	t.Log("--- waiting for replicas to scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 30, 10),
 		fmt.Sprintf("replica count should be %d after five minutes", maxReplicaCount))
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	cmd := fmt.Sprintf("%sgcloud pubsub subscriptions seek %s --time=-P1S", gsPrefix, subscriptionID)
 	_, err := ExecuteCommand(cmd)
 	assert.NoErrorf(t, err, "cannot reset subscription position - %s", err)
 
-	t.Log("--- waiting for replicas to scale down to zero ---")
+	t.Log("--- waiting for replicas to scale in to zero ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
 		"replica count should be 0 after five minute")
 }

--- a/tests/scalers/gcp_storage/gcp_storage_test.go
+++ b/tests/scalers/gcp_storage/gcp_storage_test.go
@@ -166,8 +166,8 @@ func TestScaler(t *testing.T) {
 	if createBucket(t) == nil {
 		// test scaling
 		testActivation(t, kc)
-		testScaleUp(t, kc)
-		testScaleDown(t, kc)
+		testScaleOut(t, kc)
+		testScaleIn(t, kc)
 	}
 
 	// cleanup
@@ -240,26 +240,26 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 240)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 
 	uploadFiles(t, "scaling", 30-activationThreshold)
 
-	t.Log("--- waiting for replicas to scale up ---")
+	t.Log("--- waiting for replicas to scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 5),
 		fmt.Sprintf("replica count should be %d after five minutes", maxReplicaCount))
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	// Delete files so we are still left with activationThreshold number of files which should be enough
-	// to scale down to 0.
+	// to scale in to 0.
 	cmd := fmt.Sprintf("%sgsutil -m rm -a gs://%s/gsutil*", gsPrefix, bucketName)
 	_, err := ExecuteCommand(cmd)
 	assert.NoErrorf(t, err, "cannot clear bucket - %s", err)
 
-	t.Log("--- waiting for replicas to scale down to zero")
+	t.Log("--- waiting for replicas to scale in to zero")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
 		"replica count should be 0 after 5 minutes")
 }

--- a/tests/scalers/graphite/graphite_test.go
+++ b/tests/scalers/graphite/graphite_test.go
@@ -528,8 +528,8 @@ func TestGraphiteScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -542,16 +542,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "requestsJobTemplate", requestsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 	KubectlApplyWithTemplate(t, data, "emptyRequestsJobTemplate", emptyRequestsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),

--- a/tests/scalers/influxdb/influxdb_test.go
+++ b/tests/scalers/influxdb/influxdb_test.go
@@ -313,7 +313,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 }
 
 func testScaleFloat(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up float---")
+	t.Log("--- testing scale out float---")
 	data := runWriteJob(t, kc)
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplateFloat", scaledObjectTemplateFloat)
@@ -322,7 +322,7 @@ func testScaleFloat(t *testing.T, kc *kubernetes.Clientset) {
 }
 
 func testScaleInt(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up with int ---")
+	t.Log("--- testing scale out with int ---")
 	data := runWriteJob(t, kc)
 	KubectlApplyWithTemplate(t, data, "basicDeploymentIntTemplate", basicDeploymentIntTemplate)
 

--- a/tests/scalers/kafka/kafka_test.go
+++ b/tests/scalers/kafka/kafka_test.go
@@ -275,7 +275,7 @@ func TestScaler(t *testing.T) {
 }
 
 func testEarliestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing earliest policy: scale up ---")
+	t.Log("--- testing earliest policy: scale out ---")
 	data.Params = fmt.Sprintf("--topic %s --group earliest --from-beginning", topic1)
 	data.Commit = StringFalse
 	data.TopicName = topic1
@@ -309,7 +309,7 @@ func testEarliestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateDat
 }
 
 func testLatestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing latest policy: scale up ---")
+	t.Log("--- testing latest policy: scale out ---")
 	commitPartition(t, topic1, "latest")
 	data.Params = fmt.Sprintf("--topic %s --group latest", topic1)
 	data.Commit = StringFalse
@@ -344,7 +344,7 @@ func testLatestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData)
 }
 
 func testMultiTopic(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing multi topic: scale up ---")
+	t.Log("--- testing multi topic: scale out ---")
 	commitPartition(t, topic1, "multiTopic")
 	commitPartition(t, topic2, "multiTopic")
 	data.Topic1Name = topic1
@@ -375,7 +375,7 @@ func testMultiTopic(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 }
 
 func testZeroOnInvalidOffset(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing zeroInvalidOffsetTopic: scale up ---")
+	t.Log("--- testing zeroInvalidOffsetTopic: scale out ---")
 	data.Params = fmt.Sprintf("--topic %s --group %s", zeroInvalidOffsetTopic, invalidOffsetGroup)
 	data.Commit = StringTrue
 	data.TopicName = zeroInvalidOffsetTopic
@@ -392,7 +392,7 @@ func testZeroOnInvalidOffset(t *testing.T, kc *kubernetes.Clientset, data templa
 }
 
 func testOneOnInvalidOffset(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing oneInvalidOffsetTopic: scale up ---")
+	t.Log("--- testing oneInvalidOffsetTopic: scale out ---")
 	data.Params = fmt.Sprintf("--topic %s --group %s --from-beginning", oneInvalidOffsetTopic, invalidOffsetGroup)
 	data.Commit = StringTrue
 	data.TopicName = oneInvalidOffsetTopic

--- a/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
+++ b/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
@@ -115,8 +115,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc)
-	testScaleUp(t, kc)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -127,7 +127,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, sutDeploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 5, 60, 2),
@@ -139,7 +139,7 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be 10 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 5, 60, 2),

--- a/tests/scalers/loki/loki_test.go
+++ b/tests/scalers/loki/loki_test.go
@@ -156,8 +156,8 @@ func TestLokiScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	KubectlDeleteMultipleWithTemplate(t, data, templates)
@@ -171,16 +171,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 5),
 		"replica count should be %d after 5 minutes", minReplicaCount)
 }

--- a/tests/scalers/memory/memory_test.go
+++ b/tests/scalers/memory/memory_test.go
@@ -104,15 +104,15 @@ func TestMemoryScaler(t *testing.T) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"Replica count should start out as 1")
 
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	t.Log("--- applying scaled object with scaled up utilization ---")
 
 	KubectlApplyMultipleWithTemplate(t, data, []Template{{Name: "scaledObjectTemplate", Config: scaledObjectTemplate}})
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 180, 1),
-		"Replica count should scale up in next 3 minutes")
+		"Replica count should scale out in next 3 minutes")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	t.Log("--- applying scaled object with scaled down utilization ---")
 
 	data, _ = getTemplateData(testNamespace, deploymentName, scaledObjectName, scaleDownValue)

--- a/tests/scalers/metrics_api/metrics_api_test.go
+++ b/tests/scalers/metrics_api/metrics_api_test.go
@@ -198,8 +198,8 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -213,8 +213,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	data.MetricValue = 50
 	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
@@ -222,8 +222,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 	data.MetricValue = 0
 	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 

--- a/tests/scalers/mongodb/mongodb_test.go
+++ b/tests/scalers/mongodb/mongodb_test.go
@@ -165,7 +165,7 @@ func TestScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, mongoPod)
-	testScaleUp(t, kc, mongoPod)
+	testScaleOut(t, kc, mongoPod)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -238,8 +238,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, mongoPod string) {
 		"job count should be 0 after 1 minute")
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, mongoPod string) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, mongoPod string) {
+	t.Log("--- testing scale out ---")
 
 	insertCmd := fmt.Sprintf(`db.%s.insert([
 		{"region":"eu-1","state":"running","plan":"planA","goods":"strawberry"},

--- a/tests/scalers/mssql/mssql_test.go
+++ b/tests/scalers/mssql/mssql_test.go
@@ -272,8 +272,8 @@ func TestMssqlScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -288,16 +288,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 }
 
 // insert another 10 records in the table, which in total is 20 -> should be scaled up
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate2", insertRecordsJobTemplate2)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/mysql/mysql_test.go
+++ b/tests/scalers/mysql/mysql_test.go
@@ -237,8 +237,8 @@ func TestMySQLScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -277,20 +277,20 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	t.Log("--- applying job ---")
 	data.ItemsToWrite = 4000
 	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
 	// Check if deployment scale to 2 (the max)
 	maxReplicaCount := 2
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 120, 1),
-		"Replica count should scale up in next 2 minutes")
+		"Replica count should scale out in next 2 minutes")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
-	// Check if deployment scale down to 0 after 5 minutes
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
+	// Check if deployment scale in to 0 after 5 minutes
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 360, 1),
 		"Replica count should be 0 after 5 minutes")
 }

--- a/tests/scalers/nats_jetstream/nats_jetstream_test.go
+++ b/tests/scalers/nats_jetstream/nats_jetstream_test.go
@@ -171,8 +171,8 @@ func TestNATSJetStreamScaler(t *testing.T) {
 		"stream and consumer creation job should be success")
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// Cleanup.
 	nats.RemoveServer(t, kc, natsNamespace)
@@ -187,16 +187,16 @@ func testActivation(t *testing.T, kc *k8s.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *k8s.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *k8s.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "publishJobTemplate", publishJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *k8s.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *k8s.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)
 }

--- a/tests/scalers/new_relic/new_relic_test.go
+++ b/tests/scalers/new_relic/new_relic_test.go
@@ -226,8 +226,8 @@ func TestNewRelicScaler(t *testing.T) {
 
 	// test scaling
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -240,16 +240,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "heavyLoadTemplate", heavyLoadTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
 	KubectlDeleteWithTemplate(t, data, "lightLoadTemplate", lightLoadTemplate)
 	KubectlDeleteWithTemplate(t, data, "heavyLoadTemplate", heavyLoadTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),

--- a/tests/scalers/openstack_swift/openstack_swift_test.go
+++ b/tests/scalers/openstack_swift/openstack_swift_test.go
@@ -167,8 +167,8 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	testActivation(t, kc, client)
-	testScaleUp(t, kc, client)
-	testScaleDown(t, kc, client)
+	testScaleOut(t, kc, client)
+	testScaleIn(t, kc, client)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -185,8 +185,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, client *gophercloud.
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *gophercloud.ServiceClient) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, client *gophercloud.ServiceClient) {
+	t.Log("--- testing scale out ---")
 	for _, object := range containerObjects {
 		helper.CreateObject(t, client, containerName, object)
 	}
@@ -195,8 +195,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *gophercloud.Ser
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, client *gophercloud.ServiceClient) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, client *gophercloud.ServiceClient) {
+	t.Log("--- testing scale in ---")
 	for _, object := range containerObjects {
 		helper.DeleteObject(t, client, containerName, object)
 	}

--- a/tests/scalers/postgresql/postgresql_test.go
+++ b/tests/scalers/postgresql/postgresql_test.go
@@ -270,8 +270,8 @@ func TestPostreSQLScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	KubectlDeleteMultipleWithTemplate(t, data, templates)
@@ -285,16 +285,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/predictkube/predictkube_test.go
+++ b/tests/scalers/predictkube/predictkube_test.go
@@ -223,8 +223,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	KubectlDeleteMultipleWithTemplate(t, data, templates)
@@ -238,16 +238,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateHeavyLoadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 5),
 		"replica count should be %d after 5 minutes", minReplicaCount)
 }

--- a/tests/scalers/prometheus/prometheus_test.go
+++ b/tests/scalers/prometheus/prometheus_test.go
@@ -222,8 +222,8 @@ func TestPrometheusScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	KubectlDeleteMultipleWithTemplate(t, data, templates)
@@ -237,16 +237,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 5),
 		"replica count should be %d after 5 minutes", minReplicaCount)
 }

--- a/tests/scalers/pulsar/helper/helper.go
+++ b/tests/scalers/pulsar/helper/helper.go
@@ -292,10 +292,10 @@ func TestScalerWithConfig(t *testing.T, testName string, numPartitions int) {
 		"replica count should be 0 after a minute")
 
 	testActivation(t, kc, data)
-	// scale up
-	testScaleUp(t, kc, data)
-	// scale down
-	testScaleDown(t, kc, testName)
+	// scale out
+	testScaleOut(t, kc, data)
+	// scale in
+	testScaleIn(t, kc, testName)
 
 	// cleanup
 	helper.KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
@@ -330,16 +330,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	helper.KubectlDeleteWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	data.MessageCount = 100
 	helper.KubectlApplyWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
 	assert.True(t, helper.WaitForDeploymentReplicaReadyCount(t, kc, getConsumerDeploymentName(data.TestName), data.TestName, 5, 300, 1),
 		"replica count should be 5 within 5 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, testName string) {
-	t.Log("--- testing scale down ---")
-	// Check if deployment scale down to 0 after 5 minutes
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, testName string) {
+	t.Log("--- testing scale in ---")
+	// Check if deployment scale in to 0 after 5 minutes
 	assert.True(t, helper.WaitForDeploymentReplicaReadyCount(t, kc, getConsumerDeploymentName(testName), testName, 0, 300, 1),
 		"Replica count should be 0 within 5 minutes")
 }

--- a/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
@@ -111,12 +111,12 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
 		"replica count should be 4 after 1 minute")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")
 }

--- a/tests/scalers/rabbitmq/rabbitmq_queue_amqp_vhost/rabbitmq_queue_amqp_vhost_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_amqp_vhost/rabbitmq_queue_amqp_vhost_test.go
@@ -111,12 +111,12 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
 		"replica count should be 4 after 1 minute")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")
 }

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
@@ -110,12 +110,12 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
 		"replica count should be 4 after 1 minute")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")
 }

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_regex/rabbitmq_queue_http_regex_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_regex/rabbitmq_queue_http_regex_test.go
@@ -113,7 +113,7 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
 	// dummies
 	RMQPublishMessages(t, rmqNamespace, connectionString, fmt.Sprintf("%s-1", queueName), messageCount)
@@ -122,7 +122,7 @@ func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 2),
 		"replica count should be 4 after 2 minute")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")
 }

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_regex_vhost/rabbitmq_queue_http_regex_vhost_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_regex_vhost/rabbitmq_queue_http_regex_vhost_test.go
@@ -121,7 +121,7 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
 	// dummies
 	RMQPublishMessages(t, rmqNamespace, dummyConnectionString1, fmt.Sprintf("%s-1", queueName), messageCount)
@@ -130,7 +130,7 @@ func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 2),
 		"replica count should be 4 after 2 minute")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")
 }

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_vhost/rabbitmq_queue_http_vhost_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_vhost/rabbitmq_queue_http_vhost_test.go
@@ -110,12 +110,12 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
 		"replica count should be 4 after 1 minute")
 
-	t.Log("--- testing scale down ---")
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")
 }

--- a/tests/scalers/redis/redis_cluster_lists/redis_cluster_lists_test.go
+++ b/tests/scalers/redis/redis_cluster_lists/redis_cluster_lists_test.go
@@ -178,8 +178,8 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	redis.RemoveCluster(t, kc, testName, redisNamespace)
@@ -194,8 +194,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	data.ItemsToWrite = 200
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
@@ -203,8 +203,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/redis/redis_cluster_streams/redis_cluster_streams_test.go
+++ b/tests/scalers/redis/redis_cluster_streams/redis_cluster_streams_test.go
@@ -181,24 +181,24 @@ func TestScaler(t *testing.T) {
 	data, templates := getTemplateData()
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	redis.RemoveCluster(t, kc, testName, redisNamespace)
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
+++ b/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
@@ -186,8 +186,8 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	redis.RemoveSentinel(t, kc, testName, redisNamespace)
@@ -201,8 +201,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	data.ItemsToWrite = 200
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
@@ -210,8 +210,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/redis/redis_sentinel_streams/redis_sentinel_streams_test.go
+++ b/tests/scalers/redis/redis_sentinel_streams/redis_sentinel_streams_test.go
@@ -195,24 +195,24 @@ func TestScaler(t *testing.T) {
 	data, templates := getTemplateData()
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	redis.RemoveSentinel(t, kc, testName, redisNamespace)
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
+++ b/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
@@ -174,8 +174,8 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	redis.RemoveStandalone(t, kc, testName, redisNamespace)
@@ -190,8 +190,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	data.ItemsToWrite = 200
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
@@ -199,8 +199,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/redis/redis_standalone_streams/redis_standalone_streams_test.go
+++ b/tests/scalers/redis/redis_standalone_streams/redis_standalone_streams_test.go
@@ -175,16 +175,16 @@ func TestScaler(t *testing.T) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 3),
 		"replica count should be %d after 3 minutes", 1)
 
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	redis.RemoveStandalone(t, kc, testName, redisNamespace)
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	data.ItemsToWrite = 20
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
@@ -192,8 +192,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 5 minutes", minReplicaCount)

--- a/tests/scalers/selenium/selenium_test.go
+++ b/tests/scalers/selenium/selenium_test.go
@@ -472,8 +472,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -492,8 +492,8 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, edgeDeploymentName, testNamespace, minReplicaCount, 5)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 
 	data.JobName = "scaleup"
 	data.WithVersion = false
@@ -507,8 +507,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 		"replica count should be %s after 1 minute", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, chromeDeploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %s after 3 minutes", minReplicaCount)

--- a/tests/scalers/solace/solace_test.go
+++ b/tests/scalers/solace/solace_test.go
@@ -170,8 +170,8 @@ func TestStanScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	testActivation(t, kc)
-	testScaleUp(t, kc)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc)
+	testScaleIn(t, kc)
 
 	// cleanup
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
@@ -209,15 +209,15 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale out ---")
 	publishMessages(t, 50, 40, 256)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)
 }

--- a/tests/scalers/stan/stan_test.go
+++ b/tests/scalers/stan/stan_test.go
@@ -245,8 +245,8 @@ func TestStanScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -259,16 +259,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "publishDeploymentTemplate", publishDeploymentTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)
 }

--- a/tests/secret-providers/azure_keyvault/azure_keyvault_test.go
+++ b/tests/secret-providers/azure_keyvault/azure_keyvault_test.go
@@ -167,8 +167,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc, messageURL)
-	testScaleDown(t, kc, messageURL)
+	testScaleOut(t, kc, messageURL)
+	testScaleIn(t, kc, messageURL)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -219,8 +219,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale out ---")
 	for i := 0; i < 5; i++ {
 		msg := fmt.Sprintf("Message - %d", i)
 		_, err := messageURL.Enqueue(context.Background(), msg, 0*time.Second, time.Hour)
@@ -231,8 +231,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.Mess
 		"replica count should be 0 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale in ---")
 	_, err := messageURL.Clear(context.Background())
 	assert.NoErrorf(t, err, "cannot clear queue - %s", err)
 

--- a/tests/secret-providers/azure_keyvault_workload_identity/azure_keyvault_workload_identity_test.go
+++ b/tests/secret-providers/azure_keyvault_workload_identity/azure_keyvault_workload_identity_test.go
@@ -151,8 +151,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc, messageURL)
-	testScaleDown(t, kc, messageURL)
+	testScaleOut(t, kc, messageURL)
+	testScaleIn(t, kc, messageURL)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -199,8 +199,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale out ---")
 	for i := 0; i < 5; i++ {
 		msg := fmt.Sprintf("Message - %d", i)
 		_, err := messageURL.Enqueue(context.Background(), msg, 0*time.Second, time.Hour)
@@ -211,8 +211,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.Mess
 		"replica count should be 0 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale in ---")
 	_, err := messageURL.Clear(context.Background())
 	assert.NoErrorf(t, err, "cannot clear queue - %s", err)
 

--- a/tests/secret-providers/azure_workload_identity/azure_workload_identity_test.go
+++ b/tests/secret-providers/azure_workload_identity/azure_workload_identity_test.go
@@ -119,8 +119,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc, client)
-	testScaleDown(t, kc, adminClient)
+	testScaleOut(t, kc, client)
+	testScaleIn(t, kc, adminClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -160,8 +160,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
+	t.Log("--- testing scale out ---")
 	sender, err := client.NewSender(queueName, nil)
 	assert.NoErrorf(t, err, "cannot create the sender - %s", err)
 	for i := 0; i < 5; i++ {
@@ -175,8 +175,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Cl
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
+	t.Log("--- testing scale in ---")
 
 	_, err := adminClient.DeleteQueue(context.Background(), queueName, nil)
 	assert.NoErrorf(t, err, "cannot delete the queue - %s", err)

--- a/tests/secret-providers/azure_workload_identity_user_assigned/azure_workload_identity_user_assigned_test.go
+++ b/tests/secret-providers/azure_workload_identity_user_assigned/azure_workload_identity_user_assigned_test.go
@@ -134,9 +134,9 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUpWithIncorrectIdentity(t, kc, client)
-	testScaleUpWithCorrectIdentity(t, kc, data)
-	testScaleDown(t, kc, adminClient)
+	testScaleOutWithIncorrectIdentity(t, kc, client)
+	testScaleOutWithCorrectIdentity(t, kc, data)
+	testScaleIn(t, kc, adminClient)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -177,8 +177,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUpWithIncorrectIdentity(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
-	t.Log("--- testing scale up with incorrect identity ---")
+func testScaleOutWithIncorrectIdentity(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Client) {
+	t.Log("--- testing scale out with incorrect identity ---")
 	sender, err := client.NewSender(queueName, nil)
 	assert.NoErrorf(t, err, "cannot create the sender - %s", err)
 	for i := 0; i < 5; i++ {
@@ -188,13 +188,13 @@ func testScaleUpWithIncorrectIdentity(t *testing.T, kc *kubernetes.Clientset, cl
 		}, nil)
 	}
 
-	// scale up should fail as we are using the incorrect identity
+	// scale out should fail as we are using the incorrect identity
 	assert.True(t, WaitForDeploymentReplicaCountChange(t, kc, deploymentName, testNamespace, 30, 1) == 0,
 		"replica count should be 0 after 1 minute")
 }
 
-func testScaleUpWithCorrectIdentity(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up with correct identity ---")
+func testScaleOutWithCorrectIdentity(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out with correct identity ---")
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	KubectlDeleteWithTemplate(t, data, "triggerAuthTemplate", triggerAuthTemplate)
 
@@ -205,8 +205,8 @@ func testScaleUpWithCorrectIdentity(t *testing.T, kc *kubernetes.Clientset, data
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, adminClient *admin.Client) {
+	t.Log("--- testing scale in ---")
 
 	_, err := adminClient.DeleteQueue(context.Background(), queueName, nil)
 	assert.NoErrorf(t, err, "cannot delete the queue - %s", err)

--- a/tests/secret-providers/hashicorp_vault/hashicorp_vault_test.go
+++ b/tests/secret-providers/hashicorp_vault/hashicorp_vault_test.go
@@ -289,8 +289,8 @@ func TestPostreSQLScaler(t *testing.T) {
 		"replica count should be %d after 3 minutes", minReplicaCount)
 
 	testActivation(t, kc, data)
-	testScaleUp(t, kc, data)
-	testScaleDown(t, kc)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
 
 	// cleanup
 	KubectlDeleteMultipleWithTemplate(t, data, templates)
@@ -338,16 +338,16 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/secret-providers/trigger_auth_secret/trigger_auth_secret_test.go
+++ b/tests/secret-providers/trigger_auth_secret/trigger_auth_secret_test.go
@@ -145,8 +145,8 @@ func TestScaler(t *testing.T) {
 		"replica count should be 0 after 1 minute")
 
 	// test scaling
-	testScaleUp(t, kc, messageURL)
-	testScaleDown(t, kc, messageURL)
+	testScaleOut(t, kc, messageURL)
+	testScaleIn(t, kc, messageURL)
 
 	// cleanup
 	DeleteKubernetesResources(t, kc, testNamespace, data, templates)
@@ -192,8 +192,8 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale up ---")
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale out ---")
 	for i := 0; i < 5; i++ {
 		msg := fmt.Sprintf("Message - %d", i)
 		_, err := messageURL.Enqueue(context.Background(), msg, 0*time.Second, time.Hour)
@@ -204,8 +204,8 @@ func testScaleUp(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.Mess
 		"replica count should be 1 after 1 minute")
 }
 
-func testScaleDown(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
-	t.Log("--- testing scale down ---")
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, messageURL azqueue.MessagesURL) {
+	t.Log("--- testing scale in ---")
 	_, err := messageURL.Clear(context.Background())
 	assert.NoErrorf(t, err, "cannot clear queue - %s", err)
 


### PR DESCRIPTION
Use scale in/out instead of up/down as we do horizontal scaling and is confusing to use the wrong terminology.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))