### PR TITLE
chore: Add a warning when KEDA run outside supported k8s versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Here is an overview of all new **experimental** features:
 
 ### Improvements
 
+- **General**: Add a warning when KEDA run outside supported k8s versions ([#4130](https://github.com/kedacore/keda/issues/4130))
 - **General**: Use (self-signed) certificates for all the communications (internals and externals) ([#3931](https://github.com/kedacore/keda/issues/3931))
 - **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))
 

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -273,7 +273,7 @@ func main() {
 	}
 	kubeVersion := kedautil.NewK8sVersion(version)
 
-	kedautil.PrintMotd(logger, kubeVersion, "metrics server")
+	kedautil.PrintWelcome(logger, kubeVersion, "metrics server")
 
 	logger.Info(cmd.Message)
 	if err = cmd.Run(stopCh); err != nil {

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"sync"
 	"time"
 
@@ -48,7 +47,6 @@ import (
 	kedaprovider "github.com/kedacore/keda/v2/pkg/provider"
 	"github.com/kedacore/keda/v2/pkg/scaling"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
-	"github.com/kedacore/keda/v2/version"
 )
 
 // Adapter creates External Metrics Provider
@@ -202,13 +200,6 @@ func generateDefaultMetricsServiceAddr() string {
 	return fmt.Sprintf("keda-operator.%s.svc.cluster.local:9666", kedautil.GetPodNamespace())
 }
 
-func printVersion() {
-	logger.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
-	logger.Info(fmt.Sprintf("KEDA Commit: %s", version.GitCommit))
-	logger.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	logger.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-}
-
 // getWatchNamespace returns the namespace the operator should be watching for changes
 func getWatchNamespace() (string, error) {
 	const WatchNamespaceEnvVar = "WATCH_NAMESPACE"
@@ -248,8 +239,6 @@ func main() {
 		return
 	}
 
-	printVersion()
-
 	ctrl.SetLogger(logger)
 
 	// default to 3 seconds if they don't pass the env var
@@ -271,6 +260,20 @@ func main() {
 		return
 	}
 	cmd.WithExternalMetrics(kedaProvider)
+
+	clientset, err := cmd.DiscoveryClient()
+	if err != nil {
+		logger.Error(err, "not able to get Kubernetes version")
+		return
+	}
+	version, err := clientset.ServerVersion()
+	if err != nil {
+		logger.Error(err, "not able to get Kubernetes version")
+		return
+	}
+	kubeVersion := kedautil.NewK8sVersion(version)
+
+	kedautil.PrintMotd(logger, kubeVersion, "metrics server")
 
 	logger.Info(cmd.Message)
 	if err = cmd.Run(stopCh); err != nil {

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -43,7 +42,6 @@ import (
 	"github.com/kedacore/keda/v2/pkg/metricsservice"
 	"github.com/kedacore/keda/v2/pkg/scaling"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
-	"github.com/kedacore/keda/v2/version"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -273,12 +271,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("Starting manager")
-	setupLog.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
-	setupLog.Info(fmt.Sprintf("Git Commit: %s", version.GitCommit))
-	setupLog.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	setupLog.Info(fmt.Sprintf("Running on Kubernetes %s", kubeVersion.PrettyVersion), "version", kubeVersion.Version)
+	kedautil.PrintMotd(setupLog, kubeVersion, "manager")
 
 	kubeInformerFactory.Start(ctx.Done())
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -271,7 +271,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	kedautil.PrintMotd(setupLog, kubeVersion, "manager")
+	kedautil.PrintWelcome(setupLog, kubeVersion, "manager")
 
 	kubeInformerFactory.Start(ctx.Done())
 

--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/spf13/pflag"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
@@ -34,7 +32,7 @@ import (
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/k8s"
-	"github.com/kedacore/keda/v2/version"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -98,12 +96,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("Starting admission webhooks")
-	setupLog.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
-	setupLog.Info(fmt.Sprintf("Git Commit: %s", version.GitCommit))
-	setupLog.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	setupLog.Info(fmt.Sprintf("Running on Kubernetes %s", kubeVersion.PrettyVersion), "version", kubeVersion.Version)
+	kedautil.PrintMotd(setupLog, kubeVersion, "admission webhooks")
 
 	setupWebhook(mgr, tlsMinVersion)
 

--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -96,7 +96,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	kedautil.PrintMotd(setupLog, kubeVersion, "admission webhooks")
+	kedautil.PrintWelcome(setupLog, kubeVersion, "admission webhooks")
 
 	setupWebhook(mgr, tlsMinVersion)
 

--- a/pkg/util/motd.go
+++ b/pkg/util/motd.go
@@ -40,7 +40,7 @@ func PrintMotd(logger logr.Logger, kubeVersion K8sVersion, component string) {
 
 	if kubeVersion.MinorVersion < minSupportedVersion ||
 		kubeVersion.MinorVersion > maxSupportedVersion {
-		logger.Info(fmt.Sprintf("WARNING: KEDA %s doesn't officially support Kubernetes %s", version.Version, kubeVersion.Version))
+		logger.Info(fmt.Sprintf("WARNING: KEDA %s does not provide support for Kubernetes %s", version.Version, kubeVersion.Version))
 		logger.Info("Check officially supported versions in https://keda.sh")
 	}
 }

--- a/pkg/util/motd.go
+++ b/pkg/util/motd.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/go-logr/logr"
+
+	"github.com/kedacore/keda/v2/version"
+)
+
+const (
+	minSupportedVersion = 23
+	maxSupportedVersion = 26
+)
+
+func PrintMotd(logger logr.Logger, kubeVersion K8sVersion, component string) {
+	logger.Info(fmt.Sprintf("Starting %s", component))
+	logger.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
+	logger.Info(fmt.Sprintf("Git Commit: %s", version.GitCommit))
+	logger.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
+	logger.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	logger.Info(fmt.Sprintf("Running on Kubernetes %s", kubeVersion.PrettyVersion), "version", kubeVersion.Version)
+
+	if kubeVersion.MinorVersion < minSupportedVersion ||
+		kubeVersion.MinorVersion > maxSupportedVersion {
+		logger.Info(fmt.Sprintf("WARNING: KEDA %s doesn't officially support Kubernetes %s", version.Version, kubeVersion.Version))
+		logger.Info("Check officially supported versions in https://keda.sh")
+	}
+}

--- a/pkg/util/welcome.go
+++ b/pkg/util/welcome.go
@@ -41,6 +41,6 @@ func PrintWelcome(logger logr.Logger, kubeVersion K8sVersion, component string) 
 	if kubeVersion.MinorVersion < minSupportedVersion ||
 		kubeVersion.MinorVersion > maxSupportedVersion {
 		logger.Info(fmt.Sprintf("WARNING: KEDA %s hasn't been tested on Kubernetes %s", version.Version, kubeVersion.Version))
-		logger.Info("You can check tested versions in https://keda.sh")
+		logger.Info("You can check recommended versions on https://keda.sh")
 	}
 }

--- a/pkg/util/welcome.go
+++ b/pkg/util/welcome.go
@@ -30,7 +30,7 @@ const (
 	maxSupportedVersion = 26
 )
 
-func PrintMotd(logger logr.Logger, kubeVersion K8sVersion, component string) {
+func PrintWelcome(logger logr.Logger, kubeVersion K8sVersion, component string) {
 	logger.Info(fmt.Sprintf("Starting %s", component))
 	logger.Info(fmt.Sprintf("KEDA Version: %s", version.Version))
 	logger.Info(fmt.Sprintf("Git Commit: %s", version.GitCommit))
@@ -40,7 +40,7 @@ func PrintMotd(logger logr.Logger, kubeVersion K8sVersion, component string) {
 
 	if kubeVersion.MinorVersion < minSupportedVersion ||
 		kubeVersion.MinorVersion > maxSupportedVersion {
-		logger.Info(fmt.Sprintf("WARNING: KEDA %s does not provide support for Kubernetes %s", version.Version, kubeVersion.Version))
-		logger.Info("Check officially supported versions in https://keda.sh")
+		logger.Info(fmt.Sprintf("WARNING: KEDA %s hasn't been tested on Kubernetes %s", version.Version, kubeVersion.Version))
+		logger.Info("You can check tested versions in https://keda.sh")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #4130