### PR TITLE
fix(az key vault): Raise an error instead of panic if authentication not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Here is an overview of all new **experimental** features:
 ### Fixes
 
 - **General**: Properly retrieve and close scalers cache ([#4011](https://github.com/kedacore/keda/issues/4011))
+- **Azure Key Vault:** Raise an error if authentication mechanism not provided ([#4010](https://github.com/kedacore/keda/issues/4010))
 
 ### Deprecations
 

--- a/pkg/scaling/resolver/azure_keyvault_handler.go
+++ b/pkg/scaling/resolver/azure_keyvault_handler.go
@@ -109,6 +109,11 @@ func (vh *AzureKeyVaultHandler) getAuthConfig(ctx context.Context, client client
 	}
 	switch podIdentity.Provider {
 	case "", kedav1alpha1.PodIdentityProviderNone:
+		missingErr := fmt.Errorf("clientID, tenantID and clientSecret are expected when not using a pod identity provider")
+		if vh.vault.Credentials == nil {
+			return nil, missingErr
+		}
+
 		clientID := vh.vault.Credentials.ClientID
 		tenantID := vh.vault.Credentials.TenantID
 
@@ -117,7 +122,7 @@ func (vh *AzureKeyVaultHandler) getAuthConfig(ctx context.Context, client client
 		clientSecret := resolveAuthSecret(ctx, client, logger, clientSecretName, triggerNamespace, clientSecretKey, secretsLister)
 
 		if clientID == "" || tenantID == "" || clientSecret == "" {
-			return nil, fmt.Errorf("clientID, tenantID and clientSecret are expected when not using a pod identity provider")
+			return nil, missingErr
 		}
 
 		config := auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID)


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4010

