### PR TITLE
Add support for avg_rate from rabbitmq metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Pulsar Scaler**: Improve error messages for unsuccessful connections ([#4563](https://github.com/kedacore/keda/issues/4563))
 - **Security:** Enable secret scanning in GitHub repo
 - **RabbitMQ Scaler**: Add support for `unsafeSsl` in trigger metadata ([#4448](https://github.com/kedacore/keda/issues/4448))
+- **RabbitMQ Scaler**: Add support for `avg_rate` in trigger metadata ([#4507](https://github.com/kedacore/keda/issues/4507))
 - **Prometheus Metrics**: Add new metric with KEDA build info ([#4647](https://github.com/kedacore/keda/issues/4647))
 
 ### Fixes
@@ -74,6 +75,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Prometheus Metrics**: Create e2e tests for all exposed Prometheus metrics ([#4127](https://github.com/kedacore/keda/issues/4127))
 - **Grafana Dashboard**: Fix HPA metrics panel to use range instead of instant ([#4513](https://github.com/kedacore/keda/pull/4513))
 - **Grafana Dashboard**: Fix HPA metrics panel by replacing $namepsace to $exported_namespace due to label conflict ([#4539](https://github.com/kedacore/keda/pull/4539))
+- **RabbitMQ Scaler**: Fix erroneous queue length check for MessageRate activation `avg_rate` in trigger metadata ([#4507](https://github.com/kedacore/keda/issues/4507#issuecomment-1577227024))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Pulsar Scaler**: Improve error messages for unsuccessful connections ([#4563](https://github.com/kedacore/keda/issues/4563))
 - **Security:** Enable secret scanning in GitHub repo
 - **RabbitMQ Scaler**: Add support for `unsafeSsl` in trigger metadata ([#4448](https://github.com/kedacore/keda/issues/4448))
-- **RabbitMQ Scaler**: Add support for `avg_rate` in trigger metadata ([#4507](https://github.com/kedacore/keda/issues/4507))
+- **RabbitMQ Scaler**: Add support for RabbitMQ's `avg_rate` field by supporting `messageRateAge` and `messageRateIncrement` trigger metadata ([#4507](https://github.com/kedacore/keda/issues/4507))
 - **Prometheus Metrics**: Add new metric with KEDA build info ([#4647](https://github.com/kedacore/keda/issues/4647))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Prometheus Metrics**: Create e2e tests for all exposed Prometheus metrics ([#4127](https://github.com/kedacore/keda/issues/4127))
 - **Grafana Dashboard**: Fix HPA metrics panel to use range instead of instant ([#4513](https://github.com/kedacore/keda/pull/4513))
 - **Grafana Dashboard**: Fix HPA metrics panel by replacing $namepsace to $exported_namespace due to label conflict ([#4539](https://github.com/kedacore/keda/pull/4539))
-- **RabbitMQ Scaler**: Fix erroneous queue length check for MessageRate activation `avg_rate` in trigger metadata ([#4507](https://github.com/kedacore/keda/issues/4507#issuecomment-1577227024))
+- **RabbitMQ Scaler**: Fix erroneous queue length check for message rate activation `avg_rate` in trigger metadata ([#4507](https://github.com/kedacore/keda/issues/4507#issuecomment-1577227024))
 
 ### Deprecations
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -37,8 +37,8 @@ const (
 	rabbitMetricType                       = "External"
 	rabbitRootVhostPath                    = "/%2F"
 	rmqTLSEnable                           = "enable"
-	rabbitHttpQueryMessageRateAge          = "messageRatesAge"
-	rabbitHttpQueryMessageRatesIncrement   = "messageRatesIncrement"
+	rabbitHttpQueryMessageRateAge          = "messageRateAge"
+	rabbitHttpQueryMessageRatesIncrement   = "messageRateIncrement"
 )
 
 const (

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -363,20 +363,20 @@ func parseRabbitMQHttpProtocolMetadata(config *ScalerConfig, meta *rabbitMQMetad
 
 	httpMessageRatesAge, httpMessageRatesAgePresent := config.TriggerMetadata[rabbitHttpQueryMessageRateAge]
 	if httpMessageRatesAgePresent {
-		messageRatesAge, err := strconv.ParseInt(httpMessageRatesAge, 10, 0)
+		messageRateAge, err := strconv.ParseInt(httpMessageRatesAge, 10, 0)
 		if err != nil {
 			return fmt.Errorf("can't parse %s: %w", rabbitHttpQueryMessageRateAge, err)
 		}
-		meta.httpQueryParameters.MessageRatesAge = messageRatesAge
+		meta.httpQueryParameters.MessageRatesAge = messageRateAge
 	}
 
 	httpMessageRatesIncrement, httpMessageRatesIncrementPresent := config.TriggerMetadata[rabbitHttpQueryMessageRatesIncrement]
 	if httpMessageRatesIncrementPresent {
-		messageRatesIncrement, err := strconv.ParseInt(httpMessageRatesIncrement, 10, 0)
+		messageRateIncrement, err := strconv.ParseInt(httpMessageRatesIncrement, 10, 0)
 		if err != nil {
 			return fmt.Errorf("can't parse %s: %w", rabbitHttpQueryMessageRatesIncrement, err)
 		}
-		meta.httpQueryParameters.MessageRatesIncrement = messageRatesIncrement
+		meta.httpQueryParameters.MessageRatesIncrement = messageRateIncrement
 	}
 
 	return nil

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -338,8 +338,8 @@ var testQueueInfoTestData = []getQueueInfoTestData{
 		isActive:       true,
 		extraMetadata: map[string]string{
 			"mode":                  "MessageRate",
-			"messageRatesAge":       "5",
-			"messageRatesIncrement": "1",
+			"messageRateAge":       "5",
+			"messageRateIncrement": "1",
 			"activationValue":       "4",
 			"value":                 "99",
 		},
@@ -364,8 +364,8 @@ var testQueueInfoTestData = []getQueueInfoTestData{
 		isActive:       false,
 		extraMetadata: map[string]string{
 			"mode":                  "MessageRate",
-			"messageRatesAge":       "5",
-			"messageRatesIncrement": "1",
+			"messageRateAge":       "5",
+			"messageRateIncrement": "1",
 			"activationValue":       "5",
 			"value":                 "99",
 		},
@@ -880,8 +880,8 @@ var _testQueueInfoTestAvgRate = []getQueueInfoTestData{
 		extraMetadata: map[string]string{
 			"useRegex":              "true",
 			"mode":                  "MessageRate",
-			"messageRatesAge":       "5",
-			"messageRatesIncrement": "1",
+			"messageRateAge":       "5",
+			"messageRateIncrement": "1",
 			"activationValue":       "11",
 			"value":                 "99",
 		},
@@ -919,8 +919,8 @@ var _testQueueInfoTestAvgRate = []getQueueInfoTestData{
 		extraMetadata: map[string]string{
 			"useRegex":              "true",
 			"mode":                  "MessageRate",
-			"messageRatesAge":       "5",
-			"messageRatesIncrement": "1",
+			"messageRateAge":       "5",
+			"messageRateIncrement": "1",
 			"activationValue":       "9",
 			"value":                 "99",
 		},
@@ -967,11 +967,11 @@ func TestGetQueueInfoWithRegex(t *testing.T) {
 				"use_regex":  {"true"},
 			}
 
-			val, ok := testData.extraMetadata["messageRatesAge"]
+			val, ok := testData.extraMetadata["messageRateAge"]
 			if ok {
 				expectedValues["msg_rates_age"] = []string{val}
 			}
-			val, ok = testData.extraMetadata["messageRatesIncrement"]
+			val, ok = testData.extraMetadata["messageRateIncrement"]
 			if ok {
 				expectedValues["msg_rates_incr"] = []string{val}
 			}


### PR DESCRIPTION
- Add support for specifying httpQueryParameters to rabbitmq metadata. This supports two fields
  + MessageRatesAge
  + MessageRatesIncrement Note that ATOW both parameters must be sent to rabbit for the api to return avg_rate values.
- Update logic for mode: MessageRate so it doesn't implicitly activate the scaler if the queue _length_ exceeds the `activationValue`.
- Update the tests to support the above changes

fixes #4507

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added support for using the rabbitmq `avg_rate` as the scaler value, as discussed in #4507 . 

Adds two new fields to scaler metadata
1. messageRatesAge
2. messageRatesIncrement
Which correspond to msg_rates_age / msg_rates_incr in the rabbitmq http api. If both of these are supplied, the scaler will use the `avg_rate` in the response, rather than `rate`

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
https://github.com/kedacore/keda-docs/pull/1148 
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4507

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
