### PR TITLE
Support using connection strings for Event Hub namespace instead of the Event Hub itself.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Apache Kafka Scaler:** SASL/OAuthbearer Implementation ([#3681](https://github.com/kedacore/keda/issues/3681))
 - **Azure AD Pod Identity Authentication:** Improve error messages to emphasize problems around the integration with aad-pod-identity itself ([#3610](https://github.com/kedacore/keda/issues/3610))
 - **Azure Event Hub Scaler:** Support Azure Active Direcotry Pod & Workload Identity for Storage Blobs ([#3569](https://github.com/kedacore/keda/issues/3569))
+- **Azure Event Hub Scaler:** Support using connection strings for Event Hub namespace instead of the Event Hub itself. ([#3922](https://github.com/kedacore/keda/issues/3922))
 - **Azure Pipelines Scaler:** Improved speed of profiling large set of Job Requests from Azure Pipelines ([#3702](https://github.com/kedacore/keda/issues/3702))
 - **GCP Storage Scaler:** Add prefix and delimiter support ([#3756](https://github.com/kedacore/keda/issues/3756))
 - **Metrics API Scaler:** Add unsafeSsl paramater to skip certificate validation when connecting over HTTPS ([#3728](https://github.com/kedacore/keda/discussions/3728))

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,8 @@ clientset-generate: ## Generate client-go clientset, listers and informers.
 	./hack/update-codegen.sh
 
 proto-gen: protoc-gen ## Generate Liiklus, ExternalScaler and MetricsService proto
-	PATH=$(LOCALBIN):$(PATH) protoc -I vendor --proto_path=hack LiiklusService.proto --go_out=pkg/scalers/liiklus --go-grpc_out=pkg/scalers/liiklus
-	PATH=$(LOCALBIN):$(PATH) protoc -I vendor --proto_path=pkg/scalers/externalscaler externalscaler.proto --go_out=pkg/scalers/externalscaler --go-grpc_out=pkg/scalers/externalscaler
+	PATH="$(LOCALBIN):$(PATH)" protoc -I vendor --proto_path=hack LiiklusService.proto --go_out=pkg/scalers/liiklus --go-grpc_out=pkg/scalers/liiklus
+	PATH="$(LOCALBIN):$(PATH)" protoc -I vendor --proto_path=pkg/scalers/externalscaler externalscaler.proto --go_out=pkg/scalers/externalscaler --go-grpc_out=pkg/scalers/externalscaler
 
 .PHONY: mockgen-gen
 mockgen-gen: mockgen pkg/mock/mock_scaling/mock_interface.go pkg/mock/mock_scaler/mock_scaler.go pkg/mock/mock_scale/mock_interfaces.go pkg/mock/mock_client/mock_interfaces.go pkg/scalers/liiklus/mocks/mock_liiklus.go

--- a/pkg/scalers/liiklus/LiiklusService.pb.go
+++ b/pkg/scalers/liiklus/LiiklusService.pb.go
@@ -7,10 +7,10 @@
 package liiklus
 
 import (
+	empty "github.com/golang/protobuf/ptypes/empty"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	emptypb "google.golang.org/protobuf/types/known/emptypb"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -326,7 +326,6 @@ type SubscribeReply struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Reply:
-	//
 	//	*SubscribeReply_Assignment
 	Reply isSubscribeReply_Reply `protobuf_oneof:"reply"`
 }
@@ -537,7 +536,6 @@ type ReceiveReply struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Reply:
-	//
 	//	*ReceiveReply_Record_
 	Reply isReceiveReply_Reply `protobuf_oneof:"reply"`
 }
@@ -807,11 +805,11 @@ type ReceiveReply_Record struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Offset    uint64                 `protobuf:"varint,1,opt,name=offset,proto3" json:"offset,omitempty"`
-	Key       []byte                 `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
-	Value     []byte                 `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
-	Timestamp *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Replay    bool                   `protobuf:"varint,5,opt,name=replay,proto3" json:"replay,omitempty"`
+	Offset    uint64               `protobuf:"varint,1,opt,name=offset,proto3" json:"offset,omitempty"`
+	Key       []byte               `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	Value     []byte               `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
+	Timestamp *timestamp.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Replay    bool                 `protobuf:"varint,5,opt,name=replay,proto3" json:"replay,omitempty"`
 }
 
 func (x *ReceiveReply_Record) Reset() {
@@ -867,7 +865,7 @@ func (x *ReceiveReply_Record) GetValue() []byte {
 	return nil
 }
 
-func (x *ReceiveReply_Record) GetTimestamp() *timestamppb.Timestamp {
+func (x *ReceiveReply_Record) GetTimestamp() *timestamp.Timestamp {
 	if x != nil {
 		return x.Timestamp
 	}
@@ -1073,8 +1071,8 @@ var file_LiiklusService_proto_goTypes = []interface{}{
 	(*ReceiveReply_Record)(nil),           // 13: com.github.bsideup.liiklus.ReceiveReply.Record
 	nil,                                   // 14: com.github.bsideup.liiklus.GetOffsetsReply.OffsetsEntry
 	nil,                                   // 15: com.github.bsideup.liiklus.GetEndOffsetsReply.OffsetsEntry
-	(*timestamppb.Timestamp)(nil),         // 16: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),                 // 17: google.protobuf.Empty
+	(*timestamp.Timestamp)(nil),           // 16: google.protobuf.Timestamp
+	(*empty.Empty)(nil),                   // 17: google.protobuf.Empty
 }
 var file_LiiklusService_proto_depIdxs = []int32{
 	0,  // 0: com.github.bsideup.liiklus.SubscribeRequest.autoOffsetReset:type_name -> com.github.bsideup.liiklus.SubscribeRequest.AutoOffsetReset

--- a/pkg/scalers/liiklus/LiiklusService_grpc.pb.go
+++ b/pkg/scalers/liiklus/LiiklusService_grpc.pb.go
@@ -8,10 +8,10 @@ package liiklus
 
 import (
 	context "context"
+	empty "github.com/golang/protobuf/ptypes/empty"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	emptypb "google.golang.org/protobuf/types/known/emptypb"
 )
 
 // This is a compile-time assertion to ensure that this generated file
@@ -26,7 +26,7 @@ type LiiklusServiceClient interface {
 	Publish(ctx context.Context, in *PublishRequest, opts ...grpc.CallOption) (*PublishReply, error)
 	Subscribe(ctx context.Context, in *SubscribeRequest, opts ...grpc.CallOption) (LiiklusService_SubscribeClient, error)
 	Receive(ctx context.Context, in *ReceiveRequest, opts ...grpc.CallOption) (LiiklusService_ReceiveClient, error)
-	Ack(ctx context.Context, in *AckRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	Ack(ctx context.Context, in *AckRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	GetOffsets(ctx context.Context, in *GetOffsetsRequest, opts ...grpc.CallOption) (*GetOffsetsReply, error)
 	GetEndOffsets(ctx context.Context, in *GetEndOffsetsRequest, opts ...grpc.CallOption) (*GetEndOffsetsReply, error)
 }
@@ -112,8 +112,8 @@ func (x *liiklusServiceReceiveClient) Recv() (*ReceiveReply, error) {
 	return m, nil
 }
 
-func (c *liiklusServiceClient) Ack(ctx context.Context, in *AckRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	out := new(emptypb.Empty)
+func (c *liiklusServiceClient) Ack(ctx context.Context, in *AckRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	out := new(empty.Empty)
 	err := c.cc.Invoke(ctx, "/com.github.bsideup.liiklus.LiiklusService/Ack", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ type LiiklusServiceServer interface {
 	Publish(context.Context, *PublishRequest) (*PublishReply, error)
 	Subscribe(*SubscribeRequest, LiiklusService_SubscribeServer) error
 	Receive(*ReceiveRequest, LiiklusService_ReceiveServer) error
-	Ack(context.Context, *AckRequest) (*emptypb.Empty, error)
+	Ack(context.Context, *AckRequest) (*empty.Empty, error)
 	GetOffsets(context.Context, *GetOffsetsRequest) (*GetOffsetsReply, error)
 	GetEndOffsets(context.Context, *GetEndOffsetsRequest) (*GetEndOffsetsReply, error)
 	mustEmbedUnimplementedLiiklusServiceServer()
@@ -165,7 +165,7 @@ func (UnimplementedLiiklusServiceServer) Subscribe(*SubscribeRequest, LiiklusSer
 func (UnimplementedLiiklusServiceServer) Receive(*ReceiveRequest, LiiklusService_ReceiveServer) error {
 	return status.Errorf(codes.Unimplemented, "method Receive not implemented")
 }
-func (UnimplementedLiiklusServiceServer) Ack(context.Context, *AckRequest) (*emptypb.Empty, error) {
+func (UnimplementedLiiklusServiceServer) Ack(context.Context, *AckRequest) (*empty.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Ack not implemented")
 }
 func (UnimplementedLiiklusServiceServer) GetOffsets(context.Context, *GetOffsetsRequest) (*GetOffsetsReply, error) {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #3922

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
