### PR TITLE
chore: use ARM64 runner for main/release build

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ARM64
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Push Release
-    runs-on: ubuntu-latest
+    runs-on: ARM64
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
As the image build generates multi-arch output, we can use our own runners instead of GH hosted runners. As our runners are more power, this change can improve build times

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

