### PR TITLE
Patch Keda metrics names on Grafana Dashboard

### DIFF
--- a/config/grafana/keda-dashboard.json
+++ b/config/grafana/keda-dashboard.json
@@ -525,7 +525,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(metric) (rate(keda_scaler_metrics_value{namespace=~\"$namespace\", metric=~\"$metric\"}[5m]))",
+          "expr": "sum by(metric) (rate(keda_metrics_adapter_scaler_metrics_value{namespace=~\"$namespace\", metric=~\"$metric\"}[5m]))",
           "legendFormat": "{{ metric }}",
           "range": true,
           "refId": "A"

--- a/config/grafana/keda-dashboard.json
+++ b/config/grafana/keda-dashboard.json
@@ -171,7 +171,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(job) (rate(keda_scaler_errors_total{}[5m]))",
+          "expr": "sum by(job) (rate(keda_metrics_adapter_scaler_errors_total{}[5m]))",
           "legendFormat": "{{ job }}",
           "range": true,
           "refId": "A"
@@ -309,7 +309,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(scaler) (rate(keda_scaler_errors{namespace=~\"$namespace\", scaledObject=~\"$scaledObject\", scaler=~\"$scaler\"}[5m]))",
+          "expr": "sum by(scaler) (rate(keda_metrics_adapter_scaler_errors{namespace=~\"$namespace\", scaledObject=~\"$scaledObject\", scaler=~\"$scaler\"}[5m]))",
           "legendFormat": "{{ scaler }}",
           "range": true,
           "refId": "A"
@@ -417,7 +417,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(scaledObject) (rate(keda_scaled_object_errors{namespace=~\"$namespace\", scaledObject=~\"$scaledObject\"}[5m]))",
+          "expr": "sum by(scaledObject) (rate(keda_metrics_adapter_scaled_object_errors{namespace=~\"$namespace\", scaledObject=~\"$scaledObject\"}[5m]))",
           "legendFormat": "{{ scaledObject }}",
           "range": true,
           "refId": "A"
@@ -872,14 +872,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(keda_scaled_object_errors, namespace)",
+        "definition": "label_values(keda_metrics_adapter_scaled_object_errors, namespace)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(keda_scaled_object_errors, namespace)",
+          "query": "label_values(keda_metrics_adapter_scaled_object_errors, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -902,14 +902,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(keda_scaled_object_errors{namespace=\"$namespace\"}, scaledObject)",
+        "definition": "label_values(keda_metrics_adapter_scaled_object_errors{namespace=\"$namespace\"}, scaledobject)",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "scaledObject",
         "options": [],
         "query": {
-          "query": "label_values(keda_scaled_object_errors{namespace=\"$namespace\"}, scaledObject)",
+          "query": "label_values(keda_metrics_adapter_scaled_object_errors{namespace=\"$namespace\"}, scaledobject)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -928,14 +928,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(keda_scaler_errors{namespace=\"$namespace\"}, scaler)",
+        "definition": "label_values(keda_metrics_adapter_scaler_errors{namespace=\"$namespace\"}, scaler)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "scaler",
         "options": [],
         "query": {
-          "query": "label_values(keda_scaler_errors{namespace=\"$namespace\"}, scaler)",
+          "query": "label_values(keda_metrics_adapter_scaler_errors{namespace=\"$namespace\"}, scaler)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -954,14 +954,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(keda_scaler_errors{namespace=\"$namespace\"}, metric)",
+        "definition": "label_values(keda_metrics_adapter_scaler_errors{namespace=\"$namespace\"}, metric)",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "metric",
         "options": [],
         "query": {
-          "query": "label_values(keda_scaler_errors{namespace=\"$namespace\"}, metric)",
+          "query": "label_values(keda_metrics_adapter_scaler_errors{namespace=\"$namespace\"}, metric)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The Keda Grafana Dashboard held incorrect metric names , for example 
_keda_scaler_errors_total_ should be _**keda_metrics_adapter_scaler_errors**_
_keda_scaled_object_errors_ should be _**keda_metrics_adapter_scaled_object_errors**_
_keda_scaler_metrics_value_ should be _**keda_metrics_adapter_scaler_metrics_value**_

verification on this name was to see what Prometheus actually scrapes from the pod by querying the endpoint : 
![image](https://github.com/kedacore/keda/assets/512709/1cbbf535-c73c-417e-a763-d8149847dd9c)


### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Created a new Dashboard with the changes and ensured the metrics arrives correctly.
![image](https://github.com/kedacore/keda/assets/512709/d51588eb-cb6b-435c-adf7-ab01a8e1f8a2)

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
