### PR TITLE
Azure Application Insights: Add option to ignore null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Add a warning when KEDA run outside supported k8s versions ([#4130](https://github.com/kedacore/keda/issues/4130))
 - **General**: Use (self-signed) certificates for all the communications (internals and externals) ([#3931](https://github.com/kedacore/keda/issues/3931))
 - **General**: Use TLS1.2 as minimum TLS version ([#4193](https://github.com/kedacore/keda/issues/4193))
+- **Azure Application Insights Scaler**: Add ignoreNullValues to ignore errors when the data returned has null in its values ([#4316](https://github.com/kedacore/keda/issues/4316))
 - **Azure Pipelines Scaler**: Improve error logging for `validatePoolID` ([#3996](https://github.com/kedacore/keda/issues/3996))
 - **Azure Pipelines Scaler**: New configuration parameter `requireAllDemands` to scale only if jobs request all demands provided by the scaling definition ([#4138](https://github.com/kedacore/keda/issues/4138))
 - **Hashicorp Vault**: Add support to secrets backend version 1 ([#2645](https://github.com/kedacore/keda/issues/2645))

--- a/pkg/scalers/azure/azure_app_insights.go
+++ b/pkg/scalers/azure/azure_app_insights.go
@@ -89,7 +89,7 @@ func extractAppInsightValue(info AppInsightsInfo, metric ApplicationInsightsMetr
 		}
 		floatVal = val.(float64)
 	} else {
-		return -1, fmt.Errorf("metric %s did not containe aggregation type %s", info.MetricID, info.AggregationType)
+		return -1, fmt.Errorf("metric %s did not contain aggregation type %s", info.MetricID, info.AggregationType)
 	}
 
 	azureAppInsightsLog.V(2).Info("value extracted from metric request", "metric type", info.AggregationType, "metric value", floatVal)
@@ -115,7 +115,7 @@ func queryParamsForAppInsightsRequest(info AppInsightsInfo) (map[string]interfac
 }
 
 // GetAzureAppInsightsMetricValue returns the value of an Azure App Insights metric, rounded to the nearest int
-func GetAzureAppInsightsMetricValue(ctx context.Context, info AppInsightsInfo, podIdentity kedav1alpha1.AuthPodIdentity) (float64, error) {
+func GetAzureAppInsightsMetricValue(ctx context.Context, info AppInsightsInfo, podIdentity kedav1alpha1.AuthPodIdentity, ignoreNullValues bool) (float64, error) {
 	config := getAuthConfig(ctx, info, podIdentity)
 	authorizer, err := config.Authorizer()
 	if err != nil {
@@ -154,5 +154,9 @@ func GetAzureAppInsightsMetricValue(ctx context.Context, info AppInsightsInfo, p
 		return -1, err
 	}
 
-	return extractAppInsightValue(info, *metric)
+	val, err := extractAppInsightValue(info, *metric)
+	if err != nil && ignoreNullValues {
+		return 0.0, nil
+	}
+	return val, err
 }

--- a/pkg/scalers/azure_app_insights_scaler.go
+++ b/pkg/scalers/azure_app_insights_scaler.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	azureAppInsightsDefaultIgnoreNullValues = true
+	azureAppInsightsDefaultIgnoreNullValues = false
 )
 
 type azureAppInsightsMetadata struct {

--- a/pkg/scalers/azure_app_insights_scaler_test.go
+++ b/pkg/scalers/azure_app_insights_scaler_test.go
@@ -150,7 +150,7 @@ var azureAppInsightsScalerData = []azureAppInsightsScalerTestData{
 		},
 		PodIdentity: kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload},
 	}},
-	{name: "incorrect ignoreNullValues", isError: false, config: ScalerConfig{
+	{name: "incorrect ignoreNullValues", isError: true, config: ScalerConfig{
 		TriggerMetadata: map[string]string{
 			"targetValue": "11", "applicationInsightsId": "1234", "metricId": "unittest/test", "metricAggregationTimespan": "01:02", "metricAggregationType": "max", "metricFilter": "cloud/roleName eq 'test'", "tenantId": "1234", "ignoreNullValues": "not a boolean",
 		},

--- a/pkg/scalers/azure_app_insights_scaler_test.go
+++ b/pkg/scalers/azure_app_insights_scaler_test.go
@@ -138,6 +138,24 @@ var azureAppInsightsScalerData = []azureAppInsightsScalerTestData{
 		},
 		PodIdentity: kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProvider("notAzureWorkload")},
 	}},
+	{name: "correct ignoreNullValues (true)", isError: false, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"targetValue": "11", "applicationInsightsId": "1234", "metricId": "unittest/test", "metricAggregationTimespan": "01:02", "metricAggregationType": "max", "metricFilter": "cloud/roleName eq 'test'", "tenantId": "1234", "ignoreNullValues": "true",
+		},
+		PodIdentity: kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload},
+	}},
+	{name: "correct ignoreNullValues (false)", isError: false, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"targetValue": "11", "applicationInsightsId": "1234", "metricId": "unittest/test", "metricAggregationTimespan": "01:02", "metricAggregationType": "max", "metricFilter": "cloud/roleName eq 'test'", "tenantId": "1234", "ignoreNullValues": "false",
+		},
+		PodIdentity: kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload},
+	}},
+	{name: "incorrect ignoreNullValues", isError: false, config: ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"targetValue": "11", "applicationInsightsId": "1234", "metricId": "unittest/test", "metricAggregationTimespan": "01:02", "metricAggregationType": "max", "metricFilter": "cloud/roleName eq 'test'", "tenantId": "1234", "ignoreNullValues": "not a boolean",
+		},
+		PodIdentity: kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload},
+	}},
 	{name: "app insights id in auth", isError: false, config: ScalerConfig{
 		TriggerMetadata: map[string]string{
 			"targetValue": "11", "metricId": "unittest/test", "metricAggregationTimespan": "01:02", "metricAggregationType": "max", "metricFilter": "cloud/roleName eq 'test'", "tenantId": "1234",


### PR DESCRIPTION
Added the option to ignore errors during the extraction of Azure Application Insights values

### Checklist
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #4316

Inspired by #3073
Relates to https://github.com/kedacore/keda-docs/pull/1084
