### PR TITLE
docs(security): Secret scanning is now enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **External Scaler**: Add tls options in TriggerAuth metadata. ([#3565](https://github.com/kedacore/keda/issues/3565))
 - **GCP PubSub Scaler**: Make it more flexible for metrics ([#4243](https://github.com/kedacore/keda/issues/4243))
 - **Kafka Scaler:** Add support for OAuth extensions ([#4544](https://github.com/kedacore/keda/issues/4544))
+- **Security:** Enable secret scanning in GitHub repo
 
 ### Fixes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,7 @@ We have a few preventive measures in place to detect security vulnerabilities:
 - [GitHub's security features](https://github.com/features/security) are constantly monitoring our repo and dependencies:
   - All pull requests (PRs) are using CodeQL to scan our source code for vulnerabilities
   - Dependabot will automatically identify vulnerabilities based on GitHub Advisory Database and open PRs with patches
+  - Automated [secret scanning](https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/about-secret-scanning#about-secret-scanning-for-partner-patterns) & alerts
 
 KEDA maintainers are working to improve our prevention by adding additional measures:
 


### PR DESCRIPTION
Secret scanning is now enabled and added to our security policy

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
