### PR TITLE
Improve error logging by skipping logging of errors related to paused scalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ## Unreleased
 
-- **General** 
-
 ### Breaking Changes
 
 - TODO 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,14 +41,17 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ## Unreleased
 
+- **General** 
+
 ### Breaking Changes
 
-- TODO
+- TODO 
 
 ### New
 
 Here is an overview of all **stable** additions:
 
+- **General**: Improve error logging by skipping reconciliation and therefore logging of errors related to paused ScaledObject ([#4254](https://github.com/kedacore/keda/issues/4254))
 - **General**: Add support to register custom CAs globally in KEDA operator ([#4168](https://github.com/kedacore/keda/issues/4168))
 - **General**: Introduce admission webhooks to automatically validate resource changes to prevent misconfiguration and enforce best practices ([#3755](https://github.com/kedacore/keda/issues/3755))
 - **General**: Introduce new ArangoDB Scaler ([#4000](https://github.com/kedacore/keda/issues/4000))

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -149,6 +149,13 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	// if the ScaledObject is paused, skip processing the request
+	_, paused := scaledObject.GetAnnotations()[kedacontrollerutil.PausedReplicasAnnotation]
+	if paused {
+		reqLogger.Info("ScaledObject is paused, so skipping the request.")
+		return ctrl.Result{}, nil
+	}
+
 	reqLogger.Info("Reconciling ScaledObject")
 
 	// Check if the ScaledObject instance is marked to be deleted, which is


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

A small addition to the Reconciliation loop to allow for skipping the reconciliation of the paused scaled objects. This addition is **beneficial** as without it, as it is now, many log messages are caused by a paused scaledobject whose scaler's running pre-conditions are not satisfied. For an example a database mysql scaler depends on may be down while the scaledobject is paused. There is no value in those logs so better to remove them **to keep the logs useful, clean of noise, and efficient and easy to use**.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
