### PR TITLE
feat: configurable K8s cluster domain for Cert Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Add standalone CRD generation to release workflow ([#2726](https://github.com/kedacore/keda/issues/2726))
 - **General**: Adding a changelog validating script to check for formatting and order ([#3190](https://github.com/kedacore/keda/issues/3190))
 - **General**: Automatically set `GOMAXPROCS` to match Linux container CPU quota ([#4999](https://github.com/kedacore/keda/issues/4999))
+- **General**: Configurable K8s cluster domain for Cert Manager ([#4861](https://github.com/kedacore/keda/issues/4861))
 - **General**: Emit more Kubernetes events about internal state and scaling ([#3764](https://github.com/kedacore/keda/issues/3764))
 - **General**: Introduce annotation `autoscaling.keda.sh/paused: true` for ScaledObject to pause autoscaling ([#3304](https://github.com/kedacore/keda/issues/3304))
 - **General**: Updated AWS SDK and updated all the aws scalers ([#4905](https://github.com/kedacore/keda/issues/4905))

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -73,6 +73,7 @@ func main() {
 	var operatorServiceName string
 	var metricsServerServiceName string
 	var webhooksServiceName string
+	var k8sClusterDomain string
 	var enableCertRotation bool
 	var validatingWebhookName string
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -89,6 +90,7 @@ func main() {
 	pflag.StringVar(&operatorServiceName, "operator-service-name", "keda-operator", "Operator service name. Defaults to keda-operator")
 	pflag.StringVar(&metricsServerServiceName, "metrics-server-service-name", "keda-metrics-apiserver", "Metrics server service name. Defaults to keda-metrics-apiserver")
 	pflag.StringVar(&webhooksServiceName, "webhooks-service-name", "keda-admission-webhooks", "Webhook service name. Defaults to keda-admission-webhooks")
+	pflag.StringVar(&k8sClusterDomain, "k8s-cluster-domain", "cluster.local", "Kubernetes cluster domain. Defaults to cluster.local")
 	pflag.BoolVar(&enableCertRotation, "enable-cert-rotation", false, "enable automatic generation and rotation of TLS certificates/keys")
 	pflag.StringVar(&validatingWebhookName, "validating-webhook-name", "keda-admission", "ValidatingWebhookConfiguration name. Defaults to keda-admission")
 	opts := zap.Options{}
@@ -253,6 +255,7 @@ func main() {
 			OperatorService:       operatorServiceName,
 			MetricsServerService:  metricsServerServiceName,
 			WebhookService:        webhooksServiceName,
+			K8sClusterDomain:      k8sClusterDomain,
 			CAName:                "KEDA",
 			CAOrganization:        "KEDAORG",
 			ValidatingWebhookName: validatingWebhookName,

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -42,6 +42,7 @@ type CertManager struct {
 	OperatorService       string
 	MetricsServerService  string
 	WebhookService        string
+	K8sClusterDomain      string
 	CAName                string
 	CAOrganization        string
 	ValidatingWebhookName string
@@ -68,9 +69,9 @@ func (cm CertManager) AddCertificateRotation(ctx context.Context, mgr manager.Ma
 		return err
 	}
 	extraDNSNames := []string{}
-	extraDNSNames = append(extraDNSNames, getDNSNames(cm.OperatorService)...)
-	extraDNSNames = append(extraDNSNames, getDNSNames(cm.WebhookService)...)
-	extraDNSNames = append(extraDNSNames, getDNSNames(cm.MetricsServerService)...)
+	extraDNSNames = append(extraDNSNames, getDNSNames(cm.OperatorService, cm.K8sClusterDomain)...)
+	extraDNSNames = append(extraDNSNames, getDNSNames(cm.WebhookService, cm.K8sClusterDomain)...)
+	extraDNSNames = append(extraDNSNames, getDNSNames(cm.MetricsServerService, cm.K8sClusterDomain)...)
 
 	cm.Logger.V(1).Info("setting up cert rotation")
 	err = rotator.AddRotator(mgr, &rotator.CertRotator{
@@ -96,14 +97,13 @@ func (cm CertManager) AddCertificateRotation(ctx context.Context, mgr manager.Ma
 }
 
 // getDNSNames  creates all the possible DNS names for a given service
-func getDNSNames(service string) []string {
+func getDNSNames(service, k8sClusterDomain string) []string {
 	namespace := kedautil.GetPodNamespace()
 	return []string{
 		service,
 		fmt.Sprintf("%s.%s", service, namespace),
 		fmt.Sprintf("%s.%s.svc", service, namespace),
-		fmt.Sprintf("%s.%s.svc.local", service, namespace),
-		fmt.Sprintf("%s.%s.svc.cluster.local", service, namespace),
+		fmt.Sprintf("%s.%s.svc.%s", service, namespace, k8sClusterDomain),
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Default is `cluster.local`, users have a possibility to overwrite via parameter `--k8s-cluster-domain` on KEDA operator 

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart https://github.com/kedacore/charts/pull/531
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs/pull/1232
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #4861 

