### PR TITLE
fix: Use explicit parameter for workflow step (#4376

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -193,3 +193,4 @@ jobs:
         with:
           name: e2e-test-logs
           path: '${{ github.workspace }}/tests/**/*.log'
+          if-no-files-found: ignore

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -41,3 +41,4 @@ jobs:
         with:
           name: e2e-test-logs
           path: '${{ github.workspace }}/tests/**/*.log'
+          if-no-files-found: ignore

--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Upload test logs
         uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
           name: smoke-test-logs ${{ inputs.kubernetesVersion }}
           path: '${{ github.workspace }}/tests/**/*.log'
+          if-no-files-found: ignore


### PR DESCRIPTION

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

