### PR TITLE
Fixed azure agent image ref

### DIFF
--- a/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
+++ b/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
 )
 
 // Load environment variables from .env file

--- a/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
+++ b/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
-
-	. "github.com/kedacore/keda/v2/tests/helper"
 )
 
 // Load environment variables from .env file
@@ -97,7 +95,7 @@ spec:
           preStop:
             exec:
               command: ["/bin/sleep","60"]
-        image: eldarrin/azure:main
+        image: ghcr.io/kedacore/tests-azure-pipelines-advagent:latest
         env:
           - name: AZP_URL
             value: {{.URL}}
@@ -128,7 +126,7 @@ spec:
       spec:
         containers:
         - name: {{.ScaledJobName}}
-          image: eldarrin/azure:main
+          image: ghcr.io/kedacore/tests-azure-pipelines-advagent:latest
           env:
             - name: AZP_URL
               value: {{.URL}}
@@ -168,7 +166,7 @@ spec:
       spec:
         containers:
         - name: {{.ScaledJobName}}
-          image: eldarrin/azure:main
+          image: ghcr.io/kedacore/tests-azure-pipelines-advagent:latest
           env:
             - name: AZP_URL
               value: {{.URL}}
@@ -210,7 +208,7 @@ spec:
       spec:
         containers:
         - name: {{.ScaledJobName}}
-          image: eldarrin/azure:main
+          image: ghcr.io/kedacore/tests-azure-pipelines-advagent:latest
           env:
             - name: AZP_URL
               value: {{.URL}}
@@ -250,7 +248,7 @@ spec:
       spec:
         containers:
         - name: {{.ScaledJobName}}
-          image: eldarrin/azure:main
+          image: ghcr.io/kedacore/tests-azure-pipelines-advagent:latest
           env:
             - name: AZP_URL
               value: {{.URL}}


### PR DESCRIPTION
Fixed image ref of azure agent to use keda, not eldarrin

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Fixes #

Relates to #
