### PR TITLE
Fix docker build error for go 1.20.5 version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM golang:1.20.4
+FROM golang:1.20.5
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -72,16 +72,20 @@ RUN apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
-    # Docker install
-    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
-    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
-    && add-apt-repository "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
-    && apt-get update \
+    # Docker install https://docs.docker.com/engine/install/debian/
+    && sudo install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && sudo chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo \
+      "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+      "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && sudo apt-get update \
     && apt-get install -y docker-ce-cli \
     #
     # Install pip & pre-commit
     && apt-get -y install python3-pip \
-    && python3 -m pip install --no-cache-dir pre-commit \
+    && python3 -m pip install --no-cache-dir --break-system-packages pre-commit \
     #
     # Clean up
     && apt-get autoremove -y \


### PR DESCRIPTION
Hi team,
This MR fixes the following two errors when I break down the `RUN` command line by line
- The first error is about installing `docker-ce-cli`
```
142.7 Package docker-ce-cli is not available, but is referred to by another package.
142.7 This may mean that the package is missing, has been obsoleted, or
142.7 is only available from another source
142.7 
142.8 E: Package 'docker-ce-cli' has no installation candidate
```
- The second error happens when we try to install `pre-commit` python package with `pip`
```
161.2 error: externally-managed-environment
161.2 
161.2 × This environment is externally managed
161.2 ╰─> To install Python packages system-wide, try apt install
161.2     python3-xyz, where xyz is the package you are trying to
161.2     install.
161.2     
161.2     If you wish to install a non-Debian-packaged Python package,
161.2     create a virtual environment using python3 -m venv path/to/venv.
161.2     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
161.2     sure you have python3-full installed.
161.2     
161.2     If you wish to install a non-Debian packaged Python application,
161.2     it may be easiest to use pipx install xyz, which will manage a
161.2     virtual environment for you. Make sure you have pipx installed.
161.2     
161.2     See /usr/share/doc/python3.11/README.venv for more information.
```
### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/4719
Related to https://github.com/kedacore/keda/actions/runs/5331741740/jobs/9660245056
