### PR TITLE
Prometheus Scaler: Remove trailing whitespaces in customAuthHeader and customAuthValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Update golangci-lint version documented in CONTRIBUTING.md since old version doesn't support go 1.20 (N/A)
 - **General**: Updated AWS SDK and updated all the aws scalers ([#4905](https://github.com/kedacore/keda/issues/4905))
 - **Azure Pod Identity**: Introduce validation to prevent usage of empty identity ID for Azure identity providers ([#4528](https://github.com/kedacore/keda/issues/4528))
-- **Prometheus CustomAuth Params**: Remove trailing whitespaces in customAtuhHeader and value. ([#4960](https://github.com/kedacore/keda/issues/4960)) 
+- **Prometheus CustomAuth Params**: Remove trailing whitespaces in customAtuhHeader and value. ([#4960](https://github.com/kedacore/keda/issues/4960))
 
 ### Fixes
 - **RabbitMQ Scaler**: Allow subpaths along with vhost in connection string ([#2634](https://github.com/kedacore/keda/issues/2634))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Update golangci-lint version documented in CONTRIBUTING.md since old version doesn't support go 1.20 (N/A)
 - **General**: Updated AWS SDK and updated all the aws scalers ([#4905](https://github.com/kedacore/keda/issues/4905))
 - **Azure Pod Identity**: Introduce validation to prevent usage of empty identity ID for Azure identity providers ([#4528](https://github.com/kedacore/keda/issues/4528))
+- **Prometheus CustomAuth Params**: Remove trailing whitespaces in customAtuhHeader and value. ([#4960](https://github.com/kedacore/keda/issues/4960)) 
 
 ### Fixes
 - **RabbitMQ Scaler**: Allow subpaths along with vhost in connection string ([#2634](https://github.com/kedacore/keda/issues/2634))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Update golangci-lint version documented in CONTRIBUTING.md since old version doesn't support go 1.20 (N/A)
 - **General**: Updated AWS SDK and updated all the aws scalers ([#4905](https://github.com/kedacore/keda/issues/4905))
 - **Azure Pod Identity**: Introduce validation to prevent usage of empty identity ID for Azure identity providers ([#4528](https://github.com/kedacore/keda/issues/4528))
-- **Prometheus CustomAuth Params**: Remove trailing whitespaces in customAtuhHeader and value. ([#4960](https://github.com/kedacore/keda/issues/4960))
+- **Prometheus Scaler**: Remove trailing whitespaces in customAuthHeader and customAuthValue ([#4960](https://github.com/kedacore/keda/issues/4960))
 
 ### Fixes
 - **RabbitMQ Scaler**: Allow subpaths along with vhost in connection string ([#2634](https://github.com/kedacore/keda/issues/2634))

--- a/pkg/scalers/authentication/authentication_helpers.go
+++ b/pkg/scalers/authentication/authentication_helpers.go
@@ -73,12 +73,12 @@ func GetAuthConfigs(triggerMetadata, authParams map[string]string) (out *AuthMet
 			if len(authParams["customAuthHeader"]) == 0 {
 				return nil, errors.New("no custom auth header given")
 			}
-			out.CustomAuthHeader = authParams["customAuthHeader"]
+			out.CustomAuthHeader = strings.TrimSuffix(authParams["customAuthHeader"], "\n")
 
 			if len(authParams["customAuthValue"]) == 0 {
 				return nil, errors.New("no custom auth value given")
 			}
-			out.CustomAuthValue = authParams["customAuthValue"]
+			out.CustomAuthValue = strings.TrimSuffix(authParams["customAuthValue"], "\n")
 			out.EnableCustomAuth = true
 		default:
 			return nil, fmt.Errorf("incorrect value for authMode is given: %s", t)

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -101,6 +101,8 @@ var testPrometheusAuthMetadata = []prometheusAuthMetadataTestData{
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "custom"}, map[string]string{"customAuthHeader": ""}, "", true},
 	// fail custom auth with no customAuthValue
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "custom"}, map[string]string{"customAuthValue": ""}, "", true},
+	// success custom auth with newlines in customAuthHeader
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "custom"}, map[string]string{"customAuthHeader": "header\n", "customAuthValue": "value\n"}, "", false},
 
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "tls,basic"}, map[string]string{"username": "user", "password": "pass"}, "", true},
 	// pod identity and other auth modes enabled together


### PR DESCRIPTION
Added strings.TrimSuffix to customAuth interpreter to avoid auth failure.

*TrimSuffix was used rather than TrimSpace to avoid unwanted removal of randomly generated strings with "\n" 
### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #
https://kubernetes.slack.com/archives/CKZJ36A5D/p1694069463138859

Fixes #4960