### PR TITLE
feat: Supported Kubernetes versions will be v1.25 - v1.27 in KEDA v2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **General**: Metrics Adapter: remove deprecated Prometheus Metrics and non-gRPC code ([#3930](https://github.com/kedacore/keda/issues/3930))
+- **General**: Kubernetes v1.25, v1.26 or v1.27 are supported
 - **AWS DynamoDB**: Add support for `indexName` ([#4680](https://github.com/kedacore/keda/issues/4680))
 - **Azure Data Explorer Scaler**: Use azidentity SDK ([#4489](https://github.com/kedacore/keda/issues/4489))
 - **External Scaler**: Add tls options in TriggerAuth metadata. ([#3565](https://github.com/kedacore/keda/issues/3565))

--- a/pkg/util/welcome.go
+++ b/pkg/util/welcome.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	minSupportedVersion = 24
-	maxSupportedVersion = 26
+	minSupportedVersion = 25
+	maxSupportedVersion = 27
 )
 
 func PrintWelcome(logger logr.Logger, kubeVersion K8sVersion, component string) {


### PR DESCRIPTION
Supported Kubernetes versions will be v1.25 - v1.27 in KEDA v2.11

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/4710 (release)
Relates to https://github.com/kedacore/keda-docs/pull/1162 (docs)
