### PR TITLE
fix: prevent panic while refreshing a scaler cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))
 - **CPU Memory Scaler** Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))
 
 ### Deprecations

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -237,17 +237,20 @@ func (c *ScalersCache) refreshScaler(ctx context.Context, id int) (scalers.Scale
 	}
 
 	sb := c.Scalers[id]
+	defer sb.Scaler.Close(ctx)
 	ns, sConfig, err := sb.Factory()
 	if err != nil {
 		return nil, err
 	}
 
+	if id < 0 || id >= len(c.Scalers) {
+		return nil, fmt.Errorf("scaler with id %d not found. Len = %d", id, len(c.Scalers))
+	}
 	c.Scalers[id] = ScalerBuilder{
 		Scaler:       ns,
 		ScalerConfig: *sConfig,
 		Factory:      sb.Factory,
 	}
-	sb.Scaler.Close(ctx)
 
 	return ns, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist


- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [N/A ] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [N/A ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [N/A ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4092

