### PR TITLE
fix(aws-sqs): Respect `scaleOnInFlight` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issue/XXX))
+- **AWS SQS Scaler**: Respect `scaleOnInFlight` value ([#4276](https://github.com/kedacore/keda/issue/4276))
 
 ### Deprecations
 

--- a/pkg/scalers/aws_sqs_queue_scaler_test.go
+++ b/pkg/scalers/aws_sqs_queue_scaler_test.go
@@ -308,7 +308,8 @@ var awsSQSMetricIdentifiers = []awsSQSMetricIdentifier{
 }
 
 var awsSQSGetMetricTestData = []*awsSqsQueueMetadata{
-	{queueURL: testAWSSQSProperQueueURL},
+	{queueURL: testAWSSQSProperQueueURL, scaleOnInFlight: false},
+	{queueURL: testAWSSQSProperQueueURL, scaleOnInFlight: true},
 	{queueURL: testAWSSQSErrorQueueURL},
 	{queueURL: testAWSSQSBadDataQueueURL},
 }

--- a/pkg/scalers/aws_sqs_queue_scaler_test.go
+++ b/pkg/scalers/aws_sqs_queue_scaler_test.go
@@ -307,11 +307,43 @@ var awsSQSMetricIdentifiers = []awsSQSMetricIdentifier{
 	{&testAWSSQSMetadata[1], 1, "s1-aws-sqs-DeleteArtifactQ"},
 }
 
-var awsSQSGetMetricTestData = []*awsSqsQueueMetadata{
-	{queueURL: testAWSSQSProperQueueURL, scaleOnInFlight: false},
-	{queueURL: testAWSSQSProperQueueURL, scaleOnInFlight: true},
-	{queueURL: testAWSSQSErrorQueueURL},
-	{queueURL: testAWSSQSBadDataQueueURL},
+var awsSQSGetMetricTestData = []*parseAWSSQSMetadataTestData{
+	{map[string]string{
+		"queueURL":        testAWSSQSProperQueueURL,
+		"queueLength":     "1",
+		"awsRegion":       "eu-west-1",
+		"scaleOnInFlight": "false"},
+		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
+		false,
+		"not error with scaleOnInFlight disabled"},
+	{map[string]string{
+		"queueURL":        testAWSSQSProperQueueURL,
+		"queueLength":     "1",
+		"awsRegion":       "eu-west-1",
+		"scaleOnInFlight": "true"},
+		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
+		false,
+		"not error with scaleOnInFlight enabled"},
+	{map[string]string{
+		"queueURL":        testAWSSQSErrorQueueURL,
+		"queueLength":     "1",
+		"awsRegion":       "eu-west-1",
+		"scaleOnInFlight": "false"},
+		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
+		false,
+		"error queue"},
+	{map[string]string{
+		"queueURL":        testAWSSQSBadDataQueueURL,
+		"queueLength":     "1",
+		"awsRegion":       "eu-west-1",
+		"scaleOnInFlight": "true"},
+		testAWSSQSAuthentication,
+		testAWSSQSEmptyResolvedEnv,
+		false,
+		"bad data"},
 }
 
 func TestSQSParseMetadata(t *testing.T) {
@@ -344,8 +376,13 @@ func TestAWSSQSGetMetricSpecForScaling(t *testing.T) {
 }
 
 func TestAWSSQSScalerGetMetrics(t *testing.T) {
-	for _, meta := range awsSQSGetMetricTestData {
+	for index, testData := range awsSQSGetMetricTestData {
+		meta, err := parseAwsSqsQueueMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: testData.resolvedEnv, AuthParams: testData.authParams, ScalerIndex: index}, logr.Discard())
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
 		scaler := awsSqsQueueScaler{"", meta, &mockSqs{}, logr.Discard()}
+
 		value, _, err := scaler.GetMetricsAndActivity(context.Background(), "MetricName")
 		switch meta.queueURL {
 		case testAWSSQSErrorQueueURL:


### PR DESCRIPTION
`awsSqsQueueMetricNames` variable was defined at package level and it was modified based on trigger parameters. 
This makes it shared across all the ScaledObjects, which isn't correct

### Checklist

- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/4276

