### PR TITLE
chore: Review CodeQL config

### DIFF
--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -1,4 +1,4 @@
-name: "Static Analysers"
+name: "CodeQL"
 
 on:
   push:
@@ -31,21 +31,3 @@ jobs:
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:go"
-
-  semgrep:
-    name: Analyze Semgrep
-    runs-on: ubuntu-latest
-    container: returntocorp/semgrep
-    if: (github.actor != 'dependabot[bot]')
-    steps:
-      - uses: actions/checkout@v3
-
-      - run: semgrep ci --sarif --output=semgrep.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ vars.SEMGREP_APP_TOKEN }}
-
-      - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: semgrep.sarif
-        if: ${{ github.event.number == '' && !cancelled() }}

--- a/.github/workflows/static-analysis-semgrep.yml
+++ b/.github/workflows/static-analysis-semgrep.yml
@@ -1,0 +1,37 @@
+name: "Semgrep"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request_target: {}
+
+jobs:
+  semgrep:
+    name: Analyze Semgrep
+    runs-on: ubuntu-latest
+    container: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Register workspace path
+        if: ${{ github.event.number > 0 }}
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Checkout Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: checkout
+        if: ${{ github.event.number > 0 }}
+        run: |
+          apk add github-cli
+          gh pr checkout ${{ github.event.number }}
+
+      - run: semgrep ci --sarif --output=semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+
+      - name: Upload SARIF file for GitHub Advanced Security Dashboard
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: semgrep.sarif
+        if: ${{ github.event.number == '' && !cancelled() }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,46 +3,26 @@ name: "Static Analysers"
 on:
   push:
     branches: [ "main" ]
-  pull_request_target: {}
+  pull_request: {}
 
 jobs:
   codeQl:
-    name: Analyze CodeQL ${{ matrix.language }}
+    name: Analyze CodeQL Go
     runs-on: ubuntu-latest
     container: ghcr.io/kedacore/build-tools:1.19.5
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'go' ]
-
+    if: (github.actor != 'dependabot[bot]')
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-
     - name: Register workspace path
-      if: ${{ github.event.number > 0 }}
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-    - name: Checkout Pull Request
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      id: checkout
-      if: ${{ github.event.number > 0 }}
-      run: |
-        gh pr checkout ${{ github.event.number }}
-
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
+        languages: go
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
+        queries: +security-and-quality
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
@@ -50,7 +30,7 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:go"
 
   semgrep:
     name: Analyze Semgrep
@@ -59,22 +39,10 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v3
-      - name: Register workspace path
-        if: ${{ github.event.number > 0 }}
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Checkout Pull Request
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        id: checkout
-        if: ${{ github.event.number > 0 }}
-        run: |
-          apk add github-cli
-          gh pr checkout ${{ github.event.number }}
 
       - run: semgrep ci --sarif --output=semgrep.sarif
         env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_APP_TOKEN: ${{ vars.SEMGREP_APP_TOKEN }}
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,13 @@ New deprecation(s):
 
 ### Other
 
-- **RabbitMQ Scaler:** Move from `streadway/amqp` to `rabbitmq/amqp091-go` ([#4004](https://github.com/kedacore/keda/pull/4039))
 - **General**: Bump Golang to 1.19 ([#4094](https://github.com/kedacore/keda/issues/4094))
-- **General:** Compare error with `errors.Is` ([#4004](https://github.com/kedacore/keda/pull/4004))
 - **General:** Check that ScaledObject name is specified as part of a query for getting metrics ([#4088](https://github.com/kedacore/keda/pull/4088))
+- **General:** Compare error with `errors.Is` ([#4004](https://github.com/kedacore/keda/pull/4004))
+- **General:** Review CodeQL rules and enable it on PRs ([#4032](https://github.com/kedacore/keda/pull/4032))
+- **RabbitMQ Scaler:** Move from `streadway/amqp` to `rabbitmq/amqp091-go` ([#4004](https://github.com/kedacore/keda/pull/4039))
+
+
 
 ## v2.9.2
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

I have split into 2 different workflows, the static analyzers because they need different triggers, in theory both can be executed with a regular `pull_request` trigger but semgrep still has secrets (the token), so makes sense to have it safely, but CodeQL doesn't use secrets so moving it from `pull_request_target` to `pull_request` helps for future changes.

I have added more rules to CodeQL, I'm not 100% sure if it will work or not, but I think so

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/4032

