### PR TITLE
fix(config/grafana): use range for HPA metrics

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -126,6 +126,11 @@ jobs:
         with:
           secrets: ${{ toJSON(secrets) }}
 
+      - name: Scale cluster
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 4
+
       - name: Run end to end tests
         continue-on-error: true
         id: test
@@ -151,6 +156,12 @@ jobs:
         run: make e2e-test-clean
         env:
           TEST_CLUSTER_NAME: keda-pr-run
+
+      - name: Scale cluster
+        if: ${{ always() }}
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 1
 
       - name: React to comment with success
         uses: dkershner6/reaction-action@v1

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           secrets: ${{ toJSON(secrets) }}
 
+      - name: Scale cluster
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 4
+
       - name: Run end to end tests
         env:
           AWS_RUN_IDENTITY_TESTS: true
@@ -34,6 +39,12 @@ jobs:
       - name: Delete all e2e related namespaces
         if: ${{ always() }}
         run: make e2e-test-clean
+
+      - name: Scale cluster
+        if: ${{ always() }}
+        run: make scale-node-pool
+        env:
+          NODE_POOL_SIZE: 1
 
       - name: Upload test logs
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Pipelines**: Fix for disallowing `$top` on query when using `meta.parentID` method ([#4397])
 - **Azure Pipelines**: Respect all required demands ([#4404](https://github.com/kedacore/keda/issues/4404))
 - **Prometheus Metrics**: Create e2e tests for all exposed Prometheus metrics ([#4127](https://github.com/kedacore/keda/issues/4127))
+- **Grafana Dashboard**: Fix HPA metrics panel to use range instead of instant ([#4511](https://github.com/kedacore/keda/pull/4511))
 
 ### Deprecations
 
@@ -74,6 +75,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Drop a transitive dependency on bou.ke/monkey ([#4364](https://github.com/kedacore/keda/issues/4364))
 - **General**: Fix odd number of arguments passed as key-value pairs for logging ([#4368](https://github.com/kedacore/keda/issues/4368))
+- **General**: Automatically scale test clusters in/out to reduce environmental footprint & improve cost-efficiency ([#4456](https://github.com/kedacore/keda/pull/4456))
 
 ## v2.10.0
 

--- a/config/grafana/keda-dashboard.json
+++ b/config/grafana/keda-dashboard.json
@@ -735,18 +735,23 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
+            "drawStyle": "line",
             "fillOpacity": 100,
-            "gradientMode": "hue",
+            "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
             "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -756,7 +761,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -787,7 +792,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -804,10 +810,10 @@
           "exemplar": false,
           "expr": "kube_horizontalpodautoscaler_status_current_replicas{namespace=\"$namespace\",horizontalpodautoscaler=\"keda-hpa-$scaledObject\"}",
           "format": "time_series",
-          "instant": true,
+          "instant": false,
           "interval": "",
           "legendFormat": "current_replicas",
-          "range": false,
+          "range": true,
           "refId": "A"
         },
         {
@@ -820,9 +826,9 @@
           "expr": "kube_horizontalpodautoscaler_spec_max_replicas{namespace=\"$namespace\",horizontalpodautoscaler=\"keda-hpa-$scaledObject\"}",
           "format": "time_series",
           "hide": false,
-          "instant": true,
+          "instant": false,
           "legendFormat": "max_replicas",
-          "range": false,
+          "range": true,
           "refId": "B"
         }
       ],

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -167,7 +167,7 @@ func (s *pubsubScaler) GetMetricsAndActivity(ctx context.Context, metricName str
 
 	value, err := s.getMetrics(ctx, metricType)
 	if err != nil {
-		s.logger.Error(err, "error getting metric", metricType)
+		s.logger.Error(err, "error getting metric", "metricType", metricType)
 		return []external_metrics.ExternalMetricValue{}, false, err
 	}
 

--- a/tests/scalers/solace/solace_test.go
+++ b/tests/scalers/solace/solace_test.go
@@ -180,11 +180,11 @@ func TestStanScaler(t *testing.T) {
 }
 
 func installSolace(t *testing.T) {
-	_, err := ExecuteCommand("helm repo add solacecharts https://solaceproducts.github.io/pubsubplus-kubernetes-quickstart/helm-charts")
+	_, err := ExecuteCommand("helm repo add solacecharts https://solaceproducts.github.io/pubsubplus-kubernetes-helm-quickstart/helm-charts")
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 	_, err = ExecuteCommand("helm repo update")
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
-	_, err = ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set solace.usernameAdminPassword=KedaLabAdminPwd1 --set storage.persistent=false --namespace %s --wait kedalab solacecharts/pubsubplus-dev`,
+	_, err = ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set solace.usernameAdminPassword=KedaLabAdminPwd1 --set storage.persistent=false --namespace %s --wait --timeout 900s kedalab solacecharts/pubsubplus-dev`,
 		testNamespace))
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 	// Create the pubsub broker

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -31,6 +31,7 @@ var (
 	monitoredDeploymentName   = fmt.Sprintf("%s-monitored", testName)
 	scaledObjectName          = fmt.Sprintf("%s-so", testName)
 	wrongScaledObjectName     = fmt.Sprintf("%s-wrong", testName)
+	wrongScalerName           = fmt.Sprintf("%s-wrong-scaler", testName)
 	cronScaledJobName         = fmt.Sprintf("%s-cron-sj", testName)
 	clientName                = fmt.Sprintf("%s-client", testName)
 	kedaOperatorPrometheusURL = "http://keda-operator.keda.svc.cluster.local:8080/metrics"
@@ -44,6 +45,7 @@ type templateData struct {
 	DeploymentName          string
 	ScaledObjectName        string
 	WrongScaledObjectName   string
+	WrongScalerName         string
 	CronScaledJobName       string
 	MonitoredDeploymentName string
 	ClientName              string
@@ -133,6 +135,7 @@ spec:
   cooldownPeriod: 10
   triggers:
     - type: prometheus
+      name: {{.WrongScalerName}}
       metadata:
         serverAddress: http://keda-prometheus.keda.svc.cluster.local:8080
         metricName: keda_scaler_errors_total
@@ -274,6 +277,7 @@ func getTemplateData() (templateData, []Template) {
 			DeploymentName:          deploymentName,
 			ScaledObjectName:        scaledObjectName,
 			WrongScaledObjectName:   wrongScaledObjectName,
+			WrongScalerName:         wrongScalerName,
 			MonitoredDeploymentName: monitoredDeploymentName,
 			ClientName:              clientName,
 			CronScaledJobName:       cronScaledJobName,
@@ -361,8 +365,8 @@ func testScalerErrors(t *testing.T, data templateData) {
 	if val, ok := family["keda_scaler_errors"]; ok {
 		errCounterVal1 := getErrorMetricsValue(val)
 
-		// wait for 2 seconds as pollinginterval is 2
-		time.Sleep(2 * time.Second)
+		// wait for 10 seconds to correctly fetch metrics.
+		time.Sleep(10 * time.Second)
 
 		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
 		if val, ok := family["keda_scaler_errors"]; ok {
@@ -431,7 +435,7 @@ func getErrorMetricsValue(val *promModel.MetricFamily) float64 {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			for _, label := range labels {
-				if *label.Name == "scaler" && *label.Value == "prometheusScaler" {
+				if *label.Name == "scaler" && *label.Value == wrongScalerName {
 					return *metric.Counter.Value
 				}
 			}


### PR DESCRIPTION
Use `range` instead of `instant` for HPA current/max replicas (time based).

Right now, we are using the `instant` selector, which given that the panel should be time-based (as per the title), it should use a `range` selector, thus getting all metrics in a given timeframe, not just one data point.

Also, moved from bars to lines because bars are hard to visualize using ranges containing several days worth of data.

Before:

<img width="755" alt="Screenshot 2023-04-26 at 19 29 15" src="https://user-images.githubusercontent.com/2865071/235660484-ce36f343-2451-4517-a553-2f6df8ee3f2b.png">

After:

<img width="757" alt="Screenshot 2023-04-26 at 19 28 50" src="https://user-images.githubusercontent.com/2865071/235660540-dd2593c2-9187-44a5-ab6f-c6d2e7d48477.png">

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))