### PR TITLE
chore: GCP - fix logger

### DIFF
--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -167,7 +167,7 @@ func (s *pubsubScaler) GetMetricsAndActivity(ctx context.Context, metricName str
 
 	value, err := s.getMetrics(ctx, metricType)
 	if err != nil {
-		s.logger.Error(err, "error getting metric", metricType)
+		s.logger.Error(err, "error getting metric", "metricType", metricType)
 		return []external_metrics.ExternalMetricValue{}, false, err
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
Causing:

```
DPANIC	gcp_pub_sub_scaler	odd number of arguments passed as key-value pairs for logging	
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--

