### PR TITLE
fix(kafka): Make parsing partitionLimitation more resilient against ws

### DIFF
--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -212,7 +212,8 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 	}
 
 	meta.partitionLimitation = nil
-	if config.TriggerMetadata["partitionLimitation"] != "" {
+	partitionLimitationMetadata := strings.TrimSpace(config.TriggerMetadata["partitionLimitation"])
+	if partitionLimitationMetadata != "" {
 		if meta.topic == "" {
 			logger.V(1).Info("no specific topic set, ignoring partitionLimitation setting")
 		} else {


### PR DESCRIPTION
Ignores whitespaces in partitionLimitation.
Fix a spelling mistake on the way.
Add a few more tests cases.
Note that currently it is not possible to configure a limitation so that
no partition will be consumed!

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #4328
