### PR TITLE
chore: use random queue name for servicebus e2e test

### DIFF
--- a/tests/scalers/azure/azure_service_bus_queue_aad_wi/azure_service_bus_queue_aad_wi_test.go
+++ b/tests/scalers/azure/azure_service_bus_queue_aad_wi/azure_service_bus_queue_aad_wi_test.go
@@ -32,7 +32,7 @@ var (
 	deploymentName   = fmt.Sprintf("%s-deployment", testName)
 	triggerAuthName  = fmt.Sprintf("%s-ta", testName)
 	scaledObjectName = fmt.Sprintf("%s-so", testName)
-	queueName        = fmt.Sprintf("%s-queue", testName)
+	queueName        = fmt.Sprintf("queue-%d", GetRandomNumber())
 )
 
 type templateData struct {


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

