### PR TITLE
fix: NewRelic scaler crashes on logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General:** Provide patch for CVE-2022-3172 vulnerability ([#3690](https://github.com/kedacore/keda/issues/3690))
 - **General:** Respect optional parameter inside envs for ScaledJobs ([#3568](https://github.com/kedacore/keda/issues/3568))
 - **Azure Blob Scaler** Store forgotten logger ([#3811](https://github.com/kedacore/keda/issues/3811))
+- **New Relic Scaler** Store forgotten logger ([#3945](https://github.com/kedacore/keda/issues/3945))
 - **Prometheus Scaler:** Treat Inf the same as Null result ([#3644](https://github.com/kedacore/keda/issues/3644))
 - **NATS Jetstream:** Correctly count messages that should be redelivered (waiting for ack) towards keda value ([#3787](https://github.com/kedacore/keda/issues/3787))
 

--- a/pkg/scalers/newrelic_scaler.go
+++ b/pkg/scalers/newrelic_scaler.go
@@ -71,7 +71,8 @@ func NewNewRelicScaler(config *ScalerConfig) (Scaler, error) {
 	return &newrelicScaler{
 		metricType: metricType,
 		metadata:   meta,
-		nrClient:   nrClient}, nil
+		nrClient:   nrClient,
+		logger:     logger}, nil
 }
 
 func parseNewRelicMetadata(config *ScalerConfig, logger logr.Logger) (*newrelicMetadata, error) {


### PR DESCRIPTION
Signed-off-by: Laszlo Kishalmi <laszlo.kishalmi@partech.com>

Trivial fix for #3945. The logging was initialized, but not saved return value. Took the idea from: #3811

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #3945

