### PR TITLE
Add Fix to solace `endpointURL` to query escape special character from `queueName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **Solace Scaler**: Fix a bug where `queueName` is not properly escaped during URL encode ([#4936](https://github.com/kedacore/keda/issues/4936))
 
 ### Deprecations
 

--- a/pkg/scalers/solace_scaler.go
+++ b/pkg/scalers/solace_scaler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -252,7 +253,8 @@ func parseSolaceMetadata(config *ScalerConfig) (*SolaceMetadata, error) {
 		solaceAPIVersion,
 		meta.messageVpn,
 		solaceAPIObjectTypeQueue,
-		meta.queueName)
+		url.QueryEscape(meta.queueName),
+	)
 
 	// Get Credentials
 	var e error


### PR DESCRIPTION
Hi team,

This PR aims to fix a bug where `queueName` is not properly escaped before adding to `endpointURL`

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/4936
