### PR TITLE
fix(aws-cloudwatch): Not require uneeded fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Fix regression in fallback mechanism ([#4249](https://github.com/kedacore/keda/issues/4249))
 - **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))
-- **AWS Cloudwatch Scaler:** Not require `metricName` and `namespace` when using `expression` ([#4334](https://github.com/kedacore/keda/issues/4262))
+- **AWS Cloudwatch Scaler:** Make `metricName` and `namespace` optional when using `expression` ([#4334](https://github.com/kedacore/keda/issues/4262))
 - **Azure Pipelines Scaler**: Add new parameter to limit the jobs returned ([#4324](https://github.com/kedacore/keda/issues/4324))
 - **Azure Queue Scaler**: Fix azure queue length ([#4002](https://github.com/kedacore/keda/issues/4002))
 - **Azure Service Bus Scaler:** Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026)|[#4123](https://github.com/kedacore/keda/issues/4123))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Fix regression in fallback mechanism ([#4249](https://github.com/kedacore/keda/issues/4249))
 - **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))
-- **AWS Cloudwatch Scaler:** Not require `metricName` and `namespace` using `expression` ([#4334](https://github.com/kedacore/keda/issues/4262))
+- **AWS Cloudwatch Scaler:** Not require `metricName` and `namespace` when using `expression` ([#4334](https://github.com/kedacore/keda/issues/4262))
 - **Azure Pipelines Scaler**: Add new parameter to limit the jobs returned ([#4324](https://github.com/kedacore/keda/issues/4324))
 - **Azure Queue Scaler**: Fix azure queue length ([#4002](https://github.com/kedacore/keda/issues/4002))
 - **Azure Service Bus Scaler:** Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026)|[#4123](https://github.com/kedacore/keda/issues/4123))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Fix regression in fallback mechanism ([#4249](https://github.com/kedacore/keda/issues/4249))
 - **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))
+- **AWS Cloudwatch Scaler:** Not require `metricName` and `namespace` using `expression` ([#4334](https://github.com/kedacore/keda/issues/4262))
 - **Azure Pipelines Scaler**: Add new parameter to limit the jobs returned ([#4324](https://github.com/kedacore/keda/issues/4324))
 - **Azure Queue Scaler**: Fix azure queue length ([#4002](https://github.com/kedacore/keda/issues/4002))
 - **Azure Service Bus Scaler:** Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026)|[#4123](https://github.com/kedacore/keda/issues/4123))

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -13,8 +13,6 @@ import (
 	"github.com/go-logr/logr"
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/metrics/pkg/apis/external_metrics"
-
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 const (
@@ -294,17 +292,9 @@ func (s *awsCloudwatchScaler) GetMetricsAndActivity(ctx context.Context, metricN
 }
 
 func (s *awsCloudwatchScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
-	var metricNameSuffix string
-
-	if s.metadata.expression != "" {
-		metricNameSuffix = s.metadata.metricsName
-	} else {
-		metricNameSuffix = s.metadata.dimensionName[0]
-	}
-
 	externalMetric := &v2.ExternalMetricSource{
 		Metric: v2.MetricIdentifier{
-			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, kedautil.NormalizeString(fmt.Sprintf("aws-cloudwatch-%s", metricNameSuffix))),
+			Name: GenerateMetricNameWithIndex(s.metadata.scalerIndex, "aws-cloudwatch"),
 		},
 		Target: GetMetricTargetMili(s.metricType, s.metadata.targetMetricValue),
 	}

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -120,18 +120,6 @@ func parseAwsCloudwatchMetadata(config *ScalerConfig) (*awsCloudwatchMetadata, e
 	var err error
 	meta := awsCloudwatchMetadata{}
 
-	if val, ok := config.TriggerMetadata["namespace"]; ok && val != "" {
-		meta.namespace = val
-	} else {
-		return nil, fmt.Errorf("namespace not given")
-	}
-
-	if val, ok := config.TriggerMetadata["metricName"]; ok && val != "" {
-		meta.metricsName = val
-	} else {
-		return nil, fmt.Errorf("metric name not given")
-	}
-
 	if config.TriggerMetadata["expression"] != "" {
 		if val, ok := config.TriggerMetadata["expression"]; ok && val != "" {
 			meta.expression = val
@@ -139,6 +127,18 @@ func parseAwsCloudwatchMetadata(config *ScalerConfig) (*awsCloudwatchMetadata, e
 			return nil, fmt.Errorf("expression not given")
 		}
 	} else {
+		if val, ok := config.TriggerMetadata["namespace"]; ok && val != "" {
+			meta.namespace = val
+		} else {
+			return nil, fmt.Errorf("namespace not given")
+		}
+
+		if val, ok := config.TriggerMetadata["metricName"]; ok && val != "" {
+			meta.metricsName = val
+		} else {
+			return nil, fmt.Errorf("metric name not given")
+		}
+
 		if val, ok := config.TriggerMetadata["dimensionName"]; ok && val != "" {
 			meta.dimensionName = strings.Split(val, ";")
 		} else {
@@ -331,7 +331,6 @@ func (s *awsCloudwatchScaler) GetCloudwatchMetrics() (float64, error) {
 					Expression: aws.String(s.metadata.expression),
 					Id:         aws.String("q1"),
 					Period:     aws.Int64(s.metadata.metricStatPeriod),
-					Label:      aws.String(s.metadata.metricsName),
 				},
 			},
 		}

--- a/pkg/scalers/aws_cloudwatch_scaler_test.go
+++ b/pkg/scalers/aws_cloudwatch_scaler_test.go
@@ -357,9 +357,9 @@ var testAWSCloudwatchMetadata = []parseAWSCloudwatchMetadataTestData{
 }
 
 var awsCloudwatchMetricIdentifiers = []awsCloudwatchMetricIdentifier{
-	{&testAWSCloudwatchMetadata[1], 0, "s0-aws-cloudwatch-QueueName"},
-	{&testAWSCloudwatchMetadata[1], 3, "s3-aws-cloudwatch-QueueName"},
-	{&testAWSCloudwatchMetadata[2], 5, "s5-aws-cloudwatch-ApproximateNumberOfMessagesVisible"},
+	{&testAWSCloudwatchMetadata[1], 0, "s0-aws-cloudwatch"},
+	{&testAWSCloudwatchMetadata[1], 3, "s3-aws-cloudwatch"},
+	{&testAWSCloudwatchMetadata[2], 5, "s5-aws-cloudwatch"},
 }
 
 var awsCloudwatchGetMetricTestData = []awsCloudwatchMetadata{

--- a/tests/scalers/aws/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
@@ -36,8 +36,6 @@ type templateData struct {
 	AwsAccessKeyID             string
 	AwsSecretAccessKey         string
 	AwsRegion                  string
-	CloudWatchMetricName       string
-	CloudWatchMetricNamespace  string
 	CloudwatchMetricExpression string
 }
 
@@ -112,9 +110,7 @@ spec:
         name: keda-trigger-auth-aws-credentials
       metadata:
         awsRegion: {{.AwsRegion}}
-        namespace: {{.CloudWatchMetricNamespace}}
         expression: {{.CloudwatchMetricExpression}}
-        metricName: {{.CloudWatchMetricName}}
         targetMetricValue: "1"
         activationTargetMetricValue: "5"
         minMetricValue: "0"
@@ -228,8 +224,6 @@ func getTemplateData() (templateData, []Template) {
 			AwsAccessKeyID:             base64.StdEncoding.EncodeToString([]byte(awsAccessKeyID)),
 			AwsSecretAccessKey:         base64.StdEncoding.EncodeToString([]byte(awsSecretAccessKey)),
 			AwsRegion:                  awsRegion,
-			CloudWatchMetricName:       cloudwatchMetricName,
-			CloudWatchMetricNamespace:  cloudwatchMetricNamespace,
 			CloudwatchMetricExpression: cloudwatchMetricExpression,
 		}, []Template{
 			{Name: "secretTemplate", Config: secretTemplate},


### PR DESCRIPTION
When we use `expression` in cloudwatch scalers, metricName and namespace aren't needed but even though it, they were required. This PR removes this requirement

### Checklist

- [x] Tests have been added
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* https://github.com/kedacore/keda-docs/pull/1085
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/4334
