### PR TITLE
fix: expose `keda_scaled_object_errors` metric from the operator

### DIFF
--- a/pkg/prommetrics/prommetrics.go
+++ b/pkg/prommetrics/prommetrics.go
@@ -67,7 +67,7 @@ var (
 	scaledObjectErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: DefaultPromMetricsNamespace,
-			Subsystem: "scaled",
+			Subsystem: "scaled_object",
 			Name:      "errors",
 			Help:      "Number of scaled object errors",
 		},


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4116


