### PR TITLE
chore: reduce infra costs during e2e tests

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -91,6 +91,7 @@ jobs:
         id: checkout
         run: |
           gh pr checkout ${{ needs.triage.outputs.pr_num }}
+          git checkout ${{ needs.triage.outputs.commit_sha }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -134,6 +135,7 @@ jobs:
         id: checkout
         run: |
           gh pr checkout ${{ needs.triage.outputs.pr_num }}
+          git checkout ${{ needs.triage.outputs.commit_sha }}
 
       - uses: oNaiPs/secrets-to-env-action@v1
         with:

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Scale cluster
         run: make scale-node-pool
         env:
-          NODE_POOL_SIZE: 4
+          NODE_POOL_SIZE: 2
           TEST_CLUSTER_NAME: keda-e2e-cluster-pr
 
       - name: Run end to end tests

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Scale cluster
         run: make scale-node-pool
         env:
-          NODE_POOL_SIZE: 4
+          NODE_POOL_SIZE: 2
 
       - name: Run end to end tests
         env:

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,11 @@ get-cluster-context: az-login ## Get Azure cluster context.
 
 .PHONY: scale-node-pool
 scale-node-pool: az-login ## Scale nodepool.
-	
+	@az aks scale \
+		--name $(TEST_CLUSTER_NAME) \
+		--subscription $(TF_AZURE_SUBSCRIPTION) \
+		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
+		--node-count $$(($(NODE_POOL_SIZE)/2))
 
 .PHONY: e2e-test
 e2e-test: get-cluster-context ## Run e2e tests against Azure cluster.

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,7 @@ get-cluster-context: az-login ## Get Azure cluster context.
 
 .PHONY: scale-node-pool
 scale-node-pool: az-login ## Scale nodepool.
-	@az aks scale \
-		--name $(TEST_CLUSTER_NAME) \
-		--subscription $(TF_AZURE_SUBSCRIPTION) \
-		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
-		--node-count $(NODE_POOL_SIZE)
+	
 
 .PHONY: e2e-test
 e2e-test: get-cluster-context ## Run e2e tests against Azure cluster.

--- a/Makefile
+++ b/Makefile
@@ -92,21 +92,11 @@ get-cluster-context: az-login ## Get Azure cluster context.
 
 .PHONY: scale-node-pool
 scale-node-pool: az-login ## Scale nodepool.
-	if [ "$(NODE_POOL_SIZE)" = "4" ]; then \
-		az aks scale \
+	@az aks scale \
 		--name $(TEST_CLUSTER_NAME) \
 		--subscription $(TF_AZURE_SUBSCRIPTION) \
 		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
-		--node-count 2; \
-	fi
-	
-	if [ "$(NODE_POOL_SIZE)" != "4" ]; then \
-		az aks scale \
-		--name $(TEST_CLUSTER_NAME) \
-		--subscription $(TF_AZURE_SUBSCRIPTION) \
-		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
-		--node-count $(NODE_POOL_SIZE); \
-	fi
+		--node-count $(NODE_POOL_SIZE)
 
 .PHONY: e2e-test
 e2e-test: get-cluster-context ## Run e2e tests against Azure cluster.

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,21 @@ get-cluster-context: az-login ## Get Azure cluster context.
 
 .PHONY: scale-node-pool
 scale-node-pool: az-login ## Scale nodepool.
-	@az aks scale \
+	if [ "$(NODE_POOL_SIZE)" = "4" ]; then \
+		az aks scale \
 		--name $(TEST_CLUSTER_NAME) \
 		--subscription $(TF_AZURE_SUBSCRIPTION) \
 		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
-		--node-count $$(($(NODE_POOL_SIZE)/2))
+		--node-count 2; \
+	fi
+	
+	if [ "$(NODE_POOL_SIZE)" != "4" ]; then \
+		az aks scale \
+		--name $(TEST_CLUSTER_NAME) \
+		--subscription $(TF_AZURE_SUBSCRIPTION) \
+		--resource-group $(TF_AZURE_RESOURCE_GROUP) \
+		--node-count $(NODE_POOL_SIZE); \
+	fi
 
 .PHONY: e2e-test
 e2e-test: get-cluster-context ## Run e2e tests against Azure cluster.

--- a/tests/internals/custom_hpa_name/custom_hpa_name_test.go
+++ b/tests/internals/custom_hpa_name/custom_hpa_name_test.go
@@ -46,11 +46,6 @@ spec:
         image: registry.k8s.io/hpa-example
         ports:
         - containerPort: 80
-        resources:
-          limits:
-            cpu: 500m
-          requests:
-            cpu: 200m
         imagePullPolicy: IfNotPresent
 `
 

--- a/tests/internals/custom_hpa_name/custom_hpa_name_test.go
+++ b/tests/internals/custom_hpa_name/custom_hpa_name_test.go
@@ -63,10 +63,12 @@ spec:
   maxReplicaCount: 1
   cooldownPeriod: 10
   triggers:
-    - type: cpu
-      metadata:
-        type: Utilization
-        value: "50"
+  - type: metrics-api
+    metadata:
+      targetValue: "2"
+      url: "invalid-invalid"
+      valueLocation: 'value'
+      method: "query"
 `
 
 	scaledObjectTemplateWithCustomName = `
@@ -85,10 +87,12 @@ spec:
     horizontalPodAutoscalerConfig:
       name: {{.CustomHpaName}}
   triggers:
-      - type: cpu
-        metadata:
-          type: Utilization
-          value: "50"
+  - type: metrics-api
+    metadata:
+      targetValue: "2"
+      url: "invalid-invalid"
+      valueLocation: 'value'
+      method: "query"
 `
 )
 

--- a/tests/internals/replica_update_so/replica_update_so_test.go
+++ b/tests/internals/replica_update_so/replica_update_so_test.go
@@ -112,11 +112,6 @@ spec:
         image: nginxinc/nginx-unprivileged
         ports:
         - containerPort: 80
-        resources:
-          requests:
-            cpu: "200m"
-          limits:
-            cpu: "500m"
 `
 
 	metricsServerDeploymentTemplate = `

--- a/tests/internals/trigger_update_so/trigger_update_so_test.go
+++ b/tests/internals/trigger_update_so/trigger_update_so_test.go
@@ -114,11 +114,6 @@ spec:
         image: nginxinc/nginx-unprivileged
         ports:
         - containerPort: 80
-        resources:
-          requests:
-            cpu: "200m"
-          limits:
-            cpu: "500m"
 `
 
 	workloadDeploymentTemplate = `apiVersion: apps/v1

--- a/tests/internals/trigger_update_so/trigger_update_so_test.go
+++ b/tests/internals/trigger_update_so/trigger_update_so_test.go
@@ -265,10 +265,12 @@ spec:
     metadata:
       podSelector: 'pod={{.WorkloadDeploymentName}}'
       value: '1'
-  - type: cpu
-    metricType: Utilization
+  - type: metrics-api
     metadata:
-      value: "50"
+      targetValue: "2"
+      url: "invalid-invalid"
+      valueLocation: 'value'
+      method: "query"
 `
 
 	updateMetricTemplate = `

--- a/tests/internals/update_ta/update_ta_test.go
+++ b/tests/internals/update_ta/update_ta_test.go
@@ -100,11 +100,6 @@ spec:
         image: nginxinc/nginx-unprivileged
         ports:
         - containerPort: 80
-        resources:
-          requests:
-            cpu: "200m"
-          limits:
-            cpu: "500m"
 `
 
 	deployment2Template = `
@@ -130,11 +125,6 @@ spec:
         image: nginxinc/nginx-unprivileged
         ports:
         - containerPort: 80
-        resources:
-          requests:
-            cpu: "200m"
-          limits:
-            cpu: "500m"
 `
 
 	scaledObjectTriggerTemplate = `

--- a/tests/internals/update_ta/update_ta_test.go
+++ b/tests/internals/update_ta/update_ta_test.go
@@ -148,10 +148,12 @@ spec:
   maxReplicaCount: {{.MaxReplicas}}
   cooldownPeriod: 1
   triggers:
-  - type: cpu
-    metricType: Utilization
+  - type: metrics-api
     metadata:
-      value: "50"
+      targetValue: "2"
+      url: "invalid-invalid"
+      valueLocation: 'value'
+      method: "query"
     authenticationRef:
       name: {{.TriggerAuthName}}
       kind: {{.TriggerAuthKind}}
@@ -178,10 +180,12 @@ spec:
   maxReplicaCount: {{.MaxReplicas}}
   cooldownPeriod: 1
   triggers:
-  - type: cpu
-    metricType: Utilization
+  - type: metrics-api
     metadata:
-      value: "50"
+      targetValue: "2"
+      url: "invalid-invalid"
+      valueLocation: 'value'
+      method: "query"
     authenticationRef:
       name: {{.TriggerAuthName}}
       kind: {{.TriggerAuthKind}}
@@ -212,10 +216,12 @@ spec:
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 0
   triggers:
-  - type: cpu
+  - type: metrics-api
     metadata:
-      type: Utilization
-      value: "50"
+      targetValue: "2"
+      url: "invalid-invalid"
+      valueLocation: 'value'
+      method: "query"
     authenticationRef:
       name: {{.TriggerAuthName}}
       kind: {{.TriggerAuthKind}}
@@ -246,10 +252,12 @@ spec:
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 0
   triggers:
-  - type: cpu
+  - type: metrics-api
     metadata:
-      type: Utilization
-      value: "50"
+      targetValue: "2"
+      url: "invalid-invalid"
+      valueLocation: 'value'
+      method: "query"
     authenticationRef:
       name: {{.TriggerAuthName}}
       kind: {{.TriggerAuthKind}}

--- a/tests/scalers/activemq/activemq_test.go
+++ b/tests/scalers/activemq/activemq_test.go
@@ -145,7 +145,6 @@ spec:
         - containerPort: 1883
           name: mqtt
           protocol: TCP
-        resources:
         volumeMounts:
         - name: remote-access-cm
           mountPath: /opt/apache-activemq-5.16.3/webapps/api/WEB-INF/classes/jolokia-access.xml

--- a/tests/scalers/arangodb/helper.go
+++ b/tests/scalers/arangodb/helper.go
@@ -29,7 +29,7 @@ spec:
   architectures:
     - arm64
     - amd64
-  mode: Cluster
+  mode: Single
   image: "arangodb/arangodb:3.10.1"
 `
 
@@ -90,12 +90,12 @@ func InstallArangoDB(t *testing.T, kc *kubernetes.Clientset, testNamespace strin
 	assert.NoErrorf(t, err, "cannot install crds - %s", err)
 
 	t.Log("installing arangodb operator")
-	_, err = helper.ExecuteCommand(fmt.Sprintf("helm install arangodb https://github.com/arangodb/kube-arangodb/releases/download/1.2.20/kube-arangodb-1.2.20.tgz --set 'operator.architectures={arm64,amd64}' --namespace=%s --wait", testNamespace))
+	_, err = helper.ExecuteCommand(fmt.Sprintf("helm install arangodb https://github.com/arangodb/kube-arangodb/releases/download/1.2.20/kube-arangodb-1.2.20.tgz --set 'operator.architectures={arm64,amd64}' --set 'operator.resources.requests.cpu=1m' --set 'operator.resources.requests.memory=1Mi' --namespace=%s --wait", testNamespace))
 	assert.NoErrorf(t, err, "cannot create operator deployment - %s", err)
 
 	t.Log("creating arangodeployment resource")
 	helper.KubectlApplyWithTemplate(t, templateData{Namespace: testNamespace}, "arangoDeploymentTemplate", arangoDeploymentTemplate)
-	assert.True(t, helper.WaitForPodCountInNamespace(t, kc, testNamespace, 11, 5, 20), "pod count should be 11")
+	assert.True(t, helper.WaitForPodCountInNamespace(t, kc, testNamespace, 3, 5, 20), "pod count should be 3")
 	assert.True(t, helper.WaitForAllPodRunningInNamespace(t, kc, testNamespace, 5, 20), "all pods should be running")
 }
 

--- a/tests/scalers/artemis/artemis_test.go
+++ b/tests/scalers/artemis/artemis_test.go
@@ -139,7 +139,6 @@ spec:
         - name: artemis-activemq-artemis
           image: docker.io/vromero/activemq-artemis:2.6.2
           imagePullPolicy:
-          resources:
           env:
             - name: ARTEMIS_PASSWORD
               valueFrom:

--- a/tests/scalers/azure/azure_blob/azure_blob_test.go
+++ b/tests/scalers/azure/azure_blob/azure_blob_test.go
@@ -82,7 +82,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: slurplk/blob-consumer:latest
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: dotnet

--- a/tests/scalers/azure/azure_blob_aad_pod_identity/azure_blob_aad_pod_identity_test.go
+++ b/tests/scalers/azure/azure_blob_aad_pod_identity/azure_blob_aad_pod_identity_test.go
@@ -86,7 +86,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: slurplk/blob-consumer:latest
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: dotnet

--- a/tests/scalers/azure/azure_blob_aad_wi/azure_blob_aad_wi_test.go
+++ b/tests/scalers/azure/azure_blob_aad_wi/azure_blob_aad_wi_test.go
@@ -86,7 +86,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: slurplk/blob-consumer:latest
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: dotnet

--- a/tests/scalers/azure/azure_event_hub_aad_pod_identity/azure_event_hub_aad_pod_identity_test.go
+++ b/tests/scalers/azure/azure_event_hub_aad_pod_identity/azure_event_hub_aad_pod_identity_test.go
@@ -97,7 +97,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-eventhub-golang
-          resources:
           env:
             - name: EVENTHUB_CONNECTION_STRING
               valueFrom:

--- a/tests/scalers/azure/azure_event_hub_aad_wi/azure_event_hub_aad_wi_test.go
+++ b/tests/scalers/azure/azure_event_hub_aad_wi/azure_event_hub_aad_wi_test.go
@@ -97,7 +97,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-eventhub-golang
-          resources:
           env:
             - name: EVENTHUB_CONNECTION_STRING
               valueFrom:

--- a/tests/scalers/azure/azure_event_hub_blob_metadata/azure_event_hub_blob_metadata_test.go
+++ b/tests/scalers/azure/azure_event_hub_blob_metadata/azure_event_hub_blob_metadata_test.go
@@ -90,7 +90,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-eventhub-dotnet
-          resources:
           env:
             - name: EVENTHUB_CONNECTION_STRING
               valueFrom:

--- a/tests/scalers/azure/azure_event_hub_dapr/azure_event_hub_dapr_test.go
+++ b/tests/scalers/azure/azure_event_hub_dapr/azure_event_hub_dapr_test.go
@@ -123,14 +123,12 @@ spec:
           image: daprio/daprd:1.9.5-mariner
           imagePullPolicy: Always
           command: ["./daprd", "-app-id", "azure-eventhub-dapr", "-app-port", "3000", "-components-path", "/components", "-log-level", "debug"]
-          resources:
           volumeMounts:
           - mountPath: "/components"
             name: {{.SecretName}}
             readOnly: true
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-eventhub-dapr
-          resources:
           env:
             - name: APP_PORT
               value: "3000"

--- a/tests/scalers/azure/azure_event_hub_go_sdk/azure_event_hub_go_sdk_test.go
+++ b/tests/scalers/azure/azure_event_hub_go_sdk/azure_event_hub_go_sdk_test.go
@@ -90,7 +90,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-eventhub-golang
-          resources:
           env:
             - name: EVENTHUB_CONNECTION_STRING
               valueFrom:

--- a/tests/scalers/azure/azure_queue/azure_queue_test.go
+++ b/tests/scalers/azure/azure_queue/azure_queue_test.go
@@ -80,7 +80,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-queue
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: node

--- a/tests/scalers/azure/azure_queue_aad_pod_identity/azure_queue_aad_pod_identity_test.go
+++ b/tests/scalers/azure/azure_queue_aad_pod_identity/azure_queue_aad_pod_identity_test.go
@@ -85,7 +85,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-queue
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: node

--- a/tests/scalers/azure/azure_queue_aad_wi/azure_queue_aad_wi_test.go
+++ b/tests/scalers/azure/azure_queue_aad_wi/azure_queue_aad_wi_test.go
@@ -85,7 +85,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-queue
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: node

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -63,7 +63,6 @@ spec:
         image: registry.k8s.io/hpa-example
         ports:
         - containerPort: 80
-        resources:
           limits:
             cpu: 500m
           requests:

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -63,6 +63,7 @@ spec:
         image: registry.k8s.io/hpa-example
         ports:
         - containerPort: 80
+        resources:
           limits:
             cpu: 500m
           requests:

--- a/tests/scalers/elasticsearch/elasticsearch_test.go
+++ b/tests/scalers/elasticsearch/elasticsearch_test.go
@@ -170,7 +170,6 @@ spec:
         - containerPort: 9300
           name: transport
           protocol: TCP
-        resources:
         readinessProbe:
           exec:
             command:

--- a/tests/scalers/etcd/helper/helper.go
+++ b/tests/scalers/etcd/helper/helper.go
@@ -73,13 +73,6 @@ spec:
           - containerPort: 2379
             name: client
             protocol: TCP
-          resources:
-            requests:
-              memory: "0.5Gi"
-              cpu: "500m"
-            limits:
-              memory: "1Gi"
-              cpu: "1000m"
           volumeMounts:
           - mountPath: /etcd-data
             name: cache-volume

--- a/tests/scalers/github_runner/github_runner_test.go
+++ b/tests/scalers/github_runner/github_runner_test.go
@@ -132,7 +132,7 @@ spec:
       containers:
       - name: github-runner
         image: myoung34/github-runner
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         env:
           - name: EPHEMERAL
             value: "true"

--- a/tests/scalers/graphite/graphite_test.go
+++ b/tests/scalers/graphite/graphite_test.go
@@ -405,8 +405,7 @@ spec:
           httpGet:
             path: /
             port: graphite-gui
-        resources:
-          {}
+
         volumeMounts:
           - name: graphite-configmap
             mountPath: /opt/graphite/conf/

--- a/tests/scalers/prometheus/prometheus_helper.go
+++ b/tests/scalers/prometheus/prometheus_helper.go
@@ -426,8 +426,6 @@ spec:
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://127.0.0.1:9090/-/reload
-          resources:
-            {}
 
           volumeMounts:
             - name: config-volume
@@ -462,8 +460,6 @@ spec:
             timeoutSeconds: 30
             failureThreshold: 3
             successThreshold: 1
-          resources:
-            {}
 
           volumeMounts:
             - name: config-volume

--- a/tests/scalers/selenium/selenium_test.go
+++ b/tests/scalers/selenium/selenium_test.go
@@ -133,7 +133,6 @@ spec:
         volumeMounts:
         - name: dshm
           mountPath: /dev/shm
-        resources: {}
       volumes:
       - name: dshm
         emptyDir:
@@ -222,7 +221,6 @@ spec:
         volumeMounts:
         - name: dshm
           mountPath: /dev/shm
-        resources: {}
       volumes:
       - name: dshm
         emptyDir:
@@ -312,7 +310,6 @@ spec:
         volumeMounts:
         - name: dshm
           mountPath: /dev/shm
-        resources: {}
       volumes:
       - name: dshm
         emptyDir:

--- a/tests/scalers/solace/solace_test.go
+++ b/tests/scalers/solace/solace_test.go
@@ -234,7 +234,7 @@ func installSolace(t *testing.T) {
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 	_, err = ExecuteCommand("helm repo update")
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
-	_, err = ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set solace.usernameAdminPassword=KedaLabAdminPwd1 --set storage.persistent=false,solace.size=dev,nameOverride=pubsubplus-dev --namespace %s kedalab solacecharts/pubsubplus`,
+	_, err = ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set solace.usernameAdminPassword=KedaLabAdminPwd1 --set storage.persistent=false,solace.size=dev,nameOverride=pubsubplus-dev,service.type=ClusterIP --namespace %s kedalab solacecharts/pubsubplus`,
 		testNamespace))
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 	_, err = ExecuteCommand("sleep 60") // there is a bug in the solace helm chart where it is looking for the wrong number of replicas on --wait

--- a/tests/secret-providers/azure_keyvault/azure_keyvault_test.go
+++ b/tests/secret-providers/azure_keyvault/azure_keyvault_test.go
@@ -91,7 +91,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-queue
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: node

--- a/tests/secret-providers/azure_keyvault_workload_identity/azure_keyvault_workload_identity_test.go
+++ b/tests/secret-providers/azure_keyvault_workload_identity/azure_keyvault_workload_identity_test.go
@@ -84,7 +84,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-queue
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: node

--- a/tests/secret-providers/trigger_auth_secret/trigger_auth_secret_test.go
+++ b/tests/secret-providers/trigger_auth_secret/trigger_auth_secret_test.go
@@ -82,7 +82,6 @@ spec:
       containers:
         - name: {{.DeploymentName}}
           image: ghcr.io/kedacore/tests-azure-queue
-          resources:
           env:
             - name: FUNCTIONS_WORKER_RUNTIME
               value: node


### PR DESCRIPTION
I have reviewed e2e tests to execute them just in 2 nodes instead of 4 nodes. 
I have removed all the pod requests, where they aren't 100% required to not enforce more nodes

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

