### PR TITLE
chore: remove duplicated error message returned from `GetFromAuthOrMeta()`

### DIFF
--- a/pkg/scalers/newrelic_scaler.go
+++ b/pkg/scalers/newrelic_scaler.go
@@ -81,7 +81,7 @@ func parseNewRelicMetadata(config *ScalerConfig, logger logr.Logger) (*newrelicM
 
 	val, err := GetFromAuthOrMeta(config, account)
 	if err != nil {
-		return nil, fmt.Errorf("no %s given", account)
+		return nil, err
 	}
 
 	t, err := strconv.Atoi(val)
@@ -98,7 +98,7 @@ func parseNewRelicMetadata(config *ScalerConfig, logger logr.Logger) (*newrelicM
 
 	queryKey, err := GetFromAuthOrMeta(config, queryKeyParamater)
 	if err != nil {
-		return nil, fmt.Errorf("no %s given", queryKeyParamater)
+		return nil, err
 	}
 	meta.queryKey = queryKey
 

--- a/tests/scalers/newrelic/newrelic_test.go
+++ b/tests/scalers/newrelic/newrelic_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package new_relic_test
+package newrelic_test
 
 import (
 	"encoding/base64"


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The same error is already generated in `GetFromAuthOrMeta()`

### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


