### PR TITLE
feat: Use self-signed certs for TLS (between components and between k8s and KEDA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ Here is an overview of all new **experimental** features:
 
 ### Improvements
 
-- **Redis**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))
+- **General**: Use (self-signed) certificates for all the communications (internals and externals) ([#3931](https://github.com/kedacore/keda/issues/3931))
+- **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))
 
 ### Fixes
 

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -20,8 +20,6 @@ COPY vendor/ vendor/
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-RUN mkdir -p /apiserver.local.config/certificates && chmod -R 777 /apiserver.local.config
-
 # Build
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
 ARG TARGETOS
@@ -32,7 +30,6 @@ RUN VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION}
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder --chown=nonroot:nonroot /apiserver.local.config  /apiserver.local.config
 COPY --from=builder /workspace/bin/keda-adapter .
 # 65532 is numeric for nonroot
 USER 65532:65532

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -199,7 +199,7 @@ func runScaledObjectController(ctx context.Context, mgr manager.Manager, scaleHa
 // generateDefaultMetricsServiceAddr generates default Metrics Service gRPC Server address based on the current Namespace.
 // By default the Metrics Service gRPC Server runs in the same namespace on the keda-operator pod.
 func generateDefaultMetricsServiceAddr() string {
-	return fmt.Sprintf("keda-operator.%s:9666", kedautil.GetPodNamespace())
+	return fmt.Sprintf("keda-operator.%s.svc.cluster.local:9666", kedautil.GetPodNamespace())
 }
 
 func printVersion() {

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -69,6 +69,7 @@ var (
 	metricsAPIServerPort      int
 	disableCompression        bool
 	metricsServiceAddr        string
+	certDir                   string
 )
 
 func (a *Adapter) makeProvider(ctx context.Context, globalHTTPTimeout time.Duration, maxConcurrentReconciles int) (provider.MetricsProvider, <-chan struct{}, error) {
@@ -160,7 +161,7 @@ func (a *Adapter) makeProvider(ctx context.Context, globalHTTPTimeout time.Durat
 	go func() { prometheusServer.NewServer(fmt.Sprintf(":%v", prometheusMetricsPort), prometheusMetricsPath) }()
 
 	logger.Info("Connecting Metrics Service gRPC client to the server", "address", metricsServiceAddr)
-	grpcClient, err := metricsservice.NewGrpcClient(metricsServiceAddr)
+	grpcClient, err := metricsservice.NewGrpcClient(metricsServiceAddr, certDir)
 	if err != nil {
 		logger.Error(err, "error connecting Metrics Service gRPC client to the server", "address", metricsServiceAddr)
 		return nil, nil, err
@@ -244,6 +245,8 @@ func main() {
 	cmd.Flags().Float32Var(&adapterClientRequestQPS, "kube-api-qps", 20.0, "Set the QPS rate for throttling requests sent to the apiserver")
 	cmd.Flags().IntVar(&adapterClientRequestBurst, "kube-api-burst", 30, "Set the burst for throttling requests sent to the apiserver")
 	cmd.Flags().BoolVar(&disableCompression, "disable-compression", true, "Disable response compression for k8s restAPI in client-go. ")
+	cmd.Flags().StringVar(&certDir, "cert-dir", "/certs", "Webhook certificates dir to use. Defaults to /certs")
+
 	if err := cmd.Flags().Parse(os.Args); err != nil {
 		return
 	}

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -199,7 +199,7 @@ func runScaledObjectController(ctx context.Context, mgr manager.Manager, scaleHa
 // generateDefaultMetricsServiceAddr generates default Metrics Service gRPC Server address based on the current Namespace.
 // By default the Metrics Service gRPC Server runs in the same namespace on the keda-operator pod.
 func generateDefaultMetricsServiceAddr() string {
-	return fmt.Sprintf("keda-operator.%s.svc.cluster.local:9666", kedautil.GetPodNamespace())
+	return fmt.Sprintf("keda-operator.%s:9666", kedautil.GetPodNamespace())
 }
 
 func printVersion() {

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -69,7 +69,6 @@ var (
 	metricsAPIServerPort      int
 	disableCompression        bool
 	metricsServiceAddr        string
-	certDir                   string
 )
 
 func (a *Adapter) makeProvider(ctx context.Context, globalHTTPTimeout time.Duration, maxConcurrentReconciles int) (provider.MetricsProvider, <-chan struct{}, error) {
@@ -82,7 +81,6 @@ func (a *Adapter) makeProvider(ctx context.Context, globalHTTPTimeout time.Durat
 		logger.Error(err, "failed to add keda scheme to runtime scheme")
 		return nil, nil, fmt.Errorf("failed to add keda scheme to runtime scheme (%s)", err)
 	}
-
 	namespace, err := getWatchNamespace()
 	if err != nil {
 		logger.Error(err, "failed to get watch namespace")
@@ -161,7 +159,7 @@ func (a *Adapter) makeProvider(ctx context.Context, globalHTTPTimeout time.Durat
 	go func() { prometheusServer.NewServer(fmt.Sprintf(":%v", prometheusMetricsPort), prometheusMetricsPath) }()
 
 	logger.Info("Connecting Metrics Service gRPC client to the server", "address", metricsServiceAddr)
-	grpcClient, err := metricsservice.NewGrpcClient(metricsServiceAddr, certDir)
+	grpcClient, err := metricsservice.NewGrpcClient(metricsServiceAddr, a.SecureServing.ServerCert.CertDirectory)
 	if err != nil {
 		logger.Error(err, "error connecting Metrics Service gRPC client to the server", "address", metricsServiceAddr)
 		return nil, nil, err
@@ -245,7 +243,6 @@ func main() {
 	cmd.Flags().Float32Var(&adapterClientRequestQPS, "kube-api-qps", 20.0, "Set the QPS rate for throttling requests sent to the apiserver")
 	cmd.Flags().IntVar(&adapterClientRequestBurst, "kube-api-burst", 30, "Set the burst for throttling requests sent to the apiserver")
 	cmd.Flags().BoolVar(&disableCompression, "disable-compression", true, "Disable response compression for k8s restAPI in client-go. ")
-	cmd.Flags().StringVar(&certDir, "cert-dir", "/certs", "Webhook certificates dir to use. Defaults to /certs")
 
 	if err := cmd.Flags().Parse(os.Args); err != nil {
 		return

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -255,7 +255,7 @@ func main() {
 			CAName:                "KEDA",
 			CAOrganization:        "KEDAORG",
 			ValidatingWebhookName: validatingWebhookName,
-			ApiServiceName:        "v1beta1.external.metrics.k8s.io",
+			APIServiceName:        "v1beta1.external.metrics.k8s.io",
 			Logger:                setupLog,
 			Ready:                 certReady,
 		}

--- a/config/metrics-server/api_service.yaml
+++ b/config/metrics-server/api_service.yaml
@@ -13,6 +13,5 @@ spec:
     namespace: keda
   group: external.metrics.k8s.io
   version: v1beta1
-  insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -59,6 +59,9 @@ spec:
           - --secure-port=6443
           - --logtostderr=true
           - --v=0
+          - --client-ca-file=/certs/ca.crt
+          - --tls-cert-file=/certs/tls.crt
+          - --tls-private-key-file=/certs/tls.key
           ports:
           - containerPort: 6443
             name: https
@@ -69,8 +72,6 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: temp-vol
-          - mountPath: /apiserver.local.config/certificates
-            name: certs
           - mountPath: /certs
             name: certificates
             readOnly: true
@@ -87,8 +88,6 @@ spec:
         kubernetes.io/os: linux
       volumes:
       - name: temp-vol
-        emptyDir: {}
-      - name: certs
         emptyDir: {}
       - name: certificates
         secret:

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -62,6 +62,7 @@ spec:
           - --client-ca-file=/certs/ca.crt
           - --tls-cert-file=/certs/tls.crt
           - --tls-private-key-file=/certs/tls.key
+          - --cert-dir=/certs
           ports:
           - containerPort: 6443
             name: https

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,6 +54,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.5.0
 	github.com/onsi/gomega v1.24.1
-	github.com/open-policy-agent/cert-controller v0.5.0
+	github.com/open-policy-agent/cert-controller v0.6.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
@@ -98,9 +98,6 @@ replace (
 
 	// https://nvd.nist.gov/vuln/detail/CVE-2022-1996
 	github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0+incompatible
-
-	// Needed for certificate generation till the PR is merged: https://github.com/open-policy-agent/cert-controller/pull/52
-	github.com/open-policy-agent/cert-controller => github.com/jorturfer/cert-controller v0.5.0
 
 	// https://avd.aquasec.com/nvd/2022/cve-2022-27191/
 	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,6 @@ github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
 github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
-github.com/jorturfer/cert-controller v0.5.0 h1:NuII7efZ14UsCn6a4vPbsQ+POvcmJ0S/UFPIkkXpRFw=
-github.com/jorturfer/cert-controller v0.5.0/go.mod h1:uOQW+2tMU51vSxy1Yt162oVUTMdqLuotC0aObQxrh6k=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
@@ -737,6 +735,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
 github.com/onsi/gomega v1.24.1/go.mod h1:3AOiACssS3/MajrniINInwbfOOtfZvplPzuRSmvt1jM=
+github.com/open-policy-agent/cert-controller v0.6.0 h1:HBhe1kS0GTk5dRHdklwgJKoGIctWisueIYnIYJu65Q0=
+github.com/open-policy-agent/cert-controller v0.6.0/go.mod h1:uOQW+2tMU51vSxy1Yt162oVUTMdqLuotC0aObQxrh6k=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
 github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -22,16 +22,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/logr"
+	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/go-logr/logr"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
-	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 )
 
 // +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=get;list;watch;update;patch
@@ -47,21 +46,20 @@ type CertManager struct {
 	CAName                string
 	CAOrganization        string
 	ValidatingWebhookName string
-	ApiServiceName        string
+	APIServiceName        string
 	Logger                logr.Logger
 	Ready                 chan struct{}
 }
 
 // AddCertificateRotation registers all needed services to generate the certificates and patches needed resources with the caBundle
 func (cm CertManager) AddCertificateRotation(ctx context.Context, mgr manager.Manager) error {
-
 	var rotatorHooks = []rotator.WebhookInfo{
 		{
 			Name: cm.ValidatingWebhookName,
 			Type: rotator.Validating,
 		},
 		{
-			Name: cm.ApiServiceName,
+			Name: cm.APIServiceName,
 			Type: rotator.APIService,
 		},
 	}

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -18,6 +18,7 @@ package certificates
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"os"
 
@@ -89,6 +90,10 @@ func (cm CertManager) AddCertificateRotation(ctx context.Context, mgr manager.Ma
 		Webhooks:               rotatorHooks,
 		RestartOnSecretRefresh: true,
 		RequireLeaderElection:  true,
+		ExtKeyUsages: &[]x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
 	}); err != nil {
 		return err
 	}

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2023 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/go-logr/logr"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+	"github.com/open-policy-agent/cert-controller/pkg/rotator"
+)
+
+// +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",namespace=keda,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+
+type CertManager struct {
+	SecretName            string
+	CertDir               string
+	OperatorService       string
+	MetricsServerService  string
+	WebhookService        string
+	CAName                string
+	CAOrganization        string
+	ValidatingWebhookName string
+	ApiServiceName        string
+	Logger                logr.Logger
+	Ready                 chan struct{}
+}
+
+// AddCertificateRotation registers all needed services to generate the certificates and patches needed resources with the caBundle
+func (cm CertManager) AddCertificateRotation(ctx context.Context, mgr manager.Manager) error {
+
+	var rotatorHooks = []rotator.WebhookInfo{
+		{
+			Name: cm.ValidatingWebhookName,
+			Type: rotator.Validating,
+		},
+		{
+			Name: cm.ApiServiceName,
+			Type: rotator.APIService,
+		},
+	}
+
+	err := cm.ensureSecret(ctx, mgr, cm.SecretName)
+	if err != nil {
+		return err
+	}
+	extraDNSNames := []string{}
+	extraDNSNames = append(extraDNSNames, getDNSNames(cm.OperatorService)...)
+	extraDNSNames = append(extraDNSNames, getDNSNames(cm.WebhookService)...)
+	extraDNSNames = append(extraDNSNames, getDNSNames(cm.MetricsServerService)...)
+
+	cm.Logger.V(1).Info("setting up cert rotation")
+	if err := rotator.AddRotator(mgr, &rotator.CertRotator{
+		SecretKey: types.NamespacedName{
+			Namespace: kedautil.GetPodNamespace(),
+			Name:      cm.SecretName,
+		},
+		CertDir:                cm.CertDir,
+		CAName:                 cm.CAName,
+		CAOrganization:         cm.CAOrganization,
+		DNSName:                extraDNSNames[0],
+		ExtraDNSNames:          extraDNSNames,
+		IsReady:                cm.Ready,
+		Webhooks:               rotatorHooks,
+		RestartOnSecretRefresh: true,
+		RequireLeaderElection:  true,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getDNSNames  creates all the possible DNS names for a given service
+func getDNSNames(service string) []string {
+	namespace := kedautil.GetPodNamespace()
+	return []string{
+		service,
+		fmt.Sprintf("%s.%s", service, namespace),
+		fmt.Sprintf("%s.%s.svc", service, namespace),
+		fmt.Sprintf("%s.%s.svc.local", service, namespace),
+	}
+}
+
+// ensureSecret ensures that the secret used for storing TLS certificates exists
+func (cm CertManager) ensureSecret(ctx context.Context, mgr manager.Manager, secretName string) error {
+	secrets := &corev1.SecretList{}
+	kedaNamespace := kedautil.GetPodNamespace()
+	opt := &client.ListOptions{
+		Namespace: kedaNamespace,
+	}
+
+	err := mgr.GetAPIReader().List(ctx, secrets, opt)
+	if err != nil {
+		cm.Logger.Error(err, "unable to check secrets")
+		os.Exit(1)
+	}
+
+	exists := false
+	for _, secret := range secrets.Items {
+		if secret.Name == secretName {
+			exists = true
+			break
+		}
+	}
+	if !exists {
+		secret := &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      secretName,
+				Namespace: kedaNamespace,
+				Labels: map[string]string{
+					"app":                         "keda-operator",
+					"app.kubernetes.io/name":      "keda-operator",
+					"app.kubernetes.io/component": "keda-operator",
+					"app.kubernetes.io/part-of":   "keda",
+				},
+			},
+		}
+		err = mgr.GetClient().Create(ctx, secret)
+		if err != nil {
+			cm.Logger.Error(err, "unable to create certificates secret")
+			return err
+		}
+		cm.Logger.V(1).Info(fmt.Sprintf("created the secret %s to store cert-controller certificates", secretName))
+	}
+	return nil
+}

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -103,6 +103,7 @@ func getDNSNames(service string) []string {
 		fmt.Sprintf("%s.%s", service, namespace),
 		fmt.Sprintf("%s.%s.svc", service, namespace),
 		fmt.Sprintf("%s.%s.svc.local", service, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", service, namespace),
 	}
 }
 

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/open-policy-agent/cert-controller/pkg/rotator"
@@ -120,7 +119,7 @@ func (cm CertManager) ensureSecret(ctx context.Context, mgr manager.Manager, sec
 	err := mgr.GetAPIReader().List(ctx, secrets, opt)
 	if err != nil {
 		cm.Logger.Error(err, "unable to check secrets")
-		os.Exit(1)
+		return err
 	}
 
 	exists := false

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -103,7 +103,6 @@ func getDNSNames(service string) []string {
 		fmt.Sprintf("%s.%s", service, namespace),
 		fmt.Sprintf("%s.%s.svc", service, namespace),
 		fmt.Sprintf("%s.%s.svc.local", service, namespace),
-		fmt.Sprintf("%s.%s.svc.cluster.local", service, namespace),
 	}
 }
 

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -105,6 +105,7 @@ func getDNSNames(service string) []string {
 		fmt.Sprintf("%s.%s", service, namespace),
 		fmt.Sprintf("%s.%s.svc", service, namespace),
 		fmt.Sprintf("%s.%s.svc.local", service, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", service, namespace),
 	}
 }
 

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -24,11 +24,11 @@ import (
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 
 	"github.com/kedacore/keda/v2/pkg/metricsservice/api"
+	"github.com/kedacore/keda/v2/pkg/metricsservice/utils"
 )
 
 type GrpcClient struct {
@@ -36,7 +36,7 @@ type GrpcClient struct {
 	connection *grpc.ClientConn
 }
 
-func NewGrpcClient(url string) (*GrpcClient, error) {
+func NewGrpcClient(url, certDir string) (*GrpcClient, error) {
 	retryPolicy := `{
 		"methodConfig": [{
 		  "timeout": "3s",
@@ -49,8 +49,15 @@ func NewGrpcClient(url string) (*GrpcClient, error) {
 		  }
 		}]}`
 
-	// TODO fix Transport layer - use TLS
-	conn, err := grpc.Dial(url, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
+	creds, err := utils.LoadTLSCredentials(certDir)
+	if err != nil {
+		return nil, err
+	}
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithDefaultServiceConfig(retryPolicy),
+	}
+	conn, err := grpc.Dial(url, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -49,7 +49,7 @@ func NewGrpcClient(url, certDir string) (*GrpcClient, error) {
 		  }
 		}]}`
 
-	creds, err := utils.LoadTLSCredentials(certDir)
+	creds, err := utils.LoadGrpcTLSCredentials(certDir, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -26,6 +26,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kedacore/keda/v2/pkg/metricsservice/api"
+	"github.com/kedacore/keda/v2/pkg/metricsservice/utils"
 	"github.com/kedacore/keda/v2/pkg/scaling"
 )
 
@@ -34,6 +35,8 @@ var log = logf.Log.WithName("grpc_server")
 type GrpcServer struct {
 	server        *grpc.Server
 	address       string
+	certDir       string
+	certsReady    chan struct{}
 	scalerHandler *scaling.ScaleHandler
 	api.UnimplementedMetricsServiceServer
 }
@@ -60,17 +63,13 @@ func (s *GrpcServer) GetMetrics(ctx context.Context, in *api.ScaledObjectRef) (*
 }
 
 // NewGrpcServer creates a new instance of GrpcServer
-func NewGrpcServer(scaleHandler *scaling.ScaleHandler, address string) GrpcServer {
-	// nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
-	gsrv := grpc.NewServer()
-	srv := GrpcServer{
-		server:        gsrv,
+func NewGrpcServer(scaleHandler *scaling.ScaleHandler, address, certDir string, certsReady chan struct{}) GrpcServer {
+	return GrpcServer{
 		address:       address,
 		scalerHandler: scaleHandler,
+		certDir:       certDir,
+		certsReady:    certsReady,
 	}
-
-	api.RegisterMetricsServiceServer(gsrv, &srv)
-	return srv
 }
 
 func (s *GrpcServer) startServer() error {
@@ -89,6 +88,16 @@ func (s *GrpcServer) startServer() error {
 // Start starts a new gRPC Metrics Service, this implements Runnable interface
 // of controller-runtime Manager, so we can use mgr.Add() to start this component.
 func (s *GrpcServer) Start(ctx context.Context) error {
+	<-s.certsReady
+	if s.server == nil {
+		creds, err := utils.LoadTLSCredentials(s.certDir)
+		if err != nil {
+			return err
+		}
+		s.server = grpc.NewServer(grpc.Creds(creds))
+		api.RegisterMetricsServiceServer(s.server, s)
+	}
+
 	errChan := make(chan error)
 
 	go func() {

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -90,7 +90,7 @@ func (s *GrpcServer) startServer() error {
 func (s *GrpcServer) Start(ctx context.Context) error {
 	<-s.certsReady
 	if s.server == nil {
-		creds, err := utils.LoadTLSCredentials(s.certDir)
+		creds, err := utils.LoadGrpcTLSCredentials(s.certDir, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/metricsservice/utils/tls.go
+++ b/pkg/metricsservice/utils/tls.go
@@ -50,18 +50,15 @@ func LoadGrpcTLSCredentials(certDir string, server bool) (credentials.TransportC
 	}
 
 	// Create the credentials and return it
-	var config *tls.Config
+	config := &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{cert},
+	}
 	if server {
-		config = &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    certPool,
-		}
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+		config.ClientCAs = certPool
 	} else {
-		config = &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			RootCAs:      certPool,
-		}
+		config.RootCAs = certPool
 	}
 
 	return credentials.NewTLS(config), nil

--- a/pkg/metricsservice/utils/tls.go
+++ b/pkg/metricsservice/utils/tls.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// LoadTLSCredentials reads the certificate from the given path and returns TLS transport credentials
+func LoadTLSCredentials(certDir string) (credentials.TransportCredentials, error) {
+	// Load certificate of the CA who signed client's certificate
+	pemClientCA, err := ioutil.ReadFile(path.Join(certDir, "ca.crt"))
+	if err != nil {
+		return nil, err
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(pemClientCA) {
+		return nil, fmt.Errorf("failed to add client CA's certificate")
+	}
+
+	// Load certificate and private key
+	cert, err := tls.LoadX509KeyPair(path.Join(certDir, "tls.crt"), path.Join(certDir, "tls.key"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the credentials and return it
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool,
+	}
+
+	return credentials.NewTLS(config), nil
+}

--- a/vendor/github.com/open-policy-agent/cert-controller/pkg/rotator/rotator.go
+++ b/vendor/github.com/open-policy-agent/cert-controller/pkg/rotator/rotator.go
@@ -476,8 +476,8 @@ func (cr *CertRotator) CreateCACert(begin, end time.Time) (*KeyPairArtifacts, er
 // CreateCertPEM takes the results of CreateCACert and uses it to create the
 // PEM-encoded public certificate and private key, respectively
 func (cr *CertRotator) CreateCertPEM(ca *KeyPairArtifacts, begin, end time.Time) ([]byte, []byte, error) {
-	dnsNames := cr.ExtraDNSNames
-	dnsNames = append(dnsNames, cr.DNSName)
+	dnsNames := []string{cr.DNSName}
+	dnsNames = append(dnsNames, cr.ExtraDNSNames...)
 	templ := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -930,7 +930,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/open-policy-agent/cert-controller v0.5.0 => github.com/jorturfer/cert-controller v0.5.0
+# github.com/open-policy-agent/cert-controller v0.6.0
 ## explicit; go 1.17
 github.com/open-policy-agent/cert-controller/pkg/rotator
 # github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
@@ -2411,7 +2411,6 @@ sigs.k8s.io/yaml
 # github.com/chzyer/logex => github.com/chzyer/logex v1.2.1
 # github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.1.0
 # github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0+incompatible
-# github.com/open-policy-agent/cert-controller => github.com/jorturfer/cert-controller v0.5.0
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 # golang.org/x/net => golang.org/x/net v0.4.0
 # golang.org/x/text => golang.org/x/text v0.4.0


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR adds support for using TLS between KEDA components with client authentication,not just for encrypting the traffic, the client MUST authenticate itself using its own certificate. This reduces the risk of exposing metrics ignoring the cluster RBAC (if the operator grpc server doesn't have authentication, everyone could connect to it and get metric values, ignoring the cluster RBAC required for querying the metrics server).
This PR also register the injected certificates in the metrics server and exposes the tls cert instead of self-generating it on every restart. Now using the injected certificate (from our self-signed cert), we can (and we do) patch the apiservice manifest to include the caBundle, removing `insecureSkipTLSVerify` and trusting in the CA

## Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/3931

