### PR TITLE
fix(solr e2e): remove '-' from status command

### DIFF
--- a/tests/scalers/solr/solr_test.go
+++ b/tests/scalers/solr/solr_test.go
@@ -227,7 +227,7 @@ func checkIfSolrStatusIsReady(t *testing.T, name string) error {
 
 	time.Sleep(time.Second * 10)
 	for i := 0; i < 60; i++ {
-		out, errOut, _ := ExecCommandOnSpecificPod(t, name, testNamespace, fmt.Sprintf("%s status –", solrPath))
+		out, errOut, _ := ExecCommandOnSpecificPod(t, name, testNamespace, fmt.Sprintf("%s status", solrPath))
 		t.Logf("Output: %s, Error: %s", out, errOut)
 		if !strings.Contains(out, "running on port") {
 			time.Sleep(time.Second * 10)


### PR DESCRIPTION

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


