### PR TITLE
Add support when JetStream cluster not on kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Here is an overview of all new **experimental** features:
 - **Datadog Scaler**: Return correct error when getting a 429 error ([#4187](https://github.com/kedacore/keda/issues/4187))
 - **Kafka Scaler**: Return error if the processing of the partition lag fails ([#4098](https://github.com/kedacore/keda/issues/4098))
 - **Kafka Scaler**: Support 0 in activationLagThreshold configuration ([#4137](https://github.com/kedacore/keda/issues/4137))
+- **NATS Jetstream Scaler:** Fix compatibility when cluster not on kubernetes ([#4101](https://github.com/kedacore/keda/issues/4101))
 - **Prometheus Metrics**: Expose Prometheus Metrics also when getting ScaledObject state ([#4075](https://github.com/kedacore/keda/issues/4075))
 - **Redis Scalers**: Fix panic produced by incorrect logger initialization ([#4197](https://github.com/kedacore/keda/issues/4197))
 

--- a/pkg/scalers/nats_jetstream_scaler_test.go
+++ b/pkg/scalers/nats_jetstream_scaler_test.go
@@ -203,21 +203,6 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			}},
 		}, true, false},
 	{
-		"Fail - Bad leader name (clustered)",
-		&natsJetStreamMetricIdentifier{
-			&parseNATSJetStreamMetadataTestData{
-				testNATSJetStreamGoodMetadata, map[string]string{}, false},
-			0, "s0-nats-jetstream-mystream",
-		},
-		&jetStreamEndpointResponse{
-			MetaCluster: metaCluster{ClusterSize: 3},
-			Accounts: []accountDetail{{Name: "$G",
-				Streams: []*streamDetail{{Name: "mystream",
-					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100, Cluster: consumerCluster{Leader: "leaderBad!!!!"}}},
-				}},
-			}},
-		}, false, true},
-	{
 		"Not Active - consumer missing - connected to node without consumer info (clustered)",
 		&natsJetStreamMetricIdentifier{
 			&parseNATSJetStreamMetadataTestData{
@@ -431,7 +416,7 @@ func TestNATSJetStreamGetNATSJetstreamServerURL(t *testing.T) {
 
 	mockJetStreamScaler.metadata.monitoringURL = "234234:::::34234234;;;;really_bad_URL;;/"
 
-	_, err = mockJetStreamScaler.getNATSJetStreamMonitoringServerURL()
+	_, err = mockJetStreamScaler.getNATSJetStreamMonitoringServerURL("")
 	if err == nil {
 		t.Error("Expected error for parsing monitoring server URL but got success")
 	}


### PR DESCRIPTION
I'm trying to use NATS Jetstream scaler, previously I workaround the lack of NATS Jetstream scaler by using Prometheus in middle of NATS and Keda. I run into issue with the NATS Jetstream scaler because our stack use 3 VMs for NATS Jetstream cluster and round robin load balancer. 

Currently the scaler assume NATS node always have `<node>.<monitoringURL>` as URL for the node, which is not the case when NATS cluster is not on kubernetes. `<monitoringURL>/varz` endpoint respond with

```
curl -s -X GET "http://nats.company.internal:8222/varz" | jq .cluster
{
  "name": "nats",
  "addr": "172.0.0.2",
  "cluster_port": 4221,
  "auth_timeout": 2,
  "urls": [
    "172.0.0.3:4221", // <--- VM's IP
    "172.0.0.4:4221"
  ],
  "tls_timeout": 2
}
```

Because the scaler assume it's on kubernetes, it splits url by `. (dot)` and take first item as node and we get `172.nats.company.internal:8222` for the `natsJetStreamMonitoringNodeURL` as shown in [code](https://github.com/kedacore/keda/blob/be56ebe0509b2a9413bfd494736976905b327f5b/pkg/scalers/nats_jetstream_scaler.go#L258-L262). 

```go
for _, clusterURL := range jetStreamServerResp.Cluster.HostUrls {
	node := strings.Split(clusterURL, ".")[0]
	natsJetStreamMonitoringNodeURL, err := s.getNATSJetStreamMonitoringNodeURL(node)
	if err != nil {
		return err
	}
	...
}
```

This PR only works if monitoring port of all node is the same as `monitoringEndpoint`

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #4101