### PR TITLE
fix: Check if MaxReplicaCount is nil before access to it

### DIFF
--- a/apis/keda/v1alpha1/scaledjob_types.go
+++ b/apis/keda/v1alpha1/scaledjob_types.go
@@ -123,7 +123,8 @@ func (s ScaledJob) MaxReplicaCount() int64 {
 // MinReplicaCount returns MinReplicaCount
 func (s ScaledJob) MinReplicaCount() int64 {
 	if s.Spec.MinReplicaCount != nil {
-		if *s.Spec.MinReplicaCount > *s.Spec.MaxReplicaCount {
+		if s.Spec.MaxReplicaCount != nil &&
+			*s.Spec.MinReplicaCount > *s.Spec.MaxReplicaCount {
 			return int64(*s.Spec.MaxReplicaCount)
 		}
 		return int64(*s.Spec.MinReplicaCount)


### PR DESCRIPTION
In ScaledJobs, during the min/max replica calculation, we access to MaxReplicaCount withoutnchecking if it's `nil` and it produces panic in case of nil

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


