### PR TITLE
Consolidate `GetMetrics()` and `IsActive()` to `GetMetricsAndActivity()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ New deprecation(s):
 - **General**: Bump Golang to 1.19 ([#4094](https://github.com/kedacore/keda/issues/4094))
 - **General**: Check that ScaledObject name is specified as part of a query for getting metrics ([#4088](https://github.com/kedacore/keda/pull/4088))
 - **General**: Compare error with `errors.Is` ([#4004](https://github.com/kedacore/keda/pull/4004))
+- **General**: Consolidate `GetMetrics` and `IsActive` to `GetMetricsAndActivity` for Azure Event Hub, Cron and External scalers ([#4015](https://github.com/kedacore/keda/issues/4015))
 - **General**: Improve test coverage in `pkg/util` ([#3871](https://github.com/kedacore/keda/issues/3871))
 - **General**: Pass deep copy object to scalers cache from the ScaledObject controller ([#4207](https://github.com/kedacore/keda/issues/4207))
 - **General**: Review CodeQL rules and enable it on PRs ([#4032](https://github.com/kedacore/keda/pull/4032))

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -369,7 +369,7 @@ func (s *azureEventHubScaler) GetMetricsAndActivity(ctx context.Context, metricN
 	}
 
 	partitionIDs := runtimeInfo.PartitionIDs
-	
+
 	for i := 0; i < len(partitionIDs); i++ {
 		partitionID := partitionIDs[i]
 		partitionRuntimeInfo, err := s.client.GetPartitionInformation(ctx, partitionID)

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -197,7 +197,7 @@ func (s *externalScaler) GetMetricsAndActivity(ctx context.Context, metricName s
 		metric := GenerateMetricInMili(metricName, float64(metricResult.MetricValue))
 		metrics = append(metrics, metric)
 	}
-	
+
 	isActiveResponse, err := grpcClient.IsActive(ctx, &s.scaledObjectRef)
 	if err != nil {
 		s.logger.Error(err, "error calling IsActive on external scaler")

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -128,22 +128,6 @@ func parseExternalScalerMetadata(config *ScalerConfig) (externalScalerMetadata, 
 	return meta, nil
 }
 
-// IsActive checks if there are any messages in the subscription
-func (s *externalScaler) IsActive(ctx context.Context) (bool, error) {
-	grpcClient, err := getClientForConnectionPool(s.metadata)
-	if err != nil {
-		return false, err
-	}
-
-	response, err := grpcClient.IsActive(ctx, &s.scaledObjectRef)
-	if err != nil {
-		s.logger.Error(err, "error calling IsActive on external scaler")
-		return false, err
-	}
-
-	return response.Result, nil
-}
-
 func (s *externalScaler) Close(context.Context) error {
 	return nil
 }
@@ -184,18 +168,18 @@ func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2.Metri
 	return result
 }
 
-// GetMetrics connects calls the gRPC interface to get the metrics with a specific name
-func (s *externalScaler) GetMetrics(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, error) {
+// GetMetricsAndActivity returns value for a supported metric and an error if there is a problem getting the metric
+func (s *externalScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
 	var metrics []external_metrics.ExternalMetricValue
 	grpcClient, err := getClientForConnectionPool(s.metadata)
 	if err != nil {
-		return metrics, err
+		return []external_metrics.ExternalMetricValue{}, false, err
 	}
 
 	// Remove the sX- prefix as the external scaler shouldn't have to know about it
 	metricNameWithoutIndex, err := RemoveIndexFromMetricName(s.metadata.scalerIndex, metricName)
 	if err != nil {
-		return metrics, err
+		return []external_metrics.ExternalMetricValue{}, false, err
 	}
 
 	request := &pb.GetMetricsRequest{
@@ -203,35 +187,24 @@ func (s *externalScaler) GetMetrics(ctx context.Context, metricName string) ([]e
 		ScaledObjectRef: &s.scaledObjectRef,
 	}
 
-	response, err := grpcClient.GetMetrics(ctx, request)
+	metricsResponse, err := grpcClient.GetMetrics(ctx, request)
 	if err != nil {
 		s.logger.Error(err, "error")
-		return []external_metrics.ExternalMetricValue{}, err
+		return []external_metrics.ExternalMetricValue{}, false, err
 	}
 
-	for _, metricResult := range response.MetricValues {
+	for _, metricResult := range metricsResponse.MetricValues {
 		metric := GenerateMetricInMili(metricName, float64(metricResult.MetricValue))
 		metrics = append(metrics, metric)
 	}
-
-	return metrics, nil
-}
-
-// TODO merge isActive() and GetMetrics()
-func (s *externalScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
-	metrics, err := s.GetMetrics(ctx, metricName)
+	
+	isActiveResponse, err := grpcClient.IsActive(ctx, &s.scaledObjectRef)
 	if err != nil {
-		s.logger.Error(err, "error getting metrics")
+		s.logger.Error(err, "error calling IsActive on external scaler")
 		return []external_metrics.ExternalMetricValue{}, false, err
 	}
 
-	isActive, err := s.IsActive(ctx)
-	if err != nil {
-		s.logger.Error(err, "error getting activity status")
-		return []external_metrics.ExternalMetricValue{}, false, err
-	}
-
-	return metrics, isActive, nil
+	return metrics, isActiveResponse.Result, nil
 }
 
 // handleIsActiveStream is the only writer to the active channel and will close it on return.


### PR DESCRIPTION
This PR consolidates `GetMetrics()` and `IsActive()` to `GetMetricsAndActivity()` for the remaining scalers (Azure Event Hub, Cron and External).

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #4015