### PR TITLE
fix(config/grafana): use range for HPA metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Pipelines**: Fix for disallowing `$top` on query when using `meta.parentID` method ([#4397])
 - **Azure Pipelines**: Respect all required demands ([#4404](https://github.com/kedacore/keda/issues/4404))
 - **Prometheus Metrics**: Create e2e tests for all exposed Prometheus metrics ([#4127](https://github.com/kedacore/keda/issues/4127))
+- **Grafana Dashboard**: Fix HPA metrics panel to use range instead of instant ([#4513](https://github.com/kedacore/keda/pull/4513))
 
 ### Deprecations
 

--- a/config/grafana/keda-dashboard.json
+++ b/config/grafana/keda-dashboard.json
@@ -735,18 +735,23 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
+            "drawStyle": "line",
             "fillOpacity": 100,
-            "gradientMode": "hue",
+            "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
             "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -756,7 +761,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -787,7 +792,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -804,10 +810,10 @@
           "exemplar": false,
           "expr": "kube_horizontalpodautoscaler_status_current_replicas{namespace=\"$namespace\",horizontalpodautoscaler=\"keda-hpa-$scaledObject\"}",
           "format": "time_series",
-          "instant": true,
+          "instant": false,
           "interval": "",
           "legendFormat": "current_replicas",
-          "range": false,
+          "range": true,
           "refId": "A"
         },
         {
@@ -820,9 +826,9 @@
           "expr": "kube_horizontalpodautoscaler_spec_max_replicas{namespace=\"$namespace\",horizontalpodautoscaler=\"keda-hpa-$scaledObject\"}",
           "format": "time_series",
           "hide": false,
-          "instant": true,
+          "instant": false,
           "legendFormat": "max_replicas",
-          "range": false,
+          "range": true,
           "refId": "B"
         }
       ],


### PR DESCRIPTION
Use `range` instead of `instant` for HPA current/max replicas (time based).

Right now, we are using the `instant` selector, which given that the panel should be time-based (as per the title), it should use a `range` selector, thus getting all metrics in a given timeframe, not just the last data point.

Also, moved from bars to lines because bars are hard to visualize using `ranges` containing several days worth of data.

Before:
<img width="755" alt="Screenshot 2023-04-26 at 19 29 15" src="https://user-images.githubusercontent.com/2865071/235666412-1d8b9c22-c2ed-4aab-a5b3-397b8ce9d33d.png">

After:
<img width="757" alt="Screenshot 2023-04-26 at 19 28 50" src="https://user-images.githubusercontent.com/2865071/235666512-17d17e8a-6d4f-4841-854c-f88cdb9563ec.png">

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))