### PR TITLE
chore: Upload artifacts in case of failure in main e2e tests

### DIFF
--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Upload test logs
         uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
           name: e2e-test-logs
           path: '${{ github.workspace }}/tests/**/*.log'


### PR DESCRIPTION

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


