### PR TITLE
feat: support `indexName` in dynamodb scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Security:** Enable secret scanning in GitHub repo
 - **RabbitMQ Scaler**: Add support for `unsafeSsl` in trigger metadata ([#4448](https://github.com/kedacore/keda/issues/4448))
 - **Prometheus Metrics**: Add new metric with KEDA build info ([#4647](https://github.com/kedacore/keda/issues/4647))
+- **AWS DynamoDB:** Add support for `indexName` ([#4680](https://github.com/kedacore/keda/issues/4680))
 
 ### Fixes
 

--- a/pkg/scalers/aws_dynamodb_scaler.go
+++ b/pkg/scalers/aws_dynamodb_scaler.go
@@ -218,10 +218,13 @@ func (s *awsDynamoDBScaler) Close(context.Context) error {
 func (s *awsDynamoDBScaler) GetQueryMetrics() (float64, error) {
 	dimensions := dynamodb.QueryInput{
 		TableName:                 aws.String(s.metadata.tableName),
-		IndexName:                 aws.String(s.metadata.indexName),
 		KeyConditionExpression:    aws.String(s.metadata.keyConditionExpression),
 		ExpressionAttributeNames:  s.metadata.expressionAttributeNames,
 		ExpressionAttributeValues: s.metadata.expressionAttributeValues,
+	}
+
+	if s.metadata.indexName != "" {
+		dimensions.IndexName = aws.String(s.metadata.indexName)
 	}
 
 	res, err := s.dbClient.Query(&dimensions)

--- a/pkg/scalers/aws_dynamodb_scaler.go
+++ b/pkg/scalers/aws_dynamodb_scaler.go
@@ -32,6 +32,7 @@ type awsDynamoDBMetadata struct {
 	keyConditionExpression    string
 	expressionAttributeNames  map[string]*string
 	expressionAttributeValues map[string]*dynamodb.AttributeValue
+	indexName                 string
 	targetValue               int64
 	activationTargetValue     int64
 	awsAuthorization          awsAuthorizationMetadata
@@ -104,6 +105,10 @@ func parseAwsDynamoDBMetadata(config *ScalerConfig) (*awsDynamoDBMetadata, error
 
 	if val, ok := config.TriggerMetadata["awsEndpoint"]; ok {
 		meta.awsEndpoint = val
+	}
+
+	if val, ok := config.TriggerMetadata["indexName"]; ok {
+		meta.indexName = val
 	}
 
 	if val, ok := config.TriggerMetadata["keyConditionExpression"]; ok && val != "" {
@@ -213,6 +218,7 @@ func (s *awsDynamoDBScaler) Close(context.Context) error {
 func (s *awsDynamoDBScaler) GetQueryMetrics() (float64, error) {
 	dimensions := dynamodb.QueryInput{
 		TableName:                 aws.String(s.metadata.tableName),
+		IndexName:                 aws.String(s.metadata.indexName),
 		KeyConditionExpression:    aws.String(s.metadata.keyConditionExpression),
 		ExpressionAttributeNames:  s.metadata.expressionAttributeNames,
 		ExpressionAttributeValues: s.metadata.expressionAttributeValues,

--- a/pkg/scalers/aws_dynamodb_scaler_test.go
+++ b/pkg/scalers/aws_dynamodb_scaler_test.go
@@ -395,7 +395,6 @@ func TestDynamoGetMetrics(t *testing.T) {
 			default:
 				assert.EqualValues(t, int64(4), value[0].Value.Value())
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
_Provide a description of what has been changed_

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4680

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda-docs/pull/1154
