### PR TITLE
chore: Provide updated roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,19 +12,20 @@ As part of our [release governance](https://github.com/kedacore/governance/blob/
 
 Here is an overview of our current release estimations:
 
-| Version | Estimated Release Date |
-|:--------|:-----------------------|
-| v2.10   | March 9th, 2023        |
-| v2.11   | June 13th, 2023         |
-| v2.12   | September 12th, 2023    |
+| Version | Estimated Release Date                               |
+|:--------|:-----------------------------------------------------|
+| v2.11   | June 13th, 2023                                      |
+| v2.12   | September 12th, 2023                                 |
+| v2.13   | January 11th, 2023 *(planned later due to holidays)* |
 
 Here is an overview of our previous releases:
 
-| Version | Release Date      | Links                                                                 |
-|:--------|:------------------|:----------------------------------------------------------------------|
-| v2.9    | Dec 9th, 2022     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.9.0) |
-| v2.8    | August 10th, 2022 | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.8.0) |
-| v2.7    | May 5th, 2022     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.7.0) |
+| Version | Release Date      | Links                                                                  |
+|:--------|:------------------|:-----------------------------------------------------------------------|
+| v2.10   | March 9th, 2023   | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.10.0) |
+| v2.9    | Dec 9th, 2022     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.9.0)  |
+| v2.8    | August 10th, 2022 | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.8.0)  |
+| v2.7    | May 5th, 2022     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.7.0)  |
 
 ## Using our roadmap
 


### PR DESCRIPTION
Provide updated roadmap which adds release notes for v2.10 and introduces 2.13 which is proposed to be 1 month later due to holidays in December.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/4349
