### PR TITLE
Made metricName optional in Prometheus Scaler

### DIFF
--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -82,7 +82,7 @@ func NewPrometheusScaler(config *ScalerConfig) (Scaler, error) {
 
 	logger := InitializeLogger(config, "prometheus_scaler")
 
-	meta, err := parsePrometheusMetadata(config)
+	meta, err := parsePrometheusMetadata(config, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing prometheus metadata: %w", err)
 	}
@@ -110,7 +110,7 @@ func NewPrometheusScaler(config *ScalerConfig) (Scaler, error) {
 	}, nil
 }
 
-func parsePrometheusMetadata(config *ScalerConfig) (meta *prometheusMetadata, err error) {
+func parsePrometheusMetadata(config *ScalerConfig, logger logr.Logger) (meta *prometheusMetadata, err error) {
 	meta = &prometheusMetadata{}
 
 	if val, ok := config.TriggerMetadata[promServerAddress]; ok && val != "" {
@@ -123,12 +123,6 @@ func parsePrometheusMetadata(config *ScalerConfig) (meta *prometheusMetadata, er
 		meta.query = val
 	} else {
 		return nil, fmt.Errorf("no %s given", promQuery)
-	}
-
-	if val, ok := config.TriggerMetadata[promMetricName]; ok && val != "" {
-		meta.metricName = val
-	} else {
-		return nil, fmt.Errorf("no %s given", promMetricName)
 	}
 
 	if val, ok := config.TriggerMetadata[promThreshold]; ok && val != "" {
@@ -150,6 +144,11 @@ func parsePrometheusMetadata(config *ScalerConfig) (meta *prometheusMetadata, er
 		}
 
 		meta.activationThreshold = t
+	}
+
+	if val, ok := config.TriggerMetadata[promMetricName]; ok && val != "" {
+		meta.metricName = val
+		logger.Info("WARNING: the field 'metricName' has been deprecated and will be removed in v2.12")
 	}
 
 	if val, ok := config.TriggerMetadata[promNamespace]; ok && val != "" {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)* https://github.com/kedacore/keda-docs/pull/1072
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
