### PR TITLE
Support ScaledObject taking over existing HPAs with the same name while they are not managed by other ScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Redis Scalers**: Allow scaling using redis stream length ([#4277](https://github.com/kedacore/keda/issues/4277))
 - **Redis Scalers**: Allow scaling using consumer group lag ([#3127](https://github.com/kedacore/keda/issues/3127))
 - **General:** Introduce new Solr Scaler ([#4234](https://github.com/kedacore/keda/issues/4234))
+- **Admission Webhooks**: Support ScaledObject taking over existing HPAs with the same name while they are not managed by other ScaledObject ([#4457](https://github.com/kedacore/keda/issues/4457))
 
 ### Improvements
 

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -48,6 +48,7 @@ type ScaledObject struct {
 }
 
 const ScaledObjectOwnerAnnotation = "scaledobject.keda.sh/name"
+const ScaledObjectTransferHpaOwnershipAnnotation = "scaledobject.keda.sh/transfer-hpa-ownership"
 
 // HealthStatus is the status for a ScaledObject's health
 type HealthStatus struct {

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -160,7 +160,7 @@ func verifyHpas(incomingSo *ScaledObject, action string) error {
 			}
 
 			if !owned {
-				if incomingSo.ObjectMeta.Annotations["keda.sh/transfer-hpa-ownership"] == "true" &&
+				if incomingSo.ObjectMeta.Annotations[ScaledObjectTransferHpaOwnershipAnnotation] == "true" &&
 					incomingSo.Spec.Advanced.HorizontalPodAutoscalerConfig.Name == hpa.Name {
 					scaledobjectlog.Info(fmt.Sprintf("%s hpa ownership being transferred to %s", hpa.Name, incomingSo.Name))
 				} else {

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -160,10 +160,15 @@ func verifyHpas(incomingSo *ScaledObject, action string) error {
 			}
 
 			if !owned {
-				err = fmt.Errorf("the workload '%s' of type '%s' is already managed by the hpa '%s'", incomingSo.Spec.ScaleTargetRef.Name, incomingSoGckr.GVKString(), hpa.Name)
-				scaledobjectlog.Error(err, "validation error")
-				prommetrics.RecordScaledObjectValidatingErrors(incomingSo.Namespace, action, "other-hpa")
-				return err
+				if incomingSo.ObjectMeta.Annotations["keda.sh/transfer-hpa-ownership"] == "true" &&
+					incomingSo.Spec.Advanced.HorizontalPodAutoscalerConfig.Name == hpa.Name {
+					scaledobjectlog.Info(fmt.Sprintf("%s hpa ownership being transferred to %s", hpa.Name, incomingSo.Name))
+				} else {
+					err = fmt.Errorf("the workload '%s' of type '%s' is already managed by the hpa '%s'", incomingSo.Spec.ScaleTargetRef.Name, incomingSoGckr.GVKString(), hpa.Name)
+					scaledobjectlog.Error(err, "validation error")
+					prommetrics.RecordScaledObjectValidatingErrors(incomingSo.Namespace, action, "other-hpa")
+					return err
+				}
 			}
 		}
 	}

--- a/apis/keda/v1alpha1/scaledobject_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook_test.go
@@ -262,7 +262,7 @@ var _ = It("shouldn't validate the so creation when there is another unmanaged h
 	namespaceName := "unmanaged-hpa-ownership"
 	namespace := createNamespace(namespaceName)
 	hpa := createHpa(hpaName, namespaceName, workloadName, "apps/v1", "Deployment", nil)
-	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{"keda.sh/transfer-hpa-ownership": "true"}, hpaName)
+	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{ScaledObjectTransferHpaOwnershipAnnotation: "true"}, hpaName)
 
 	err := k8sClient.Create(context.Background(), namespace)
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/internals/scaled_object_validation/scaled_object_validation_test.go
+++ b/tests/internals/scaled_object_validation/scaled_object_validation_test.go
@@ -113,7 +113,7 @@ metadata:
   name: {{.ScaledObjectName}}
   namespace: {{.TestNamespace}}
   annotations:
-    keda.sh/transfer-hpa-ownership: "true"
+    scaledobject.keda.sh/transfer-hpa-ownership: "true"
 spec:
   scaleTargetRef:
     name: {{.DeploymentName}}

--- a/tests/internals/scaled_object_validation/scaled_object_validation_test.go
+++ b/tests/internals/scaled_object_validation/scaled_object_validation_test.go
@@ -17,11 +17,13 @@ const (
 )
 
 var (
-	testNamespace     = fmt.Sprintf("%s-ns", testName)
-	deploymentName    = fmt.Sprintf("%s-deployment", testName)
-	scaledObject1Name = fmt.Sprintf("%s-so1", testName)
-	scaledObject2Name = fmt.Sprintf("%s-so2", testName)
-	hpaName           = fmt.Sprintf("%s-hpa", testName)
+	testNamespace                     = fmt.Sprintf("%s-ns", testName)
+	deploymentName                    = fmt.Sprintf("%s-deployment", testName)
+	scaledObject1Name                 = fmt.Sprintf("%s-so1", testName)
+	scaledObject2Name                 = fmt.Sprintf("%s-so2", testName)
+	hpaName                           = fmt.Sprintf("%s-hpa", testName)
+	ownershipTransferScaledObjectName = fmt.Sprintf("%s-ownership-transfer-so", testName)
+	ownershipTransferHpaName          = fmt.Sprintf("%s-ownership-transfer-hpa", testName)
 )
 
 type templateData struct {
@@ -218,12 +220,12 @@ func testScaledWorkloadByOtherHpa(t *testing.T, data templateData) {
 func testScaledWorkloadByOtherHpaWithOwnershipTransfer(t *testing.T, data templateData) {
 	t.Log("--- already scaled workload by other hpa ownership transfer ---")
 
-	data.HpaName = hpaName
+	data.HpaName = ownershipTransferHpaName
 	err := KubectlApplyWithErrors(t, data, "hpaTemplate", hpaTemplate)
 	assert.NoErrorf(t, err, "cannot deploy the hpa - %s", err)
 
-	data.ScaledObjectName = scaledObject1Name
-	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", ownershipTransferScaledObjectTemplate)
+	data.ScaledObjectName = ownershipTransferScaledObjectName
+	err = KubectlApplyWithErrors(t, data, "ownershipTransferScaledObjectTemplate", ownershipTransferScaledObjectTemplate)
 	assert.NoErrorf(t, err, "can deploy the scaledObject - %s", err)
 
 	KubectlDeleteWithTemplate(t, data, "hpaTemplate", hpaTemplate)

--- a/tests/internals/scaled_object_validation/scaled_object_validation_test.go
+++ b/tests/internals/scaled_object_validation/scaled_object_validation_test.go
@@ -103,6 +103,30 @@ spec:
         type: Utilization
         value: "50"
 `
+
+	ownershipTransferScaledObjectTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+  annotations:
+    keda.sh/transfer-hpa-ownership: "true"
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{.HpaName}}
+  triggers:
+  - type: cron
+    metadata:
+      timezone: Etc/UTC
+      start: 0 * * * *
+      end: 1 * * * *
+      desiredReplicas: '1'
+`
+
 	hpaTemplate = `
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -140,6 +164,8 @@ func TestScaledObjectValidations(t *testing.T) {
 	testScaledWorkloadByOtherScaledObject(t, data)
 
 	testScaledWorkloadByOtherHpa(t, data)
+
+	testScaledWorkloadByOtherHpaWithOwnershipTransfer(t, data)
 
 	testMissingCPU(t, data)
 
@@ -185,6 +211,20 @@ func testScaledWorkloadByOtherHpa(t *testing.T, data templateData) {
 	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the workload '%s' of type 'apps/v1.Deployment' is already managed by the hpa '%s", deploymentName, hpaName))
+
+	KubectlDeleteWithTemplate(t, data, "hpaTemplate", hpaTemplate)
+}
+
+func testScaledWorkloadByOtherHpaWithOwnershipTransfer(t *testing.T, data templateData) {
+	t.Log("--- already scaled workload by other hpa ownership transfer ---")
+
+	data.HpaName = hpaName
+	err := KubectlApplyWithErrors(t, data, "hpaTemplate", hpaTemplate)
+	assert.NoErrorf(t, err, "cannot deploy the hpa - %s", err)
+
+	data.ScaledObjectName = scaledObject1Name
+	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", ownershipTransferScaledObjectTemplate)
+	assert.NoErrorf(t, err, "can deploy the scaledObject - %s", err)
 
 	KubectlDeleteWithTemplate(t, data, "hpaTemplate", hpaTemplate)
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4457

