### PR TITLE
fix: move `sasl` and `tls` flag to ScaledObject instead of specifying in TriggerAuthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Here is an overview of all new **experimental** features:
 - **Azure Pipelines Scaler**: New configuration parameter `requireAllDemands` to scale only if jobs request all demands provided by the scaling definition ([#4138](https://github.com/kedacore/keda/issues/4138))
 - **Hashicorp Vault**: Add support to secrets backend version 1 ([#2645](https://github.com/kedacore/keda/issues/2645))
 - **Kafka Scaler**: Improve error logging for `GetBlock` method ([#4232](https://github.com/kedacore/keda/issues/4232))
-- **Kafka Scaler**: Add support to use `enableTls` and `saslAuthType` in ScaledObject ([#4232](https://github.com/kedacore/keda/issues/4322))
+- **Kafka Scaler**: Add support to use `tls` and `sasl` in ScaledObject ([#4232](https://github.com/kedacore/keda/issues/4322))
 - **Prometheus Scaler**: Add custom headers and custom auth support ([#4208](https://github.com/kedacore/keda/issues/4208))
 - **RabbitMQ Scaler**:  Add TLS support ([#967](https://github.com/kedacore/keda/issues/967))
 - **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Breaking Changes
 
-- TODO
+- **Kafka Scaler**: move `tls` and `sasl` in TriggerAuthentication to `enableTls` and `saslAuthType` in ScaledObject ([#4232](https://github.com/kedacore/keda/issues/4322))
 
 ### New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Breaking Changes
 
-- **Kafka Scaler**: move `tls` and `sasl` in TriggerAuthentication to `enableTls` and `saslAuthType` in ScaledObject ([#4232](https://github.com/kedacore/keda/issues/4322))
+- TODO
 
 ### New
 
@@ -72,6 +72,7 @@ Here is an overview of all new **experimental** features:
 - **Azure Pipelines Scaler**: New configuration parameter `requireAllDemands` to scale only if jobs request all demands provided by the scaling definition ([#4138](https://github.com/kedacore/keda/issues/4138))
 - **Hashicorp Vault**: Add support to secrets backend version 1 ([#2645](https://github.com/kedacore/keda/issues/2645))
 - **Kafka Scaler**: Improve error logging for `GetBlock` method ([#4232](https://github.com/kedacore/keda/issues/4232))
+- **Kafka Scaler**: Add support to use `enableTls` and `saslAuthType` in ScaledObject ([#4232](https://github.com/kedacore/keda/issues/4322))
 - **Prometheus Scaler**: Add custom headers and custom auth support ([#4208](https://github.com/kedacore/keda/issues/4208))
 - **RabbitMQ Scaler**:  Add TLS support ([#967](https://github.com/kedacore/keda/issues/967))
 - **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -139,7 +139,7 @@ func parseAzureBlobMetadata(config *ScalerConfig, logger logr.Logger) (*azure.Bl
 	meta.EndpointSuffix = endpointSuffix
 
 	// before triggerAuthentication CRD, pod identity was configured using this property
-	if val, ok := config.TriggerMetadata["useAAdPodIdentity"]; ok && config.PodIdentity.Provider == "" && val == "true" {
+	if val, ok := config.TriggerMetadata["useAAdPodIdentity"]; ok && config.PodIdentity.Provider == "" && val == stringTrue {
 		config.PodIdentity = kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzure}
 	}
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -123,15 +123,15 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	meta.saslType = KafkaSASLTypeNone
 	var saslAuthType string
 	switch {
-	case config.TriggerMetadata["saslAuthType"] != "":
-		saslAuthType = config.TriggerMetadata["saslAuthType"]
+	case config.TriggerMetadata["sasl"] != "":
+		saslAuthType = config.TriggerMetadata["sasl"]
 	default:
 		saslAuthType = ""
 	}
 
 	if val, ok := config.AuthParams["sasl"]; ok {
 		if saslAuthType != "" {
-			return errors.New("unable to set `saslAuthType` in ScaledObject and `sasl` in TriggerAuthentication together")
+			return errors.New("unable to set `sasl` in both ScaledObject and TriggerAuthentication together")
 		}
 		saslAuthType = val
 	}
@@ -166,18 +166,21 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 
 	meta.enableTLS = false
 	enableTLS := false
-	if val, ok := config.TriggerMetadata["enableTls"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return fmt.Errorf("error parsing enableTls: %w", err)
+	if val, ok := config.TriggerMetadata["tls"]; ok {
+		switch val {
+		case "enable":
+			enableTLS = true
+		case "disable":
+			enableTLS = false
+		default:
+			return fmt.Errorf("error incorrect TLS value given, got %s", val)
 		}
-		enableTLS = t
 	}
 
 	if val, ok := config.AuthParams["tls"]; ok {
 		val = strings.TrimSpace(val)
 		if enableTLS {
-			return errors.New("unable to set `enableTls` in ScaledObject and `tls` in TriggerAuthentication together")
+			return errors.New("unable to set `tls` in both ScaledObject and TriggerAuthentication together")
 		}
 		switch val {
 		case "enable":
@@ -185,7 +188,7 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 		case "disable":
 			enableTLS = false
 		default:
-			return fmt.Errorf("err incorrect TLS value given, got %s", val)
+			return fmt.Errorf("error incorrect TLS value given, got %s", val)
 		}
 	}
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -25,6 +25,11 @@ type kafkaScaler struct {
 	previousOffsets map[string]map[int32]int64
 }
 
+const (
+	stringEnable  = "enable"
+	stringDisable = "disable"
+)
+
 type kafkaMetadata struct {
 	bootstrapServers       []string
 	group                  string
@@ -168,9 +173,9 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	enableTLS := false
 	if val, ok := config.TriggerMetadata["tls"]; ok {
 		switch val {
-		case "enable":
+		case stringEnable:
 			enableTLS = true
-		case "disable":
+		case stringDisable:
 			enableTLS = false
 		default:
 			return fmt.Errorf("error incorrect TLS value given, got %s", val)
@@ -183,9 +188,9 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 			return errors.New("unable to set `tls` in both ScaledObject and TriggerAuthentication together")
 		}
 		switch val {
-		case "enable":
+		case stringEnable:
 			enableTLS = true
-		case "disable":
+		case stringDisable:
 			enableTLS = false
 		default:
 			return fmt.Errorf("error incorrect TLS value given, got %s", val)

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -168,26 +168,26 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata, logger logr
 	}
 
 	meta.enableTLS = false
-	enableTls := false
+	enableTLS := false
 	if val, ok := config.TriggerMetadata["enableTls"]; ok {
 		t, err := strconv.ParseBool(val)
 		if err != nil {
 			return fmt.Errorf("error parsing enableTls: %w", err)
 		}
-		enableTls = t
+		enableTLS = t
 	}
 
 	// FIXME: DEPRECATED, to be removed in version 2.12
 	if val, ok := config.AuthParams["tls"]; ok {
 		val = strings.TrimSpace(val)
-		if enableTls {
+		if enableTLS {
 			return errors.New("unable to set `enableTls` in ScaledObject and `tls` in TriggerAuthentication together")
 		}
 		switch val {
 		case "enable":
-			enableTls = true
+			enableTLS = true
 		case "disable":
-			enableTls = false
+			enableTLS = false
 		default:
 			return fmt.Errorf("err incorrect TLS value given, got %s", val)
 		}
@@ -195,7 +195,7 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata, logger logr
 			"going to be deprecated in version 2.12. Please use `enableTls` in ScaleObject")
 	}
 
-	if enableTls {
+	if enableTLS {
 		certGiven := config.AuthParams["cert"] != ""
 		keyGiven := config.AuthParams["key"] != ""
 		if certGiven && !keyGiven {

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -129,10 +129,7 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata, logger logr
 		saslAuthType = ""
 	}
 
-	// FIXME: DEPRECATED, to be removed in version 2.12
 	if val, ok := config.AuthParams["sasl"]; ok {
-		logger.V(1).Info("Setting `sasl` in TriggerAuthentication is " +
-			"going to be deprecated in version 2.12. Please use `saslAuthType` in ScaleObject")
 		if saslAuthType != "" {
 			return errors.New("unable to set `saslAuthType` in ScaledObject and `sasl` in TriggerAuthentication together")
 		}
@@ -177,7 +174,6 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata, logger logr
 		enableTLS = t
 	}
 
-	// FIXME: DEPRECATED, to be removed in version 2.12
 	if val, ok := config.AuthParams["tls"]; ok {
 		val = strings.TrimSpace(val)
 		if enableTLS {
@@ -191,8 +187,6 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata, logger logr
 		default:
 			return fmt.Errorf("err incorrect TLS value given, got %s", val)
 		}
-		logger.V(1).Info("Setting `tls` in TriggerAuthentication is " +
-			"going to be deprecated in version 2.12. Please use `enableTls` in ScaleObject")
 	}
 
 	if enableTLS {

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -119,7 +119,7 @@ func NewKafkaScaler(config *ScalerConfig) (Scaler, error) {
 	}, nil
 }
 
-func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata, logger logr.Logger) error {
+func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	meta.saslType = KafkaSASLTypeNone
 	var saslAuthType string
 	switch {
@@ -295,7 +295,7 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 		meta.activationLagThreshold = t
 	}
 
-	if err := parseKafkaAuthParams(config, &meta, logger); err != nil {
+	if err := parseKafkaAuthParams(config, &meta); err != nil {
 		return meta, err
 	}
 

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -23,14 +23,14 @@ type parseKafkaMetadataTestData struct {
 	excludePersistentLag bool
 }
 
-// FIXME: DEPRECATED, to be removed in version 2.12
 type parseKafkaAuthParamsTestData struct {
 	authParams map[string]string
 	isError    bool
 	enableTLS  bool
 }
 
-type parseAuthParamsTestData struct {
+// Testing the case where `enableTls` and `saslAuthType` are specified in ScaledObject
+type parseAuthParamsTestDataSecondAuthMethod struct {
 	metadata   map[string]string
 	authParams map[string]string
 	isError    bool
@@ -53,7 +53,6 @@ var validKafkaMetadata = map[string]string{
 
 // A complete valid authParams example for sasl, with username and passwd
 var validWithAuthParams = map[string]string{
-	// FIXME: DEPRECATED, to be removed in version 2.12
 	"sasl":     "plaintext",
 	"username": "admin",
 	"password": "admin",
@@ -115,7 +114,6 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic", nil, offsetResetPolicy("latest"), true, false},
 }
 
-// FIXME: DEPRECATED, to be removed in version 2.12
 var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	// success, SASL only
 	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin"}, false, false},
@@ -168,7 +166,7 @@ var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	// failure, SASL + TLS, missing key
 	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert"}, true, false},
 }
-var parseAuthParamsTestDataset = []parseAuthParamsTestData{
+var parseAuthParamsTestDataset = []parseAuthParamsTestDataSecondAuthMethod{
 	// success, SASL plaintext
 	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
 	// success, SASL scram_sha256
@@ -220,7 +218,6 @@ var parseAuthParamsTestDataset = []parseAuthParamsTestData{
 	// failure, SASL + TLS, missing key
 	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert"}, true, false},
 
-	// FIXME: DEPRECATED, to be removed in version 2.12
 	// failure, setting SASL values in both places
 	{map[string]string{"saslAuthType": "scram_sha512", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, true, false},
 	// failure, setting TLS values in both places
@@ -311,7 +308,7 @@ func TestGetBrokers(t *testing.T) {
 }
 
 func TestKafkaAuthParams(t *testing.T) {
-	// FIXME: DEPRECATED, to be removed in version 2.12
+	// Testing tls and sasl value in TriggerAuthentication
 	for _, testData := range parseKafkaAuthParamsTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
 
@@ -340,6 +337,7 @@ func TestKafkaAuthParams(t *testing.T) {
 		}
 	}
 
+	// Testing tls and sasl value in scaledObject
 	for id, testData := range parseAuthParamsTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams}, logr.Discard())
 

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -29,7 +29,7 @@ type parseKafkaAuthParamsTestData struct {
 	enableTLS  bool
 }
 
-// Testing the case where `enableTls` and `saslAuthType` are specified in ScaledObject
+// Testing the case where `tls` and `sasl` are specified in ScaledObject
 type parseAuthParamsTestDataSecondAuthMethod struct {
 	metadata   map[string]string
 	authParams map[string]string
@@ -168,60 +168,60 @@ var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 }
 var parseAuthParamsTestDataset = []parseAuthParamsTestDataSecondAuthMethod{
 	// success, SASL plaintext
-	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	{map[string]string{"sasl": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
 	// success, SASL scram_sha256
-	{map[string]string{"saslAuthType": "scram_sha256", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	{map[string]string{"sasl": "scram_sha256", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
 	// success, SASL scram_sha512
-	{map[string]string{"saslAuthType": "scram_sha512", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	{map[string]string{"sasl": "scram_sha512", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
 	// success, TLS only
-	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	{map[string]string{"tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
 	// success, TLS cert/key and assumed public CA
-	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"cert": "ceert", "key": "keey"}, false, true},
+	{map[string]string{"tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"cert": "ceert", "key": "keey"}, false, true},
 	// success, TLS cert/key + key password and assumed public CA
-	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"cert": "ceert", "key": "keey", "keyPassword": "keeyPassword"}, false, true},
+	{map[string]string{"tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"cert": "ceert", "key": "keey", "keyPassword": "keeyPassword"}, false, true},
 	// success, TLS CA only
-	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa"}, false, true},
+	{map[string]string{"tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa"}, false, true},
 	// success, SASL + TLS
-	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	{map[string]string{"sasl": "plaintext", "tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
 	// success, SASL + TLS explicitly disabled
-	{map[string]string{"saslAuthType": "plaintext", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	{map[string]string{"sasl": "plaintext", "tls": "disable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
 	// success, SASL OAUTHBEARER + TLS explicitly disabled
-	{map[string]string{"saslAuthType": "oauthbearer", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, false, false},
+	{map[string]string{"sasl": "oauthbearer", "tls": "disable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, false, false},
 	// failure, SASL OAUTHBEARER + TLS explicitly disable +  bad SASL type
-	{map[string]string{"saslAuthType": "foo", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, true, false},
+	{map[string]string{"sasl": "foo", "tls": "disable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, true, false},
 	// success, SASL OAUTHBEARER + TLS missing scope
-	{map[string]string{"saslAuthType": "oauthbearer", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "oauthTokenEndpointUri": "https://website.com"}, false, false},
+	{map[string]string{"sasl": "oauthbearer", "tls": "disable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "oauthTokenEndpointUri": "https://website.com"}, false, false},
 	// failure, SASL OAUTHBEARER + TLS missing oauthTokenEndpointUri
-	{map[string]string{"saslAuthType": "oauthbearer", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": ""}, true, false},
+	{map[string]string{"sasl": "oauthbearer", "tls": "disable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": ""}, true, false},
 	// failure, SASL incorrect type
-	{map[string]string{"saslAuthType": "foo", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, true, false},
+	{map[string]string{"sasl": "foo", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, true, false},
 	// failure, SASL missing username
-	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"password": "admin"}, true, false},
+	{map[string]string{"sasl": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"password": "admin"}, true, false},
 	// failure, SASL missing password
-	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin"}, true, false},
+	{map[string]string{"sasl": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin"}, true, false},
 	// failure, TLS missing cert
-	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "key": "keey"}, true, false},
+	{map[string]string{"tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "key": "keey"}, true, false},
 	// failure, TLS missing key
-	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "cert": "ceert"}, true, false},
+	{map[string]string{"tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "cert": "ceert"}, true, false},
 	// failure, TLS invalid
-	{map[string]string{"enableTls": "random", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"tls": "random", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, incorrect SASL type
-	{map[string]string{"saslAuthType": "foo", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"sasl": "foo", "tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, incorrect tls
-	{map[string]string{"saslAuthType": "plaintext", "enableTls": "foo", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"sasl": "plaintext", "tls": "foo", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing username
-	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"sasl": "plaintext", "tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing password
-	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	{map[string]string{"sasl": "plaintext", "tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing cert
-	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "key": "keey"}, true, false},
+	{map[string]string{"sasl": "plaintext", "tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "key": "keey"}, true, false},
 	// failure, SASL + TLS, missing key
-	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert"}, true, false},
+	{map[string]string{"sasl": "plaintext", "tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert"}, true, false},
 
 	// failure, setting SASL values in both places
-	{map[string]string{"saslAuthType": "scram_sha512", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, true, false},
+	{map[string]string{"sasl": "scram_sha512", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, true, false},
 	// failure, setting TLS values in both places
-	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, true},
+	{map[string]string{"tls": "enable", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, true},
 }
 
 var parseKafkaOAuthbrearerAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
@@ -348,8 +348,8 @@ func TestKafkaAuthParams(t *testing.T) {
 			t.Errorf("Test case: %v. Expected error but got success", id)
 		}
 		if !testData.isError {
-			if testData.metadata["enableTls"] == "true" && !meta.enableTLS {
-				t.Errorf("Test case: %v. Expected enableTls to be set to %v but got %v\n", id, testData.metadata["enableTls"], meta.enableTLS)
+			if testData.metadata["tls"] == "true" && !meta.enableTLS {
+				t.Errorf("Test case: %v. Expected tls to be set to %v but got %v\n", id, testData.metadata["tls"], meta.enableTLS)
 			}
 			if meta.enableTLS {
 				if meta.ca != testData.authParams["ca"] {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -34,7 +34,7 @@ type parseAuthParamsTestData struct {
 	metadata   map[string]string
 	authParams map[string]string
 	isError    bool
-	enableTls  bool
+	enableTLS  bool
 }
 
 type kafkaMetricIdentifier struct {
@@ -169,7 +169,7 @@ var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert"}, true, false},
 }
 var parseAuthParamsTestDataset = []parseAuthParamsTestData{
-	//success, SASL plaintext
+	// success, SASL plaintext
 	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
 	// success, SASL scram_sha256
 	{map[string]string{"saslAuthType": "scram_sha256", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
@@ -352,7 +352,6 @@ func TestKafkaAuthParams(t *testing.T) {
 		if !testData.isError {
 			if testData.metadata["enableTls"] == "true" && !meta.enableTLS {
 				t.Errorf("Test case: %v. Expected enableTls to be set to %v but got %v\n", id, testData.metadata["enableTls"], meta.enableTLS)
-
 			}
 			if meta.enableTLS {
 				if meta.ca != testData.authParams["ca"] {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -23,10 +23,18 @@ type parseKafkaMetadataTestData struct {
 	excludePersistentLag bool
 }
 
+// FIXME: DEPRECATED, to be removed in version 2.12
 type parseKafkaAuthParamsTestData struct {
 	authParams map[string]string
 	isError    bool
 	enableTLS  bool
+}
+
+type parseAuthParamsTestData struct {
+	metadata   map[string]string
+	authParams map[string]string
+	isError    bool
+	enableTls  bool
 }
 
 type kafkaMetricIdentifier struct {
@@ -45,6 +53,7 @@ var validKafkaMetadata = map[string]string{
 
 // A complete valid authParams example for sasl, with username and passwd
 var validWithAuthParams = map[string]string{
+	// FIXME: DEPRECATED, to be removed in version 2.12
 	"sasl":     "plaintext",
 	"username": "admin",
 	"password": "admin",
@@ -106,6 +115,7 @@ var parseKafkaMetadataTestDataset = []parseKafkaMetadataTestData{
 	{map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, false, 1, []string{"foobar:9092"}, "my-group", "my-topic", nil, offsetResetPolicy("latest"), true, false},
 }
 
+// FIXME: DEPRECATED, to be removed in version 2.12
 var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	// success, SASL only
 	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin"}, false, false},
@@ -158,8 +168,66 @@ var parseKafkaAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	// failure, SASL + TLS, missing key
 	{map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "tls": "enable", "ca": "caaa", "cert": "ceert"}, true, false},
 }
+var parseAuthParamsTestDataset = []parseAuthParamsTestData{
+	//success, SASL plaintext
+	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	// success, SASL scram_sha256
+	{map[string]string{"saslAuthType": "scram_sha256", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	// success, SASL scram_sha512
+	{map[string]string{"saslAuthType": "scram_sha512", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	// success, TLS only
+	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	// success, TLS cert/key and assumed public CA
+	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"cert": "ceert", "key": "keey"}, false, true},
+	// success, TLS cert/key + key password and assumed public CA
+	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"cert": "ceert", "key": "keey", "keyPassword": "keeyPassword"}, false, true},
+	// success, TLS CA only
+	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa"}, false, true},
+	// success, SASL + TLS
+	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	// success, SASL + TLS explicitly disabled
+	{map[string]string{"saslAuthType": "plaintext", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, false, false},
+	// success, SASL OAUTHBEARER + TLS explicitly disabled
+	{map[string]string{"saslAuthType": "oauthbearer", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, false, false},
+	// failure, SASL OAUTHBEARER + TLS explicitly disable +  bad SASL type
+	{map[string]string{"saslAuthType": "foo", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com"}, true, false},
+	// success, SASL OAUTHBEARER + TLS missing scope
+	{map[string]string{"saslAuthType": "oauthbearer", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "oauthTokenEndpointUri": "https://website.com"}, false, false},
+	// failure, SASL OAUTHBEARER + TLS missing oauthTokenEndpointUri
+	{map[string]string{"saslAuthType": "oauthbearer", "enableTls": "false", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": ""}, true, false},
+	// failure, SASL incorrect type
+	{map[string]string{"saslAuthType": "foo", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin"}, true, false},
+	// failure, SASL missing username
+	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"password": "admin"}, true, false},
+	// failure, SASL missing password
+	{map[string]string{"saslAuthType": "plaintext", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin"}, true, false},
+	// failure, TLS missing cert
+	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "key": "keey"}, true, false},
+	// failure, TLS missing key
+	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"ca": "caaa", "cert": "ceert"}, true, false},
+	// failure, TLS invalid
+	{map[string]string{"enableTls": "random", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"tls": "yes", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	// failure, SASL + TLS, incorrect SASL type
+	{map[string]string{"saslAuthType": "foo", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	// failure, SASL + TLS, incorrect tls
+	{map[string]string{"saslAuthType": "plaintext", "enableTls": "foo", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	// failure, SASL + TLS, missing username
+	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"password": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	// failure, SASL + TLS, missing password
+	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, false},
+	// failure, SASL + TLS, missing cert
+	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"username": "admin", "password": "admin", "ca": "caaa", "key": "keey"}, true, false},
+	// failure, SASL + TLS, missing key
+	{map[string]string{"saslAuthType": "plaintext", "enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "plaintext", "username": "admin", "password": "admin", "ca": "caaa", "cert": "ceert"}, true, false},
 
-var parseKafkaOAuthbreakerAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
+	// FIXME: DEPRECATED, to be removed in version 2.12
+	// failure, setting SASL values in both places
+	{map[string]string{"saslAuthType": "scram_sha512", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"sasl": "scram_sha512", "username": "admin", "password": "admin"}, true, false},
+	// failure, setting TLS values in both places
+	{map[string]string{"enableTls": "true", "bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "allowIdleConsumers": "true", "version": "1.0.0"}, map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, true, true},
+}
+
+var parseKafkaOAuthbrearerAuthParamsTestDataset = []parseKafkaAuthParamsTestData{
 	// success, SASL OAUTHBEARER + TLS
 	{map[string]string{"sasl": "oauthbearer", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, false, false},
 	// success, SASL OAUTHBEARER + TLS multiple scopes
@@ -243,6 +311,7 @@ func TestGetBrokers(t *testing.T) {
 }
 
 func TestKafkaAuthParams(t *testing.T) {
+	// FIXME: DEPRECATED, to be removed in version 2.12
 	for _, testData := range parseKafkaAuthParamsTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
 
@@ -270,10 +339,41 @@ func TestKafkaAuthParams(t *testing.T) {
 			}
 		}
 	}
+
+	for id, testData := range parseAuthParamsTestDataset {
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams}, logr.Discard())
+
+		if err != nil && !testData.isError {
+			t.Errorf("Test case: %v. Expected success but got error %v", id, err)
+		}
+		if testData.isError && err == nil {
+			t.Errorf("Test case: %v. Expected error but got success", id)
+		}
+		if !testData.isError {
+			if testData.metadata["enableTls"] == "true" && !meta.enableTLS {
+				t.Errorf("Test case: %v. Expected enableTls to be set to %v but got %v\n", id, testData.metadata["enableTls"], meta.enableTLS)
+
+			}
+			if meta.enableTLS {
+				if meta.ca != testData.authParams["ca"] {
+					t.Errorf("Test case: %v. Expected ca to be set to %v but got %v\n", id, testData.authParams["ca"], meta.ca)
+				}
+				if meta.cert != testData.authParams["cert"] {
+					t.Errorf("Test case: %v. Expected cert to be set to %v but got %v\n", id, testData.authParams["cert"], meta.cert)
+				}
+				if meta.key != testData.authParams["key"] {
+					t.Errorf("Test case: %v. Expected key to be set to %v but got %v\n", id, testData.authParams["key"], meta.key)
+				}
+				if meta.keyPassword != testData.authParams["keyPassword"] {
+					t.Errorf("Test case: %v. Expected key to be set to %v but got %v\n", id, testData.authParams["keyPassword"], meta.keyPassword)
+				}
+			}
+		}
+	}
 }
 
-func TestKafkaOAuthbreakerAuthParams(t *testing.T) {
-	for _, testData := range parseKafkaOAuthbreakerAuthParamsTestDataset {
+func TestKafkaOAuthbrearerAuthParams(t *testing.T) {
+	for _, testData := range parseKafkaOAuthbrearerAuthParamsTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
 
 		if err != nil && !testData.isError {


### PR DESCRIPTION
Hi team,
This MR will solve 

_Provide a description of what has been changed_

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) https://github.com/kedacore/keda-docs/pull/1016
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Example:
```diff
triggers:
- type: kafka
  metadata:
    bootstrapServers: kafka.svc:9092
    consumerGroup: my-group
    topic: test-topic
    lagThreshold: '5'
    activationLagThreshold: '3'
    offsetResetPolicy: latest
    allowIdleConsumers: false
    scaleToZeroOnInvalidOffset: false
    excludePersistentLag: false
    version: 1.0.0
+   saslAuthType: plaintext|scram_sha256|scram_sha512|oauthbearer|none
+   enableTls: true|false
```
Fixes #3611

Relates to #
