### PR TITLE
feat(scaler/prometheus): support authentication for Google Managed Prometheus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: detect-private-key
+        exclude: pkg/scalers/prometheus_scaler_test.go
       - id: end-of-file-fixer
       - id: check-merge-conflict
       - id: mixed-line-ending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Security:** Enable secret scanning in GitHub repo
 - **RabbitMQ Scaler**: Add support for `unsafeSsl` in trigger metadata ([#4448](https://github.com/kedacore/keda/issues/4448))
 - **Prometheus Metrics**: Add new metric with KEDA build info ([#4647](https://github.com/kedacore/keda/issues/4647))
+- **Prometheus Scaler**: Add support for Google Managed Prometheus ([#4675](https://github.com/kedacore/keda/pull/4675))
 
 ### Fixes
 

--- a/pkg/scalers/gcp_common.go
+++ b/pkg/scalers/gcp_common.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	defaultGCPScopes       = []string{"https://www.googleapis.com/auth/cloud-platform"}
 	gcpScopeMonitoringRead = "https://www.googleapis.com/auth/monitoring.read"
 
 	errGoogleApplicationCrendentialsNotFound = errors.New("google application credentials not found")

--- a/pkg/scalers/gcp_common.go
+++ b/pkg/scalers/gcp_common.go
@@ -1,9 +1,21 @@
 package scalers
 
 import (
-	"fmt"
+	"context"
+	"errors"
+	"net/http"
+	"os"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+var (
+	defaultGCPScopes       = []string{"https://www.googleapis.com/auth/cloud-platform"}
+	gcpScopeMonitoringRead = "https://www.googleapis.com/auth/monitoring.read"
+
+	errGoogleApplicationCrendentialsNotFound = errors.New("google application credentials not found")
 )
 
 type gcpAuthorizationMetadata struct {
@@ -12,26 +24,71 @@ type gcpAuthorizationMetadata struct {
 	podIdentityProviderEnabled       bool
 }
 
-func getGcpAuthorization(config *ScalerConfig, resolvedEnv map[string]string) (*gcpAuthorizationMetadata, error) {
-	metadata := config.TriggerMetadata
-	authParams := config.AuthParams
-	meta := gcpAuthorizationMetadata{}
-
-	switch {
-	case config.PodIdentity.Provider == kedav1alpha1.PodIdentityProviderGCP:
-		// do nothing, rely on underneath metadata google
-		meta.podIdentityProviderEnabled = true
-	case authParams["GoogleApplicationCredentials"] != "":
-		meta.GoogleApplicationCredentials = authParams["GoogleApplicationCredentials"]
-	default:
-		switch {
-		case metadata["credentialsFromEnv"] != "":
-			meta.GoogleApplicationCredentials = resolvedEnv[metadata["credentialsFromEnv"]]
-		case metadata["credentialsFromEnvFile"] != "":
-			meta.GoogleApplicationCredentialsFile = resolvedEnv[metadata["credentialsFromEnvFile"]]
-		default:
-			return nil, fmt.Errorf("GoogleApplicationCredentials not found")
-		}
+func (a *gcpAuthorizationMetadata) TokenSource(ctx context.Context, scopes ...string) (oauth2.TokenSource, error) {
+	if a.podIdentityProviderEnabled {
+		return google.DefaultTokenSource(ctx, scopes...)
 	}
-	return &meta, nil
+
+	if a.GoogleApplicationCredentials != "" {
+		creds, err := google.CredentialsFromJSON(ctx, []byte(a.GoogleApplicationCredentials), scopes...)
+		if err != nil {
+			return nil, err
+		}
+
+		return creds.TokenSource, nil
+	}
+
+	if a.GoogleApplicationCredentialsFile != "" {
+		data, err := os.ReadFile(a.GoogleApplicationCredentialsFile)
+		if err != nil {
+			return nil, err
+		}
+
+		creds, err := google.CredentialsFromJSON(ctx, data, scopes...)
+		if err != nil {
+			return nil, err
+		}
+
+		return creds.TokenSource, nil
+	}
+
+	return nil, errGoogleApplicationCrendentialsNotFound
+}
+
+func (a *gcpAuthorizationMetadata) Transport(base http.RoundTripper, scopes ...string) (http.RoundTripper, error) {
+	ts, err := a.TokenSource(context.Background(), scopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oauth2.Transport{Source: ts, Base: base}, nil
+}
+
+func getGCPAuthorization(config *ScalerConfig) (*gcpAuthorizationMetadata, error) {
+	if config.PodIdentity.Provider == kedav1alpha1.PodIdentityProviderGCP {
+		return &gcpAuthorizationMetadata{podIdentityProviderEnabled: true}, nil
+	}
+
+	if creds := config.AuthParams["GoogleApplicationCredentials"]; creds != "" {
+		return &gcpAuthorizationMetadata{GoogleApplicationCredentials: creds}, nil
+	}
+
+	if creds := config.TriggerMetadata["credentialsFromEnv"]; creds != "" {
+		return &gcpAuthorizationMetadata{GoogleApplicationCredentials: config.ResolvedEnv[creds]}, nil
+	}
+
+	if credsFile := config.TriggerMetadata["credentialsFromEnvFile"]; credsFile != "" {
+		return &gcpAuthorizationMetadata{GoogleApplicationCredentialsFile: config.ResolvedEnv[credsFile]}, nil
+	}
+
+	return nil, errGoogleApplicationCrendentialsNotFound
+}
+
+func getGCPOAuth2HTTPTransport(config *ScalerConfig, base http.RoundTripper, scopes ...string) (http.RoundTripper, error) {
+	a, err := getGCPAuthorization(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.Transport(base, scopes...)
 }

--- a/pkg/scalers/gcp_common.go
+++ b/pkg/scalers/gcp_common.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"os"
 
-	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 )
 
 var (

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -114,7 +114,7 @@ func parsePubSubMetadata(config *ScalerConfig, logger logr.Logger) (*pubsubMetad
 		meta.activationValue = activationValue
 	}
 
-	auth, err := getGcpAuthorization(config, config.ResolvedEnv)
+	auth, err := getGCPAuthorization(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/gcp_stackdriver_scaler.go
+++ b/pkg/scalers/gcp_stackdriver_scaler.go
@@ -109,7 +109,7 @@ func parseStackdriverMetadata(config *ScalerConfig, logger logr.Logger) (*stackd
 		meta.activationTargetValue = activationTargetValue
 	}
 
-	auth, err := getGcpAuthorization(config, config.ResolvedEnv)
+	auth, err := getGCPAuthorization(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/gcp_storage_scaler.go
+++ b/pkg/scalers/gcp_storage_scaler.go
@@ -145,7 +145,7 @@ func parseGcsMetadata(config *ScalerConfig, logger logr.Logger) (*gcsMetadata, e
 		meta.blobPrefix = val
 	}
 
-	auth, err := getGcpAuthorization(config, config.ResolvedEnv)
+	auth, err := getGCPAuthorization(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -110,25 +110,25 @@ func NewPrometheusScaler(config *ScalerConfig) (Scaler, error) {
 	} else {
 		// could be the case of azure managed prometheus. Try and get the roundtripper.
 		// If its not the case of azure managed prometheus, we will get both transport and err as nil and proceed assuming no auth.
-		transport, err := azure.TryAndGetAzureManagedPrometheusHTTPRoundTripper(config.PodIdentity, config.TriggerMetadata)
+		azureTransport, err := azure.TryAndGetAzureManagedPrometheusHTTPRoundTripper(config.PodIdentity, config.TriggerMetadata)
 		if err != nil {
 			logger.V(1).Error(err, "error while init Azure Managed Prometheus client http transport")
 			return nil, err
 		}
 
 		// transport should not be nil if its a case of azure managed prometheus
-		if transport != nil {
-			httpClient.Transport = transport
+		if azureTransport != nil {
+			httpClient.Transport = azureTransport
 		}
 
-		transport, err = getGCPOAuth2HTTPTransport(config, httpClient.Transport, gcpScopeMonitoringRead)
+		gcpTransport, err := getGCPOAuth2HTTPTransport(config, httpClient.Transport, gcpScopeMonitoringRead)
 		if err != nil && !errors.Is(err, errGoogleApplicationCrendentialsNotFound) {
 			logger.V(1).Error(err, "failed to get GCP client HTTP transport (either using Google application credentials or workload identity)")
 			return nil, err
 		}
 
-		if err == nil && transport != nil {
-			httpClient.Transport = transport
+		if err == nil && gcpTransport != nil {
+			httpClient.Transport = gcpTransport
 		}
 	}
 

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -67,12 +68,12 @@ type prometheusMetadata struct {
 
 type promQueryResult struct {
 	Status string `json:"status"`
-	Data   struct {
+
+	Data struct {
 		ResultType string `json:"resultType"`
 		Result     []struct {
-			Metric struct {
-			} `json:"metric"`
-			Value []interface{} `json:"value"`
+			Metric struct{}      `json:"metric"`
+			Value  []interface{} `json:"value"`
 		} `json:"result"`
 	} `json:"data"`
 }
@@ -110,7 +111,6 @@ func NewPrometheusScaler(config *ScalerConfig) (Scaler, error) {
 		// could be the case of azure managed prometheus. Try and get the roundtripper.
 		// If its not the case of azure managed prometheus, we will get both transport and err as nil and proceed assuming no auth.
 		transport, err := azure.TryAndGetAzureManagedPrometheusHTTPRoundTripper(config.PodIdentity, config.TriggerMetadata)
-
 		if err != nil {
 			logger.V(1).Error(err, "error while init Azure Managed Prometheus client http transport")
 			return nil, err
@@ -118,6 +118,16 @@ func NewPrometheusScaler(config *ScalerConfig) (Scaler, error) {
 
 		// transport should not be nil if its a case of azure managed prometheus
 		if transport != nil {
+			httpClient.Transport = transport
+		}
+
+		transport, err = getGCPOAuth2HTTPTransport(config, httpClient.Transport, gcpScopeMonitoringRead)
+		if err != nil && !errors.Is(err, errGoogleApplicationCrendentialsNotFound) {
+			logger.V(1).Error(err, "failed to get GCP client HTTP transport (either using Google application credentials or workload identity)")
+			return nil, err
+		}
+
+		if err == nil && transport != nil {
 			httpClient.Transport = transport
 		}
 	}
@@ -292,7 +302,7 @@ func (s *prometheusScaler) ExecutePromQuery(ctx context.Context) (float64, error
 	if err != nil {
 		return -1, err
 	}
-	_ = r.Body.Close()
+	defer r.Body.Close()
 
 	if !(r.StatusCode >= 200 && r.StatusCode <= 299) {
 		err := fmt.Errorf("prometheus query api returned error. status: %d response: %s", r.StatusCode, string(b))

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -376,12 +376,7 @@ func TestPrometheusScaler_ExecutePromQuery_WithGCPNativeAuthentication(t *testin
 	}))
 	defer fakeGoogleOAuthServer.Close()
 
-	filename := filepath.Join(t.TempDir(), "fake_application_default_credentials.json")
-	f, err := os.Create(filename)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, f.Close()) }()
-
-	fakeGCPCreds := map[string]string{
+	fakeGCPCredsJSON, err := json.Marshal(map[string]string{
 		"type": "service_account",
 		"private_key": `-----BEGIN RSA PRIVATE KEY-----
 MIIBOwIBAAJBAOfgBHLEOcXo2X+8SSzF1rEsTewRzZIOZAak4XRULY+dBd1bsGBM
@@ -393,49 +388,110 @@ m0Lc0xIXFuYd+QIgZ9DpkomnVd3/BytxQqJ2I+tXmpXfmfwkA9lRXOJ94uECIQC8
 IisErx3ap2o99Zn+Yotv/TGZkS+lfMLdbcOBr8a57Q==
 -----END RSA PRIVATE KEY-----`,
 		"token_uri": fakeGoogleOAuthServer.URL,
-	}
-	require.NoError(t, json.NewEncoder(f).Encode(fakeGCPCreds))
-	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filename)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/v1/projects/my-fake-project/location/global/prometheus/api/v1/query", r.URL.Path)
-		assert.True(t, r.URL.Query().Has("time"))
-		assert.Equal(t, "sum(rate(http_requests_total{instance=\"my-instance\"}[5m]))", r.URL.Query().Get("query"))
-
-		if !assert.Equal(t, "Bearer fake_access_token", r.Header.Get("Authorization")) {
-			w.WriteHeader(http.StatusUnauthorized)
-		}
-
-		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
-			"status": "success",
-			"data": map[string]any{
-				"resultType": "vector",
-				"result": []map[string]any{
-					{"metric": map[string]string{}, "value": []any{1686063687, "777"}},
-				},
-			},
-		}))
-	}))
-	defer server.Close()
-
-	scaler, err := NewPrometheusScaler(&ScalerConfig{
-		PodIdentity: kedav1alpha1.AuthPodIdentity{
-			Provider: kedav1alpha1.PodIdentityProviderGCP,
-		},
-		TriggerMetadata: map[string]string{
-			"serverAddress": server.URL + "/v1/projects/my-fake-project/location/global/prometheus",
-			"query":         "sum(rate(http_requests_total{instance=\"my-instance\"}[5m]))",
-			"threshold":     "100",
-		},
 	})
 	require.NoError(t, err)
 
-	s, ok := scaler.(*prometheusScaler)
-	require.True(t, ok, "Scaler must be a Prometheus Scaler")
-	_, ok = s.httpClient.Transport.(*oauth2.Transport)
-	require.True(t, ok, "HTTP transport must be Google OAuth2")
+	fakeGCPCredsPath := filepath.Join(t.TempDir(), "fake_application_default_credentials.json")
 
-	got, err := s.ExecutePromQuery(context.TODO())
+	f, err := os.Create(fakeGCPCredsPath)
 	require.NoError(t, err)
-	assert.Equal(t, float64(777), got)
+	_, err = f.Write(fakeGCPCredsJSON)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newFakeServer := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/v1/projects/my-fake-project/location/global/prometheus/api/v1/query", r.URL.Path)
+			assert.True(t, r.URL.Query().Has("time"))
+			assert.Equal(t, "sum(rate(http_requests_total{instance=\"my-instance\"}[5m]))", r.URL.Query().Get("query"))
+
+			if !assert.Equal(t, "Bearer fake_access_token", r.Header.Get("Authorization")) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"status": "success",
+				"data": map[string]any{
+					"resultType": "vector",
+					"result": []map[string]any{
+						{"metric": map[string]string{}, "value": []any{1686063687, "777"}},
+					},
+				},
+			}))
+		}))
+	}
+
+	tests := map[string]struct {
+		config func(*testing.T, *ScalerConfig) *ScalerConfig
+	}{
+		"using GCP workload identity": {
+			config: func(t *testing.T, config *ScalerConfig) *ScalerConfig {
+				t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeGCPCredsPath)
+				config.PodIdentity = kedav1alpha1.AuthPodIdentity{
+					Provider: kedav1alpha1.PodIdentityProviderGCP,
+				}
+				return config
+			},
+		},
+
+		"with Google app credentials on auth params": {
+			config: func(t *testing.T, config *ScalerConfig) *ScalerConfig {
+				config.AuthParams = map[string]string{
+					"GoogleApplicationCredentials": string(fakeGCPCredsJSON),
+				}
+				return config
+			},
+		},
+
+		"with Google app credentials on envs": {
+			config: func(t *testing.T, config *ScalerConfig) *ScalerConfig {
+				config.TriggerMetadata["credentialsFromEnv"] = "GCP_APP_CREDENTIALS"
+				config.ResolvedEnv = map[string]string{
+					"GCP_APP_CREDENTIALS": string(fakeGCPCredsJSON),
+				}
+				return config
+			},
+		},
+
+		"with Google app credentials file on auth params": {
+			config: func(t *testing.T, config *ScalerConfig) *ScalerConfig {
+				config.TriggerMetadata["credentialsFromEnvFile"] = "GCP_APP_CREDENTIALS"
+				config.ResolvedEnv = map[string]string{
+					"GCP_APP_CREDENTIALS": fakeGCPCredsPath,
+				}
+				return config
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := newFakeServer(t)
+			defer server.Close()
+
+			baseConfig := &ScalerConfig{
+				TriggerMetadata: map[string]string{
+					"serverAddress": server.URL + "/v1/projects/my-fake-project/location/global/prometheus",
+					"query":         "sum(rate(http_requests_total{instance=\"my-instance\"}[5m]))",
+					"threshold":     "100",
+				},
+			}
+
+			require.NotNil(t, tt.config, "you must provide a config generator func")
+			config := tt.config(t, baseConfig)
+
+			scaler, err := NewPrometheusScaler(config)
+			require.NoError(t, err)
+
+			s, ok := scaler.(*prometheusScaler)
+			require.True(t, ok, "Scaler must be a Prometheus Scaler")
+			_, ok = s.httpClient.Transport.(*oauth2.Transport)
+			require.True(t, ok, "HTTP transport must be Google OAuth2")
+
+			got, err := s.ExecutePromQuery(context.TODO())
+			require.NoError(t, err)
+			assert.Equal(t, float64(777), got)
+		})
+	}
 }

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -2,13 +2,19 @@ package scalers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 )
@@ -362,4 +368,74 @@ func TestPrometheusScalerCustomHeaders(t *testing.T) {
 	_, err := scaler.ExecutePromQuery(context.TODO())
 
 	assert.NoError(t, err)
+}
+
+func TestPrometheusScaler_ExecutePromQuery_WithGCPNativeAuthentication(t *testing.T) {
+	fakeGoogleOAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"token_type": "Bearer", "access_token": "fake_access_token"}`)
+	}))
+	defer fakeGoogleOAuthServer.Close()
+
+	filename := filepath.Join(t.TempDir(), "fake_application_default_credentials.json")
+	f, err := os.Create(filename)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	fakeGCPCreds := map[string]string{
+		"type": "service_account",
+		"private_key": `-----BEGIN RSA PRIVATE KEY-----
+MIIBOwIBAAJBAOfgBHLEOcXo2X+8SSzF1rEsTewRzZIOZAak4XRULY+dBd1bsGBM
++dOb9a65cJbDuL3zmTZnfAxjmh2ueNTZvOcCAwEAAQJBAMwwibpG8llF48KInCfB
+UH5U9YmdY9nqskrnh2JZfoWnpBbGxtqg0vbdmvEL2bcbeUnudF25mPpoONw1F6G6
+5IECIQD0ouUBttDMacs5XqQppYCb8eAmiMkJxwgtJfPb9iGm0wIhAPKlXzNgIsMP
+v3sqXcOO3tNjEohptOpEyLWyCt3Htm0dAiB9w/CvfOjC7fCIQdtrfaYshaCSrueL
+m0Lc0xIXFuYd+QIgZ9DpkomnVd3/BytxQqJ2I+tXmpXfmfwkA9lRXOJ94uECIQC8
+IisErx3ap2o99Zn+Yotv/TGZkS+lfMLdbcOBr8a57Q==
+-----END RSA PRIVATE KEY-----`,
+		"token_uri": fakeGoogleOAuthServer.URL,
+	}
+	require.NoError(t, json.NewEncoder(f).Encode(fakeGCPCreds))
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filename)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/projects/my-fake-project/location/global/prometheus/api/v1/query", r.URL.Path)
+		assert.True(t, r.URL.Query().Has("time"))
+		assert.Equal(t, "sum(rate(http_requests_total{instance=\"my-instance\"}[5m]))", r.URL.Query().Get("query"))
+
+		if !assert.Equal(t, "Bearer fake_access_token", r.Header.Get("Authorization")) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "vector",
+				"result": []map[string]any{
+					{"metric": map[string]string{}, "value": []any{1686063687, "777"}},
+				},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	scaler, err := NewPrometheusScaler(&ScalerConfig{
+		PodIdentity: kedav1alpha1.AuthPodIdentity{
+			Provider: kedav1alpha1.PodIdentityProviderGCP,
+		},
+		TriggerMetadata: map[string]string{
+			"serverAddress": server.URL + "/v1/projects/my-fake-project/location/global/prometheus",
+			"query":         "sum(rate(http_requests_total{instance=\"my-instance\"}[5m]))",
+			"threshold":     "100",
+		},
+	})
+	require.NoError(t, err)
+
+	s, ok := scaler.(*prometheusScaler)
+	require.True(t, ok, "Scaler must be a Prometheus Scaler")
+	_, ok = s.httpClient.Transport.(*oauth2.Transport)
+	require.True(t, ok, "HTTP transport must be Google OAuth2")
+
+	got, err := s.ExecutePromQuery(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, float64(777), got)
 }

--- a/tests/scalers/gcp/gcp_prometheus_workload_identity/gcp_prometheus_workload_identity_test.go
+++ b/tests/scalers/gcp/gcp_prometheus_workload_identity/gcp_prometheus_workload_identity_test.go
@@ -1,0 +1,142 @@
+//go:build e2e
+// +build e2e
+
+package gcp_prometheus_workload_identity_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
+)
+
+// Load environment variables from .env file
+var _ = godotenv.Load("../../../.env")
+
+const (
+	testName = "gcp-prometheus-test"
+)
+
+var (
+	gcpKey           = os.Getenv("TF_GCP_SA_CREDENTIALS")
+	creds            = make(map[string]interface{})
+	errGcpKey        = json.Unmarshal([]byte(gcpKey), &creds)
+	projectID        = creds["project_id"]
+	testNamespace    = fmt.Sprintf("%s-ns", testName)
+	deploymentName   = fmt.Sprintf("%s-deployment", testName)
+	scaledObjectName = fmt.Sprintf("%s-so", testName)
+)
+
+type templateData struct {
+	ProjectID        string
+	TestNamespace    string
+	ScaledObjectName string
+	DeploymentName   string
+}
+
+const (
+	triggerAuthenticationTemplate = `apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-trigger-auth-gcp-credentials
+  namespace: {{.TestNamespace}}
+spec:
+  podIdentity:
+    provider: gcp`
+
+	// NOTE: We employ a PromQL query that consistently yields a value of 100.
+	// This is due to the absence of metrics being exported to Google Managed
+	// Prometheus. In this particular test case, the crucial aspect lies in
+	// validating the workload identity authentication with the Google service.
+	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .ScaledObjectName }}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  minReplicaCount: 0
+  maxReplicaCount: 5
+  triggers:
+  - type: prometheus
+    authenticationRef:
+      name: keda-trigger-auth-gcp-credentials
+    metadata:
+      serverAddress: "https://monitoring.googleapis.com/v1/projects/{{.ProjectID}}/location/global/prometheus"
+      query: "vector(100)"
+      threshold: "50.0"
+---`
+
+	deploymentTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: {{.DeploymentName}}
+  namespace: {{.TestNamespace}}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        type: keda-testing
+    spec:
+      containers:
+      - name: prom-test-app
+        image: ghcr.io/kedacore/tests-prometheus:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+---`
+)
+
+func TestScaler(t *testing.T) {
+	require.NotEmpty(t, gcpKey, "TF_GCP_SA_CREDENTIALS env variable is required for GCP storage test")
+	require.NoErrorf(t, errGcpKey, "Failed to load credentials from gcpKey - %s", errGcpKey)
+
+	t.Log("--- setting up ---")
+
+	kc := GetKubernetesClient(t)
+
+	data, templates := getTemplateData()
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
+
+	t.Log("--- assert ---")
+	expectedReplicaCountNumber := 2 // as mentioned above, as the GMP returns 100 and the threshold set to 50, the expected replica count is 100 / 50 = 2
+	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, expectedReplicaCountNumber, 60, 1),
+		"replica count should be %d after a minute", expectedReplicaCountNumber)
+
+	t.Log("--- cleaning up ---")
+	DeleteKubernetesResources(t, testNamespace, data, templates)
+}
+
+func getTemplateData() (templateData, []Template) {
+	return templateData{
+			TestNamespace:    testNamespace,
+			DeploymentName:   deploymentName,
+			ScaledObjectName: scaledObjectName,
+			ProjectID:        projectID.(string),
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
+}

--- a/tests/scalers/gcp/gcp_prometheus_workload_identity/gcp_prometheus_workload_identity_test.go
+++ b/tests/scalers/gcp/gcp_prometheus_workload_identity/gcp_prometheus_workload_identity_test.go
@@ -20,7 +20,7 @@ import (
 var _ = godotenv.Load("../../../.env")
 
 const (
-	testName = "gcp-prometheus-test"
+	testName = "gcp-prometheus-workload-identity-test"
 )
 
 var (


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR adds Google's authentication in order to access metrics from [Google Managed Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus).

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/4674

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts

Relates to #
-->

Relates to https://github.com/kedacore/keda-docs/pull/1153