### PR TITLE
fix(e2e): Add again the path filter to ignore non e2e tests during the execution

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -130,6 +130,7 @@ jobs:
         run: make scale-node-pool
         env:
           NODE_POOL_SIZE: 4
+          TEST_CLUSTER_NAME: keda-pr-run
 
       - name: Run end to end tests
         continue-on-error: true
@@ -162,6 +163,7 @@ jobs:
         run: make scale-node-pool
         env:
           NODE_POOL_SIZE: 1
+          TEST_CLUSTER_NAME: keda-pr-run
 
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1

--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -129,7 +129,8 @@ func executeTest(ctx context.Context, file string, timeout string, tries int) Te
 func getRegularTestFiles(e2eRegex string) []string {
 	// We exclude utils and sequential folders and helper files
 	filter := func(path string, file string) bool {
-		return strings.Contains(path, "utils") ||
+		return !strings.HasPrefix(path, "tests") || // we need this condition to skip non e2e test from execution
+			strings.Contains(path, "utils") ||
 			strings.Contains(path, "sequential") ||
 			!strings.HasSuffix(file, "_test.go")
 	}
@@ -138,7 +139,8 @@ func getRegularTestFiles(e2eRegex string) []string {
 
 func getSequentialTestFiles(e2eRegex string) []string {
 	filter := func(path string, file string) bool {
-		return !strings.Contains(path, "sequential") ||
+		return !strings.HasPrefix(path, "tests") || // we need this condition to skip non e2e test from execution
+			!strings.Contains(path, "sequential") ||
 			!strings.HasSuffix(file, "_test.go")
 	}
 	return getTestFiles(e2eRegex, filter)


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
