### PR TITLE
fix: use unique names for smoke test artifacts

### DIFF
--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -46,5 +46,5 @@ jobs:
       - name: Upload test logs
         uses: actions/upload-artifact@v3
         with:
-          name: e2e-test-logs
+          name: smoke-test-logs ${{ inputs.kubernetesVersion }}
           path: '${{ github.workspace }}/tests/**/*.log'


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@scrm.lidl>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


