### PR TITLE
Fix typo and reuse predefined value

### DIFF
--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -127,7 +127,7 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 		case scaledObject.Spec.IdleReplicaCount != nil && currentReplicas < minReplicas,
 			// triggers are active, Idle Replicas mode is enabled
 			// AND
-			// replica count is less then minimum replica count
+			// replica count is less than minimum replica count
 
 			currentReplicas == 0:
 			// triggers are active

--- a/pkg/scaling/executor/scale_scaledobjects_test.go
+++ b/pkg/scaling/executor/scale_scaledobjects_test.go
@@ -18,6 +18,7 @@ package executor
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -409,12 +410,15 @@ func TestScaleToPausedReplicasCount(t *testing.T) {
 
 	scaleExecutor := NewScaleExecutor(client, mockScaleClient, nil, recorder)
 
+	pausedReplicaCount := int32(0)
+	replicaCount := int32(2)
+
 	scaledObject := v1alpha1.ScaledObject{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "name",
 			Namespace: "namespace",
 			Annotations: map[string]string{
-				"autoscaling.keda.sh/paused-replicas": "0",
+				"autoscaling.keda.sh/paused-replicas": strconv.Itoa(int(pausedReplicaCount)),
 			},
 		},
 		Spec: v1alpha1.ScaledObjectSpec{
@@ -431,9 +435,6 @@ func TestScaleToPausedReplicasCount(t *testing.T) {
 	}
 
 	scaledObject.Status.Conditions = *v1alpha1.GetInitializedConditions()
-
-	pausedReplicaCount := int32(0)
-	replicaCount := int32(2)
 
 	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
1. Fix typo: then => than
2. Use predefined variable to increase consistency.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
