### PR TITLE
feat: Kafka scaler move sasl and tls config to TriggerAuthentication metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Breaking Changes
 
-- TODO
+- Kafka: Move `sasl` and `tls` config to `TriggerAuthentication` metadata ([#4024](https://github.com/kedacore/keda/pull/4024))
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Breaking Changes
 
-- Kafka: Move `sasl` and `tls` config to `TriggerAuthentication` metadata ([#4024](https://github.com/kedacore/keda/pull/4024))
-
 ### New
 
 Here is an overview of all **stable** additions:
@@ -55,6 +53,7 @@ Here is an overview of all new **experimental** features:
 - **General**: TODO ([#TODO](https://github.com/kedacore/keda/issues/TODO))
 
 ### Improvements
+- Kafka: Support setting `sasl` and `tls` in `TriggerAuthentication` metadata ([#4024](https://github.com/kedacore/keda/pull/4024))
 
 - **Redis**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))
 

--- a/pkg/scalers/arangodb_scaler.go
+++ b/pkg/scalers/arangodb_scaler.go
@@ -133,7 +133,7 @@ func parseArangoDBMetadata(config *ScalerConfig) (*arangoDBMetadata, error) {
 	meta := arangoDBMetadata{}
 
 	// parse metaData from ScaledJob config
-	endpoints, err := GetFromAuthOrMeta(config, "endpoints")
+	endpoints, err := GetFromAuthOrMeta(config, "endpoints", false)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func parseArangoDBMetadata(config *ScalerConfig) (*arangoDBMetadata, error) {
 		meta.activationQueryValue = activationQueryValue
 	}
 
-	dbName, err := GetFromAuthOrMeta(config, "dbName")
+	dbName, err := GetFromAuthOrMeta(config, "dbName", false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/couchdb_scaler.go
+++ b/pkg/scalers/couchdb_scaler.go
@@ -127,7 +127,7 @@ func parseCouchDBMetadata(config *ScalerConfig) (*couchDBMetadata, string, error
 		meta.activationQueryValue = activationQueryValue
 	}
 
-	dbName, err := GetFromAuthOrMeta(config, "dbName")
+	dbName, err := GetFromAuthOrMeta(config, "dbName", false)
 	if err != nil {
 		return nil, "", err
 	}
@@ -140,19 +140,19 @@ func parseCouchDBMetadata(config *ScalerConfig) (*couchDBMetadata, string, error
 		meta.connectionString = config.ResolvedEnv[config.TriggerMetadata["connectionStringFromEnv"]]
 	default:
 		meta.connectionString = ""
-		host, err := GetFromAuthOrMeta(config, "host")
+		host, err := GetFromAuthOrMeta(config, "host", false)
 		if err != nil {
 			return nil, "", err
 		}
 		meta.host = host
 
-		port, err := GetFromAuthOrMeta(config, "port")
+		port, err := GetFromAuthOrMeta(config, "port", false)
 		if err != nil {
 			return nil, "", err
 		}
 		meta.port = port
 
-		username, err := GetFromAuthOrMeta(config, "username")
+		username, err := GetFromAuthOrMeta(config, "username", false)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/scalers/elasticsearch_scaler.go
+++ b/pkg/scalers/elasticsearch_scaler.go
@@ -96,7 +96,7 @@ func hasEndpointsConfig(meta *elasticsearchMetadata) bool {
 }
 
 func extractEndpointsConfig(config *ScalerConfig, meta *elasticsearchMetadata) error {
-	addresses, err := GetFromAuthOrMeta(config, "addresses")
+	addresses, err := GetFromAuthOrMeta(config, "addresses", false)
 	if err != nil {
 		return err
 	}
@@ -118,13 +118,13 @@ func extractEndpointsConfig(config *ScalerConfig, meta *elasticsearchMetadata) e
 }
 
 func extractCloudConfig(config *ScalerConfig, meta *elasticsearchMetadata) error {
-	cloudID, err := GetFromAuthOrMeta(config, "cloudID")
+	cloudID, err := GetFromAuthOrMeta(config, "cloudID", false)
 	if err != nil {
 		return err
 	}
 	meta.cloudID = cloudID
 
-	apiKey, err := GetFromAuthOrMeta(config, "apiKey")
+	apiKey, err := GetFromAuthOrMeta(config, "apiKey", false)
 	if err != nil {
 		return err
 	}
@@ -144,8 +144,8 @@ func parseElasticsearchMetadata(config *ScalerConfig) (*elasticsearchMetadata, e
 	meta := elasticsearchMetadata{}
 
 	var err error
-	addresses, err := GetFromAuthOrMeta(config, "addresses")
-	cloudID, errCloudConfig := GetFromAuthOrMeta(config, "cloudID")
+	addresses, err := GetFromAuthOrMeta(config, "addresses", false)
+	cloudID, errCloudConfig := GetFromAuthOrMeta(config, "cloudID", false)
 	if err != nil && errCloudConfig != nil {
 		return nil, ErrElasticsearchMissingAddressesOrCloudConfig
 	}
@@ -177,13 +177,13 @@ func parseElasticsearchMetadata(config *ScalerConfig) (*elasticsearchMetadata, e
 		meta.unsafeSsl = defaultUnsafeSsl
 	}
 
-	index, err := GetFromAuthOrMeta(config, "index")
+	index, err := GetFromAuthOrMeta(config, "index", false)
 	if err != nil {
 		return nil, err
 	}
 	meta.indexes = splitAndTrimBySep(index, ";")
 
-	searchTemplateName, err := GetFromAuthOrMeta(config, "searchTemplateName")
+	searchTemplateName, err := GetFromAuthOrMeta(config, "searchTemplateName", false)
 	if err != nil {
 		return nil, err
 	}
@@ -193,13 +193,13 @@ func parseElasticsearchMetadata(config *ScalerConfig) (*elasticsearchMetadata, e
 		meta.parameters = splitAndTrimBySep(val, ";")
 	}
 
-	valueLocation, err := GetFromAuthOrMeta(config, "valueLocation")
+	valueLocation, err := GetFromAuthOrMeta(config, "valueLocation", false)
 	if err != nil {
 		return nil, err
 	}
 	meta.valueLocation = valueLocation
 
-	targetValueString, err := GetFromAuthOrMeta(config, "targetValue")
+	targetValueString, err := GetFromAuthOrMeta(config, "targetValue", false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -121,7 +121,7 @@ func NewKafkaScaler(config *ScalerConfig) (Scaler, error) {
 
 func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	meta.saslType = KafkaSASLTypeNone
-	if val, ok := config.AuthParams["sasl"]; ok {
+	if val, ok := config.TriggerMetadata["sasl"]; ok {
 		val = strings.TrimSpace(val)
 		mode := kafkaSaslType(val)
 
@@ -151,7 +151,7 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	}
 
 	meta.enableTLS = false
-	if val, ok := config.AuthParams["tls"]; ok {
+	if val, ok := config.TriggerMetadata["tls"]; ok {
 		val = strings.TrimSpace(val)
 
 		if val == "enable" {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -24,9 +24,10 @@ type parseKafkaMetadataTestData struct {
 }
 
 type parseKafkaAuthParamsTestData struct {
-	authParams map[string]string
-	isError    bool
-	enableTLS  bool
+	authParams  map[string]string
+	kafkaMedata map[string]string
+	isError     bool
+	enableTLS   bool
 }
 
 type kafkaMetricIdentifier struct {
@@ -101,69 +102,69 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 }
 
 var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
-	// success, SASL only
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin"}, false, false},
-	// success, SASL only
-	{map[string]string{"sasl": "scram_sha256", "username": "admin", "password": "admin"}, false, false},
-	// success, SASL only
-	{map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, false, false},
+	// success, SASL plaintext only
+	{map[string]string{"username": "admin", "password": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "plaintext"}, false, false},
+	// success, SASL scram_sha256 only
+	{map[string]string{"username": "admin", "password": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "scram_sha256"}, false, false},
+	// success, SASL scram_sha512 only
+	{map[string]string{"username": "admin", "password": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "scram_sha512"}, false, false},
 	// success, TLS only
-	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	{map[string]string{"ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, false, true},
 	// success, TLS cert/key and assumed public CA
-	{map[string]string{"tls": "enable", "cert": "ceert", "key": "keey"}, false, true},
+	{map[string]string{"cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, false, true},
 	// success, TLS cert/key + key password and assumed public CA
-	{map[string]string{"tls": "enable", "cert": "ceert", "key": "keey", "keyPassword": "keeyPassword"}, false, true},
+	{map[string]string{"cert": "ceert", "key": "keey", "keyPassword": "keeyPassword"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, false, true},
 	// success, TLS CA only
-	{map[string]string{"tls": "enable", "ca": "caaa"}, false, true},
-	// success, SASL + TLS
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	{map[string]string{"ca": "caaa"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, false, true},
+	//// success, SASL + TLS
+	{map[string]string{"username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "plaintext", "tls": "enable"}, false, true},
 	// success, SASL + TLS explicitly disabled
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "disable"}, false, false},
+	{map[string]string{"username": "admin", "password": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "plaintext"}, false, false},
 	// success, SASL OAUTHBEARER + TLS
-	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, false, false},
+	{map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "oauthbearer"}, false, false},
 	// failure, SASL OAUTHBEARER + TLS bad sasl type
-	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "foo"}, true, false},
 	// success, SASL OAUTHBEARER + TLS missing scope
-	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, false, false},
+	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "oauthTokenEndpointUri": "https://website.com"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "oauthbearer"}, false, false},
 	// failure, SASL OAUTHBEARER + TLS missing oauthTokenEndpointUri
-	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "", "tls": "disable"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": ""}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "oauthbearer"}, true, false},
 	// failure, SASL incorrect type
-	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "foo"}, true, false},
 	// failure, SASL missing username
-	{map[string]string{"sasl": "plaintext", "password": "admin"}, true, false},
+	{map[string]string{"password": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "plaintext"}, true, false},
 	// failure, SASL missing password
-	{map[string]string{"sasl": "plaintext", "username": "admin"}, true, false},
+	{map[string]string{"username": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "plaintext"}, true, false},
 	// failure, TLS missing cert
-	{map[string]string{"tls": "enable", "ca": "caaa", "key": "keey"}, true, false},
+	{map[string]string{"ca": "caaa", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, true, false},
 	// failure, TLS missing key
-	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert"}, true, false},
+	{map[string]string{"ca": "caaa", "cert": "ceert"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, true, false},
 	// failure, TLS invalid
-	{map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "yes"}, true, false},
 	// failure, SASL + TLS, incorrect sasl
-	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable", "sasl": "foo"}, true, false},
 	// failure, SASL + TLS, incorrect tls
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "foo", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "foo", "sasl": "plaintext"}, true, false},
 	// failure, SASL + TLS, missing username
-	{map[string]string{"sasl": "plaintext", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable", "sasl": "plaintext"}, true, false},
 	// failure, SASL + TLS, missing password
-	{map[string]string{"sasl": "plaintext", "username": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"username": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable", "sasl": "plaintext"}, true, false},
 	// failure, SASL + TLS, missing cert
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "key": "keey"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable", "sasl": "plaintext"}, true, false},
 	// failure, SASL + TLS, missing key
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable", "sasl": "plaintext"}, true, false},
 }
 
 var parseKafkaOAuthbreakerAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	// success, SASL OAUTHBEARER + TLS
-	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, false, false},
+	{map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "oauthbearer"}, false, false},
 	// success, SASL OAUTHBEARER + TLS multiple scopes
-	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "scopes": "scope1, scope2", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, false, false},
+	{map[string]string{"username": "admin", "password": "admin", "scopes": "scope1, scope2", "oauthTokenEndpointUri": "https://website.com"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "oauthbearer"}, false, false},
 	// success, SASL OAUTHBEARER + TLS missing scope
-	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, false, false},
+	{map[string]string{"username": "admin", "password": "admin", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "oauthbearer"}, false, false},
 	// failure, SASL OAUTHBEARER + TLS bad sasl type
-	{map[string]string{"sasl": "foo", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "foo"}, true, false},
 	// failure, SASL OAUTHBEARER + TLS missing oauthTokenEndpointUri
-	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "", "tls": "disable"}, true, false},
+	{map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": ""}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "disable", "sasl": "oauthbearer"}, true, false},
 }
 
 var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
@@ -238,7 +239,7 @@ func TestGetBrokers(t *testing.T) {
 
 func TestKafkaAuthParams(t *testing.T) {
 	for _, testData := range parseKafkaAuthParamsTestDataset {
-		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.kafkaMedata, AuthParams: testData.authParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -268,7 +269,7 @@ func TestKafkaAuthParams(t *testing.T) {
 
 func TestKafkaOAuthbreakerAuthParams(t *testing.T) {
 	for _, testData := range parseKafkaOAuthbreakerAuthParamsTestDataset {
-		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.kafkaMedata, AuthParams: testData.authParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -36,14 +36,6 @@ type kafkaMetricIdentifier struct {
 	name             string
 }
 
-// A complete valid metadata example for reference
-var validKafkaMetadata = map[string]string{
-	"bootstrapServers":   "broker1:9092,broker2:9092",
-	"consumerGroup":      "my-group",
-	"topic":              "my-topic",
-	"allowIdleConsumers": "false",
-}
-
 // A complete valid authParams example for sasl, with username and passwd
 var validWithAuthParams = map[string]string{
 	"sasl":     "plaintext",

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -205,15 +205,6 @@ var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	{map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable", "sasl": "plaintext"}, true, false},
 	// failure, SASL + TLS, missing key
 	{map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable", "sasl": "plaintext"}, true, false},
-
-	// failure, sasl set in both metadata and spec.secretTargetRef
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "plaintext"}, true, false},
-	// failure, tls set in both metadata and spec.secretTargetRef
-	{map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, true, true},
-	// failure, tls set in metadata and sasl in spec.secretTargetRef
-	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "tls": "enable"}, true, true},
-	// failure, sasl set in metadata and tls in spec.secretTargetRef
-	{map[string]string{"tls": "enable", "username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, map[string]string{"bootstrapServers": "broker1:9092,broker2:9092", "consumerGroup": "my-group", "sasl": "plaintext"}, true, true},
 }
 
 var parseKafkaOAuthbreakerAuthParamsTestDataset = []parseKafkaAuthParamsTestData{

--- a/pkg/scalers/mongo_scaler.go
+++ b/pkg/scalers/mongo_scaler.go
@@ -147,7 +147,7 @@ func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error
 		meta.activationQueryValue = activationQueryValue
 	}
 
-	dbName, err := GetFromAuthOrMeta(config, "dbName")
+	dbName, err := GetFromAuthOrMeta(config, "dbName", false)
 	if err != nil {
 		return nil, "", err
 	}
@@ -161,19 +161,19 @@ func parseMongoDBMetadata(config *ScalerConfig) (*mongoDBMetadata, string, error
 		meta.connectionString = config.ResolvedEnv[config.TriggerMetadata["connectionStringFromEnv"]]
 	default:
 		meta.connectionString = ""
-		host, err := GetFromAuthOrMeta(config, "host")
+		host, err := GetFromAuthOrMeta(config, "host", false)
 		if err != nil {
 			return nil, "", err
 		}
 		meta.host = host
 
-		port, err := GetFromAuthOrMeta(config, "port")
+		port, err := GetFromAuthOrMeta(config, "port", false)
 		if err != nil {
 			return nil, "", err
 		}
 		meta.port = port
 
-		username, err := GetFromAuthOrMeta(config, "username")
+		username, err := GetFromAuthOrMeta(config, "username", false)
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -141,14 +141,14 @@ func parseMSSQLMetadata(config *ScalerConfig) (*mssqlMetadata, error) {
 		meta.connectionString = ""
 		var err error
 
-		host, err := GetFromAuthOrMeta(config, "host")
+		host, err := GetFromAuthOrMeta(config, "host", false)
 		if err != nil {
 			return nil, err
 		}
 		meta.host = host
 
 		var paramPort string
-		paramPort, _ = GetFromAuthOrMeta(config, "port")
+		paramPort, _ = GetFromAuthOrMeta(config, "port", false)
 		if paramPort != "" {
 			port, err := strconv.Atoi(paramPort)
 			if err != nil {
@@ -157,10 +157,10 @@ func parseMSSQLMetadata(config *ScalerConfig) (*mssqlMetadata, error) {
 			meta.port = port
 		}
 
-		meta.username, _ = GetFromAuthOrMeta(config, "username")
+		meta.username, _ = GetFromAuthOrMeta(config, "username", false)
 
 		// database is optional in SQL s
-		meta.database, _ = GetFromAuthOrMeta(config, "database")
+		meta.database, _ = GetFromAuthOrMeta(config, "database", false)
 
 		if config.AuthParams["password"] != "" {
 			meta.password = config.AuthParams["password"]

--- a/pkg/scalers/mysql_scaler.go
+++ b/pkg/scalers/mysql_scaler.go
@@ -98,25 +98,25 @@ func parseMySQLMetadata(config *ScalerConfig) (*mySQLMetadata, error) {
 	default:
 		meta.connectionString = ""
 		var err error
-		host, err := GetFromAuthOrMeta(config, "host")
+		host, err := GetFromAuthOrMeta(config, "host", false)
 		if err != nil {
 			return nil, err
 		}
 		meta.host = host
 
-		port, err := GetFromAuthOrMeta(config, "port")
+		port, err := GetFromAuthOrMeta(config, "port", false)
 		if err != nil {
 			return nil, err
 		}
 		meta.port = port
 
-		username, err := GetFromAuthOrMeta(config, "username")
+		username, err := GetFromAuthOrMeta(config, "username", false)
 		if err != nil {
 			return nil, err
 		}
 		meta.username = username
 
-		dbName, err := GetFromAuthOrMeta(config, "dbName")
+		dbName, err := GetFromAuthOrMeta(config, "dbName", false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -170,7 +170,7 @@ func parseNATSJetStreamMetadata(config *ScalerConfig) (natsJetStreamMetadata, er
 
 	meta.scalerIndex = config.ScalerIndex
 
-	natsServerEndpoint, err := GetFromAuthOrMeta(config, "natsServerMonitoringEndpoint")
+	natsServerEndpoint, err := GetFromAuthOrMeta(config, "natsServerMonitoringEndpoint", false)
 	if err != nil {
 		return meta, err
 	}

--- a/pkg/scalers/newrelic_scaler.go
+++ b/pkg/scalers/newrelic_scaler.go
@@ -79,7 +79,7 @@ func parseNewRelicMetadata(config *ScalerConfig, logger logr.Logger) (*newrelicM
 	meta := newrelicMetadata{}
 	var err error
 
-	val, err := GetFromAuthOrMeta(config, account)
+	val, err := GetFromAuthOrMeta(config, account, false)
 	if err != nil {
 		return nil, fmt.Errorf("no %s given", account)
 	}
@@ -96,13 +96,13 @@ func parseNewRelicMetadata(config *ScalerConfig, logger logr.Logger) (*newrelicM
 		return nil, fmt.Errorf("no %s given", nrql)
 	}
 
-	queryKey, err := GetFromAuthOrMeta(config, queryKeyParamater)
+	queryKey, err := GetFromAuthOrMeta(config, queryKeyParamater, false)
 	if err != nil {
 		return nil, fmt.Errorf("no %s given", queryKeyParamater)
 	}
 	meta.queryKey = queryKey
 
-	region, err := GetFromAuthOrMeta(config, regionParameter)
+	region, err := GetFromAuthOrMeta(config, regionParameter, false)
 	if err != nil {
 		region = "US"
 		logger.Info("Using default 'US' region")

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -92,27 +92,27 @@ func parsePostgreSQLMetadata(config *ScalerConfig) (*postgreSQLMetadata, error) 
 	case config.TriggerMetadata["connectionFromEnv"] != "":
 		meta.connection = config.ResolvedEnv[config.TriggerMetadata["connectionFromEnv"]]
 	default:
-		host, err := GetFromAuthOrMeta(config, "host")
+		host, err := GetFromAuthOrMeta(config, "host", false)
 		if err != nil {
 			return nil, err
 		}
 
-		port, err := GetFromAuthOrMeta(config, "port")
+		port, err := GetFromAuthOrMeta(config, "port", false)
 		if err != nil {
 			return nil, err
 		}
 
-		userName, err := GetFromAuthOrMeta(config, "userName")
+		userName, err := GetFromAuthOrMeta(config, "userName", false)
 		if err != nil {
 			return nil, err
 		}
 
-		dbName, err := GetFromAuthOrMeta(config, "dbName")
+		dbName, err := GetFromAuthOrMeta(config, "dbName", false)
 		if err != nil {
 			return nil, err
 		}
 
-		sslmode, err := GetFromAuthOrMeta(config, "sslmode")
+		sslmode, err := GetFromAuthOrMeta(config, "sslmode", false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -111,7 +111,7 @@ var (
 )
 
 // GetFromAuthOrMeta helps getting a field from Auth or Meta sections
-func GetFromAuthOrMeta(config *ScalerConfig, field string) (string, error) {
+func GetFromAuthOrMeta(config *ScalerConfig, field string, allowEmpty bool) (string, error) {
 	var result string
 	var err error
 	if config.AuthParams[field] != "" {
@@ -119,7 +119,7 @@ func GetFromAuthOrMeta(config *ScalerConfig, field string) (string, error) {
 	} else if config.TriggerMetadata[field] != "" {
 		result = config.TriggerMetadata[field]
 	}
-	if result == "" {
+	if !allowEmpty && result == "" {
 		err = fmt.Errorf("%w: no %s given", ErrScalerConfigMissingField, field)
 	}
 	return result, err

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -129,7 +129,7 @@ func parseStanMetadata(config *ScalerConfig) (stanMetadata, error) {
 			return meta, fmt.Errorf("useHTTPS parsing error %w", err)
 		}
 	}
-	natsServerEndpoint, err := GetFromAuthOrMeta(config, "natsServerMonitoringEndpoint")
+	natsServerEndpoint, err := GetFromAuthOrMeta(config, "natsServerMonitoringEndpoint", false)
 	if err != nil {
 		return meta, err
 	}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Move `sasl` and `tls` config to `metadata` section of `TriggerAuthentication` 
### Checklist


- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) https://github.com/kedacore/keda-docs/pull/1016
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Relates to #3611 

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
