### PR TITLE
bump Golang to 1.19.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM golang:1.19.6
+FROM golang:1.19.7
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -55,7 +55,7 @@ jobs:
     needs: triage
     runs-on: ubuntu-latest
     name: Build images
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     if: needs.triage.outputs.run-e2e == 'true'
     steps:
       - name: Set status in-progress
@@ -98,7 +98,7 @@ jobs:
     needs: [triage, build-test-images]
     runs-on: e2e
     name: Execute e2e tests
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     if: needs.triage.outputs.run-e2e == 'true'
     steps:
       - name: Set status in-progress

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,7 +5,7 @@ jobs:
   validate:
     name: validate - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     strategy:
       matrix:
         include:
@@ -65,7 +65,7 @@ jobs:
   validate-dockerfiles:
     name: validate-dockerfiles - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     strategy:
        matrix:
         include:
@@ -96,7 +96,7 @@ jobs:
   validate-build-tools:
     name: Validate build-tools - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     strategy:
        matrix:
         include:
@@ -133,7 +133,7 @@ jobs:
   validate-dev-container:
     name: Validate dev-container - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     strategy:
        matrix:
         include:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -9,7 +9,7 @@ jobs:
   codeQl:
     name: Analyze CodeQL Go
     runs-on: ubuntu-latest
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     if: (github.actor != 'dependabot[bot]')
     steps:
     - name: Checkout repository

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run e2e test
     runs-on: ubuntu-latest
     # build-tools is built from ../../tools/build-tools.Dockerfile
-    container: ghcr.io/kedacore/build-tools:1.19.6
+    container: ghcr.io/kedacore/build-tools:1.19.7
     concurrency: e2e-tests
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/build-tools:1.19.6 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/build-tools:1.19.7 AS builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -1,5 +1,5 @@
 # Build the adapter binary
-FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/build-tools:1.19.6 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/build-tools:1.19.7 AS builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD

--- a/Dockerfile.webhooks
+++ b/Dockerfile.webhooks
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/build-tools:1.19.6 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/build-tools:1.19.7 AS builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

go1.19.7 (released 2023-03-07) includes a security fix to the crypto/elliptic package, as well as bug fixes to the linker, the runtime, and the crypto/x509 and syscall packages. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/pull/4337
