### PR TITLE
Add 'platformName' to selenium-grid scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 Here is an overview of all **stable** additions:
 
+- **Selenium Grid Scaler**: Add 'platformName' to selenium-grid scaler metadata structure ([#4038](https://github.com/kedacore/keda/issues/4038))
 - **General**: Introduce admission webhooks to automatically validate resource changes to prevent misconfiguration and enforce best practices. ([#3755](https://github.com/kedacore/keda/issues/3755))
 - **General**: Introduce new ArangoDB Scaler ([#4000](https://github.com/kedacore/keda/issues/4000))
 - **Prometheus Metrics**: Introduce scaler latency in Prometheus metrics. ([#4037](https://github.com/kedacore/keda/issues/4037))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 Here is an overview of all **stable** additions:
 
-- **Selenium Grid Scaler**: Add 'platformName' to selenium-grid scaler metadata structure ([#4038](https://github.com/kedacore/keda/issues/4038))
 - **General**: Introduce admission webhooks to automatically validate resource changes to prevent misconfiguration and enforce best practices. ([#3755](https://github.com/kedacore/keda/issues/3755))
 - **General**: Introduce new ArangoDB Scaler ([#4000](https://github.com/kedacore/keda/issues/4000))
 - **Prometheus Metrics**: Introduce scaler latency in Prometheus metrics. ([#4037](https://github.com/kedacore/keda/issues/4037))
@@ -61,6 +60,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Use (self-signed) certificates for all the communications (internals and externals) ([#3931](https://github.com/kedacore/keda/issues/3931))
 - **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))
+- **Selenium Grid Scaler**: Add 'platformName' to selenium-grid scaler metadata structure ([#4038](https://github.com/kedacore/keda/issues/4038))
 
 ### Fixes
 

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -471,6 +471,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				sessionBrowserName: "chrome",
 				targetValue:        1,
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 		},
 		{
@@ -491,6 +492,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				sessionBrowserName: "msedge",
 				targetValue:        1,
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 		},
 		{
@@ -513,6 +515,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				sessionBrowserName: "msedge",
 				targetValue:        1,
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 		},
 		{
@@ -535,6 +538,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				targetValue:        1,
 				browserVersion:     "91.0",
 				unsafeSsl:          false,
+				platformName:       "linux",
 			},
 		},
 		{
@@ -559,6 +563,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				activationThreshold: 10,
 				browserVersion:      "91.0",
 				unsafeSsl:           true,
+				platformName:        "linux",
 			},
 		},
 		{

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -13,6 +13,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 		browserName        string
 		sessionBrowserName string
 		browserVersion     string
+		platformName       string
 	}
 	tests := []struct {
 		name    string
@@ -82,6 +83,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "",
 				sessionBrowserName: "",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    0,
 			wantErr: false,
@@ -104,6 +106,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "chrome",
 				sessionBrowserName: "chrome",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    2,
 			wantErr: false,
@@ -137,6 +140,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "chrome",
 				sessionBrowserName: "chrome",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    3,
 			wantErr: false,
@@ -170,6 +174,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "chrome",
 				sessionBrowserName: "chrome",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    2,
 			wantErr: false,
@@ -203,6 +208,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "chrome",
 				sessionBrowserName: "chrome",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    5,
 			wantErr: false,
@@ -231,12 +237,13 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "chrome",
 				sessionBrowserName: "chrome",
 				browserVersion:     "91.0",
+				platformName:       "linux",
 			},
 			want:    2,
 			wantErr: false,
 		},
 		{
-			name: "1 active msedge session with matching browsername/sessionBroswerName should return count as 3",
+			name: "1 active msedge session with matching browsername/sessionBrowserName should return count as 3",
 			args: args{
 				b: []byte(`{
 					"data": {
@@ -259,6 +266,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "MicrosoftEdge",
 				sessionBrowserName: "msedge",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    3,
 			wantErr: false,
@@ -287,6 +295,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "chrome",
 				sessionBrowserName: "chrome",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    2,
 			wantErr: false,
@@ -315,14 +324,95 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 				browserName:        "chrome",
 				sessionBrowserName: "chrome",
 				browserVersion:     "latest",
+				platformName:       "linux",
 			},
 			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "session request with matching browsername and no specific platformName should return count as 2",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"grid":{
+							"maxSession": 1,
+							"nodeCount": 1
+						},
+						"sessionsInfo": {
+							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\"\n}","{\n  \"browserName\": \"chrome\",\n \"platformName\": \"Windows 11\"\n}"],
+							"sessions": []
+						}
+					}
+				}`),
+				browserName:        "chrome",
+				sessionBrowserName: "chrome",
+				browserVersion:     "latest",
+				platformName:       "Windows 11",
+			},
+			want:    2,
+			wantErr: false,
+		},
+		{
+			name: "sessions requests with matching browsername and platformName should return count as 1",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"grid":{
+							"maxSession": 1,
+							"nodeCount": 1
+						},
+						"sessionsInfo": {
+							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\",\n \"platformName\": \"linux\"\n}","{\n  \"browserName\": \"chrome\",\n \"platformName\": \"Windows 11\"\n}"],
+							"sessions": []
+						}
+					}
+				}`),
+				browserName:        "chrome",
+				sessionBrowserName: "chrome",
+				browserVersion:     "latest",
+				platformName:       "Windows 11",
+			},
+			want:    1,
+			wantErr: false,
+		},
+		{
+			name: "sessions requests and active sessions with matching browsername and platformName should return count as 2",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"grid":{
+							"maxSession": 1,
+							"nodeCount": 1
+						},
+						"sessionsInfo": {
+							"sessionQueueRequests": ["{\n  \"browserName\": \"chrome\",\n \"platformName\": \"linux\"\n}","{\n  \"browserName\": \"chrome\",\n \"platformName\": \"Windows 11\"\n}"],
+							"sessions": [
+								{
+									"id": "0f9c5a941aa4d755a54b84be1f6535b1",
+									"capabilities": "{\n  \"acceptInsecureCerts\": false,\n  \"browserName\": \"chrome\",\n  \"browserVersion\": \"91.0.4472.114\",\n  \"chrome\": {\n    \"chromedriverVersion\": \"91.0.4472.101 (af52a90bf87030dd1523486a1cd3ae25c5d76c9b-refs\\u002fbranch-heads\\u002f4472@{#1462})\",\n    \"userDataDir\": \"\\u002ftmp\\u002f.com.google.Chrome.DMqx9m\"\n  },\n  \"goog:chromeOptions\": {\n    \"debuggerAddress\": \"localhost:35839\"\n  },\n  \"networkConnectionEnabled\": false,\n  \"pageLoadStrategy\": \"normal\",\n  \"platformName\": \"Windows 11\",\n  \"proxy\": {\n  },\n  \"se:cdp\": \"http:\\u002f\\u002flocalhost:35839\",\n  \"se:cdpVersion\": \"91.0.4472.114\",\n  \"se:vncEnabled\": true,\n  \"se:vncLocalAddress\": \"ws:\\u002f\\u002flocalhost:7900\\u002fwebsockify\",\n  \"setWindowRect\": true,\n  \"strictFileInteractability\": false,\n  \"timeouts\": {\n    \"implicit\": 0,\n    \"pageLoad\": 300000,\n    \"script\": 30000\n  },\n  \"unhandledPromptBehavior\": \"dismiss and notify\",\n  \"webauthn:extension:largeBlob\": true,\n  \"webauthn:virtualAuthenticators\": true\n}",
+									"nodeId": "d44dcbc5-0b2c-4d5e-abf4-6f6aa5e0983c"
+								},
+								{
+									"id": "0f9c5a941aa4d755a54b84be1f6535b1",
+									"capabilities": "{\n  \"acceptInsecureCerts\": false,\n  \"browserName\": \"chrome\",\n  \"browserVersion\": \"91.0.4472.114\",\n  \"chrome\": {\n    \"chromedriverVersion\": \"91.0.4472.101 (af52a90bf87030dd1523486a1cd3ae25c5d76c9b-refs\\u002fbranch-heads\\u002f4472@{#1462})\",\n    \"userDataDir\": \"\\u002ftmp\\u002f.com.google.Chrome.DMqx9m\"\n  },\n  \"goog:chromeOptions\": {\n    \"debuggerAddress\": \"localhost:35839\"\n  },\n  \"networkConnectionEnabled\": false,\n  \"pageLoadStrategy\": \"normal\",\n  \"platformName\": \"linux\",\n  \"proxy\": {\n  },\n  \"se:cdp\": \"http:\\u002f\\u002flocalhost:35839\",\n  \"se:cdpVersion\": \"91.0.4472.114\",\n  \"se:vncEnabled\": true,\n  \"se:vncLocalAddress\": \"ws:\\u002f\\u002flocalhost:7900\\u002fwebsockify\",\n  \"setWindowRect\": true,\n  \"strictFileInteractability\": false,\n  \"timeouts\": {\n    \"implicit\": 0,\n    \"pageLoad\": 300000,\n    \"script\": 30000\n  },\n  \"unhandledPromptBehavior\": \"dismiss and notify\",\n  \"webauthn:extension:largeBlob\": true,\n  \"webauthn:virtualAuthenticators\": true\n}",
+									"nodeId": "d44dcbc5-0b2c-4d5e-abf4-6f6aa5e0983c"
+								}
+							]
+						}
+					}
+				}`),
+				browserName:        "chrome",
+				sessionBrowserName: "chrome",
+				browserVersion:     "latest",
+				platformName:       "Windows 11",
+			},
+			want:    2,
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getCountFromSeleniumResponse(tt.args.b, tt.args.browserName, tt.args.browserVersion, tt.args.sessionBrowserName, logr.Discard())
+			got, err := getCountFromSeleniumResponse(tt.args.b, tt.args.browserName, tt.args.browserVersion, tt.args.sessionBrowserName, tt.args.platformName, logr.Discard())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getCountFromSeleniumResponse() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -485,6 +575,57 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "valid url, browsername, unsafeSsl and activationThreshold with default platformName should return metadata",
+			args: args{
+				config: &ScalerConfig{
+					TriggerMetadata: map[string]string{
+						"url":                 "http://selenium-hub:4444/graphql",
+						"browserName":         "chrome",
+						"browserVersion":      "91.0",
+						"unsafeSsl":           "true",
+						"activationThreshold": "10",
+					},
+				},
+			},
+			wantErr: false,
+			want: &seleniumGridScalerMetadata{
+				url:                 "http://selenium-hub:4444/graphql",
+				browserName:         "chrome",
+				sessionBrowserName:  "chrome",
+				targetValue:         1,
+				activationThreshold: 10,
+				browserVersion:      "91.0",
+				unsafeSsl:           true,
+				platformName:        "linux",
+			},
+		},
+		{
+			name: "valid url, browsername, unsafeSsl, activationThreshold and platformName should return metadata",
+			args: args{
+				config: &ScalerConfig{
+					TriggerMetadata: map[string]string{
+						"url":                 "http://selenium-hub:4444/graphql",
+						"browserName":         "chrome",
+						"browserVersion":      "91.0",
+						"unsafeSsl":           "true",
+						"activationThreshold": "10",
+						"platformName":        "Windows 11",
+					},
+				},
+			},
+			wantErr: false,
+			want: &seleniumGridScalerMetadata{
+				url:                 "http://selenium-hub:4444/graphql",
+				browserName:         "chrome",
+				sessionBrowserName:  "chrome",
+				targetValue:         1,
+				activationThreshold: 10,
+				browserVersion:      "91.0",
+				unsafeSsl:           true,
+				platformName:        "Windows 11",
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
platformName included in the selenium grid scaler metadata so that it is possible to specify the desired platform to run the automated test considering that there are multiplatform nodes such as linux, Windows 10 available in the hub.

### Checklist

~- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)~
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

~- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #4038 
