### PR TITLE
fix: Update e2e tests after upgrade k8s 1.26

### DIFF
--- a/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
+++ b/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
@@ -228,7 +228,8 @@ func testPollingIntervalUp(t *testing.T, kc *kubernetes.Clientset, data template
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	// wait until HPA to ensure that ScaledObject reconciliation loop has happened
-	WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
+	_, err := WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
+	assert.NoError(t, err)
 
 	data.MetricValue = maxReplicas
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
@@ -259,7 +260,8 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	// wait until HPA to ensure that ScaledObject reconciliation loop has happened
-	WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
+	_, err := WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
+	assert.NoError(t, err)
 
 	data.MetricValue = minReplicas
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
@@ -293,7 +295,8 @@ func testCooldownPeriod(t *testing.T, kc *kubernetes.Clientset, data templateDat
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	// wait until HPA to ensure that ScaledObject reconciliation loop has happened
-	WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
+	_, err := WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
+	assert.NoError(t, err)
 
 	data.MetricValue = 0
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)

--- a/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
+++ b/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
@@ -6,7 +6,6 @@ package polling_cooldown_so_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +30,7 @@ var (
 	scaledObjectName            = fmt.Sprintf("%s-so", testName)
 	secretName                  = fmt.Sprintf("%s-secret", testName)
 	metricsServerEndpoint       = fmt.Sprintf("http://%s.%s.svc.cluster.local:8080/api/value", serviceName, namespace)
+	hpaName                     = fmt.Sprintf("%s-hpa", testName)
 	minReplicas                 = 0
 	maxReplicas                 = 1
 	pollingInterval             = 1 // (don't set it to 0 to avoid cpu leaks)
@@ -51,6 +51,7 @@ type templateData struct {
 	MetricValue                 int
 	PollingInterval             int
 	CooldownPeriod              int
+	CustomHpaName               string
 }
 
 const (
@@ -144,6 +145,9 @@ metadata:
 spec:
   scaleTargetRef:
     name: {{.DeploymentName}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{.CustomHpaName}}
   pollingInterval: {{.PollingInterval}}
   cooldownPeriod: {{.CooldownPeriod}}
   minReplicaCount: {{.MinReplicas}}
@@ -166,6 +170,7 @@ metadata:
   name: update-ms-value
   namespace: {{.TestNamespace}}
 spec:
+  ttlSecondsAfterFinished: 0
   backoffLimit: 4
   template:
     spec:
@@ -211,8 +216,9 @@ func testPollingIntervalUp(t *testing.T, kc *kubernetes.Clientset, data template
 
 	data.MetricValue = 0
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
-	assert.True(t, WaitForJobSuccess(t, kc, "update-ms-value", data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+
+	// wait some seconds to finish the job
+	WaitForJobCount(t, kc, namespace, 0, 15, 2)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 18, 10),
 		"replica count should be %d after 3 minutes", minReplicas)
@@ -221,13 +227,11 @@ func testPollingIntervalUp(t *testing.T, kc *kubernetes.Clientset, data template
 	data.PollingInterval = 60 + 15 // 15 seconds as a reserve
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	// wait 15 sec to ensure that ScaledObject reconciliation loop has happened
-	time.Sleep(15 + time.Second)
+	// wait until HPA to ensure that ScaledObject reconciliation loop has happened
+	WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
 
 	data.MetricValue = maxReplicas
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
-	assert.True(t, WaitForJobSuccess(t, kc, "update-ms-value", data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, minReplicas, 60)
 
@@ -242,8 +246,9 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 
 	data.MetricValue = 1
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
-	assert.True(t, WaitForJobSuccess(t, kc, "update-ms-value", data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+
+	// wait some seconds to finish the job
+	WaitForJobCount(t, kc, namespace, 0, 15, 2)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 18, 10),
 		"replica count should be %d after 3 minutes", minReplicas)
@@ -253,13 +258,11 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 	data.CooldownPeriod = 0
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	// wait 15 sec to ensure that ScaledObject reconciliation loop has happened
-	time.Sleep(15 + time.Second)
+	// wait until HPA to ensure that ScaledObject reconciliation loop has happened
+	WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
 
 	data.MetricValue = minReplicas
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
-	assert.True(t, WaitForJobSuccess(t, kc, "update-ms-value", data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, maxReplicas, 60)
 
@@ -272,25 +275,28 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 func testCooldownPeriod(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- test Cooldown Period ---")
 
-	data.PollingInterval = 5      // remove polling interval to test CP (don't set it to 0 to avoid cpu leaks)
-	data.CooldownPeriod = 60 + 15 // 15 seconds as a reserve
+	data.PollingInterval = 5
+	data.CooldownPeriod = 0
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-
-	// wait 15 sec to ensure that ScaledObject reconciliation loop has happened
-	time.Sleep(15 + time.Second)
 
 	data.MetricValue = 1
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
-	assert.True(t, WaitForJobSuccess(t, kc, "update-ms-value", data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+
+	// wait some seconds to finish the job
+	WaitForJobCount(t, kc, namespace, 0, 15, 2)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 18, 10),
 		"replica count should be %d after 3 minutes", 1)
 
+	data.PollingInterval = 5      // remove polling interval to test CP (don't set it to 0 to avoid cpu leaks)
+	data.CooldownPeriod = 60 + 15 // 15 seconds as a reserve
+	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+
+	// wait until HPA to ensure that ScaledObject reconciliation loop has happened
+	WaitForHpaCreation(t, kc, hpaName, namespace, 60, 2)
+
 	data.MetricValue = 0
 	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
-	assert.True(t, WaitForJobSuccess(t, kc, "update-ms-value", data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, maxReplicas, 60)
 
@@ -315,6 +321,7 @@ func getTemplateData() (templateData, []Template) {
 			MetricValue:                 0,
 			PollingInterval:             pollingInterval,
 			CooldownPeriod:              cooldownPeriod,
+			CustomHpaName:               hpaName,
 		}, []Template{
 			{Name: "secretTemplate", Config: secretTemplate},
 			{Name: "metricsServerDeploymentTemplate", Config: metricsServerDeploymentTemplate},

--- a/tests/scalers/etcd/helper/helper.go
+++ b/tests/scalers/etcd/helper/helper.go
@@ -140,6 +140,6 @@ func InstallCluster(t *testing.T, kc *kubernetes.Clientset, name, namespace stri
 		EtcdName:  name,
 	}
 	helper.KubectlApplyMultipleWithTemplate(t, data, etcdClusterTemplates)
-	assert.True(t, helper.WaitForStatefulsetReplicaReadyCount(t, kc, name, namespace, 3, 60, 3),
+	assert.True(t, helper.WaitForStatefulsetReplicaReadyCount(t, kc, name, namespace, 3, 60, 5),
 		"etcd-cluster should be up")
 }

--- a/tests/scalers/kafka/kafka_test.go
+++ b/tests/scalers/kafka/kafka_test.go
@@ -535,13 +535,13 @@ func addTopic(t *testing.T, data templateData, name string, partitions int) {
 	data.KafkaTopicName = name
 	data.KafkaTopicPartitions = partitions
 	KubectlApplyWithTemplate(t, data, "kafkaTopicTemplate", kafkaTopicTemplate)
-	_, err := ExecuteCommand(fmt.Sprintf("kubectl wait kafkatopic/%s --for=condition=Ready --timeout=300s --namespace %s", name, testNamespace))
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl wait kafkatopic/%s --for=condition=Ready --timeout=480s --namespace %s", name, testNamespace))
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 }
 
 func addCluster(t *testing.T, data templateData) {
 	KubectlApplyWithTemplate(t, data, "kafkaClusterTemplate", kafkaClusterTemplate)
-	_, err := ExecuteCommand(fmt.Sprintf("kubectl wait kafka/%s --for=condition=Ready --timeout=300s --namespace %s", kafkaName, testNamespace))
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl wait kafka/%s --for=condition=Ready --timeout=480s --namespace %s", kafkaName, testNamespace))
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 }
 

--- a/tests/scalers/kafka/kafka_test.go
+++ b/tests/scalers/kafka/kafka_test.go
@@ -135,8 +135,25 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
+  pollingInterval: 5
+  cooldownPeriod: 0
   scaleTargetRef:
     name: {{.DeploymentName}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
   triggers:
   - type: kafka
     metadata:
@@ -156,8 +173,25 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
+  pollingInterval: 5
+  cooldownPeriod: 0
   scaleTargetRef:
     name: {{.DeploymentName}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
   triggers:
   - type: kafka
     metadata:
@@ -175,8 +209,25 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
+  pollingInterval: 5
+  cooldownPeriod: 0
   scaleTargetRef:
     name: {{.DeploymentName}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
   triggers:
   - type: kafka
     metadata:
@@ -196,20 +247,21 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  pollingInterval: 15
+  pollingInterval: 5
+  cooldownPeriod: 0
   scaleTargetRef:
     name: {{.DeploymentName}}
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleUp:
-          stabilizationWindowSeconds: 30
+          stabilizationWindowSeconds: 0
           policies:
           - type: Percent
             value: 100
             periodSeconds: 15
         scaleDown:
-          stabilizationWindowSeconds: 30
+          stabilizationWindowSeconds: 0
           policies:
           - type: Percent
             value: 100
@@ -327,11 +379,11 @@ func testEarliestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateDat
 	KubectlApplyWithTemplate(t, data, "singleScaledObjectTemplate", singleScaledObjectTemplate)
 
 	// Shouldn't scale pods applying earliest policy
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 
 	// Shouldn't scale pods with only 1 message due to activation value
 	publishMessage(t, topic1)
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 
 	// Scale application with kafka messages
 	publishMessage(t, topic1)
@@ -362,11 +414,11 @@ func testLatestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData)
 	KubectlApplyWithTemplate(t, data, "singleScaledObjectTemplate", singleScaledObjectTemplate)
 
 	// Shouldn't scale pods
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 
 	// Shouldn't scale pods with only 1 message due to activation value
 	publishMessage(t, topic1)
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 
 	// Scale application with kafka messages
 	publishMessage(t, topic1)
@@ -396,7 +448,7 @@ func testMultiTopic(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	KubectlApplyWithTemplate(t, data, "multiScaledObjectTemplate", multiScaledObjectTemplate)
 
 	// Shouldn't scale pods
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 
 	// Scale application with kafka messages in topic 1
 	publishMessage(t, topic1)
@@ -428,7 +480,7 @@ func testZeroOnInvalidOffset(t *testing.T, kc *kubernetes.Clientset, data templa
 	KubectlApplyWithTemplate(t, data, "invalidOffsetScaledObjectTemplate", invalidOffsetScaledObjectTemplate)
 
 	// Shouldn't scale pods
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 
 	KubectlDeleteWithTemplate(t, data, "singleDeploymentTemplate", singleDeploymentTemplate)
 	KubectlDeleteWithTemplate(t, data, "invalidOffsetScaledObjectTemplate", invalidOffsetScaledObjectTemplate)

--- a/tests/scalers/redis/redis_cluster_lists/redis_cluster_lists_test.go
+++ b/tests/scalers/redis/redis_cluster_lists/redis_cluster_lists_test.go
@@ -196,7 +196,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	data.ItemsToWrite = 200
+	data.ItemsToWrite = 400
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),

--- a/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
+++ b/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
@@ -203,7 +203,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	data.ItemsToWrite = 200
+	data.ItemsToWrite = 400
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),

--- a/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
+++ b/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
@@ -192,7 +192,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	data.ItemsToWrite = 200
+	data.ItemsToWrite = 400
 	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -73,16 +73,16 @@ metadata:
   name: {{.SutDeploymentName}}
   namespace: {{.TestNamespace}}
   labels:
-    deploy: workload-sut
+    deploy: {{.SutDeploymentName}}
 spec:
   replicas: 0
   selector:
     matchLabels:
-      pod: workload-sut
+      pod: {{.SutDeploymentName}}
   template:
     metadata:
       labels:
-        pod: workload-sut
+        pod: {{.SutDeploymentName}}
     spec:
       containers:
       - name: nginx

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -52,16 +52,16 @@ metadata:
   name: {{.MonitoredDeploymentName}}
   namespace: {{.TestNamespace}}
   labels:
-    deploy: workload-test
+    deploy: {{.MonitoredDeploymentName}}
 spec:
   replicas: 0
   selector:
     matchLabels:
-      pod: workload-test
+      pod: {{.MonitoredDeploymentName}}
   template:
     metadata:
       labels:
-        pod: workload-test
+        pod: {{.MonitoredDeploymentName}}
     spec:
       containers:
         - name: nginx
@@ -73,16 +73,16 @@ metadata:
   name: {{.SutDeploymentName}}
   namespace: {{.TestNamespace}}
   labels:
-    deploy: workload-sut
+    deploy: {{.SutDeploymentName}}
 spec:
   replicas: 0
   selector:
     matchLabels:
-      pod: workload-sut
+      pod: {{.SutDeploymentName}}
   template:
     metadata:
       labels:
-        pod: workload-sut
+        pod: {{.SutDeploymentName}}
     spec:
       containers:
       - name: nginx
@@ -108,7 +108,7 @@ spec:
   triggers:
   - type: kubernetes-workload
     metadata:
-      podSelector: 'pod=workload-test'
+      podSelector: 'pod={{.MonitoredDeploymentName}}'
       value: '1'`
 )
 

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -52,16 +52,16 @@ metadata:
   name: {{.MonitoredDeploymentName}}
   namespace: {{.TestNamespace}}
   labels:
-    deploy: {{.MonitoredDeploymentName}}
+    deploy: workload-test
 spec:
   replicas: 0
   selector:
     matchLabels:
-      pod: {{.MonitoredDeploymentName}}
+      pod: workload-test
   template:
     metadata:
       labels:
-        pod: {{.MonitoredDeploymentName}}
+        pod: workload-test
     spec:
       containers:
         - name: nginx
@@ -73,16 +73,16 @@ metadata:
   name: {{.SutDeploymentName}}
   namespace: {{.TestNamespace}}
   labels:
-    deploy: {{.SutDeploymentName}}
+    deploy: workload-sut
 spec:
   replicas: 0
   selector:
     matchLabels:
-      pod: {{.SutDeploymentName}}
+      pod: workload-sut
   template:
     metadata:
       labels:
-        pod: {{.SutDeploymentName}}
+        pod: workload-sut
     spec:
       containers:
       - name: nginx
@@ -108,7 +108,7 @@ spec:
   triggers:
   - type: kubernetes-workload
     metadata:
-      podSelector: 'pod={{.MonitoredDeploymentName}}'
+      podSelector: 'pod=workload-test'
       value: '1'`
 )
 


### PR DESCRIPTION
After upgrading to k8s 1.26, e2e tests have started to fail. I have noticed that HPA has set `ScalingActive` to false due `AmbiguousSelector`.

In k8s 1.26 there is a new commit disabling the HPA in case of ambiguous selectors: 
https://github.com/kubernetes/kubernetes/blob/f9340f3cf1f473f7da44594ea4974635f59f7ba1/CHANGELOG/CHANGELOG-1.26.md?plain=1#L809

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

