### PR TITLE
Revert "chore(deps): bump helm/kind-action from 1.7.0 to 1.8.0"

### DIFF
--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Create k8s ${{ inputs.kubernetesVersion }} Kind Cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1.7.0
         with:
           node_image: ${{ inputs.kindImage }}
           cluster_name: smoke-tests-cluster-${{ inputs.kubernetesVersion }}


### PR DESCRIPTION
Reverts kedacore/keda#4838

After this bump, the smoke tests on ARM64 are failing: https://github.com/kedacore/keda/actions/runs/5743980509/job/15570101840

Something looks wrong with kind version