### PR TITLE
chore: Add logic to scale out/in the AKS cluster on every e2e test execution

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -126,6 +126,12 @@ jobs:
         with:
           secrets: ${{ toJSON(secrets) }}
 
+      - name: Scale cluster
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 4
+          WAIT_NODE_POOL_SCALING: false
+
       - name: Run end to end tests
         continue-on-error: true
         id: test
@@ -151,6 +157,13 @@ jobs:
         run: make e2e-test-clean
         env:
           TEST_CLUSTER_NAME: keda-pr-run
+
+      - name: Scale cluster
+        if: ${{ always() }}
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 1
+          WAIT_NODE_POOL_SCALING: true
 
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -130,7 +130,6 @@ jobs:
         run: make scale-node-pool
         env:
           NODE_POOL_SIZE: 4
-          WAIT_NODE_POOL_SCALING: false
 
       - name: Run end to end tests
         continue-on-error: true
@@ -163,7 +162,6 @@ jobs:
         run: make scale-node-pool
         env:
           NODE_POOL_SIZE: 1
-          WAIT_NODE_POOL_SCALING: true
 
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           secrets: ${{ toJSON(secrets) }}
 
+      - name: Scale cluster
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 4
+          WAIT_NODE_POOL_SCALING: false
+
       - name: Run end to end tests
         env:
           AWS_RUN_IDENTITY_TESTS: true
@@ -34,6 +40,13 @@ jobs:
       - name: Delete all e2e related namespaces
         if: ${{ always() }}
         run: make e2e-test-clean
+
+      - name: Scale cluster
+        if: ${{ always() }}
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 1
+          WAIT_NODE_POOL_SCALING: true
 
       - name: Upload test logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -27,7 +27,6 @@ jobs:
         run: make scale-node-pool
         env:
           NODE_POOL_SIZE: 4
-          WAIT_NODE_POOL_SCALING: false
 
       - name: Run end to end tests
         env:
@@ -46,7 +45,6 @@ jobs:
         run: make scale-node-pool
         env:
           NODE_POOL_SIZE: 1
-          WAIT_NODE_POOL_SCALING: true
 
       - name: Upload test logs
         uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test: manifests generate fmt vet envtest install-test-deps ## Run tests and expo
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v 2>&1 ./... -coverprofile cover.out | go-junit-report -iocopy -set-exit-code -out report.xml
 
 .PHONY:
-az-login: 
+az-login:
 	@az login --service-principal -u $(TF_AZURE_SP_APP_ID) -p "$(AZURE_SP_KEY)" --tenant $(TF_AZURE_SP_TENANT)
 
 .PHONY: get-cluster-context

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ GIT_COMMIT  ?= $(shell git rev-list -1 HEAD)
 DATE        = $(shell date -u +"%Y.%m.%d.%H.%M.%S")
 
 TEST_CLUSTER_NAME ?= keda-nightly-run-3
+NODE_POOL_SIZE ?= 1
+WAIT_NODE_POOL_SCALING ?=true
 NON_ROOT_USER_ID ?= 1000
 
 GCP_WI_PROVIDER ?= projects/${TF_GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${TEST_CLUSTER_NAME}/providers/${TEST_CLUSTER_NAME}
@@ -81,13 +83,25 @@ install-test-deps:
 test: manifests generate fmt vet envtest install-test-deps ## Run tests and export the result to junit format.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v 2>&1 ./... -coverprofile cover.out | go-junit-report -iocopy -set-exit-code -out report.xml
 
-.PHONY: get-cluster-context
-get-cluster-context: ## Get Azure cluster context.
+.PHONY:
+az-login: 
 	@az login --service-principal -u $(TF_AZURE_SP_APP_ID) -p "$(AZURE_SP_KEY)" --tenant $(TF_AZURE_SP_TENANT)
+
+.PHONY: get-cluster-context
+get-cluster-context: az-login ## Get Azure cluster context.
 	@az aks get-credentials \
 		--name $(TEST_CLUSTER_NAME) \
 		--subscription $(TF_AZURE_SUBSCRIPTION) \
 		--resource-group $(TF_AZURE_RESOURCE_GROUP)
+
+.PHONY: scale-node-pool
+scale-node-pool: az-login ## Scale nodepool.
+	@az aks scale \
+		--name $(TEST_CLUSTER_NAME) \
+		--subscription $(TF_AZURE_SUBSCRIPTION) \
+		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
+		--node-count $(NODE_POOL_SIZE) \
+		`if [ "$(WAIT_NODE_POOL_SCALING)" == "false" ]; then echo "--no-wait"; fi`
 
 .PHONY: e2e-test
 e2e-test: get-cluster-context ## Run e2e tests against Azure cluster.

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ DATE        = $(shell date -u +"%Y.%m.%d.%H.%M.%S")
 
 TEST_CLUSTER_NAME ?= keda-nightly-run-3
 NODE_POOL_SIZE ?= 1
-WAIT_NODE_POOL_SCALING ?=true
 NON_ROOT_USER_ID ?= 1000
 
 GCP_WI_PROVIDER ?= projects/${TF_GCP_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${TEST_CLUSTER_NAME}/providers/${TEST_CLUSTER_NAME}
@@ -100,8 +99,7 @@ scale-node-pool: az-login ## Scale nodepool.
 		--name $(TEST_CLUSTER_NAME) \
 		--subscription $(TF_AZURE_SUBSCRIPTION) \
 		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
-		--node-count $(NODE_POOL_SIZE) \
-		`if [ "$(WAIT_NODE_POOL_SCALING)" == "false" ]; then echo "--no-wait"; fi`
+		--node-count $(NODE_POOL_SIZE)
 
 .PHONY: e2e-test
 e2e-test: get-cluster-context ## Run e2e tests against Azure cluster.


### PR DESCRIPTION
For reducing costs, this PR scales out the cluster to current nodes (4) before the tests execution and scales in the cluster again after them. 
I have checked the `stop` option but based on [documentation](https://learn.microsoft.com/en-us/azure/aks/start-stop-cluster?tabs=azure-cli#start-an-aks-cluster), we shouldn't stop/start the cluster too often, and we can execute several times the test in a row, stopping and starting the cluster in less than the recommended 15-30 minutes.

As we cannot guarantee the period between stop/starts, I guess that it's better if we only reduce the cluster size.

**This process increases the execution time 3-5 minutes per execution**

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more]
