### PR TITLE
chore: add manifest verification and use server-side for CRDs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Verify Generated clientset is up to date
         run: make clientset-verify
 
+      - name: Manifests
+        run: make verify-manifests
+
       - name: Build
         run: make build
 

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -6,5 +6,10 @@ patchesJson6902:
     name: keda-operator
   path: patch_operator.yml
 
-bases:
-- ../default
+resources:
+- ../general
+- ../rbac
+- ../manager
+- ../metrics-server
+- ../service_account
+- ../webhooks

--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
+# Copyright 2023 The KEDA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+DIFFROOT="${SCRIPT_ROOT}/config"
+TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/config"
+_tmp="${SCRIPT_ROOT}/_tmp"
+
+cleanup() {
+  rm -rf "${_tmp}"
+}
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+mkdir -p "${TMP_DIFFROOT}"
+cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
+
+make manifests
+echo "diffing ${DIFFROOT} against freshly generated manifests"
+ret=0
+diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
+cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFROOT} up to date."
+else
+  echo "${DIFFROOT} is out of date. Please run 'make manifests'"
+  exit 1
+fi


### PR DESCRIPTION
This PR adds a manifest up-to-date verification and also deploys the CRDs using `server-side` as part of e2e deployment

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

