### PR TITLE
fix: add missing env var for gcp e2e and missing Semgrep stuff

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -69,6 +69,7 @@ jobs:
         id: checkout
         if: ${{ github.event.number > 0 }}
         run: |
+          apk add github-cli
           gh pr checkout ${{ github.event.number }}
 
       - run: semgrep ci --sarif --output=semgrep.sarif

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -27,6 +27,7 @@ jobs:
         env:
           AWS_RUN_IDENTITY_TESTS: true
           AZURE_RUN_WORKLOAD_IDENTITY_TESTS: true
+          GCP_RUN_IDENTITY_TESTS: true
         run: make e2e-test
 
       - name: Delete all e2e related namespaces

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,7 @@ We have a few preventive measures in place to detect security vulnerabilities:
   - Published images on GitHub Container Registry are monitored to detect new vulnerabilities so we can ship patches
 - [Whitesource Bolt for GitHub](https://www.whitesourcesoftware.com/free-developer-tools/bolt/) helps us with identifying vulnerabilities in our dependencies to raise awareness.
 - [Trivy](https://aquasecurity.github.io/trivy/latest/) helps us with identifying vulnerabilities in our dependencies and docker images to raise awareness as part of our CI.
+- [Semgrep](https://semgrep.dev/) helps us with identifying vulnerabilities in our code and docker images to raise awareness as part of our CI.
 - [GitHub's security features](https://github.com/features/security) are constantly monitoring our repo and dependencies:
   - All pull requests (PRs) are using CodeQL to scan our source code for vulnerabilities
   - Dependabot will automatically identify vulnerabilities based on GitHub Advisory Database and open PRs with patches


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

I forgot to add `GCP_RUN_IDENTITY_TESTS: true` in the main-e2e workflow and that makes gcp_wi e2e tests to fail because the needed resources aren't deployed into the cluster. This PR solves it.
This PR also adds some missing things for semgrep

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/3961
