### PR TITLE
Cassandra_Scaler improvement - Fixed port error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Here is an overview of all new **experimental** features:
 - **CPU Memory Scaler** Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))
   **Kafka Scaler**: Support 0 in activationLagThreshold configuration ([#4137](https://github.com/kedacore/keda/issues/4137))
 - **Prometheus Metrics**: Expose Prometheus Metrics also when getting ScaledObject state ([#4075](https://github.com/kedacore/keda/issues/4075))
+- **Cassandra Scaler:** Fixed the assignment of port information ([4110])(https://github.com/kedacore/keda/issues/4110)
 
 
 ### Deprecations

--- a/pkg/scalers/cassandra_scaler.go
+++ b/pkg/scalers/cassandra_scaler.go
@@ -110,12 +110,15 @@ func parseCassandraMetadata(config *ScalerConfig) (*CassandraMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["clusterIPAddress"]; ok {
-		switch p := meta.port; {
-		case p > 0:
-			meta.clusterIPAddress = net.JoinHostPort(val, fmt.Sprintf("%d", meta.port))
-		case strings.Contains(val, ":"):
+		splitval := strings.Split(val, ":")
+		port := splitval[len(splitval)-1]
+
+		_, err := strconv.Atoi(port)
+		if err == nil {
 			meta.clusterIPAddress = val
-		default:
+		} else if meta.port > 0 {
+			meta.clusterIPAddress = net.JoinHostPort(val, fmt.Sprintf("%d", meta.port))
+		} else {
 			return nil, fmt.Errorf("no port given")
 		}
 	} else {

--- a/pkg/scalers/cassandra_scaler.go
+++ b/pkg/scalers/cassandra_scaler.go
@@ -114,11 +114,12 @@ func parseCassandraMetadata(config *ScalerConfig) (*CassandraMetadata, error) {
 		port := splitval[len(splitval)-1]
 
 		_, err := strconv.Atoi(port)
-		if err == nil {
+		switch {
+		case err == nil:
 			meta.clusterIPAddress = val
-		} else if meta.port > 0 {
+		case meta.port > 0:
 			meta.clusterIPAddress = net.JoinHostPort(val, fmt.Sprintf("%d", meta.port))
-		} else {
+		default:
 			return nil, fmt.Errorf("no port given")
 		}
 	} else {

--- a/pkg/scalers/cassandra_scaler.go
+++ b/pkg/scalers/cassandra_scaler.go
@@ -112,8 +112,8 @@ func parseCassandraMetadata(config *ScalerConfig) (*CassandraMetadata, error) {
 	if val, ok := config.TriggerMetadata["clusterIPAddress"]; ok {
 		splitval := strings.Split(val, ":")
 		port := splitval[len(splitval)-1]
-
 		_, err := strconv.Atoi(port)
+		
 		switch {
 		case err == nil:
 			meta.clusterIPAddress = val


### PR DESCRIPTION
Signed-off-by: ithesadson <thesadson@gmail.com>

Since the change I made before was a breaking change, I just fix the mistake and send a pr again. 
Issue : https://github.com/kedacore/keda/issues/4110
Previous PR: https://github.com/kedacore/keda/pull/4079

If the clusterIPAddress contains port information, checking if the port information is entered in the clusterIPAddress will cause some errors.

Error example in current code: User enters the following values.
clusterIPAddress: "https://cassandra.test/"
port: "9042"
->Expected clusterIPAddress : https://cassandra.test:9042/
The actual clusterIPAddress: https://cassandra.test/


### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

