### PR TITLE
chore: KEDA v2.12 is targeted for September 26th, instead of 12th

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ Here is an overview of our current release estimations:
 
 | Version | Estimated Release Date                               |
 |:--------|:-----------------------------------------------------|
-| v2.12   | September 12th, 2023                                 |
+| v2.12   | September 26th, 2023                                 |
 | v2.13   | January 11th, 2024 *(planned later due to holidays)* |
 | v2.14   | April 12th, 2024                                     |
 


### PR DESCRIPTION
KEDA v2.12 is targeted for September 26th, instead of 12th, to ensure we have enough time to incorporate all open contributions after summer vacation.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))