### PR TITLE
Add support for Hashicorp Vault KV engine V1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Add a warning when KEDA run outside supported k8s versions ([#4130](https://github.com/kedacore/keda/issues/4130))
 - **General**: Use (self-signed) certificates for all the communications (internals and externals) ([#3931](https://github.com/kedacore/keda/issues/3931))
+- **Hashicorp Vault**: Add support to secrets backend version 1 ([#2645](https://github.com/kedacore/keda/issues/2645))
 - **RabbitMQ Scaler**:  Add TLS support ([#967](https://github.com/kedacore/keda/issues/967))
 - **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))
 - **Selenium Grid Scaler**: Add 'platformName' to selenium-grid scaler metadata structure ([#4038](https://github.com/kedacore/keda/issues/4038))

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -501,6 +501,10 @@ func resolveVaultSecret(logger logr.Logger, data map[string]interface{}, key str
 			logger.Error(fmt.Errorf("key '%s' not found", key), "error trying to get key from Vault secret")
 			return ""
 		}
+	} else if vData, ok := data[key]; ok {
+		if s, ok := vData.(string); ok {
+			return s
+		}
 	}
 
 	logger.Error(fmt.Errorf("unable to convert Vault Data value"), "error trying to convert Data secret vaule")


### PR DESCRIPTION
Add support for Hashicorp Vault secrets backend version 1. The altered code is the same from the pull request #2772, with an end-to-end test to validate the changes.

### Checklist

- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #2645
Relates to #2772

Have a wonderful day,
Best regards.