### PR TITLE
Pulsar Scaler: fix `msgBacklogThreshold` field being named wrongly as `msgBacklog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Paused ScaledObject continues working after removing the annotation ([#4733](https://github.com/kedacore/keda/issues/4733))
 - **General**: Skip resolving secrets if namespace is restricted ([#4519](https://github.com/kedacore/keda/issues/4519))
-- **Prometheus**: Authenticated connections to Prometheus work in non-PodIdenty case ([#4695](https://github.com/kedacore/keda/issues/4695))
+- **Prometheus**: Authenticated connections to Prometheus work in non-PodIdentity case ([#4695](https://github.com/kedacore/keda/issues/4695))
+- **Pulsar Scaler**: Fix `msgBacklogThreshold` field being named wrongly as `msgBacklog` ([#4681](https://github.com/kedacore/keda/issues/4681))
 
 ### Deprecations
 

--- a/pkg/scalers/authentication/authentication_types.go
+++ b/pkg/scalers/authentication/authentication_types.go
@@ -6,15 +6,15 @@ import "time"
 type Type string
 
 const (
-	// APIKeyAuthType is a auth type using an API key
+	// APIKeyAuthType is an auth type using an API key
 	APIKeyAuthType Type = "apiKey"
-	// BasicAuthType is a auth type using basic auth
+	// BasicAuthType is an auth type using basic auth
 	BasicAuthType Type = "basic"
-	// TLSAuthType is a auth type using TLS
+	// TLSAuthType is an auth type using TLS
 	TLSAuthType Type = "tls"
-	// BearerAuthType is a auth type using a bearer token
+	// BearerAuthType is an auth type using a bearer token
 	BearerAuthType Type = "bearer"
-	// CustomAuthType is a auth type using a custom header
+	// CustomAuthType is an auth type using a custom header
 	CustomAuthType Type = "custom"
 )
 

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -179,10 +179,10 @@ func parsePulsarMetadata(config *ScalerConfig, logger logr.Logger) (pulsarMetada
 
 	meta.msgBacklogThreshold = defaultMsgBacklogThreshold
 
-	// FIXME: msgBacklog support DEPRECATED to be removed in v2.13
+	// FIXME: msgBacklog support DEPRECATED to be removed in v2.14
 	fmt.Println(config.TriggerMetadata)
 	if val, ok := config.TriggerMetadata[msgBacklogMetricName]; ok {
-		logger.V(1).Info("\"msgBacklog\" is deprecated and will be removed in v2.13, please use \"msgBacklogThreshold\" instead")
+		logger.V(1).Info("\"msgBacklog\" is deprecated and will be removed in v2.14, please use \"msgBacklogThreshold\" instead")
 		t, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
 			return meta, fmt.Errorf("error parsing %s: %w", msgBacklogMetricName, err)

--- a/pkg/scalers/pulsar_scaler_test.go
+++ b/pkg/scalers/pulsar_scaler_test.go
@@ -63,7 +63,7 @@ var parsePulsarMetadataTestDataset = []parsePulsarMetadataTestData{
 	{map[string]string{"adminURL": "http://127.0.0.1:8080", "topic": "persistent://public/default/my-topic", "isPartitionedTopic": "true", "subscription": "sub1"}, false, false, true, "http://127.0.0.1:8080", "persistent://public/default/my-topic", "sub1"},
 	// test metric msgBacklogThreshold
 	{map[string]string{"adminURL": "http://127.0.0.1:8080", "topic": "persistent://public/default/my-topic", "isPartitionedTopic": "true", "subscription": "sub1", "msgBacklogThreshold": "5"}, false, false, true, "http://127.0.0.1:8080", "persistent://public/default/my-topic", "sub1"},
-	// FIXME: msgBacklog support DEPRECATED to be removed in v2.13
+	// FIXME: msgBacklog support DEPRECATED to be removed in v2.14
 	// test metric msgBacklog
 	{map[string]string{"adminURL": "http://127.0.0.1:8080", "topic": "persistent://public/default/my-topic", "isPartitionedTopic": "true", "subscription": "sub1", "msgBacklog": "5"}, false, false, true, "http://127.0.0.1:8080", "persistent://public/default/my-topic", "sub1"},
 	// END FIXME
@@ -129,7 +129,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 		}
 
 		var testDataMsgBacklogThreshold int64
-		// FIXME: msgBacklog support DEPRECATED to be removed in v2.13
+		// FIXME: msgBacklog support DEPRECATED to be removed in v2.14
 		if val, ok := testData.metadata["msgBacklog"]; ok {
 			testDataMsgBacklogThreshold, err = strconv.ParseInt(val, 10, 64)
 			if err != nil {

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -149,7 +149,7 @@ func InitializeLogger(config *ScalerConfig, scalerName string) logr.Logger {
 	return logf.Log.WithName(scalerName).WithValues("type", config.ScalableObjectType, "namespace", config.ScalableObjectNamespace, "name", config.ScalableObjectName)
 }
 
-// GetMetricTargetType helps getting the metric target type of the scaler
+// GetMetricTargetType helps get the metric target type of the scaler
 func GetMetricTargetType(config *ScalerConfig) (v2.MetricTargetType, error) {
 	switch config.MetricType {
 	case v2.UtilizationMetricType:


### PR DESCRIPTION
Hi team,
This PR aims to ix `msgBacklogThreshold` field being named wrongly as `msgBacklog` . I pass down the logger into the method  `parsePulsarMetadata` as well

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #4681
