### PR TITLE
test: Improve E2E GitHub Action Names

### DIFF
--- a/.github/workflows/pr-e2e-checker.yml
+++ b/.github/workflows/pr-e2e-checker.yml
@@ -1,4 +1,4 @@
-name: e2e-tests
+name: E2E Test Checker
 on:
   pull_request_target:
     types:

--- a/.github/workflows/pr-e2e-creator.yml
+++ b/.github/workflows/pr-e2e-creator.yml
@@ -1,4 +1,4 @@
-name: e2e-tests
+name: E2E Test Creator
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Improve E2E GitHub Action Names as the current ones are confusing:
![image](https://github.com/kedacore/keda/assets/4345663/a9e5ff52-2c05-4215-8de4-0778eb6a3ed4)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
