### PR TITLE
chore: Use default script to instal az-cli

### DIFF
--- a/tools/build-tools.Dockerfile
+++ b/tools/build-tools.Dockerfile
@@ -13,8 +13,8 @@ RUN ln -sf bash /bin/sh
 # Install python3
 RUN apt install -y python3 python3-pip
 
-# Install azure-cli (using pip)
-RUN python3 -m pip install azure.cli
+# Install azure-cli
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 # Install docker
 RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release && \


### PR DESCRIPTION
The official installation script now supports ARM64. 
This PR installs az-cli in the ARM64 images using the official script instead of pip

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

