### PR TITLE
fix(mongodb): escape username and password

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -138,7 +138,10 @@ Follow these instructions if you want to debug the KEDA operator using VS Code.
             "request": "launch",
             "mode": "debug",
             "program": "${workspaceFolder}/main.go",
-            "env": {"WATCH_NAMESPACE": ""}
+            "env": {
+                "WATCH_NAMESPACE": "",
+                "KEDA_CLUSTER_OBJECT_NAMESPACE": "keda"
+            }
         }
     ]
    }
@@ -171,7 +174,10 @@ Follow these instructions if you want to debug the KEDA metrics server using VS 
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}/adapter/main.go",
-            "env": {"WATCH_NAMESPACE": ""},
+            "env": {
+                "WATCH_NAMESPACE": "",
+                "KEDA_CLUSTER_OBJECT_NAMESPACE": "keda"
+            },
             "args": [
                 "--authentication-kubeconfig=PATH_TO_YOUR_KUBECONFIG",
                 "--authentication-skip-lookup",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Blob Scaler** Store forgotten logger ([#3811](https://github.com/kedacore/keda/issues/3811))
 - **Datadog Scaler** The last data point of some specific query is always null ([#3906](https://github.com/kedacore/keda/issues/3906))
 - **GCP Stackdriver Scalar:** Update Stackdriver client to handle detecting double and int64 value types ([#3777](https://github.com/kedacore/keda/issues/3777))
+- **MongoDB Scaler:** Username/password can contain `:/?#[]@` ([#3992](https://github.com/kedacore/keda/issues/3992))
 - **New Relic Scaler** Store forgotten logger ([#3945](https://github.com/kedacore/keda/issues/3945))
 - **Prometheus Scaler:** Treat Inf the same as Null result ([#3644](https://github.com/kedacore/keda/issues/3644))
 - **NATS Jetstream:** Correctly count messages that should be redelivered (waiting for ack) towards keda value ([#3787](https://github.com/kedacore/keda/issues/3787))

--- a/pkg/scalers/couchdb_scaler.go
+++ b/pkg/scalers/couchdb_scaler.go
@@ -178,8 +178,6 @@ func parseCouchDBMetadata(config *ScalerConfig) (*couchDBMetadata, string, error
 	} else {
 		// Build connection str
 		addr := net.JoinHostPort(meta.host, meta.port)
-		// addr := fmt.Sprintf("%s:%s", meta.host, meta.port)
-		// auth := fmt.Sprintf("%s:%s", meta.username, meta.password)
 		connStr = "http://" + addr
 	}
 	if val, ok := config.TriggerMetadata["metricName"]; ok {

--- a/pkg/scalers/mongo_scaler.go
+++ b/pkg/scalers/mongo_scaler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -189,8 +190,7 @@ func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error
 	} else {
 		// Build connection str
 		addr := net.JoinHostPort(meta.host, meta.port)
-		auth := fmt.Sprintf("%s:%s", meta.username, meta.password)
-		connStr = "mongodb://" + auth + "@" + addr + "/" + meta.dbName
+		connStr = fmt.Sprintf("mongodb://%s:%s@%s/%s", url.QueryEscape(meta.username), url.QueryEscape(meta.password), addr, meta.dbName)
 	}
 
 	if val, ok := config.TriggerMetadata["metricName"]; ok {


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

If either the username or password contains a character in the set  :/?#[]@  ,  it must be percent-encoded or the scaler will fail.

### Checklist

- [x] Tests have been added
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/3992