### PR TITLE
fix: Use latest image for GH Actions e2e test to avoid agent updates (#4373

### DIFF
--- a/tests/scalers/github_runner/github_runner_test.go
+++ b/tests/scalers/github_runner/github_runner_test.go
@@ -102,7 +102,7 @@ spec:
       terminationGracePeriodSeconds: 90
       containers:
       - name: github-runner
-        image: myoung34/github-runner:2.302.1-ubuntu-focal
+        image: myoung34/github-runner
         imagePullPolicy: IfNotPresent
         env:
           - name: EPHEMERAL
@@ -159,7 +159,7 @@ spec:
       spec:
         containers:
         - name: {{.ScaledJobName}}
-          image: myoung34/github-runner:2.302.1-ubuntu-focal
+          image: myoung34/github-runner
           imagePullPolicy: IfNotPresent
           env:
           - name: EPHEMERAL


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

