### PR TITLE
disable depguard temporarily & update golangci-lint

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update \
     && mv $HOME/.local/include/ /usr/local/bin/include/ \
     && protoc --version \
     # Install golangci-lint
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2 \
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2 \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           go-version: "1.20"
       - name: Get golangci
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
       - uses: pre-commit/action@v3.0.0
 
   trivy-scan:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     - ineffassign
     - staticcheck
     - exportloopref
-    - depguard
+    #- depguard #https://github.com/kedacore/keda/issues/4980
     - dogsled
     - errcheck
     #- funlen


### PR DESCRIPTION
- disable depguard check because it reports errors in main on `pre-commit run --all-files` in newer versions 1.53 and 1.54 - probably needs to be configured.
- update golangci-lint version to 1.54.2

see issue below for output

Relates to #4980
