### PR TITLE
fix: Logging for cpu memory scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/keda/issues/TODO))
+- **CPU Memory Scaler** Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))
 
 ### Deprecations
 

--- a/pkg/scalers/cpu_memory_scaler.go
+++ b/pkg/scalers/cpu_memory_scaler.go
@@ -15,6 +15,7 @@ import (
 type cpuMemoryScaler struct {
 	metadata     *cpuMemoryMetadata
 	resourceName v1.ResourceName
+	logger       logr.Logger
 }
 
 type cpuMemoryMetadata struct {
@@ -36,6 +37,7 @@ func NewCPUMemoryScaler(resourceName v1.ResourceName, config *ScalerConfig) (Sca
 	return &cpuMemoryScaler{
 		metadata:     meta,
 		resourceName: resourceName,
+		logger:       logger,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

I did a scan through all existing scalers and found out cpu_memory_scaler has the same issue, hence I create this MR to fix the initialization of logger

### Checklist
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #3947 

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
