### PR TITLE
fix e2e test case workflow regex matching (#4363)Co-authored-by: Jorge Turrado Ferrero <Jorge_turrado@hotmail.es>

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -138,7 +138,7 @@ jobs:
           TEST_CLUSTER_NAME: keda-pr-run
         run: |
           MESSAGE="${{ github.event.comment.body }}"
-          REGEX='/run-e2e (.+)'
+          REGEX='/run-e2e (.+\*)'
           if [[ "$MESSAGE" =~ $REGEX ]]
           then
             export E2E_TEST_REGEX="${BASH_REMATCH[1]}"

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -138,7 +138,7 @@ jobs:
           TEST_CLUSTER_NAME: keda-pr-run
         run: |
           MESSAGE="${{ github.event.comment.body }}"
-          REGEX='/run-e2e (.+\*)'
+          REGEX='/run-e2e (.+[\*|.go])'
           if [[ "$MESSAGE" =~ $REGEX ]]
           then
             export E2E_TEST_REGEX="${BASH_REMATCH[1]}"


### PR DESCRIPTION

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

finish with `*` when grabbing regex

example of problematic comment body: 
- the closing `"` is on the newline and this doesnt run the tests
https://github.com/kedacore/keda/actions/runs/4413811530/jobs/7735089071#step:8:2 
the line should be `MESSAGE="/run-e2e cpu*"`, **NOT** `MESSAGE="/run-e2e cpu*` - in this case the closing double-quote is on the next line