### PR TITLE
Show only logs with a severity level of ERROR or higher in the stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,10 @@ New deprecation(s):
 
 ### Other
 
-- **General**: Add one deployment arg in keda-metrics-apiserver for only printing errors, but errors should go to stderr ([#4049](https://github.com/kedacore/keda/issues/4049))
 - **General**: Fixed a typo in the StatefulSet scaling resolver ([#4902](https://github.com/kedacore/keda/pull/4902))
 - **General**: Refactor ScaledJob related methods to be located at scale_handler  ([#4781](https://github.com/kedacore/keda/issues/4781))
 - **General**: Replace deprecated `set-output` command with environment file ([#4914](https://github.com/kedacore/keda/issues/4914))
+- **General**: Show only logs with a severity level of ERROR or higher in the stderr ([#4049](https://github.com/kedacore/keda/issues/4049))
 
 ## v2.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ New deprecation(s):
 - **General**: Fixed a typo in the StatefulSet scaling resolver ([#4902](https://github.com/kedacore/keda/pull/4902))
 - **General**: Refactor ScaledJob related methods to be located at scale_handler  ([#4781](https://github.com/kedacore/keda/issues/4781))
 - **General**: Replace deprecated `set-output` command with environment file ([#4914](https://github.com/kedacore/keda/issues/4914))
+- **General**: Add one deployment arg in keda-metrics-apiserver for only printing errors, but errors should go to stderr ([#4049](https://github.com/kedacore/keda/issues/4049))
 
 ## v2.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ New deprecation(s):
 - **General**: Fixed a typo in the StatefulSet scaling resolver ([#4902](https://github.com/kedacore/keda/pull/4902))
 - **General**: Refactor ScaledJob related methods to be located at scale_handler  ([#4781](https://github.com/kedacore/keda/issues/4781))
 - **General**: Replace deprecated `set-output` command with environment file ([#4914](https://github.com/kedacore/keda/issues/4914))
-- **General**: Show only logs with a severity level of ERROR or higher in the stderr ([#4049](https://github.com/kedacore/keda/issues/4049))
+- **General**: In Metrics server show only logs with a severity level of ERROR or higher in the stderr ([#4049](https://github.com/kedacore/keda/issues/4049))
 
 ## v2.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,10 @@ New deprecation(s):
 
 ### Other
 
+- **General**: Add one deployment arg in keda-metrics-apiserver for only printing errors, but errors should go to stderr ([#4049](https://github.com/kedacore/keda/issues/4049))
 - **General**: Fixed a typo in the StatefulSet scaling resolver ([#4902](https://github.com/kedacore/keda/pull/4902))
 - **General**: Refactor ScaledJob related methods to be located at scale_handler  ([#4781](https://github.com/kedacore/keda/issues/4781))
 - **General**: Replace deprecated `set-output` command with environment file ([#4914](https://github.com/kedacore/keda/issues/4914))
-- **General**: Add one deployment arg in keda-metrics-apiserver for only printing errors, but errors should go to stderr ([#4049](https://github.com/kedacore/keda/issues/4049))
 
 ## v2.11.2
 

--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -58,6 +58,7 @@ spec:
           - /usr/local/bin/keda-adapter
           - --secure-port=6443
           - --logtostderr=true
+          - --stderrthreshold=ERROR
           - --v=0
           - --client-ca-file=/certs/ca.crt
           - --tls-cert-file=/certs/tls.crt


### PR DESCRIPTION
Signed-off-by: Adarsh-verma-14 [t_adarsh.verma@india.nec.com](mailto:t_adarsh.verma@india.nec.com)

In the logs of keda-metrics-apiserver, show only printing errors, but errors should go to stderr.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4049 


