### PR TITLE
fix(automation): Use dedicated PAT for skipping e2e

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -38,6 +38,7 @@ jobs:
         if: ${{ startsWith(github.event.comment.body,'/skip-e2e') && steps.checkUserMember.outputs.isTeamMember == 'true' }}
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.GH_AUTOMATION_PAT }}
           script: |
             github.rest.issues.addLabels({
               issue_number: context.issue.number,


### PR DESCRIPTION
Use dedicated PAT for skipping e2e instead of GITHUB_TOKEN which does not support triggering other workflows

https://github.com/actions/github-script#using-a-separate-github-token

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
