### PR TITLE
chore: v2.9 is delayed to Dec 9th

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ Here is an overview of our current release estimations:
 
 | Version | Estimated Release Date |
 |:--------|:-----------------------|
-| v2.9    | Dec 8th, 2022          |
+| v2.9    | Dec 9th, 2022          |
 | v2.10   | March 2nd, 2023        |
 | v2.11   | June 6th, 2023         |
 


### PR DESCRIPTION
v2.9 is delayed to Dec 9th to close all open PRs that are required.

#3968 