### PR TITLE
chore: Add KEDA v2.12 to our roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,16 +14,17 @@ Here is an overview of our current release estimations:
 
 | Version | Estimated Release Date |
 |:--------|:-----------------------|
-| v2.9    | Dec 9th, 2022          |
 | v2.10   | March 2nd, 2023        |
 | v2.11   | June 6th, 2023         |
+| v2.12   | September 5th, 2023    |
 
 Here is an overview of our previous releases:
 
-| Version | Release Date  | Links             |
-|:--------|:--------------|:------------------|
+| Version | Release Date      | Links                                                                 |
+|:--------|:------------------|:----------------------------------------------------------------------|
+| v2.9    | Dec 9th, 2022     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.9.0) |
 | v2.8    | August 10th, 2022 | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.8.0) |
-| v2.7    | May 5th, 2022 | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.7.0) |
+| v2.7    | May 5th, 2022     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.7.0) |
 
 ## Using our roadmap
 


### PR DESCRIPTION
Add KEDA v2.12 to our roadmap

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/3968#
