### PR TITLE
chore: fix custom hpa name e2e test

### DIFF
--- a/tests/internals/custom_hpa_name/custom_hpa_name_test.go
+++ b/tests/internals/custom_hpa_name/custom_hpa_name_test.go
@@ -64,7 +64,7 @@ spec:
   scaleTargetRef:
     name: {{.DeploymentName}}
   pollingInterval: 5
-  minReplicaCount: 0
+  minReplicaCount: 1
   maxReplicaCount: 1
   cooldownPeriod: 10
   triggers:


### PR DESCRIPTION
After adding the new validations for the CPU, custom-hpa test is failing because minReplicaCount is 0 
with only CPU trigger

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

