### PR TITLE
Add scaler metric latency support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 Here is an overview of all **stable** additions:
 
+- **Prometheus Metrics**: Introduce scaler latency in Prometheus metrics. ([#4037](https://github.com/kedacore/keda/issues/4037))
 - **General**: Introduce new ArangoDB Scaler ([#4000](https://github.com/kedacore/keda/issues/4000))
 
 Here is an overview of all new **experimental** features:

--- a/pkg/prommetrics/adapter/adapter_prommetrics.go
+++ b/pkg/prommetrics/adapter/adapter_prommetrics.go
@@ -45,15 +45,6 @@ var (
 		},
 		metricLabels,
 	)
-	scalerMetricsLatency = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "keda_metrics_adapter",
-			Subsystem: "scaler",
-			Name:      "metrics_latency",
-			Help:      "Scaler Metrics Latency",
-		},
-		metricLabels,
-	)
 	scalerErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "keda_metrics_adapter",
@@ -83,7 +74,6 @@ func init() {
 	registry = prometheus.NewRegistry()
 	registry.MustRegister(scalerErrorsTotal)
 	registry.MustRegister(scalerMetricsValue)
-	registry.MustRegister(scalerMetricsLatency)
 	registry.MustRegister(scalerErrors)
 	registry.MustRegister(scaledObjectErrors)
 }
@@ -112,11 +102,6 @@ func (metricsServer PrometheusMetricServer) NewServer(address string, pattern st
 // RecordHPAScalerMetric create a measurement of the external metric used by the HPA
 func (metricsServer PrometheusMetricServer) RecordHPAScalerMetric(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
 	scalerMetricsValue.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
-}
-
-// RecordHPAScalerLatency create a measurement of the latency to external metric
-func (metricsServer PrometheusMetricServer) RecordHPAScalerLatency(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
-	scalerMetricsLatency.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
 }
 
 // RecordHPAScalerError counts the number of errors occurred in trying get an external metric used by the HPA

--- a/pkg/prommetrics/adapter/adapter_prommetrics.go
+++ b/pkg/prommetrics/adapter/adapter_prommetrics.go
@@ -45,6 +45,15 @@ var (
 		},
 		metricLabels,
 	)
+	scalerMetricsLatency = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "keda_metrics_adapter",
+			Subsystem: "scaler",
+			Name:      "metrics_latency",
+			Help:      "Scaler Metrics Latency",
+		},
+		metricLabels,
+	)
 	scalerErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "keda_metrics_adapter",
@@ -74,6 +83,7 @@ func init() {
 	registry = prometheus.NewRegistry()
 	registry.MustRegister(scalerErrorsTotal)
 	registry.MustRegister(scalerMetricsValue)
+	registry.MustRegister(scalerMetricsLatency)
 	registry.MustRegister(scalerErrors)
 	registry.MustRegister(scaledObjectErrors)
 }
@@ -102,6 +112,11 @@ func (metricsServer PrometheusMetricServer) NewServer(address string, pattern st
 // RecordHPAScalerMetric create a measurement of the external metric used by the HPA
 func (metricsServer PrometheusMetricServer) RecordHPAScalerMetric(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
 	scalerMetricsValue.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
+}
+
+// RecordHPAScalerLatency create a measurement of the latency to external metric
+func (metricsServer PrometheusMetricServer) RecordHPAScalerLatency(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
+	scalerMetricsLatency.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
 }
 
 // RecordHPAScalerError counts the number of errors occurred in trying get an external metric used by the HPA

--- a/pkg/prommetrics/prommetrics.go
+++ b/pkg/prommetrics/prommetrics.go
@@ -55,6 +55,15 @@ var (
 		},
 		metricLabels,
 	)
+	scalerMetricsLatency = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "scaler",
+			Name:      "metrics_latency",
+			Help:      "Scaler Metrics Latency",
+		},
+		metricLabels,
+	)
 	scalerErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: DefaultPromMetricsNamespace,
@@ -96,6 +105,7 @@ var (
 func init() {
 	metrics.Registry.MustRegister(scalerErrorsTotal)
 	metrics.Registry.MustRegister(scalerMetricsValue)
+	metrics.Registry.MustRegister(scalerMetricsLatency)
 	metrics.Registry.MustRegister(scalerErrors)
 	metrics.Registry.MustRegister(scaledObjectErrors)
 
@@ -106,6 +116,11 @@ func init() {
 // RecordScalerMetric create a measurement of the external metric used by the HPA
 func RecordScalerMetric(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
 	scalerMetricsValue.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
+}
+
+// RecordScalerLatency create a measurement of the latency to external metric
+func RecordScalerLatency(namespace string, scaledObject string, scaler string, scalerIndex int, metric string, value float64) {
+	scalerMetricsLatency.With(getLabels(namespace, scaledObject, scaler, scalerIndex, metric)).Set(value)
 }
 
 // RecordScalerError counts the number of errors occurred in trying get an external metric used by the HPA

--- a/pkg/prommetrics/prommetrics.go
+++ b/pkg/prommetrics/prommetrics.go
@@ -76,7 +76,7 @@ var (
 	scaledObjectErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: DefaultPromMetricsNamespace,
-			Subsystem: "scaled",
+			Subsystem: "scaled_object",
 			Name:      "errors",
 			Help:      "Number of scaled object errors",
 		},

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -166,7 +166,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 			}
 			// Filter only the desired metric
 			if strings.EqualFold(metricSpec.External.Metric.Name, info.Metric) {
-				metrics, err := cache.GetMetricsForScaler(ctx, scalerIndex, info.Metric)
+				metrics, _, err := cache.GetMetricsForScaler(ctx, scalerIndex, info.Metric)
 				metrics, err = fallback.GetMetricsWithFallback(ctx, p.client, logger, metrics, err, info.Metric, scaledObject, metricSpec)
 				if err != nil {
 					scalerError = true

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/go-logr/logr"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -167,10 +166,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 			}
 			// Filter only the desired metric
 			if strings.EqualFold(metricSpec.External.Metric.Name, info.Metric) {
-				startTime := time.Now()
 				metrics, err := cache.GetMetricsForScaler(ctx, scalerIndex, info.Metric)
-				scalerLatency := time.Since(startTime).Milliseconds()
-				promMetricsServer.RecordHPAScalerLatency(namespace, scaledObject.Name, scalerName, scalerIndex, info.Metric, float64(scalerLatency))
 				metrics, err = fallback.GetMetricsWithFallback(ctx, p.client, logger, metrics, err, info.Metric, scaledObject, metricSpec)
 				if err != nil {
 					scalerError = true

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -440,7 +440,10 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 				}
 
 				if !metricsFoundInCache {
+					startTime := time.Now()
 					metrics, err = cache.GetMetricsForScaler(ctx, scalerIndex, metricName)
+					scalerLatency := time.Since(startTime).Milliseconds()
+					prommetrics.RecordScalerLatency(scaledObjectNamespace, scaledObject.Name, scalerName, scalerIndex, metricName, float64(scalerLatency))
 					h.logger.V(1).Info("Getting metrics from scaler", "scaledObject.Namespace", scaledObjectNamespace, "scaledObject.Name", scaledObjectName, "scaler", scalerName, "metricName", metricSpec.External.Metric.Name, "metrics", metrics, "scalerError", err)
 				}
 				metrics, err = fallback.GetMetricsWithFallback(ctx, h.client, h.logger, metrics, err, metricName, scaledObject, metricSpec)

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -440,10 +440,10 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 				}
 
 				if !metricsFoundInCache {
-					startTime := time.Now()
-					metrics, err = cache.GetMetricsForScaler(ctx, scalerIndex, metricName)
-					scalerLatency := time.Since(startTime).Milliseconds()
-					prommetrics.RecordScalerLatency(scaledObjectNamespace, scaledObject.Name, scalerName, scalerIndex, metricName, float64(scalerLatency))
+					metrics, latency, err := cache.GetMetricsForScaler(ctx, scalerIndex, metricName)
+					if latency != -1 {
+						prommetrics.RecordScalerLatency(scaledObjectNamespace, scaledObject.Name, scalerName, scalerIndex, metricName, float64(latency))
+					}
 					h.logger.V(1).Info("Getting metrics from scaler", "scaledObject.Namespace", scaledObjectNamespace, "scaledObject.Name", scaledObjectName, "scaler", scalerName, "metricName", metricSpec.External.Metric.Name, "metrics", metrics, "scalerError", err)
 				}
 				metrics, err = fallback.GetMetricsWithFallback(ctx, h.client, h.logger, metrics, err, metricName, scaledObject, metricSpec)

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -440,7 +440,8 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 				}
 
 				if !metricsFoundInCache {
-					metrics, latency, err := cache.GetMetricsForScaler(ctx, scalerIndex, metricName)
+					var latency int64
+					metrics, latency, err = cache.GetMetricsForScaler(ctx, scalerIndex, metricName)
 					if latency != -1 {
 						prommetrics.RecordScalerLatency(scaledObjectNamespace, scaledObject.Name, scalerName, scalerIndex, metricName, float64(latency))
 					}

--- a/tests/internals/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/internals/prometheus_metrics/prometheus_metrics_test.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	testName = "prometheus-metrics-test"
+	labelScaledObject = "scaledObject"
 )
 
 var (
@@ -275,7 +276,7 @@ func testScalerMetricValue(t *testing.T) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			for _, label := range labels {
-				if *label.Name == "scaledObject" && *label.Value == scaledObjectName {
+				if *label.Name == labelScaledObject && *label.Value == scaledObjectName {
 					assert.Equal(t, float64(4), *metric.Gauge.Value)
 					found = true
 				}
@@ -298,7 +299,7 @@ func testScalerMetricLatency(t *testing.T) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			for _, label := range labels {
-				if *label.Name == "scaledObject" && *label.Value == scaledObjectName {
+				if *label.Name == labelScaledObject && *label.Value == scaledObjectName {
 					assert.Equal(t, float64(0), *metric.Gauge.Value)
 					found = true
 				}
@@ -322,7 +323,7 @@ func testMetricsServerScalerMetricValue(t *testing.T) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			for _, label := range labels {
-				if *label.Name == "scaledObject" && *label.Value == scaledObjectName {
+				if *label.Name == labelScaledObject && *label.Value == scaledObjectName {
 					assert.Equal(t, float64(4), *metric.Gauge.Value)
 					found = true
 				}

--- a/tests/internals/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/internals/prometheus_metrics/prometheus_metrics_test.go
@@ -225,6 +225,7 @@ func TestScaler(t *testing.T) {
 		"replica count should be 2 after 2 minute")
 
 	testScalerMetricValue(t)
+	testScalerMetricLatency(t)
 	testMetricsServerScalerMetricValue(t)
 	testOperatorMetrics(t, kc, data)
 
@@ -276,6 +277,29 @@ func testScalerMetricValue(t *testing.T) {
 			for _, label := range labels {
 				if *label.Name == "scaledObject" && *label.Value == scaledObjectName {
 					assert.Equal(t, float64(4), *metric.Gauge.Value)
+					found = true
+				}
+			}
+		}
+		assert.Equal(t, true, found)
+	} else {
+		t.Errorf("metric not available")
+	}
+}
+
+func testScalerMetricLatency(t *testing.T) {
+	t.Log("--- testing scaler metric latency ---")
+
+	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+
+	if val, ok := family["keda_scaler_metrics_latency"]; ok {
+		var found bool
+		metrics := val.GetMetric()
+		for _, metric := range metrics {
+			labels := metric.GetLabel()
+			for _, label := range labels {
+				if *label.Name == "scaledObject" && *label.Value == scaledObjectName {
+					assert.Equal(t, float64(0), *metric.Gauge.Value)
 					found = true
 				}
 			}

--- a/tests/internals/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/internals/prometheus_metrics/prometheus_metrics_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	testName = "prometheus-metrics-test"
+	testName          = "prometheus-metrics-test"
 	labelScaledObject = "scaledObject"
 )
 


### PR DESCRIPTION
Add scaler metric latency support


### Checklist

- ~[ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)~
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- ~[ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))



Relates to [#4037](https://github.com/kedacore/keda/issues/4037)
