### PR TITLE
fix: use net.JoinHostPort and fix semgrep pipeline

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -80,4 +80,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: semgrep.sarif
-        if: github.ref == 'refs/heads/main'
+        if: ${{ github.event.number == '' }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -80,4 +80,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: semgrep.sarif
-        if: ${{ github.event.number == '' }}
+        if: ${{ github.event.number == '' && !cancelled() }} 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -80,4 +80,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: semgrep.sarif
-        if: ${{ github.event.number == '' && !cancelled() }} 
+        if: ${{ github.event.number == '' && !cancelled() }}

--- a/pkg/scalers/cassandra_scaler.go
+++ b/pkg/scalers/cassandra_scaler.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -111,7 +112,7 @@ func parseCassandraMetadata(config *ScalerConfig) (*CassandraMetadata, error) {
 	if val, ok := config.TriggerMetadata["clusterIPAddress"]; ok {
 		switch p := meta.port; {
 		case p > 0:
-			meta.clusterIPAddress = fmt.Sprintf("%s:%d", val, meta.port)
+			meta.clusterIPAddress = net.JoinHostPort(val, fmt.Sprintf("%d", meta.port))
 		case strings.Contains(val, ":"):
 			meta.clusterIPAddress = val
 		default:

--- a/pkg/scalers/mongo_scaler.go
+++ b/pkg/scalers/mongo_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"time"
 
@@ -187,7 +188,7 @@ func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error
 		connStr = meta.connectionString
 	} else {
 		// Build connection str
-		addr := fmt.Sprintf("%s:%s", meta.host, meta.port)
+		addr := net.JoinHostPort(meta.host, meta.port)
 		auth := fmt.Sprintf("%s:%s", meta.username, meta.password)
 		connStr = "mongodb://" + auth + "@" + addr + "/" + meta.dbName
 	}

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 
@@ -216,7 +217,7 @@ func getMSSQLConnectionString(meta *mssqlMetadata) string {
 		}
 
 		if meta.port > 0 {
-			connectionURL.Host = fmt.Sprintf("%s:%d", meta.host, meta.port)
+			connectionURL.Host = net.JoinHostPort(meta.host, fmt.Sprintf("%d", meta.port))
 		} else {
 			connectionURL.Host = meta.host
 		}

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -145,7 +146,7 @@ func metadataToConnectionStr(meta *mySQLMetadata) string {
 	} else {
 		// Build connection str
 		config := mysql.NewConfig()
-		config.Addr = fmt.Sprintf("%s:%s", meta.host, meta.port)
+		config.Addr = net.JoinHostPort(meta.host, meta.port)
 		config.DBName = meta.dbName
 		config.Passwd = meta.password
 		config.User = meta.username

--- a/pkg/scalers/predictkube_scaler.go
+++ b/pkg/scalers/predictkube_scaler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -124,7 +125,7 @@ func (s *PredictKubeScaler) setupClientConn() error {
 		return err
 	}
 
-	s.grpcConn, err = grpc.Dial(fmt.Sprintf("%s:%d", mlEngineHost, mlEnginePort), clientOpt...)
+	s.grpcConn, err = grpc.Dial(net.JoinHostPort(mlEngineHost, fmt.Sprintf("%d", mlEnginePort)), clientOpt...)
 	if err != nil {
 		return err
 	}

--- a/pkg/scalers/redis_scaler.go
+++ b/pkg/scalers/redis_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -292,7 +293,7 @@ func parseRedisAddress(metadata, resolvedEnv, authParams map[string]string) (red
 		}
 
 		if len(info.hosts) != 0 && len(info.ports) != 0 {
-			info.addresses = append(info.addresses, fmt.Sprintf("%s:%s", info.hosts[0], info.ports[0]))
+			info.addresses = append(info.addresses, net.JoinHostPort(info.hosts[0], info.ports[0]))
 		}
 	}
 
@@ -360,7 +361,7 @@ func parseRedisMultipleAddress(metadata, resolvedEnv, authParams map[string]stri
 				return info, fmt.Errorf("not enough hosts or ports given. number of hosts should be equal to the number of ports")
 			}
 			for i := range info.hosts {
-				info.addresses = append(info.addresses, fmt.Sprintf("%s:%s", info.hosts[i], info.ports[i]))
+				info.addresses = append(info.addresses, net.JoinHostPort(info.hosts[i], info.ports[i]))
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

After adding semgrep, some alerts about using fmt.Sprintf($XX, $NET) instead of net.JoinHostPort were raised. This PR solves them replacing all the cases with net.JoinHostPort


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

