### PR TITLE
fix: PR Welcome bot fails with resource not accessible by integration

### DIFF
--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -7,6 +7,7 @@ on:
     - 'main'
 
 permissions:
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
PR Welcome bot fails with resource not accessible by integration for external contributors and is lacking permissions, let's find out which ones!

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #4640
