### PR TITLE
fix: stop scale loop for pause Scaledbject (issue #4253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ New deprecation(s):
 - **General**: Use default metrics provider from sigs.k8s.io/custom-metrics-apiserver ([#4473](https://github.com/kedacore/keda/pull/4473))
 - **General**: Refactor several functions for Status & Conditions handling into pkg util functions ([#2906](https://github.com/kedacore/keda/pull/2906))
 - **General**: Bump `kubernetes-sigs/controller-runtime` to v0.15.0 and code alignment ([#4582](https://github.com/kedacore/keda/pull/4582))
+- **General**: Stop logging errors for paused ScaledObject (with "autoscaling.keda.sh/paused-replicas" annotation) by skipping reconciliation loop for the object (stop the scale loop and delete the HPA) ([#4253](https://github.com/kedacore/keda/pull/4253))
 
 ## v2.10.1
 

--- a/apis/keda/v1alpha1/condition_types.go
+++ b/apis/keda/v1alpha1/condition_types.go
@@ -32,6 +32,8 @@ const (
 	ConditionActive ConditionType = "Active"
 	// ConditionFallback specifies that the resource has a fallback active.
 	ConditionFallback ConditionType = "Fallback"
+	// ConditionPaused specifies that the resource is paused.
+	ConditionPaused ConditionType = "Paused"
 )
 
 const (
@@ -39,6 +41,8 @@ const (
 	ScaledObjectConditionReadySucccesReason = "ScaledObjectReady"
 	// ScaledObjectConditionReadySuccessMessage defines the default Message for correct ScaledObject
 	ScaledObjectConditionReadySuccessMessage = "ScaledObject is defined correctly and is ready for scaling"
+	// ScaledObjectConditionPausedReason defines the default Reason for paused ScaledObject
+	ScaledObjectConditionPausedReason = "ScaledObjectPaused"
 	// ScaledObjectConditionPausedMessage defines the default Message for paused ScaledObject
 	ScaledObjectConditionPausedMessage = "ScaledObject is paused"
 )
@@ -72,6 +76,7 @@ func (c *Conditions) AreInitialized() bool {
 	foundReady := false
 	foundActive := false
 	foundFallback := false
+	foundPaused := false
 	if *c != nil {
 		for _, condition := range *c {
 			if condition.Type == ConditionReady {
@@ -91,14 +96,20 @@ func (c *Conditions) AreInitialized() bool {
 				break
 			}
 		}
+		for _, condition := range *c {
+			if condition.Type == ConditionPaused {
+				foundPaused = true
+				break
+			}
+		}
 	}
 
-	return foundReady && foundActive && foundFallback
+	return foundReady && foundActive && foundFallback && foundPaused
 }
 
 // GetInitializedConditions returns Conditions initialized to the default -> Status: Unknown
 func GetInitializedConditions() *Conditions {
-	return &Conditions{{Type: ConditionReady, Status: metav1.ConditionUnknown}, {Type: ConditionActive, Status: metav1.ConditionUnknown}, {Type: ConditionFallback, Status: metav1.ConditionUnknown}}
+	return &Conditions{{Type: ConditionReady, Status: metav1.ConditionUnknown}, {Type: ConditionActive, Status: metav1.ConditionUnknown}, {Type: ConditionFallback, Status: metav1.ConditionUnknown}, {Type: ConditionPaused, Status: metav1.ConditionUnknown}}
 }
 
 // IsTrue is true if the condition is True
@@ -149,6 +160,14 @@ func (c *Conditions) SetFallbackCondition(status metav1.ConditionStatus, reason 
 	c.setCondition(ConditionFallback, status, reason, message)
 }
 
+// SetPausedCondition modifies Paused Condition according to input parameters
+func (c *Conditions) SetPausedCondition(status metav1.ConditionStatus, reason string, message string) {
+	if *c == nil {
+		c = GetInitializedConditions()
+	}
+	c.setCondition(ConditionPaused, status, reason, message)
+}
+
 // GetActiveCondition returns Condition of type Active
 func (c *Conditions) GetActiveCondition() Condition {
 	if *c == nil {
@@ -165,12 +184,20 @@ func (c *Conditions) GetReadyCondition() Condition {
 	return c.getCondition(ConditionReady)
 }
 
-// GetFallbackCondition returns Condition of type Ready
+// GetFallbackCondition returns Condition of type Fallback
 func (c *Conditions) GetFallbackCondition() Condition {
 	if *c == nil {
 		c = GetInitializedConditions()
 	}
 	return c.getCondition(ConditionFallback)
+}
+
+// GetPausedCondition returns Condition of type Paused
+func (c *Conditions) GetPausedCondition() Condition {
+	if *c == nil {
+		c = GetInitializedConditions()
+	}
+	return c.getCondition(ConditionPaused)
 }
 
 func (c Conditions) getCondition(conditionType ConditionType) Condition {

--- a/apis/keda/v1alpha1/condition_types.go
+++ b/apis/keda/v1alpha1/condition_types.go
@@ -39,6 +39,8 @@ const (
 	ScaledObjectConditionReadySucccesReason = "ScaledObjectReady"
 	// ScaledObjectConditionReadySuccessMessage defines the default Message for correct ScaledObject
 	ScaledObjectConditionReadySuccessMessage = "ScaledObject is defined correctly and is ready for scaling"
+	// ScaledObjectConditionPausedMessage defines the default Message for paused ScaledObject
+	ScaledObjectConditionPausedMessage = "ScaledObject is paused"
 )
 
 // Condition to store the condition state

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
 // +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.conditions[?(@.type==\"Active\")].status"
 // +kubebuilder:printcolumn:name="Fallback",type="string",JSONPath=".status.conditions[?(@.type==\"Fallback\")].status"
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=".status.conditions[?(@.type==\"Paused\")].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ScaledObject is a specification for a ScaledObject resource

--- a/config/crd/bases/keda.sh_scaledobjects.yaml
+++ b/config/crd/bases/keda.sh_scaledobjects.yaml
@@ -44,6 +44,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Fallback")].status
       name: Fallback
       type: string
+    - jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/controllers/keda/hpa.go
+++ b/controllers/keda/hpa.go
@@ -269,9 +269,6 @@ func updateHealthStatus(scaledObject *kedav1alpha1.ScaledObject, externalMetricN
 
 // getHPAName returns generated HPA name for ScaledObject specified in the parameter
 func getHPAName(scaledObject *kedav1alpha1.ScaledObject) string {
-	if scaledObject.Status.HpaName != "" {
-		return scaledObject.Status.HpaName
-	}
 	if scaledObject.Spec.Advanced != nil && scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig != nil && scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Name != "" {
 		return scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Name
 	}

--- a/controllers/keda/hpa.go
+++ b/controllers/keda/hpa.go
@@ -269,6 +269,9 @@ func updateHealthStatus(scaledObject *kedav1alpha1.ScaledObject, externalMetricN
 
 // getHPAName returns generated HPA name for ScaledObject specified in the parameter
 func getHPAName(scaledObject *kedav1alpha1.ScaledObject) string {
+	if scaledObject.Status.HpaName != "" {
+		return scaledObject.Status.HpaName
+	}
 	if scaledObject.Spec.Advanced != nil && scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig != nil && scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Name != "" {
 		return scaledObject.Spec.Advanced.HorizontalPodAutoscalerConfig.Name
 	}

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -903,6 +903,15 @@ var _ = Describe("ScaledObjectController", func() {
 		Eventually(func() error {
 			return k8sClient.Get(context.Background(), types.NamespacedName{Name: fmt.Sprintf("keda-hpa-%s", soName), Namespace: "default"}, hpa)
 		}).Should(HaveOccurred())
+
+		// wait so's Paused condition true
+		Eventually(func() metav1.ConditionStatus {
+			err := k8sClient.Get(context.Background(), types.NamespacedName{Name: soName, Namespace: "default"}, so)
+			if err != nil {
+				return metav1.ConditionUnknown
+			}
+			return so.Status.Conditions.GetPausedCondition().Status
+		}, 1*time.Minute).Should(Equal(metav1.ConditionTrue))
 	})
 })
 

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -38,7 +38,6 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 	logger := e.logger.WithValues("scaledobject.Name", scaledObject.Name,
 		"scaledObject.Namespace", scaledObject.Namespace,
 		"scaleTarget.Name", scaledObject.Spec.ScaleTargetRef.Name)
-
 	// Get the current replica count. As a special case, Deployments and StatefulSets fetch directly from the object so they can use the informer cache
 	// to reduce API calls. Everything else uses the scale subresource.
 	var currentScale *autoscalingv1.Scale
@@ -71,7 +70,6 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 		}
 		currentReplicas = currentScale.Spec.Replicas
 	}
-
 	// if the ScaledObject's triggers aren't in the error state,
 	// but ScaledObject.Status.ReadyCondition is set not set to 'true' -> set it back to 'true'
 	readyCondition := scaledObject.Status.Conditions.GetReadyCondition()
@@ -92,7 +90,6 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 		logger.Error(err, "error getting the paused replica count on the current ScaledObject.")
 		return
 	}
-
 	status := scaledObject.Status.DeepCopy()
 	if pausedCount != nil {
 		// Scale the target to the paused replica count
@@ -106,6 +103,8 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 				}
 				return
 			}
+		}
+		if *pausedCount != currentReplicas || status.PausedReplicaCount == nil {
 			status.PausedReplicaCount = pausedCount
 			err = kedautil.UpdateScaledObjectStatus(ctx, e.client, logger, scaledObject, status)
 			if err != nil {

--- a/tests/internals/pause_scaling/pause_scaling_test.go
+++ b/tests/internals/pause_scaling/pause_scaling_test.go
@@ -26,9 +26,9 @@ var (
 	scaledObjectName        = fmt.Sprintf("%s-so", testName)
 	maxReplicaCount         = 1
 	minReplicaCount         = 0
-	testScaleOutWaitMin     = 3
-	testPauseAtNWaitMin     = 3
-	testScaleInWaitMin      = 3
+	testScaleOutWaitMin     = 5
+	testPauseAtNWaitMin     = 5
+	testScaleInWaitMin      = 5
 )
 
 type templateData struct {

--- a/tests/internals/pause_scaling/pause_scaling_test.go
+++ b/tests/internals/pause_scaling/pause_scaling_test.go
@@ -26,6 +26,9 @@ var (
 	scaledObjectName        = fmt.Sprintf("%s-so", testName)
 	maxReplicaCount         = 1
 	minReplicaCount         = 0
+	testScaleOutWaitMin     = 3
+	testPauseAtNWaitMin     = 3
+	testScaleInWaitMin      = 3
 )
 
 type templateData struct {
@@ -175,8 +178,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 1),
-		"replica count should be 1 after 1 minute")
+	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, testScaleOutWaitMin),
+		"replica count should be 1 after %d minute(s)", testScaleOutWaitMin)
 }
 
 func testPauseAtN(t *testing.T, kc *kubernetes.Clientset, data templateData, n int) {
@@ -186,14 +189,14 @@ func testPauseAtN(t *testing.T, kc *kubernetes.Clientset, data templateData, n i
 
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 0, testNamespace)
 
-	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, n, 60, 1),
-		"replica count should be %d after 1 minute", n)
+	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, n, 60, testPauseAtNWaitMin),
+		"replica count should be %d after %d minute(s)", n, testPauseAtNWaitMin)
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 2),
-		"replica count should be 0 after 2 minutes")
+	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, testScaleInWaitMin),
+		"replica count should be 0 after %d minutes", testScaleInWaitMin)
 }


### PR DESCRIPTION
In the controller in the reconcile loop, when a scaledObject is paused (annotated with ), this fix stops the scaling logic (to prevent attempt to connect the to scalers), and deletes the generated HPA (so it is not querying KEDA Metric Server for metrics)

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Fixes #4253