### PR TITLE
fix: Added port information check in ClusterIPAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Here is an overview of all new **experimental** features:
 - **CPU Memory Scaler** Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))
   **Kafka Scaler**: Support 0 in activationLagThreshold configuration ([#4137](https://github.com/kedacore/keda/issues/4137))
 - **Prometheus Metrics**: Expose Prometheus Metrics also when getting ScaledObject state ([#4075](https://github.com/kedacore/keda/issues/4075))
+- **Cassandra Scaler**: Checking whether the port information is entered in the ClusterIPAddres is done correctly. ([#4110](https://github.com/kedacore/keda/issues/4110))
 
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,10 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))
 - **Azure Service Bus Scaler:** Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026)|[#4123](https://github.com/kedacore/keda/issues/4123))
+- **Cassandra Scaler**: Checking whether the port information is entered in the ClusterIPAddres is done correctly. ([#4110](https://github.com/kedacore/keda/issues/4110))
 - **CPU Memory Scaler** Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))
   **Kafka Scaler**: Support 0 in activationLagThreshold configuration ([#4137](https://github.com/kedacore/keda/issues/4137))
 - **Prometheus Metrics**: Expose Prometheus Metrics also when getting ScaledObject state ([#4075](https://github.com/kedacore/keda/issues/4075))
-- **Cassandra Scaler**: Checking whether the port information is entered in the ClusterIPAddres is done correctly. ([#4110](https://github.com/kedacore/keda/issues/4110))
 
 
 ### Deprecations

--- a/pkg/scalers/cassandra_scaler.go
+++ b/pkg/scalers/cassandra_scaler.go
@@ -110,11 +110,15 @@ func parseCassandraMetadata(config *ScalerConfig) (*CassandraMetadata, error) {
 	}
 
 	if val, ok := config.TriggerMetadata["clusterIPAddress"]; ok {
-		switch p := meta.port; {
-		case p > 0:
-			meta.clusterIPAddress = net.JoinHostPort(val, fmt.Sprintf("%d", meta.port))
-		case strings.Contains(val, ":"):
+		splitval := strings.Split(val, ":")
+		port := splitval[len(splitval)-1]
+
+		_, err := strconv.Atoi(port)
+		switch {
+		case err == nil:
 			meta.clusterIPAddress = val
+		case meta.port > 0:
+			meta.clusterIPAddress = net.JoinHostPort(val, fmt.Sprintf("%d", meta.port))
 		default:
 			return nil, fmt.Errorf("no port given")
 		}

--- a/pkg/scalers/cassandra_scaler_test.go
+++ b/pkg/scalers/cassandra_scaler_test.go
@@ -41,6 +41,8 @@ var testCassandraMetadata = []parseCassandraMetadataTestData{
 	{map[string]string{"query": "SELECT COUNT(*) FROM test_keyspace.test_table;", "targetQueryValue": "1", "username": "cassandra", "clusterIPAddress": "cassandra.test:9042", "ScalerIndex": "0", "metricName": "myMetric"}, true, map[string]string{"password": "Y2Fzc2FuZHJhCg=="}},
 	// no password passed
 	{map[string]string{"query": "SELECT COUNT(*) FROM test_keyspace.test_table;", "targetQueryValue": "1", "username": "cassandra", "clusterIPAddress": "cassandra.test:9042", "keyspace": "test_keyspace", "ScalerIndex": "0", "metricName": "myMetric"}, true, map[string]string{}},
+	// fix issue[4110] passed
+	{map[string]string{"query": "SELECT COUNT(*) FROM test_keyspace.test_table;", "targetQueryValue": "1", "username": "cassandra", "port": "9042", "clusterIPAddress": "https://cassandra.test", "keyspace": "test_keyspace", "ScalerIndex": "0", "metricName": "myMetric"}, false, map[string]string{"password": "Y2Fzc2FuZHJhCg=="}},
 }
 
 var cassandraMetricIdentifiers = []cassandraMetricIdentifier{


### PR DESCRIPTION
Signed-off-by: ithesadson <thesadson@gmail.com>

Since the change I made before was a breaking change, I just fix the mistake and send a pr again.
Issue : #4110
Previous PR: #4079

If the clusterIPAddress contains port information, checking if the port information is entered in the clusterIPAddress will cause some errors.

Error example in current code: User enters the following values.
clusterIPAddress: "https://cassandra.test/"
port: "9042"
->Expected clusterIPAddress : https://cassandra.test:9042/
The actual clusterIPAddress: https://cassandra.test/

### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

