### PR TITLE
chore: add `stale-bot-ignore` label to stale bot ignores

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - stale-bot-cant-touch-this
   - cant-touch-this
   - feature
   - security

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,8 +6,7 @@ daysUntilClose: 7
 
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - stale-bot-cant-touch-this
-  - cant-touch-this
+  - stale-bot-ignore
   - feature
   - security
   - Epic


### PR DESCRIPTION
Signed-off-by: Jorge Turrado Ferrero <Jorge_turrado@hotmail.es>

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

