### PR TITLE
expose Prom Metrics also when getting ScaledObject State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,9 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 Here is an overview of all **stable** additions:
 
-- **General**: Introduce admission webhooks to automatically validate resource changes to prevent misconfiguration and enforce best practices. ([#3755](https://github.com/kedacore/keda/issues/3755))
+- **General**: Introduce admission webhooks to automatically validate resource changes to prevent misconfiguration and enforce best practices ([#3755](https://github.com/kedacore/keda/issues/3755))
 - **General**: Introduce new ArangoDB Scaler ([#4000](https://github.com/kedacore/keda/issues/4000))
-- **Prometheus Metrics**: Introduce scaler latency in Prometheus metrics. ([#4037](https://github.com/kedacore/keda/issues/4037))
+- **Prometheus Metrics**: Introduce scaler latency in Prometheus metrics ([#4037](https://github.com/kedacore/keda/issues/4037))
 
 Here is an overview of all new **experimental** features:
 
@@ -64,6 +64,7 @@ Here is an overview of all new **experimental** features:
 ### Fixes
 
 - **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))
+- **Prometheus Metrics**: Expose Prometheus Metrics also when getting ScaledObject state ([#4075](https://github.com/kedacore/keda/issues/4075))
 - **Azure Service Bus Scaler:** Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026))
 - **CPU Memory Scaler** Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -172,7 +172,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 			}
 			// Filter only the desired metric
 			if strings.EqualFold(metricSpec.External.Metric.Name, info.Metric) {
-				metrics, _, err := cache.GetMetricsForScaler(ctx, scalerIndex, info.Metric)
+				metrics, _, _, err := cache.GetMetricsAndActivityForScaler(ctx, scalerIndex, info.Metric)
 				metrics, err = fallback.GetMetricsWithFallback(ctx, p.client, logger, metrics, err, info.Metric, scaledObject, metricSpec)
 				if err != nil {
 					scalerError = true

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -342,28 +342,28 @@ func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav
 // checkScalers contains the main logic for the ScaleHandler scaling logic.
 // It'll check each trigger active status then call RequestScale
 func (h *scaleHandler) checkScalers(ctx context.Context, scalableObject interface{}, scalingMutex sync.Locker) {
-	cache, err := h.GetScalersCache(ctx, scalableObject)
-	if err != nil {
-		h.logger.Error(err, "Error getting scalers", "object", scalableObject)
-		return
-	}
-
 	scalingMutex.Lock()
 	defer scalingMutex.Unlock()
 	switch obj := scalableObject.(type) {
 	case *kedav1alpha1.ScaledObject:
-		err = h.client.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, obj)
+		err := h.client.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, obj)
 		if err != nil {
 			h.logger.Error(err, "Error getting scaledObject", "object", scalableObject)
 			return
 		}
-		isActive, isError, metricsRecords := cache.GetScaledObjectState(ctx, obj)
+		isActive, isError, metricsRecords := h.getScaledObjectState(ctx, obj)
 		h.scaleExecutor.RequestScale(ctx, obj, isActive, isError)
 		if len(metricsRecords) > 0 {
 			h.logger.V(1).Info("Storing metrics to cache", "scaledObject.Namespace", obj.Namespace, "scaledObject.Name", obj.Name, "metricsRecords", metricsRecords)
 			h.scaledObjectsMetricCache.StoreRecords(obj.GenerateIdentifier(), metricsRecords)
 		}
 	case *kedav1alpha1.ScaledJob:
+		cache, err := h.GetScalersCache(ctx, scalableObject)
+		if err != nil {
+			h.logger.Error(err, "Error getting scalers", "object", scalableObject)
+			return
+		}
+
 		err = h.client.Get(ctx, types.NamespacedName{Name: obj.Name, Namespace: obj.Namespace}, obj)
 		if err != nil {
 			h.logger.Error(err, "Error getting scaledJob", "object", scalableObject)
@@ -405,35 +405,40 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 		return nil, &exportedPromMetrics, err
 	}
 
-	scalerError := false
+	isScalerError := false
 	scaledObjectIdentifier := scaledObject.GenerateIdentifier()
 
 	// let's check metrics for all scalers in a ScaledObject
 	scalers, scalerConfigs := cache.GetScalers()
 	for scalerIndex := 0; scalerIndex < len(scalers); scalerIndex++ {
-		metricSpecs := scalers[scalerIndex].GetMetricSpecForScaling(ctx)
-
 		scalerName := strings.Replace(fmt.Sprintf("%T", scalers[scalerIndex]), "*scalers.", "", 1)
 		if scalerConfigs[scalerIndex].TriggerName != "" {
 			scalerName = scalerConfigs[scalerIndex].TriggerName
 		}
 
-		for _, metricSpec := range metricSpecs {
+		metricSpecs, err := cache.GetMetricSpecForScalingForScaler(ctx, scalerIndex)
+		if err != nil {
+			isScalerError = true
+			h.logger.Error(err, "error getting metric spec for the scaler", "name", scaledObjectName, "namespace", scaledObjectNamespace, "scaler", scalerName)
+			cache.Recorder.Event(scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, err.Error())
+		}
+
+		for _, spec := range metricSpecs {
 			// skip cpu/memory resource scaler
-			if metricSpec.External == nil {
+			if spec.External == nil {
 				continue
 			}
 
 			// Filter only the desired metric
-			if strings.EqualFold(metricSpec.External.Metric.Name, metricName) {
+			if strings.EqualFold(spec.External.Metric.Name, metricName) {
 				var metrics []external_metrics.ExternalMetricValue
 
 				// if cache is defined for this scaler/metric, let's try to hit it first
 				metricsFoundInCache := false
 				if scalerConfigs[scalerIndex].TriggerUseCachedMetrics {
 					var metricsRecord metricscache.MetricsRecord
-					if metricsRecord, metricsFoundInCache = h.scaledObjectsMetricCache.ReadRecord(scaledObjectIdentifier, metricSpec.External.Metric.Name); metricsFoundInCache {
-						h.logger.V(1).Info("Reading metrics from cache", "scaledObject.Namespace", scaledObjectNamespace, "scaledObject.Name", scaledObjectName, "scaler", scalerName, "metricName", metricSpec.External.Metric.Name, "metricsRecord", metricsRecord)
+					if metricsRecord, metricsFoundInCache = h.scaledObjectsMetricCache.ReadRecord(scaledObjectIdentifier, spec.External.Metric.Name); metricsFoundInCache {
+						h.logger.V(1).Info("Reading metrics from cache", "scaledObject.Namespace", scaledObjectNamespace, "scaledObject.Name", scaledObjectName, "scaler", scalerName, "metricName", spec.External.Metric.Name, "metricsRecord", metricsRecord)
 						metrics = metricsRecord.Metric
 						err = metricsRecord.ScalerError
 					}
@@ -441,15 +446,18 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 
 				if !metricsFoundInCache {
 					var latency int64
-					metrics, latency, err = cache.GetMetricsForScaler(ctx, scalerIndex, metricName)
+					metrics, _, latency, err = cache.GetMetricsAndActivityForScaler(ctx, scalerIndex, metricName)
 					if latency != -1 {
 						prommetrics.RecordScalerLatency(scaledObjectNamespace, scaledObject.Name, scalerName, scalerIndex, metricName, float64(latency))
 					}
-					h.logger.V(1).Info("Getting metrics from scaler", "scaledObject.Namespace", scaledObjectNamespace, "scaledObject.Name", scaledObjectName, "scaler", scalerName, "metricName", metricSpec.External.Metric.Name, "metrics", metrics, "scalerError", err)
+					h.logger.V(1).Info("Getting metrics from scaler", "scaledObject.Namespace", scaledObjectNamespace, "scaledObject.Name", scaledObjectName, "scaler", scalerName, "metricName", spec.External.Metric.Name, "metrics", metrics, "scalerError", err)
 				}
-				metrics, err = fallback.GetMetricsWithFallback(ctx, h.client, h.logger, metrics, err, metricName, scaledObject, metricSpec)
+
+				// check if we need to set a fallback
+				metrics, err = fallback.GetMetricsWithFallback(ctx, h.client, h.logger, metrics, err, metricName, scaledObject, spec)
+
 				if err != nil {
-					scalerError = true
+					isScalerError = true
 					h.logger.Error(err, "error getting metric for scaler", "scaledObject.Namespace", scaledObjectNamespace, "scaledObject.Name", scaledObjectName, "scaler", scalerName)
 				} else {
 					for _, metric := range metrics {
@@ -483,12 +491,12 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 
 	// invalidate the cache for the ScaledObject, if we hit an error in any scaler
 	// in this case we try to build all scalers (and resolve all secrets/creds) again in the next call
-	if scalerError {
+	if isScalerError {
 		err := h.ClearScalersCache(ctx, scaledObject)
 		if err != nil {
-			h.logger.Error(err, "error clearing scalers cache")
+			h.logger.Error(err, "error clearing scalers cache", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
 		}
-		h.logger.V(1).Info("scaler error encountered, clearing scaler cache")
+		h.logger.V(1).Info("scaler error encountered, clearing scaler cache", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
 	}
 
 	if len(matchingMetrics) == 0 {
@@ -498,6 +506,93 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 	return &external_metrics.ExternalMetricValueList{
 		Items: matchingMetrics,
 	}, &exportedPromMetrics, nil
+}
+
+// getScaledObjectState returns whether the input ScaledObject is active as the first parameter,
+// the second parameter indicates whether there was any error during quering scalers
+// the third parameter returns map of metrics record - a metric value for each scaler and it's metric
+func (h *scaleHandler) getScaledObjectState(ctx context.Context, scaledObject *kedav1alpha1.ScaledObject) (bool, bool, map[string]metricscache.MetricsRecord) {
+	isScaledObjectActive := false
+	isScalerError := false
+	metricsRecord := map[string]metricscache.MetricsRecord{}
+
+	cache, err := h.GetScalersCache(ctx, scaledObject)
+	prommetrics.RecordScaledObjectError(scaledObject.Namespace, scaledObject.Name, err)
+
+	// Let's collect status of all scalers, no matter if any scaler raises error or is active
+	scalers, scalerConfigs := cache.GetScalers()
+	for scalerIndex := 0; scalerIndex < len(scalers); scalerIndex++ {
+		scalerName := strings.Replace(fmt.Sprintf("%T", scalers[scalerIndex]), "*scalers.", "", 1)
+		if scalerConfigs[scalerIndex].TriggerName != "" {
+			scalerName = scalerConfigs[scalerIndex].TriggerName
+		}
+
+		metricSpecs, err := cache.GetMetricSpecForScalingForScaler(ctx, scalerIndex)
+		if err != nil {
+			isScalerError = true
+			h.logger.Error(err, "error getting metric spec for the scaler", "name", scaledObject.Name, "namespace", scaledObject.Namespace, "scaler", scalerName)
+			cache.Recorder.Event(scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, err.Error())
+		}
+
+		for _, spec := range metricSpecs {
+			// skip cpu/memory resource scaler, these scalers are also always Active
+			if spec.External == nil {
+				isScaledObjectActive = true
+				continue
+			}
+
+			metricName := spec.External.Metric.Name
+
+			var latency int64
+			metrics, isMetricActive, latency, err := cache.GetMetricsAndActivityForScaler(ctx, scalerIndex, metricName)
+			if latency != -1 {
+				prommetrics.RecordScalerLatency(scaledObject.Namespace, scaledObject.Name, scalerName, scalerIndex, metricName, float64(latency))
+			}
+			h.logger.V(1).Info("Getting metrics and activity from scaler", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name, "scaler", scalerName, "metricName", metricName, "metrics", metrics, "activity", isMetricActive, "scalerError", err)
+
+			if scalerConfigs[scalerIndex].TriggerUseCachedMetrics {
+				metricsRecord[metricName] = metricscache.MetricsRecord{
+					IsActive:    isMetricActive,
+					Metric:      metrics,
+					ScalerError: err,
+				}
+			}
+
+			if err != nil {
+				isScalerError = true
+				h.logger.Error(err, "error getting scale decision", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name, "scaler", scalerName)
+				cache.Recorder.Event(scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, err.Error())
+			} else {
+				for _, metric := range metrics {
+					metricValue := metric.Value.AsApproximateFloat64()
+					prommetrics.RecordScalerMetric(scaledObject.Namespace, scaledObject.Name, scalerName, scalerIndex, metric.MetricName, metricValue)
+				}
+
+				if isMetricActive {
+					isScaledObjectActive = true
+					if spec.External != nil {
+						h.logger.V(1).Info("Scaler for scaledObject is active", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name, "scaler", scalerName, "metricName", metricName)
+					}
+					if spec.Resource != nil {
+						h.logger.V(1).Info("Scaler for scaledObject is active", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name, "scaler", scalerName, "metricName", spec.Resource.Name)
+					}
+				}
+			}
+			prommetrics.RecordScalerError(scaledObject.Namespace, scaledObject.Name, scalerName, scalerIndex, metricName, err)
+		}
+	}
+
+	// invalidate the cache for the ScaledObject, if we hit an error in any scaler
+	// in this case we try to build all scalers (and resolve all secrets/creds) again in the next call
+	if isScalerError {
+		err := h.ClearScalersCache(ctx, scaledObject)
+		if err != nil {
+			h.logger.Error(err, "error clearing scalers cache", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
+		}
+		h.logger.V(1).Info("scaler error encountered, clearing scaler cache", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
+	}
+
+	return isScaledObjectActive, isScalerError, metricsRecord
 }
 
 // buildScalers returns list of Scalers for the specified triggers

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -228,6 +228,8 @@ func TestGetScaledObjectMetrics_FromCache(t *testing.T) {
 
 func TestCheckScaledObjectScalersWithError(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	mockExecutor := mock_executor.NewMockScaleExecutor(ctrl)
 	recorder := record.NewFakeRecorder(1)
 
 	metricsSpecs := []v2.MetricSpec{createMetricSpec(1, "metric-name")}
@@ -256,7 +258,7 @@ func TestCheckScaledObjectScalersWithError(t *testing.T) {
 		},
 	}
 
-	cache := cache.ScalersCache{
+	scalerCache := cache.ScalersCache{
 		Scalers: []cache.ScalerBuilder{{
 			Scaler:  scaler,
 			Factory: factory,
@@ -264,8 +266,23 @@ func TestCheckScaledObjectScalersWithError(t *testing.T) {
 		Recorder: recorder,
 	}
 
-	isActive, isError, _ := cache.GetScaledObjectState(context.TODO(), &scaledObject)
-	cache.Close(context.Background())
+	caches := map[string]*cache.ScalersCache{}
+	caches[scaledObject.GenerateIdentifier()] = &scalerCache
+
+	sh := scaleHandler{
+		client:                   mockClient,
+		logger:                   logr.Discard(),
+		scaleLoopContexts:        &sync.Map{},
+		scaleExecutor:            mockExecutor,
+		globalHTTPTimeout:        time.Duration(1000),
+		recorder:                 recorder,
+		scalerCaches:             caches,
+		scalerCachesLock:         &sync.RWMutex{},
+		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+	}
+
+	isActive, isError, _ := sh.getScaledObjectState(context.TODO(), &scaledObject)
+	scalerCache.Close(context.Background())
 
 	assert.Equal(t, false, isActive)
 	assert.Equal(t, true, isError)
@@ -273,6 +290,8 @@ func TestCheckScaledObjectScalersWithError(t *testing.T) {
 
 func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	mockExecutor := mock_executor.NewMockScaleExecutor(ctrl)
 	recorder := record.NewFakeRecorder(1)
 
 	metricsSpecs := []v2.MetricSpec{createMetricSpec(1, "metric-name")}
@@ -298,7 +317,7 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 	failingScaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).Return([]external_metrics.ExternalMetricValue{}, false, errors.New("some error"))
 	failingScaler.EXPECT().Close(gomock.Any())
 
-	scaledObject := &kedav1alpha1.ScaledObject{
+	scaledObject := kedav1alpha1.ScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "test",
@@ -318,13 +337,28 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 		Factory: failingFactory,
 	}}
 
-	scalersCache := cache.ScalersCache{
+	scalerCache := cache.ScalersCache{
 		Scalers:  scalers,
 		Recorder: recorder,
 	}
 
-	isActive, isError, _ := scalersCache.GetScaledObjectState(context.TODO(), scaledObject)
-	scalersCache.Close(context.Background())
+	caches := map[string]*cache.ScalersCache{}
+	caches[scaledObject.GenerateIdentifier()] = &scalerCache
+
+	sh := scaleHandler{
+		client:                   mockClient,
+		logger:                   logr.Discard(),
+		scaleLoopContexts:        &sync.Map{},
+		scaleExecutor:            mockExecutor,
+		globalHTTPTimeout:        time.Duration(1000),
+		recorder:                 recorder,
+		scalerCaches:             caches,
+		scalerCachesLock:         &sync.RWMutex{},
+		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+	}
+
+	isActive, isError, _ := sh.getScaledObjectState(context.TODO(), &scaledObject)
+	scalerCache.Close(context.Background())
 
 	assert.Equal(t, true, isActive)
 	assert.Equal(t, true, isError)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

I have also taken the chance and refactored the code a little bit, to be more consistent and move the ScaledObject scaling related logic to scaler_handler.go and keep the scalers_cache.go just around the cache.


### Checklist


- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4075
