### PR TITLE
fix: Use the previous regex removing the multilines from matches (#4438

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -138,10 +138,10 @@ jobs:
           TEST_CLUSTER_NAME: keda-pr-run
         run: |
           MESSAGE="${{ github.event.comment.body }}"
-          REGEX='/run-e2e (.+[\*|.go])'
+          REGEX='/run-e2e (.+)'
           if [[ "$MESSAGE" =~ $REGEX ]]
           then
-            export E2E_TEST_REGEX="${BASH_REMATCH[1]}"
+            export E2E_TEST_REGEX="$(echo ${BASH_REMATCH[1]} | head -1)"
           fi
           echo "${{ needs.triage.outputs.pr_num }}"
           make e2e-test


### PR DESCRIPTION
After switching to go script for e2e tests, the regex has changed and this PR updates the workflow to capture the correct regex (using the original approach) and removing the whitespaces to avoid problems with the command

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

