### PR TITLE
fix: properly retrieve and close scalers cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/keda/issues/TODO))
+- **General**: Properly retrieve and close scalers cache ([#4011](https://github.com/kedacore/keda/issues/4011))
 
 ### Deprecations
 

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -36,9 +36,10 @@ import (
 var log = logf.Log.WithName("scalers_cache")
 
 type ScalersCache struct {
-	ScaledObject *kedav1alpha1.ScaledObject
-	Scalers      []ScalerBuilder
-	Recorder     record.EventRecorder
+	ScaledObject             *kedav1alpha1.ScaledObject
+	Scalers                  []ScalerBuilder
+	ScalableObjectGeneration int64
+	Recorder                 record.EventRecorder
 }
 
 type ScalerBuilder struct {


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The latest refactoring done in https://github.com/kedacore/keda/issues/2282 introduced a regression in ScaledJobs. Scalers cache hasn't been used and a new scaler(and connection) has been opened for each request.

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4011

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/2282
