### PR TITLE
fix: use correct wildcard for uploading logs

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -190,4 +190,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: e2e-test-logs
-          path: '*.log'
+          path: '${{ github.workspace }}/tests/**/*.log'

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -37,4 +37,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: e2e-test-logs
-          path: '*.log'
+          path: '${{ github.workspace }}/tests/**/*.log'

--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: e2e-test-logs
-          path: '*.log'
+          path: '${{ github.workspace }}/tests/**/*.log'


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@scrm.lidl>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

