### PR TITLE
feat: Support path prefix in RabbitMQ scaler host URI

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -415,6 +415,15 @@ func getConnectionAndChannel(host string, meta *rabbitMQMetadata) (*amqp.Connect
 	return conn, channel, nil
 }
 
+// Get path prefix and vhost from RabbitMQ host Url path
+func getPathPrefixAndVhostFromURLPath(urlPath string) (string, string) {
+	// Extract vhost and prefix from URL's path.
+	parts := strings.Split(urlPath, "/")
+	prefix := strings.Join(parts[0:len(parts)-1], "/")
+	vhost := "/" + parts[len(parts)-1]
+	return prefix, vhost
+}
+
 // Close disposes of RabbitMQ connections
 func (s *rabbitMQScaler) Close(context.Context) error {
 	if s.connection != nil {
@@ -488,8 +497,8 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 		return nil, err
 	}
 
-	// Extract vhost from URL's path.
-	vhost := parsedURL.Path
+	// Extract prefix and vhost from URL's path.
+	prefix, vhost := getPathPrefixAndVhostFromURLPath(parsedURL.Path)
 
 	if s.metadata.vhostName != "" {
 		vhost = "/" + url.QueryEscape(s.metadata.vhostName)
@@ -500,7 +509,7 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP() (*queueInfo, error) {
 	}
 
 	// Clear URL path to get the correct host.
-	parsedURL.Path = ""
+	parsedURL.Path = prefix
 
 	var getQueueInfoManagementURI string
 	if s.metadata.useRegex {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_This change in RabbitMQ Scaler is to support path prefix in RabbitMQ URI as allowed by the management plugin here: https://www.rabbitmq.com/management.html#path-prefix_

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #2634
