### PR TITLE
fix: Set POD_NAMESPACE env var on manager deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,6 +59,10 @@ spec:
             name: http
             protocol: TCP
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: WATCH_NAMESPACE
               value: ""
             - name: KEDA_HTTP_DEFAULT_TIMEOUT


### PR DESCRIPTION
Unlike the webhooks and metrics API server deployment, the `POD_NAMESPACE` environment variable is not set by the manager deployment, which causes problems when the manager is deployed to a namespace other than `keda` and then tries to create a secret containing its self-signed certs for the gRPC service (but attempts to create it in the `keda` namespace).

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))