### PR TITLE
fix(azure event hub): wrong calc of the remaining items

### DIFF
--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -286,7 +286,7 @@ func (s *azureEventHubScaler) GetUnprocessedEventCountInPartition(ctx context.Co
 
 	// Partition is a circular buffer, so it is possible that
 	// partitionInfo.LastSequenceNumber < blob checkpoint's SequenceNumber
-	unprocessedEventCountInPartition = (math.MaxInt64 - partitionInfo.LastSequenceNumber) + checkpoint.SequenceNumber
+	unprocessedEventCountInPartition = (math.MaxInt64 - checkpoint.SequenceNumber) + partitionInfo.LastSequenceNumber
 
 	// Checkpointing may or may not be always behind partition's LastSequenceNumber.
 	// The partition information read could be stale compared to checkpoint,


### PR DESCRIPTION
as the scenario covered in this line is for the case in which the partition reached maxInt and started from zero. the calc is done wrongly.
![image](https://user-images.githubusercontent.com/37622785/203792819-429c6682-7ce7-4800-a2a9-65663b173a51.png)

Signed-off-by: Yoav Dobrin <37622785+yodobrin@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

the calc of the remaining items to process is wrong

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
