### PR TITLE
External Scaler: Add tls options in TriggerAuth metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **Azure Data Exporer Scaler**: Use azidentity SDK ([#4489](https://github.com/kedacore/keda/issues/4489))
+- **External Scaler**: Add tls options in TriggerAuth metadata. ([#3565](https://github.com/kedacore/keda/issues/3565))
 - **GCP PubSub Scaler**: Make it more flexible for metrics ([#4243](https://github.com/kedacore/keda/issues/4243))
 
 ### Fixes

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -121,7 +121,7 @@ func parseAzureQueueMetadata(config *ScalerConfig, logger logr.Logger) (*azureQu
 
 	// before triggerAuthentication CRD, pod identity was configured using this property
 	if val, ok := config.TriggerMetadata["useAAdPodIdentity"]; ok && config.PodIdentity.Provider == "" {
-		if val == "true" {
+		if val == stringTrue {
 			config.PodIdentity = kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzure}
 		}
 	}

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -33,14 +33,14 @@ type externalPushScaler struct {
 }
 
 type externalScalerMetadata struct {
-	scalerAddress      string
-	tlsCertFile        string
-	originalMetadata   map[string]string
-	scalerIndex        int
-	caCert             string
-	tlsClientCert      string
-	tlsClientKey       string
-	insecureSkipVerify bool
+	scalerAddress    string
+	tlsCertFile      string
+	originalMetadata map[string]string
+	scalerIndex      int
+	caCert           string
+	tlsClientCert    string
+	tlsClientKey     string
+	unsafeSsl        bool
 }
 
 type connectionGroup struct {
@@ -130,13 +130,13 @@ func parseExternalScalerMetadata(config *ScalerConfig) (externalScalerMetadata, 
 		meta.tlsClientKey = val
 	}
 
-	meta.insecureSkipVerify = false
-	if val, ok := config.TriggerMetadata["insecureSkipVerify"]; ok && val != "" {
+	meta.unsafeSsl = false
+	if val, ok := config.TriggerMetadata["unsafeSsl"]; ok && val != "" {
 		boolVal, err := strconv.ParseBool(val)
 		if err != nil {
 			return meta, fmt.Errorf("failed to parse insecureSkipVerify value. Must be either true or false")
 		}
-		meta.insecureSkipVerify = boolVal
+		meta.unsafeSsl = boolVal
 	}
 	// Add elements to metadata
 	for key, value := range config.TriggerMetadata {
@@ -314,7 +314,7 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 			return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(creds))
 		}
 
-		tlsConfig, err := util.NewTLSConfig(metadata.tlsClientCert, metadata.tlsClientKey, metadata.caCert, metadata.insecureSkipVerify)
+		tlsConfig, err := util.NewTLSConfig(metadata.tlsClientCert, metadata.tlsClientKey, metadata.caCert, metadata.unsafeSsl)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -320,8 +320,8 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 		}
 
 		if len(tlsConfig.Certificates) > 0 || metadata.caCert != "" {
-			creds := credentials.NewTLS(tlsConfig)
-			return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(creds))
+			// nosemgrep: go.grpc.ssrf.grpc-tainted-url-host.grpc-tainted-url-host
+			return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
 
 		return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -320,7 +320,8 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 		}
 
 		if len(tlsConfig.Certificates) > 0 || metadata.caCert != "" {
-			return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+			creds := credentials.NewTLS(tlsConfig)
+			return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(creds))
 		}
 
 		return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -337,7 +337,7 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 			return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(creds))
 		}
 
-		tlsConfig := &tls.Config{}
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS13}
 
 		if metadata.caCert != nil {
 			tlsConfig.RootCAs = metadata.caCert

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -303,7 +303,7 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 	defer connectionPoolMutex.Unlock()
 
 	buildGRPCConnection := func(metadata externalScalerMetadata) (*grpc.ClientConn, error) {
-		// FIXME: DEPRECATED to be removed in v2.13
+		// FIXME: DEPRECATED to be removed in v2.13 https://github.com/kedacore/keda/issues/4549
 		if metadata.tlsCertFile != "" {
 			logger.V(1).Info("tlsCertFile in ScaleObject metadata will be deprecated in v2.12. Please use" +
 				"tlsClientCert, tlsClientKey and caCert in TriggerAuthentication instead.")

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -319,7 +319,7 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 			return nil, err
 		}
 
-		if len(tlsConfig.Certificates) > 0 || tlsConfig.RootCAs != nil {
+		if len(tlsConfig.Certificates) > 0 || metadata.caCert != "" {
 			return grpc.Dial(metadata.scalerAddress, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
 

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/kedacore/keda/v2/pkg/util"
 	"github.com/mitchellh/hashstructure"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -19,6 +18,7 @@ import (
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
 	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
+	"github.com/kedacore/keda/v2/pkg/util"
 )
 
 type externalScaler struct {

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -95,7 +95,7 @@ type parseExternalScalerMetadataTestData struct {
 var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
 	{map[string]string{}, true, map[string]string{}},
 	// all properly formed
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, false, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert, "tlsClientKey": clientKey}},
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS", "insecureSkipVerify": "true"}, false, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert, "tlsClientKey": clientKey}},
 	// bad caCert
 	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": "random", "tlsClientCert": clientCert, "tlsClientKey": clientKey}},
 	// bad tlsClientCert
@@ -108,9 +108,13 @@ var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
 
 func TestExternalScalerParseMetadata(t *testing.T) {
 	for _, testData := range testExternalScalerMetadata {
-		_, err := parseExternalScalerMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: map[string]string{}, AuthParams: testData.authParams})
+		metadata, err := parseExternalScalerMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: map[string]string{}, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
+		}
+
+		if testData.metadata["insecureSkipVerify"] == "true" && !metadata.insecureSkipVerify {
+			t.Error("Expected insecureSkipVerify to be true but got", metadata.insecureSkipVerify)
 		}
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -17,22 +17,98 @@ import (
 	pb "github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 )
 
+var serverRootCA = `-----BEGIN CERTIFICATE-----
+MIIDPTCCAiWgAwIBAgIUTPXiztn8CG3+NQdeEIlpA1F9Ec4wDQYJKoZIhvcNAQEL
+BQAwLTEOMAwGA1UEAwwFa2VkYTExCzAJBgNVBAYTAlVTMQ4wDAYDVQQHDAVFYXJ0
+aDAgFw0yMzAzMjYxMzU1MDJaGA8yMDUxMDgwMjEzNTUwMlowLTEOMAwGA1UEAwwF
+a2VkYTExCzAJBgNVBAYTAlVTMQ4wDAYDVQQHDAVFYXJ0aDCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAOaQl2+EEZycNQlO1nEeFgheUZ20gTVAButKjvEK
+vIZv+x4AdwNaOcKahro5b09QinoGakTJEOrpks+VUSqQpJ+zVmja5vpIb92gnmGQ
+B3rl7nD9rP/bLffa5bNDhmMR7vRd88PYvopn6+hTyX3EGkvbCZD8WNs5f8jslzek
+0xj4U4LgC9T1pBykNl5nZs5Fd4CdaO+vi3cywmgjaiPzDOYMbYH4pzflH7aNsEEc
+IYs9fQ8SwzsocXpKUS+bTg9OmrDMAwan+mxz6m15BxvJzHQqmp/aE70BSkinBwCg
+dgzgQUwg6ko/jnJixP4tkr8p8nURBL7GNvuVIS7Z2EjD240CAwEAAaNTMFEwHQYD
+VR0OBBYEFN03E9o2ne0s5GZSZ7rZczisME5RMB8GA1UdIwQYMBaAFN03E9o2ne0s
+5GZSZ7rZczisME5RMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB
+ADM6vkgjttrU9bYRviwdgohvGNYegDXfyKt25gwYn5+UwUtqjjztTWMr6aAKLNob
+Dqjb0BDR5Ow0kD9KXyO4m0gTBzxrHzDnFeTQxE2h8Gl/VRGueJQ2sfmU8oG2/3GV
+4nEWLAu1XMqXcFQWT9X+JS3Wxqc1DLrAeX8u0ZIx5Lkk4kPV3d3BP8KyX+AQGt57
+p0kdhXOTNW1kUPCrtnc0uBJNHqlev3KkHebH20G7iAZFCCpul9cyLK1fftCBuVE/
+jtq3TnHHw+BroQPje3zF/MZTAA8Z9RejkpALMtoHeE68ar07FPlC8wZXDlfQXzYS
+PWO1PoIiMX1UsfdZ35JCOF4=
+-----END CERTIFICATE-----
+`
+var clientCert = `-----BEGIN CERTIFICATE-----
+MIIC9jCCAd4CFEGcfEWHP2ckC/kIgUEDUPkAVHHIMA0GCSqGSIb3DQEBCwUAMC0x
+DjAMBgNVBAMMBWtlZGEyMQswCQYDVQQGEwJVUzEOMAwGA1UEBwwFRWFydGgwIBcN
+MjMwMzI2MTM1NTAzWhgPMjA1MTA2MDcxMzU1MDNaMEAxCzAJBgNVBAYTAlVTMQsw
+CQYDVQQIDAJDQTEUMBIGA1UECgwLTXlPcmcsIEluYy4xDjAMBgNVBAMMBWtlZGEy
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3k7zr+QbOHXMqhyUM6Oz
+SuGGqQttIGZEs12eLSRlGY9vL+pf/G3CubkGsTtp5b5tmP4CNYcGtU8wSJMn23Bq
+BbXECpDXh6cuo+56VVAMJyNqZoIeS4JfKX5mvj4WrfpVJ3e+o6lrebAICK1qqTwq
+z6N6ZUkeF552aTh8RAgEiKJlylmKdHc/IF3+oLc2aA7IAl+zxYOTCrjIiUrc54OB
+gYCkCSb0P4SPHE8ryB0pN8S3LdtZrgVIzewd24joKbXL7hBZ3ltaj0t2kK2CTCxb
+I3te0JdIaPV2TxCnK9dxLRkFXNjz/7V45rbRLXtSPoirKseUR2zbo5kfquY0J2hv
+nwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCiZI/N/60Gj8711V+Uhj1j9iw3s4oU
+qT4r9NozotrhjIMe14rhkJ1k+1x7pyLX8QHgO0WxiAp8tKX0kcUQO/ZQfTAM6FpW
+cevGTxrVk5CcilafIBzaZF5Mz6diBxbTnhFS+hZXiwavkImBK4zZY9aUcVIjJfPv
+xSaEVvMdofrhaio9M0deYzQ/Bf/uMkR3Fxs4qbhsg3gkbepFm3yJoSANzXCMvDnv
+mauSvQwA0SRKECr46F8dSeFE1uIbN4ZNgrisBTVkoPYZuF7pAsSsjqGM0phUKiI8
+5thG2dnqJSunC+vZW8QY+x3eq4XzFEpIYcaV9YpiGHbv8N6gzJydL/GB
+-----END CERTIFICATE-----
+`
+var clientKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA3k7zr+QbOHXMqhyUM6OzSuGGqQttIGZEs12eLSRlGY9vL+pf
+/G3CubkGsTtp5b5tmP4CNYcGtU8wSJMn23BqBbXECpDXh6cuo+56VVAMJyNqZoIe
+S4JfKX5mvj4WrfpVJ3e+o6lrebAICK1qqTwqz6N6ZUkeF552aTh8RAgEiKJlylmK
+dHc/IF3+oLc2aA7IAl+zxYOTCrjIiUrc54OBgYCkCSb0P4SPHE8ryB0pN8S3LdtZ
+rgVIzewd24joKbXL7hBZ3ltaj0t2kK2CTCxbI3te0JdIaPV2TxCnK9dxLRkFXNjz
+/7V45rbRLXtSPoirKseUR2zbo5kfquY0J2hvnwIDAQABAoIBAQC66kksZ6+Xbjxx
+/2uAa7BxUmRFt+y+JB65bQp0zDgRIK+M6xRfiu4B+BcvZ1QnrlA6JcA3v1sdkQJ4
+0vndIIyUVnsJozUEwsWNYhMLri05ryZkIB1Wwbw/iB7c8BljmKqGb8EjnGxYOXDX
+0u9ucb9RLBPaG3sowryuxaZ+EPu24Ls/WnL6zZ3WarhuL3j3toWGzTaAriL2J9kB
+VbeTGb8IoLbR6uzYg0SdRTzx4obIHwl2kYO/l+9bZMJU3WUTE62lbw56Zg1sENdm
+sIIx/DWWhZiXJl9sJ7jOW9JY7rsvHvxxEh64o+WRa3KaHgBTFGw+3pjf3Dw/XM4a
+iQY8MbhRAoGBAPVzB7s1OzrNLdUOTDq6k6NNsD2xrUepBE1tm6sSGHSjNR5SvYFa
+3bx7O0OQm0Fmu6qVyetlebnkxZCUjgo6jk8FrpytKa+KoPYN7qsXH19FGj+qmtWh
+QAGfV3SgtepGZf5Gj5DGNMEuCWQAmPmn4CzrWJ2BjnhF0NMcBkOUoOInAoGBAOfd
+Rk4N3pv0tSeyCbi9TXDrXRIGarsahIHUb9zokRzw9DJqDKFshgSS/gPO1GhynAD8
+Ysvxb+DnW1R3CH+E5nh5nx//dTELsHcQMXtoXeltCKoNEOReWrQ8jy6JBqoFEYRU
+WRBK8fDKG8w2dzq5ggFmDOoiVG3lS/zubz8dcInJAoGAWf1erEiL+rcXQrIHSND3
+KDxnjXcDLO7O4QR6unHb/YeJBiEX0cFa4qvbwp3WDlh4HcblTSTbSEiUFrogiaeG
+XXqb1l22luGguhXJl3jWy7suMIGAWyrPqMie6+ewSsCczGlaYZ4J4Xnbf4qoi3/9
+NPrkdnr1nSsbsQrpUQXBJqkCgYBChubJNomMzeW8ggTwEMDLiXym01iEXtNuPPnr
+tH8OgsROQsdk+bJqVZK0nP+tCFViowfl5Fxpd3ho/85caFGId70EfVOuwt/bCbZo
+5kUr2LEHucADBl+YH1glzgMvfUzNXzY+yoIoyJS5P1dubhOzOwixlTAMaCIpbHBW
+96d2oQKBgCFhqmBv2swexhyu46ol4lOus78NpSMyvnG5GqcRBlcFiQNI/hQ78MW0
+vnC/XfKzpLiOmdCMVO4eUM6R41blE9/QFm/XIoshoFkubii4DgqTcxK4Z3WMolkh
+Qcz/BgNq+YA4o5WduTBKalU8bZ9cEuwh4SMMPPqolHZxWkhVI85L
+-----END RSA PRIVATE KEY-----
+`
+
 type parseExternalScalerMetadataTestData struct {
-	metadata map[string]string
-	isError  bool
+	metadata   map[string]string
+	isError    bool
+	authParams map[string]string
 }
 
 var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
-	{map[string]string{}, true},
+	{map[string]string{}, true, map[string]string{}},
 	// all properly formed
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, false},
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, false, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert, "tlsClientKey": clientKey}},
+	// bad caCert
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": "random", "tlsClientCert": clientCert, "tlsClientKey": clientKey}},
+	// bad tlsClientCert
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": serverRootCA, "tlsClientCert": "random", "tlsClientKey": clientKey}},
+	// bad tlsClientKey
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert, "tlsClientKey": "random"}},
 	// missing scalerAddress
-	{map[string]string{"test1": "1", "test2": "SAMPLE_CREDS"}, true},
+	{map[string]string{"test1": "1", "test2": "SAMPLE_CREDS"}, true, map[string]string{}},
 }
 
 func TestExternalScalerParseMetadata(t *testing.T) {
 	for _, testData := range testExternalScalerMetadata {
-		_, err := parseExternalScalerMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: map[string]string{}})
+		_, err := parseExternalScalerMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, ResolvedEnv: map[string]string{}, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}
@@ -104,7 +180,6 @@ type testServer struct {
 
 func createGRPCServers(count int, t *testing.T) []testServer {
 	result := make([]testServer, 0, count)
-
 	for i := 0; i < count; i++ {
 		grpcServer := grpc.NewServer()
 		address := fmt.Sprintf("127.0.0.1:%d", 5050+i)
@@ -211,7 +286,7 @@ func TestWaitForState(t *testing.T) {
 		// server stop will lead to Idle.
 		<-waitForState(context.TODO(), grpcClient, connectivity.Idle, connectivity.Shutdown)
 		grpcClient.Close()
-		// after close the state to Shutdown.
+		// after close the state to shut down.
 		t.Log("close state:", grpcClient.GetState().String())
 		close(graceDone)
 	}()

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -57,34 +57,6 @@ mauSvQwA0SRKECr46F8dSeFE1uIbN4ZNgrisBTVkoPYZuF7pAsSsjqGM0phUKiI8
 5thG2dnqJSunC+vZW8QY+x3eq4XzFEpIYcaV9YpiGHbv8N6gzJydL/GB
 -----END CERTIFICATE-----
 `
-var clientKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA3k7zr+QbOHXMqhyUM6OzSuGGqQttIGZEs12eLSRlGY9vL+pf
-/G3CubkGsTtp5b5tmP4CNYcGtU8wSJMn23BqBbXECpDXh6cuo+56VVAMJyNqZoIe
-S4JfKX5mvj4WrfpVJ3e+o6lrebAICK1qqTwqz6N6ZUkeF552aTh8RAgEiKJlylmK
-dHc/IF3+oLc2aA7IAl+zxYOTCrjIiUrc54OBgYCkCSb0P4SPHE8ryB0pN8S3LdtZ
-rgVIzewd24joKbXL7hBZ3ltaj0t2kK2CTCxbI3te0JdIaPV2TxCnK9dxLRkFXNjz
-/7V45rbRLXtSPoirKseUR2zbo5kfquY0J2hvnwIDAQABAoIBAQC66kksZ6+Xbjxx
-/2uAa7BxUmRFt+y+JB65bQp0zDgRIK+M6xRfiu4B+BcvZ1QnrlA6JcA3v1sdkQJ4
-0vndIIyUVnsJozUEwsWNYhMLri05ryZkIB1Wwbw/iB7c8BljmKqGb8EjnGxYOXDX
-0u9ucb9RLBPaG3sowryuxaZ+EPu24Ls/WnL6zZ3WarhuL3j3toWGzTaAriL2J9kB
-VbeTGb8IoLbR6uzYg0SdRTzx4obIHwl2kYO/l+9bZMJU3WUTE62lbw56Zg1sENdm
-sIIx/DWWhZiXJl9sJ7jOW9JY7rsvHvxxEh64o+WRa3KaHgBTFGw+3pjf3Dw/XM4a
-iQY8MbhRAoGBAPVzB7s1OzrNLdUOTDq6k6NNsD2xrUepBE1tm6sSGHSjNR5SvYFa
-3bx7O0OQm0Fmu6qVyetlebnkxZCUjgo6jk8FrpytKa+KoPYN7qsXH19FGj+qmtWh
-QAGfV3SgtepGZf5Gj5DGNMEuCWQAmPmn4CzrWJ2BjnhF0NMcBkOUoOInAoGBAOfd
-Rk4N3pv0tSeyCbi9TXDrXRIGarsahIHUb9zokRzw9DJqDKFshgSS/gPO1GhynAD8
-Ysvxb+DnW1R3CH+E5nh5nx//dTELsHcQMXtoXeltCKoNEOReWrQ8jy6JBqoFEYRU
-WRBK8fDKG8w2dzq5ggFmDOoiVG3lS/zubz8dcInJAoGAWf1erEiL+rcXQrIHSND3
-KDxnjXcDLO7O4QR6unHb/YeJBiEX0cFa4qvbwp3WDlh4HcblTSTbSEiUFrogiaeG
-XXqb1l22luGguhXJl3jWy7suMIGAWyrPqMie6+ewSsCczGlaYZ4J4Xnbf4qoi3/9
-NPrkdnr1nSsbsQrpUQXBJqkCgYBChubJNomMzeW8ggTwEMDLiXym01iEXtNuPPnr
-tH8OgsROQsdk+bJqVZK0nP+tCFViowfl5Fxpd3ho/85caFGId70EfVOuwt/bCbZo
-5kUr2LEHucADBl+YH1glzgMvfUzNXzY+yoIoyJS5P1dubhOzOwixlTAMaCIpbHBW
-96d2oQKBgCFhqmBv2swexhyu46ol4lOus78NpSMyvnG5GqcRBlcFiQNI/hQ78MW0
-vnC/XfKzpLiOmdCMVO4eUM6R41blE9/QFm/XIoshoFkubii4DgqTcxK4Z3WMolkh
-Qcz/BgNq+YA4o5WduTBKalU8bZ9cEuwh4SMMPPqolHZxWkhVI85L
------END RSA PRIVATE KEY-----
-`
 
 type parseExternalScalerMetadataTestData struct {
 	metadata   map[string]string
@@ -95,11 +67,11 @@ type parseExternalScalerMetadataTestData struct {
 var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
 	{map[string]string{}, true, map[string]string{}},
 	// all properly formed
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS", "insecureSkipVerify": "true"}, false, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert, "tlsClientKey": clientKey}},
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS", "insecureSkipVerify": "true"}, false, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert}},
 	// bad caCert
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": "random", "tlsClientCert": clientCert, "tlsClientKey": clientKey}},
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": "random", "tlsClientCert": clientCert}},
 	// bad tlsClientCert
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": serverRootCA, "tlsClientCert": "random", "tlsClientKey": clientKey}},
+	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": serverRootCA, "tlsClientCert": "random"}},
 	// bad tlsClientKey
 	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert, "tlsClientKey": "random"}},
 	// missing scalerAddress

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -79,8 +79,8 @@ func TestExternalScalerParseMetadata(t *testing.T) {
 			t.Error("Expected success but got error", err)
 		}
 
-		if testData.metadata["insecureSkipVerify"] == "true" && !metadata.insecureSkipVerify {
-			t.Error("Expected insecureSkipVerify to be true but got", metadata.insecureSkipVerify)
+		if testData.metadata["unsafeSsl"] == "true" && !metadata.unsafeSsl {
+			t.Error("Expected unsafeSsl to be true but got", metadata.unsafeSsl)
 		}
 		if testData.isError && err == nil {
 			t.Error("Expected error but got success")

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -68,12 +68,6 @@ var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
 	{map[string]string{}, true, map[string]string{}},
 	// all properly formed
 	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS", "insecureSkipVerify": "true"}, false, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert}},
-	// bad caCert
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": "random", "tlsClientCert": clientCert}},
-	// bad tlsClientCert
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": serverRootCA, "tlsClientCert": "random"}},
-	// bad tlsClientKey
-	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS"}, true, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert, "tlsClientKey": "random"}},
 	// missing scalerAddress
 	{map[string]string{"test1": "1", "test2": "SAMPLE_CREDS"}, true, map[string]string{}},
 }

--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"os"
 
@@ -60,15 +59,7 @@ func NewTLSConfigWithPassword(clientCert, clientKey, clientKeyPassword, caCert s
 	}
 
 	if caCert != "" {
-		validCA, err := isValidCACert(caCert)
-		if err != nil {
-			return nil, err
-		}
-		if validCA {
-			config.RootCAs.AppendCertsFromPEM([]byte(caCert))
-		} else {
-			return nil, fmt.Errorf("not a valid CA")
-		}
+		config.RootCAs.AppendCertsFromPEM([]byte(caCert))
 	}
 
 	return config, nil
@@ -137,21 +128,4 @@ func decryptClientKey(clientKey, clientKeyPassword string) ([]byte, error) {
 	encodedData := pem.EncodeToMemory(pemPrivateBlock)
 
 	return encodedData, nil
-}
-
-func isValidCACert(cert string) (bool, error) {
-	block, _ := pem.Decode([]byte(cert))
-	if block == nil {
-		return false, errors.New("invalid certificate format")
-	}
-
-	parsedCert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return false, err
-	}
-
-	if !parsedCert.IsCA {
-		return false, nil
-	}
-	return true, nil
 }

--- a/pkg/util/tls_config_test.go
+++ b/pkg/util/tls_config_test.go
@@ -187,6 +187,7 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 		password string
 		issuer   string
 		CACert   string
+		isError  bool
 	}{
 		{
 			name:     "rsaCert_WithCACert",
@@ -195,6 +196,7 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 			password: "keypass",
 			issuer:   "O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
 			CACert:   randomCACert,
+			isError:  false,
 		},
 		{
 			name:     "Cert_WithCACert",
@@ -203,6 +205,7 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 			password: "keypass",
 			issuer:   "O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
 			CACert:   randomCACert,
+			isError:  false,
 		},
 		{
 			name:     "rsaCert_WithoutCACert",
@@ -211,6 +214,7 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 			password: "keypass",
 			issuer:   "O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
 			CACert:   "",
+			isError:  false,
 		},
 		{
 			name:     "Cert_WithoutCACert",
@@ -219,28 +223,41 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 			password: "keypass",
 			issuer:   "O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
 			CACert:   "",
+			isError:  false,
+		},
+		{
+			name:     "Cert_WithInvalidCACert",
+			cert:     rsaCertPEM,
+			key:      encryptedKeyPEM,
+			password: "keypass",
+			issuer:   "O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
+			CACert:   "invalidCACert",
+			isError:  true,
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			config, err := NewTLSConfigWithPassword(test.cert, test.key, test.password, test.CACert, false)
-			if err != nil {
-				t.Errorf("Should have no error: %s", err)
-			}
-			cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
-			if err != nil {
-				t.Errorf("Bad certificate")
-			}
-
-			if test.CACert != "" {
-				caCertPool := getRootCAs()
-				caCertPool.AppendCertsFromPEM([]byte(randomCACert))
-				if !config.RootCAs.Equal(caCertPool) {
-					t.Errorf("TLS config return different CA cert")
+			if err != nil && !test.isError {
+				t.Errorf("Expected sucess but got error: %s", err)
+			} else if test.isError && err == nil {
+				t.Errorf("Expect error but got success")
+			} else if err == nil {
+				cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
+				if err != nil {
+					t.Errorf("Bad certificate")
 				}
-			}
-			if cert.Issuer.String() != test.issuer {
-				t.Errorf("Expected Issuer %s but got %s\n", test.issuer, cert.Issuer.String())
+
+				if test.CACert != "" {
+					caCertPool := getRootCAs()
+					caCertPool.AppendCertsFromPEM([]byte(randomCACert))
+					if !config.RootCAs.Equal(caCertPool) {
+						t.Errorf("TLS config return different CA cert")
+					}
+				}
+				if cert.Issuer.String() != test.issuer {
+					t.Errorf("Expected Issuer %s but got %s\n", test.issuer, cert.Issuer.String())
+				}
 			}
 		})
 	}

--- a/pkg/util/tls_config_test.go
+++ b/pkg/util/tls_config_test.go
@@ -225,15 +225,6 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 			CACert:   "",
 			isError:  false,
 		},
-		{
-			name:     "Cert_WithInvalidCACert",
-			cert:     rsaCertPEM,
-			key:      encryptedKeyPEM,
-			password: "keypass",
-			issuer:   "O=Internet Widgits Pty Ltd,ST=Some-State,C=AU",
-			CACert:   "invalidCACert",
-			isError:  true,
-		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/util/tls_config_test.go
+++ b/pkg/util/tls_config_test.go
@@ -238,11 +238,12 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			config, err := NewTLSConfigWithPassword(test.cert, test.key, test.password, test.CACert, false)
-			if err != nil && !test.isError {
+			switch {
+			case err != nil && !test.isError:
 				t.Errorf("Expected success but got error: %s", err)
-			} else if test.isError && err == nil {
+			case test.isError && err == nil:
 				t.Errorf("Expect error but got success")
-			} else if err == nil {
+			case err == nil:
 				cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
 				if err != nil {
 					t.Errorf("Bad certificate")

--- a/pkg/util/tls_config_test.go
+++ b/pkg/util/tls_config_test.go
@@ -239,7 +239,7 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			config, err := NewTLSConfigWithPassword(test.cert, test.key, test.password, test.CACert, false)
 			if err != nil && !test.isError {
-				t.Errorf("Expected sucess but got error: %s", err)
+				t.Errorf("Expected success but got error: %s", err)
 			} else if test.isError && err == nil {
 				t.Errorf("Expect error but got success")
 			} else if err == nil {


### PR DESCRIPTION
Hi team,
This PR will fix the issue #3565

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs/pull/1133
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Relates: https://github.com/kedacore/keda/issues/4549
