### PR TITLE
chore: Provide more robust release tracker issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_release_tracker.md
+++ b/.github/ISSUE_TEMPLATE/4_release_tracker.md
@@ -10,6 +10,14 @@ This issue template is used to track the rollout of a new KEDA version.
 
 For the full release process, we recommend reading [this document](https://github.com/kedacore/keda/blob/main/RELEASE-PROCESS.md).
 
+## Required items
+
+- [ ] List items that are still open, but required for this release
+
+# Timeline
+
+We aim to release this release in the week of <week range, example March 27-31>.
+
 ## Progress
 
 - [ ] Prepare changelog


### PR DESCRIPTION
Provide more robust release tracker issue template so we can add more information and also use it for hotifxes.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Example: https://github.com/kedacore/keda/issues/4374
