### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -25,8 +25,8 @@ jobs:
 
       - id: go-paths
         run: |
-          echo ::set-output name=mod_cache::$(go env GOMODCACHE)
-          echo ::set-output name=build_cache::$(go env GOCACHE)
+          echo "mod_cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "build_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
       - name: Go modules cache
         uses: actions/cache@v3.3.1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -57,12 +57,12 @@ jobs:
           PR_URL="${{ github.event.issue.pull_request.url }}"
           PR_NUM=${PR_URL##*/}
           echo "Checking out from PR #$PR_NUM based on URL: $PR_URL"
-          echo "::set-output name=pr_num::$PR_NUM"
+          echo "pr_num=$PR_NUM" >> $GITHUB_OUTPUT
           # Get commit SHA
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           gh pr checkout $PR_NUM
           SHA=$(git log -n 1 --pretty=format:"%H")
-          echo "::set-output name=commit_sha::$SHA"
+          echo "commit_sha=$SHA" >> $GITHUB_OUTPUT
 
   build-test-images:
     needs: triage

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Set Go paths
         id: go-paths
         run: |
-          echo ::set-output name=mod_cache::$(go env GOMODCACHE)
-          echo ::set-output name=build_cache::$(go env GOCACHE)
+          echo "mod_cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "build_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
       - name: Go modules cache
         uses: actions/cache@v3.3.1

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -25,8 +25,8 @@ jobs:
 
       - id: go-paths
         run: |
-          echo ::set-output name=mod_cache::$(go env GOMODCACHE)
-          echo ::set-output name=build_cache::$(go env GOCACHE)
+          echo "mod_cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "build_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
       - name: Go modules cache
         uses: actions/cache@v3.3.1
@@ -55,7 +55,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Release Deployment YAML file
         run: make release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ New deprecation(s):
 
 - **General**: Fixed a typo in the StatefulSet scaling resolver ([#4902](https://github.com/kedacore/keda/pull/4902))
 - **General**: Refactor ScaledJob related methods to be located at scale_handler  ([#4781](https://github.com/kedacore/keda/issues/4781))
+- **General**: Replace deprecated `set-output` command with environment file ([#4914](https://github.com/kedacore/keda/issues/4914))
 
 ## v2.11.2
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

## Description

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=mod_cache::$(go env GOMODCACHE)
echo ::set-output name=build_cache::$(go env GOCACHE)
```

**TO-BE**

```yaml
echo "mod_cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
echo "build_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
```

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4914 
