### PR TITLE
refactor(scaler): compare error with `errors.Is`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ New deprecation(s):
 ### Other
 
 - **RabbitMQ Scaler:** Move from `streadway/amqp` to `rabbitmq/amqp091-go` ([#4004](https://github.com/kedacore/keda/pull/4039))
+- **General:** Compare error with `errors.Is` ([#4004](https://github.com/kedacore/keda/pull/4004))
 
 ## v2.9.1
 

--- a/pkg/scalers/aws_common.go
+++ b/pkg/scalers/aws_common.go
@@ -1,6 +1,7 @@
 package scalers
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -8,6 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
+
+// ErrAwsNoAccessKey is returned when awsAccessKeyID is missing.
+var ErrAwsNoAccessKey = errors.New("awsAccessKeyID not found")
 
 type awsAuthorizationMetadata struct {
 	awsRoleArn string
@@ -81,7 +85,7 @@ func getAwsAuthorization(authParams, metadata, resolvedEnv map[string]string) (a
 			}
 
 			if len(meta.awsAccessKeyID) == 0 {
-				return meta, fmt.Errorf("awsAccessKeyID not found")
+				return meta, ErrAwsNoAccessKey
 			}
 
 			if metadata["awsSecretAccessKeyFromEnv"] != "" {

--- a/pkg/scalers/azure/azure_blob_test.go
+++ b/pkg/scalers/azure/azure_blob_test.go
@@ -2,8 +2,9 @@ package azure
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 	"net/http"
-	"strings"
 	"testing"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -22,7 +23,7 @@ func TestGetBlobLength(t *testing.T) {
 		t.Error("Expected error for empty connection string, but got nil")
 	}
 
-	if !strings.Contains(err.Error(), "parse storage connection string") {
+	if !errors.Is(err, ErrAzureConnectionStringKeyName) {
 		t.Error("Expected error to contain parsing error message, but got", err.Error())
 	}
 
@@ -37,7 +38,8 @@ func TestGetBlobLength(t *testing.T) {
 		t.Error("Expected error for empty connection string, but got nil")
 	}
 
-	if !strings.Contains(err.Error(), "illegal base64") {
+	var base64Error base64.CorruptInputError
+	if !errors.As(err, &base64Error) {
 		t.Error("Expected error to contain base64 error message, but got", err.Error())
 	}
 }

--- a/pkg/scalers/azure/azure_queue_test.go
+++ b/pkg/scalers/azure/azure_queue_test.go
@@ -2,8 +2,9 @@ package azure
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 	"net/http"
-	"strings"
 	"testing"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -19,7 +20,7 @@ func TestGetQueueLength(t *testing.T) {
 		t.Error("Expected error for empty connection string, but got nil")
 	}
 
-	if !strings.Contains(err.Error(), "parse storage connection string") {
+	if !errors.Is(err, ErrAzureConnectionStringKeyName) {
 		t.Error("Expected error to contain parsing error message, but got", err.Error())
 	}
 
@@ -33,7 +34,8 @@ func TestGetQueueLength(t *testing.T) {
 		t.Error("Expected error for empty connection string, but got nil")
 	}
 
-	if !strings.Contains(err.Error(), "illegal base64") {
+	var base64Error base64.CorruptInputError
+	if !errors.As(err, &base64Error) {
 		t.Error("Expected error to contain base64 error message, but got", err.Error())
 	}
 }

--- a/pkg/scalers/azure/azure_storage.go
+++ b/pkg/scalers/azure/azure_storage.go
@@ -55,6 +55,14 @@ const (
 	storageResource = "https://storage.azure.com/"
 )
 
+var (
+	// ErrAzureConnectionStringKeyName indicates an error in the connection string AccountKey or AccountName.
+	ErrAzureConnectionStringKeyName = errors.New("can't parse storage connection string. Missing key or name")
+
+	// ErrAzureConnectionStringEndpoint indicates an error in the connection string DefaultEndpointsProtocol or EndpointSuffix.
+	ErrAzureConnectionStringEndpoint = errors.New("can't parse storage connection string. Missing DefaultEndpointsProtocol or EndpointSuffix")
+)
+
 // Prefix returns prefix for a StorageEndpointType
 func (e StorageEndpointType) Prefix() string {
 	return [...]string{"BlobEndpoint", "QueueEndpoint", "TableEndpoint", "FileEndpoint"}[e]
@@ -169,7 +177,7 @@ func parseAzureStorageConnectionString(connectionString string, endpointType Sto
 	}
 
 	if name == "" || key == "" {
-		return nil, "", "", errors.New("can't parse storage connection string. Missing key or name")
+		return nil, "", "", ErrAzureConnectionStringKeyName
 	}
 
 	if endpoint != "" {
@@ -181,7 +189,7 @@ func parseAzureStorageConnectionString(connectionString string, endpointType Sto
 	}
 
 	if endpointProtocol == "" || endpointSuffix == "" {
-		return nil, "", "", errors.New("can't parse storage connection string. Missing DefaultEndpointsProtocol or EndpointSuffix")
+		return nil, "", "", ErrAzureConnectionStringEndpoint
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s://%s.%s.%s", endpointProtocol, name, endpointType.Name(), endpointSuffix))

--- a/pkg/scalers/gcp_storage_scaler.go
+++ b/pkg/scalers/gcp_storage_scaler.go
@@ -2,9 +2,9 @@ package scalers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/go-logr/logr"
@@ -206,7 +206,7 @@ func (s *gcsScaler) getItemCount(ctx context.Context, maxCount int64) (int64, er
 			break
 		}
 		if err != nil {
-			if strings.Contains(err.Error(), "bucket doesn't exist") {
+			if errors.Is(err, storage.ErrBucketNotExist) {
 				s.logger.Info("Bucket " + s.metadata.bucketName + " doesn't exist")
 				return 0, nil
 			}

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -46,6 +46,17 @@ const (
 	liiklusMetricType                       = "External"
 )
 
+var (
+	// ErrLiiklusNoTopic is returned when "topic" in the config is empty.
+	ErrLiiklusNoTopic = errors.New("no topic provided")
+
+	// ErrLiiklusNoAddress is returned when "address" in the config is empty.
+	ErrLiiklusNoAddress = errors.New("no liiklus API address provided")
+
+	// ErrLiiklusNoGroup is returned when "group" in the config is empty.
+	ErrLiiklusNoGroup = errors.New("no consumer group provided")
+)
+
 // NewLiiklusScaler creates a new liiklusScaler scaler
 func NewLiiklusScaler(config *ScalerConfig) (Scaler, error) {
 	metricType, err := GetMetricTargetType(config)
@@ -157,7 +168,7 @@ func parseLiiklusMetadata(config *ScalerConfig) (*liiklusMetadata, error) {
 	if val, ok := config.TriggerMetadata[liiklusActivationLagThresholdMetricName]; ok {
 		t, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing %s: %s", liiklusActivationLagThresholdMetricName, err)
+			return nil, fmt.Errorf("error parsing %s: %w", liiklusActivationLagThresholdMetricName, err)
 		}
 		activationLagThreshold = t
 	}
@@ -173,11 +184,11 @@ func parseLiiklusMetadata(config *ScalerConfig) (*liiklusMetadata, error) {
 
 	switch {
 	case config.TriggerMetadata["topic"] == "":
-		return nil, errors.New("no topic provided")
+		return nil, ErrLiiklusNoTopic
 	case config.TriggerMetadata["address"] == "":
-		return nil, errors.New("no liiklus API address provided")
+		return nil, ErrLiiklusNoAddress
 	case config.TriggerMetadata["group"] == "":
-		return nil, errors.New("no consumer group provided")
+		return nil, ErrLiiklusNoGroup
 	}
 
 	return &liiklusMetadata{

--- a/pkg/scalers/liiklus_scaler_test.go
+++ b/pkg/scalers/liiklus_scaler_test.go
@@ -2,11 +2,12 @@ package scalers
 
 import (
 	"context"
+	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
-	"github.com/pkg/errors"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/liiklus"
 	mock_liiklus "github.com/kedacore/keda/v2/pkg/scalers/liiklus/mocks"
@@ -28,11 +29,11 @@ type liiklusMetricIdentifier struct {
 }
 
 var parseLiiklusMetadataTestDataset = []parseLiiklusMetadataTestData{
-	{map[string]string{}, errors.New("no topic provided"), "", "", "", 0},
-	{map[string]string{"topic": "foo"}, errors.New("no liiklus API address provided"), "", "", "", 0},
-	{map[string]string{"topic": "foo", "address": "bar:6565"}, errors.New("no consumer group provided"), "", "", "", 0},
+	{map[string]string{}, ErrLiiklusNoTopic, "", "", "", 0},
+	{map[string]string{"topic": "foo"}, ErrLiiklusNoAddress, "", "", "", 0},
+	{map[string]string{"topic": "foo", "address": "bar:6565"}, ErrLiiklusNoGroup, "", "", "", 0},
 	{map[string]string{"topic": "foo", "address": "bar:6565", "group": "mygroup"}, nil, "bar:6565", "mygroup", "foo", 10},
-	{map[string]string{"topic": "foo", "address": "bar:6565", "group": "mygroup", "activationLagThreshold": "aa"}, errors.New("error parsing activationLagThreshold: strconv.ParseInt: parsing \"aa\": invalid syntax"), "bar:6565", "mygroup", "foo", 10},
+	{map[string]string{"topic": "foo", "address": "bar:6565", "group": "mygroup", "activationLagThreshold": "aa"}, strconv.ErrSyntax, "bar:6565", "mygroup", "foo", 10},
 	{map[string]string{"topic": "foo", "address": "bar:6565", "group": "mygroup", "lagThreshold": "15"}, nil, "bar:6565", "mygroup", "foo", 15},
 }
 
@@ -52,7 +53,7 @@ func TestLiiklusParseMetadata(t *testing.T) {
 			t.Error("Expected error but got success")
 			continue
 		}
-		if testData.err != nil && err != nil && testData.err.Error() != err.Error() {
+		if testData.err != nil && err != nil && !errors.Is(err, testData.err) {
 			t.Errorf("Expected error %v but got %v", testData.err, err)
 			continue
 		}

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -15,6 +16,14 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
+)
+
+var (
+	// ErrMsSQLNoQuery is returned when "query" is missing from the config.
+	ErrMsSQLNoQuery = errors.New("no query given")
+
+	// ErrMsSQLNoTargetValue is returned when "targetValue" is missing from the config.
+	ErrMsSQLNoTargetValue = errors.New("no targetValue given")
 )
 
 // mssqlScaler exposes a data pointer to mssqlMetadata and sql.DB connection
@@ -98,7 +107,7 @@ func parseMSSQLMetadata(config *ScalerConfig) (*mssqlMetadata, error) {
 	if val, ok := config.TriggerMetadata["query"]; ok {
 		meta.query = val
 	} else {
-		return nil, fmt.Errorf("no query given")
+		return nil, ErrMsSQLNoQuery
 	}
 
 	// Target query value
@@ -109,7 +118,7 @@ func parseMSSQLMetadata(config *ScalerConfig) (*mssqlMetadata, error) {
 		}
 		meta.targetValue = targetValue
 	} else {
-		return nil, fmt.Errorf("no targetValue given")
+		return nil, ErrMsSQLNoTargetValue
 	}
 
 	// Activation target value

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -92,21 +92,21 @@ var testInputs = []mssqlTestData{
 		metadata:      map[string]string{"targetValue": "1"},
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{"connectionString": "sqlserver://localhost"},
-		expectedError: errors.New("no query given"),
+		expectedError: ErrMsSQLNoQuery,
 	},
 	// Error: missing targetValue
 	{
 		metadata:      map[string]string{"query": "SELECT 1"},
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{"connectionString": "sqlserver://localhost"},
-		expectedError: errors.New("no targetValue given"),
+		expectedError: ErrMsSQLNoTargetValue,
 	},
 	// Error: missing host
 	{
 		metadata:      map[string]string{"query": "SELECT 1", "targetValue": "1"},
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{},
-		expectedError: errors.New("no host given"),
+		expectedError: ErrScalerConfigMissingField,
 	},
 }
 
@@ -122,7 +122,7 @@ func TestMSSQLMetadataParsing(t *testing.T) {
 		if err != nil {
 			if testData.expectedError == nil {
 				t.Errorf("Unexpected error parsing input metadata: %v", err)
-			} else if testData.expectedError.Error() != err.Error() {
+			} else if !errors.Is(err, testData.expectedError) {
 				t.Errorf("Expected error '%v' but got '%v'", testData.expectedError, err)
 			}
 

--- a/pkg/scalers/redis_scaler_test.go
+++ b/pkg/scalers/redis_scaler_test.go
@@ -2,7 +2,7 @@ package scalers
 
 import (
 	"context"
-	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -114,7 +114,7 @@ func TestParseRedisClusterMetadata(t *testing.T) {
 		{
 			name:     "empty metadata",
 			wantMeta: nil,
-			wantErr:  errors.New("no addresses or hosts given. address should be a comma separated list of host:port or set the host/port values"),
+			wantErr:  ErrRedisNoAddresses,
 		},
 		{
 			name: "unequal number of hosts/ports",
@@ -123,7 +123,7 @@ func TestParseRedisClusterMetadata(t *testing.T) {
 				"ports": "1, 2",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("not enough hosts or ports given. number of hosts should be equal to the number of ports"),
+			wantErr:  ErrRedisUnequalHostsAndPorts,
 		},
 		{
 			name: "no list name",
@@ -133,7 +133,7 @@ func TestParseRedisClusterMetadata(t *testing.T) {
 				"listLength": "5",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("no list name given"),
+			wantErr:  ErrRedisNoListName,
 		},
 		{
 			name: "invalid list length",
@@ -144,7 +144,7 @@ func TestParseRedisClusterMetadata(t *testing.T) {
 				"listLength": "invalid",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("list length parsing error"),
+			wantErr:  strconv.ErrSyntax,
 		},
 		{
 			name: "address is defined in auth params",
@@ -345,7 +345,7 @@ func TestParseRedisClusterMetadata(t *testing.T) {
 			}
 			meta, err := parseRedisMetadata(config, parseRedisClusterAddress)
 			if c.wantErr != nil {
-				assert.Contains(t, err.Error(), c.wantErr.Error())
+				assert.ErrorIs(t, err, c.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -366,7 +366,7 @@ func TestParseRedisSentinelMetadata(t *testing.T) {
 		{
 			name:     "empty metadata",
 			wantMeta: nil,
-			wantErr:  errors.New("no addresses or hosts given. address should be a comma separated list of host:port or set the host/port values"),
+			wantErr:  ErrRedisNoAddresses,
 		},
 		{
 			name: "unequal number of hosts/ports",
@@ -375,7 +375,7 @@ func TestParseRedisSentinelMetadata(t *testing.T) {
 				"ports": "1, 2",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("not enough hosts or ports given. number of hosts should be equal to the number of ports"),
+			wantErr:  ErrRedisUnequalHostsAndPorts,
 		},
 		{
 			name: "no list name",
@@ -385,7 +385,7 @@ func TestParseRedisSentinelMetadata(t *testing.T) {
 				"listLength": "5",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("no list name given"),
+			wantErr:  ErrRedisNoListName,
 		},
 		{
 			name: "invalid list length",
@@ -396,7 +396,7 @@ func TestParseRedisSentinelMetadata(t *testing.T) {
 				"listLength": "invalid",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("list length parsing error"),
+			wantErr:  strconv.ErrSyntax,
 		},
 		{
 			name: "address is defined in auth params",
@@ -791,7 +791,7 @@ func TestParseRedisSentinelMetadata(t *testing.T) {
 			}
 			meta, err := parseRedisMetadata(config, parseRedisSentinelAddress)
 			if c.wantErr != nil {
-				assert.Contains(t, err.Error(), c.wantErr.Error())
+				assert.ErrorIs(t, err, c.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/scalers/redis_streams_scaler_test.go
+++ b/pkg/scalers/redis_streams_scaler_test.go
@@ -2,7 +2,6 @@ package scalers
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"testing"
 
@@ -168,7 +167,7 @@ func TestParseRedisClusterStreamsMetadata(t *testing.T) {
 		{
 			name:     "empty metadata",
 			wantMeta: nil,
-			wantErr:  errors.New("no addresses or hosts given. address should be a comma separated list of host:port or set the host/port values"),
+			wantErr:  ErrRedisNoAddresses,
 		},
 		{
 			name: "unequal number of hosts/ports",
@@ -177,7 +176,7 @@ func TestParseRedisClusterStreamsMetadata(t *testing.T) {
 				"ports": "1, 2",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("not enough hosts or ports given. number of hosts should be equal to the number of ports"),
+			wantErr:  ErrRedisUnequalHostsAndPorts,
 		},
 		{
 			name: "no stream name",
@@ -187,7 +186,7 @@ func TestParseRedisClusterStreamsMetadata(t *testing.T) {
 				"pendingEntriesCount": "5",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("missing redis stream name"),
+			wantErr:  ErrRedisMissingStreamName,
 		},
 		{
 			name: "missing pending entries count",
@@ -197,7 +196,7 @@ func TestParseRedisClusterStreamsMetadata(t *testing.T) {
 				"stream": "my-stream",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("missing pending entries count"),
+			wantErr:  ErrRedisMissingPendingEntriesCount,
 		},
 		{
 			name: "invalid pending entries count",
@@ -207,7 +206,7 @@ func TestParseRedisClusterStreamsMetadata(t *testing.T) {
 				"pendingEntriesCount": "invalid",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("error parsing pending entries count"),
+			wantErr:  strconv.ErrSyntax,
 		},
 		{
 			name: "address is defined in auth params",
@@ -445,7 +444,7 @@ func TestParseRedisClusterStreamsMetadata(t *testing.T) {
 			}
 			meta, err := parseRedisStreamsMetadata(config, parseRedisClusterAddress)
 			if c.wantErr != nil {
-				assert.Contains(t, err.Error(), c.wantErr.Error())
+				assert.ErrorIs(t, err, c.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -466,7 +465,7 @@ func TestParseRedisSentinelStreamsMetadata(t *testing.T) {
 		{
 			name:     "empty metadata",
 			wantMeta: nil,
-			wantErr:  errors.New("no addresses or hosts given. address should be a comma separated list of host:port or set the host/port values"),
+			wantErr:  ErrRedisNoAddresses,
 		},
 		{
 			name: "unequal number of hosts/ports",
@@ -475,7 +474,7 @@ func TestParseRedisSentinelStreamsMetadata(t *testing.T) {
 				"ports": "1, 2",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("not enough hosts or ports given. number of hosts should be equal to the number of ports"),
+			wantErr:  ErrRedisUnequalHostsAndPorts,
 		},
 		{
 			name: "no stream name",
@@ -485,7 +484,7 @@ func TestParseRedisSentinelStreamsMetadata(t *testing.T) {
 				"pendingEntriesCount": "5",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("missing redis stream name"),
+			wantErr:  ErrRedisMissingStreamName,
 		},
 		{
 			name: "missing pending entries count",
@@ -495,7 +494,7 @@ func TestParseRedisSentinelStreamsMetadata(t *testing.T) {
 				"stream": "my-stream",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("missing pending entries count"),
+			wantErr:  ErrRedisMissingPendingEntriesCount,
 		},
 		{
 			name: "invalid pending entries count",
@@ -505,7 +504,7 @@ func TestParseRedisSentinelStreamsMetadata(t *testing.T) {
 				"pendingEntriesCount": "invalid",
 			},
 			wantMeta: nil,
-			wantErr:  errors.New("error parsing pending entries count"),
+			wantErr:  strconv.ErrSyntax,
 		},
 		{
 			name: "address is defined in auth params",
@@ -941,7 +940,7 @@ func TestParseRedisSentinelStreamsMetadata(t *testing.T) {
 			}
 			meta, err := parseRedisStreamsMetadata(config, parseRedisSentinelAddress)
 			if c.wantErr != nil {
-				assert.Contains(t, err.Error(), c.wantErr.Error())
+				assert.ErrorIs(t, err, c.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -18,6 +18,7 @@ package scalers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -100,6 +101,10 @@ type ScalerConfig struct {
 	MetricType v2.MetricTargetType
 }
 
+// ErrScalerUnsupportedUtilizationMetricType is returned when v2.UtilizationMetricType
+// is provided as the metric target type for scaler.
+var ErrScalerUnsupportedUtilizationMetricType = errors.New("'Utilization' metric type is unsupported for external metrics, allowed values are 'Value' or 'AverageValue'")
+
 // GetFromAuthOrMeta helps getting a field from Auth or Meta sections
 func GetFromAuthOrMeta(config *ScalerConfig, field string) (string, error) {
 	var result string
@@ -143,7 +148,7 @@ func InitializeLogger(config *ScalerConfig, scalerName string) logr.Logger {
 func GetMetricTargetType(config *ScalerConfig) (v2.MetricTargetType, error) {
 	switch config.MetricType {
 	case v2.UtilizationMetricType:
-		return "", fmt.Errorf("'Utilization' metric type is unsupported for external metrics, allowed values are 'Value' or 'AverageValue'")
+		return "", ErrScalerUnsupportedUtilizationMetricType
 	case "":
 		// Use AverageValue if no metric type was provided
 		return v2.AverageValueMetricType, nil

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -101,9 +101,14 @@ type ScalerConfig struct {
 	MetricType v2.MetricTargetType
 }
 
-// ErrScalerUnsupportedUtilizationMetricType is returned when v2.UtilizationMetricType
-// is provided as the metric target type for scaler.
-var ErrScalerUnsupportedUtilizationMetricType = errors.New("'Utilization' metric type is unsupported for external metrics, allowed values are 'Value' or 'AverageValue'")
+var (
+	// ErrScalerUnsupportedUtilizationMetricType is returned when v2.UtilizationMetricType
+	// is provided as the metric target type for scaler.
+	ErrScalerUnsupportedUtilizationMetricType = errors.New("'Utilization' metric type is unsupported for external metrics, allowed values are 'Value' or 'AverageValue'")
+
+	// ErrScalerConfigMissingField is returned when a required field is missing from the scaler config.
+	ErrScalerConfigMissingField = errors.New("missing required field in scaler config")
+)
 
 // GetFromAuthOrMeta helps getting a field from Auth or Meta sections
 func GetFromAuthOrMeta(config *ScalerConfig, field string) (string, error) {
@@ -115,7 +120,7 @@ func GetFromAuthOrMeta(config *ScalerConfig, field string) (string, error) {
 		result = config.TriggerMetadata[field]
 	}
 	if result == "" {
-		err = fmt.Errorf("no %s given", field)
+		err = fmt.Errorf("%w: no %s given", ErrScalerConfigMissingField, field)
 	}
 	return result, err
 }

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -1,7 +1,6 @@
 package scalers
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,7 @@ func TestGetMetricTargetType(t *testing.T) {
 			name:           "utilization metric type",
 			config:         &ScalerConfig{MetricType: v2.UtilizationMetricType},
 			wantmetricType: "",
-			wantErr:        fmt.Errorf("'Utilization' metric type is unsupported for external metrics, allowed values are 'Value' or 'AverageValue'"),
+			wantErr:        ErrScalerUnsupportedUtilizationMetricType,
 		},
 		{
 			name:           "average value metric type",
@@ -47,7 +46,7 @@ func TestGetMetricTargetType(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			metricType, err := GetMetricTargetType(c.config)
 			if c.wantErr != nil {
-				assert.Contains(t, err.Error(), c.wantErr.Error())
+				assert.ErrorIs(t, err, c.wantErr)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
Starting from Go 1.13, errors.Is is the preferable way to compare error equality.

Reference: https://go.dev/blog/go1.13-errors

### Checklist

- [x] ~~When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)~~
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] ~~Tests have been added~~
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] ~~A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~~
- [x] ~~A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*~~
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
