### PR TITLE
cherry-pick: Use new SDK with proper errors for service bus with pod identity (#4030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,42 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **Azure Service Bus Scaler:** Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026)|[#4123](https://github.com/kedacore/keda/issues/4123))
+
+### Deprecations
+
+You can find all deprecations in [this overview](https://github.com/kedacore/keda/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Abreaking-change) and [join the discussion here](https://github.com/kedacore/keda/discussions/categories/deprecations).
+
+New deprecation(s):
+
+- TODO
+
+### Other
+
+- TODO
+
+## v2.9.2
+
+### Breaking Changes
+
+- TODO
+
+### New
+
+Here is an overview of all **stable** additions:
+
+- **General**: TODO ([#TODO](https://github.com/kedacore/keda/issues/TODO))
+
+Here is an overview of all new **experimental** features:
+
+- **General**: TODO ([#TODO](https://github.com/kedacore/keda/issues/TODO))
+
+### Improvements
+
+- **General**: TODO ([#TODO](https://github.com/kedacore/keda/issues/TODO))
+
+### Fixes
+
 - **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))
 - **Azure Service Bus Scaler:** Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026))
 - **Prometheus Metrics**: Fix exposed metric from `keda_scaled_errors` to `keda_scaled_object_errors` ([#4037](https://github.com/kedacore/keda/issues/4037))

--- a/pkg/scalers/azure/azure_azidentity_chain.go
+++ b/pkg/scalers/azure/azure_azidentity_chain.go
@@ -5,9 +5,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 )
 
-func NewChainedCredential(identityID string) (*azidentity.ChainedTokenCredential, error) {
+func NewChainedCredential(identityID string, podIdentity v1alpha1.PodIdentityProvider) (*azidentity.ChainedTokenCredential, error) {
 	var creds []azcore.TokenCredential
 
 	// Used for local debug based on az-cli user
@@ -19,15 +21,24 @@ func NewChainedCredential(identityID string) (*azidentity.ChainedTokenCredential
 		}
 	}
 
-	// Used for aad-pod-identity
-	msiCred, err := ManagedIdentityWrapperCredential(identityID)
-	if err == nil {
-		creds = append(creds, msiCred)
-	}
-
-	wiCred, err := NewADWorkloadIdentityCredential(identityID)
-	if err == nil {
-		creds = append(creds, wiCred)
+	// https://github.com/kedacore/keda/issues/4123
+	// We shouldn't register both in the same chain because if both are registered, KEDA will use the first one
+	// which returns a valid token. This could produce an unintended behaviour if end-users use 2 different identities
+	// with 2 different permissions. They could set workload-identity with the identity A, but KEDA would use
+	// aad-pod-identity with the identity B. If both identities are differents or have different permissions, this blocks
+	// workload identity
+	switch podIdentity {
+	case v1alpha1.PodIdentityProviderAzure:
+		// Used for aad-pod-identity
+		msiCred, err := ManagedIdentityWrapperCredential(identityID)
+		if err == nil {
+			creds = append(creds, msiCred)
+		}
+	case v1alpha1.PodIdentityProviderAzureWorkload:
+		wiCred, err := NewADWorkloadIdentityCredential(identityID)
+		if err == nil {
+			creds = append(creds, wiCred)
+		}
 	}
 
 	// Create the chained credential based on the previous 3

--- a/pkg/scalers/azure_servicebus_scaler.go
+++ b/pkg/scalers/azure_servicebus_scaler.go
@@ -296,7 +296,7 @@ func (s *azureServiceBusScaler) getServiceBusAdminClient() (*admin.Client, error
 	case "", kedav1alpha1.PodIdentityProviderNone:
 		return admin.NewClientFromConnectionString(s.metadata.connection, nil)
 	case kedav1alpha1.PodIdentityProviderAzure, kedav1alpha1.PodIdentityProviderAzureWorkload:
-		creds, err := azure.NewChainedCredential(s.podIdentity.IdentityID)
+		creds, err := azure.NewChainedCredential(s.podIdentity.IdentityID, s.podIdentity.Provider)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION


### Checklist
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/4123
