### PR TITLE
Improve Azure Event Hub scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Prevented stuck status due to timeouts during scalers generation ([#5083](https://github.com/kedacore/keda/issues/5083))
 - **General**: ScaledObject Validating Webhook should support dry-run=server requests ([#5306](https://github.com/kedacore/keda/issues/5306))
 - **AWS Scalers**: Ensure session tokens are included when instantiating AWS credentials ([#5156](https://github.com/kedacore/keda/issues/5156))
+- **Azure Event Hub Scaler**: Improve unprocessedEventThreshold calculation ([#4250](https://github.com/kedacore/keda/issues/4250))
 - **Azure Pipelines**: No more HTTP 400 errors produced by poolName with spaces ([#5107](https://github.com/kedacore/keda/issues/5107))
 - **GCP pubsub scaler**: Added `project_id` to filter for metrics queries ([#5256](https://github.com/kedacore/keda/issues/5256))
 - **GCP pubsub scaler**: Missing use of default value of `value` added ([#5093](https://github.com/kedacore/keda/issues/5093))

--- a/pkg/scalers/azure/azure_eventhub_checkpoint.go
+++ b/pkg/scalers/azure/azure_eventhub_checkpoint.go
@@ -92,6 +92,10 @@ type defaultCheckpointer struct {
 	containerName string
 }
 
+func NewCheckpoint(offset string, sequenceNumber int64) Checkpoint {
+	return Checkpoint{baseCheckpoint: baseCheckpoint{Offset: offset}, SequenceNumber: sequenceNumber}
+}
+
 // GetCheckpointFromBlobStorage reads depending of the CheckpointStrategy the checkpoint from a azure storage
 func GetCheckpointFromBlobStorage(ctx context.Context, httpClient util.HTTPDoer, info EventHubInfo, partitionID string) (Checkpoint, error) {
 	checkpointer := newCheckpointer(info, partitionID)

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -297,12 +297,12 @@ func (s *azureEventHubScaler) GetUnprocessedEventCountInPartition(ctx context.Co
 		return -1, azure.Checkpoint{}, fmt.Errorf("unable to get checkpoint from storage: %w", err)
 	}
 
-	unprocessedEventCountInPartition := calculateUnprocessedEvents(ctx, partitionInfo, checkpoint, s.metadata.stalePartitionInfoThreshold)
+	unprocessedEventCountInPartition := calculateUnprocessedEvents(partitionInfo, checkpoint, s.metadata.stalePartitionInfoThreshold)
 
 	return unprocessedEventCountInPartition, checkpoint, nil
 }
 
-func calculateUnprocessedEvents(ctx context.Context, partitionInfo *eventhub.HubPartitionRuntimeInformation, checkpoint azure.Checkpoint, stalePartitionInfoThreshold int64) int64 {
+func calculateUnprocessedEvents(partitionInfo *eventhub.HubPartitionRuntimeInformation, checkpoint azure.Checkpoint, stalePartitionInfoThreshold int64) int64 {
 	unprocessedEventCount := int64(0)
 
 	// If checkpoint.Offset is empty that means no messages has been processed from an event hub partition

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -38,13 +38,14 @@ import (
 )
 
 const (
-	defaultEventHubMessageThreshold = 64
-	eventHubMetricType              = "External"
-	thresholdMetricName             = "unprocessedEventThreshold"
-	activationThresholdMetricName   = "activationUnprocessedEventThreshold"
-	defaultEventHubConsumerGroup    = "$Default"
-	defaultBlobContainer            = ""
-	defaultCheckpointStrategy       = ""
+	defaultEventHubMessageThreshold    = 64
+	eventHubMetricType                 = "External"
+	thresholdMetricName                = "unprocessedEventThreshold"
+	activationThresholdMetricName      = "activationUnprocessedEventThreshold"
+	defaultEventHubConsumerGroup       = "$Default"
+	defaultBlobContainer               = ""
+	defaultCheckpointStrategy          = ""
+	defaultStalePartitionInfoThreshold = 10000
 )
 
 type azureEventHubScaler struct {
@@ -56,10 +57,11 @@ type azureEventHubScaler struct {
 }
 
 type eventHubMetadata struct {
-	eventHubInfo        azure.EventHubInfo
-	threshold           int64
-	activationThreshold int64
-	scalerIndex         int
+	eventHubInfo                azure.EventHubInfo
+	threshold                   int64
+	activationThreshold         int64
+	stalePartitionInfoThreshold int64
+	scalerIndex                 int
 }
 
 // NewAzureEventHubScaler creates a new scaler for eventHub
@@ -178,6 +180,15 @@ func parseCommonAzureEventHubMetadata(config *ScalerConfig, meta *eventHubMetada
 	}
 	meta.eventHubInfo.ActiveDirectoryEndpoint = activeDirectoryEndpoint
 
+	meta.stalePartitionInfoThreshold = defaultStalePartitionInfoThreshold
+	if val, ok := config.TriggerMetadata["stalePartitionInfoThreshold"]; ok {
+		stalePartitionInfoThreshold, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return fmt.Errorf("error parsing azure eventhub metadata stalePartitionInfoThreshold: %w", err)
+		}
+		meta.stalePartitionInfoThreshold = stalePartitionInfoThreshold
+	}
+
 	meta.scalerIndex = config.ScalerIndex
 
 	return nil
@@ -286,35 +297,45 @@ func (s *azureEventHubScaler) GetUnprocessedEventCountInPartition(ctx context.Co
 		return -1, azure.Checkpoint{}, fmt.Errorf("unable to get checkpoint from storage: %w", err)
 	}
 
-	unprocessedEventCountInPartition := int64(0)
+	unprocessedEventCountInPartition := calculateUnprocessedEvents(ctx, partitionInfo, checkpoint, s.metadata.stalePartitionInfoThreshold)
+
+	return unprocessedEventCountInPartition, checkpoint, nil
+}
+
+func calculateUnprocessedEvents(ctx context.Context, partitionInfo *eventhub.HubPartitionRuntimeInformation, checkpoint azure.Checkpoint, stalePartitionInfoThreshold int64) int64 {
+	unprocessedEventCount := int64(0)
 
 	// If checkpoint.Offset is empty that means no messages has been processed from an event hub partition
 	// And since partitionInfo.LastSequenceNumber = 0 for the very first message hence
 	// total unprocessed message will be partitionInfo.LastSequenceNumber + 1
 	if checkpoint.Offset == "" {
-		unprocessedEventCountInPartition = partitionInfo.LastSequenceNumber + 1
-		return unprocessedEventCountInPartition, checkpoint, nil
+		unprocessedEventCount = partitionInfo.LastSequenceNumber + 1
+		return unprocessedEventCount
 	}
 
 	if partitionInfo.LastSequenceNumber >= checkpoint.SequenceNumber {
-		unprocessedEventCountInPartition = partitionInfo.LastSequenceNumber - checkpoint.SequenceNumber
-		return unprocessedEventCountInPartition, checkpoint, nil
+		unprocessedEventCount = partitionInfo.LastSequenceNumber - checkpoint.SequenceNumber
+	} else {
+		// Partition is a circular buffer, so it is possible that
+		// partitionInfo.LastSequenceNumber < blob checkpoint's SequenceNumber
+
+		// Checkpointing may or may not be always behind partition's LastSequenceNumber.
+		// The partition information read could be stale compared to checkpoint,
+		// especially when load is very small and checkpointing is happening often.
+		// This also results in partitionInfo.LastSequenceNumber < blob checkpoint's SequenceNumber
+		// e.g., (9223372036854775807 - 15) + 10 = 9223372036854775802
+
+		// Calculate the unprocessed events
+		unprocessedEventCount = (math.MaxInt64 - checkpoint.SequenceNumber) + partitionInfo.LastSequenceNumber
 	}
 
-	// Partition is a circular buffer, so it is possible that
-	// partitionInfo.LastSequenceNumber < blob checkpoint's SequenceNumber
-	unprocessedEventCountInPartition = (math.MaxInt64 - checkpoint.SequenceNumber) + partitionInfo.LastSequenceNumber
-
-	// Checkpointing may or may not be always behind partition's LastSequenceNumber.
-	// The partition information read could be stale compared to checkpoint,
-	// especially when load is very small and checkpointing is happening often.
-	// e.g., (9223372036854775807 - 10) + 11 = -9223372036854775808
-	// If unprocessedEventCountInPartition is negative that means there are 0 unprocessed messages in the partition
-	if unprocessedEventCountInPartition < 0 {
-		unprocessedEventCountInPartition = 0
+	// If the result is greater than the buffer size - stale partition threshold
+	// we assume the partition info is stale.
+	if unprocessedEventCount > (math.MaxInt64 - stalePartitionInfoThreshold) {
+		return 0
 	}
 
-	return unprocessedEventCountInPartition, checkpoint, nil
+	return unprocessedEventCount
 }
 
 // GetUnprocessedEventCountWithoutCheckpoint returns the number of messages on the without a checkoutpoint info
@@ -386,8 +407,14 @@ func (s *azureEventHubScaler) GetMetricsAndActivity(ctx context.Context, metricN
 
 		totalUnprocessedEventCount += unprocessedEventCount
 
-		s.logger.V(1).Info(fmt.Sprintf("Partition ID: %s, Last Enqueued Offset: %s, Checkpoint Offset: %s, Total new events in partition: %d",
-			partitionRuntimeInfo.PartitionID, partitionRuntimeInfo.LastEnqueuedOffset, checkpoint.Offset, unprocessedEventCount))
+		s.logger.V(1).Info(fmt.Sprintf("Partition ID: %s, Last SequenceNumber: %d, Checkpoint SequenceNumber: %d, Total new events in partition: %d",
+			partitionRuntimeInfo.PartitionID, partitionRuntimeInfo.LastSequenceNumber, checkpoint.SequenceNumber, unprocessedEventCount))
+	}
+
+	// set count to max if the sum is negative (Int64 overflow) to prevent negative metric values
+	// e.g., 9223372036854775797 (Partition 1) + 20 (Partition 2) = -9223372036854775799
+	if totalUnprocessedEventCount < 0 {
+		totalUnprocessedEventCount = math.MaxInt64
 	}
 
 	// don't scale out beyond the number of partitions

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -666,7 +666,7 @@ func TestEventHubGetMetricSpecForScaling(t *testing.T) {
 
 func TestCalculateUnprocessedEvents(t *testing.T) {
 	for _, testData := range calculateUnprocessedEventsDataset {
-		v := calculateUnprocessedEvents(context.Background(), testData.partitionInfo, testData.checkpoint, defaultStalePartitionInfoThreshold)
+		v := calculateUnprocessedEvents(testData.partitionInfo, testData.checkpoint, defaultStalePartitionInfoThreshold)
 		if v != testData.unprocessedEvents {
 			t.Errorf("Wrong calculation: expected %d, got %d", testData.unprocessedEvents, v)
 		}

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -43,6 +43,12 @@ type eventHubMetricIdentifier struct {
 	name             string
 }
 
+type calculateUnprocessedEventsTestData struct {
+	partitionInfo     *eventhub.HubPartitionRuntimeInformation
+	checkpoint        azure.Checkpoint
+	unprocessedEvents int64
+}
+
 var sampleEventHubResolvedEnv = map[string]string{eventHubConnectionSetting: eventHubsConnection, storageConnectionSetting: "none"}
 
 var parseEventHubMetadataDataset = []parseEventHubMetadataTestData{
@@ -199,6 +205,57 @@ var parseEventHubMetadataDatasetWithPodIdentity = []parseEventHubMetadataTestDat
 		metadata:    map[string]string{"cloud": "private", "endpointSuffix": serviceBusEndpointSuffix, "activeDirectoryEndpoint": activeDirectoryEndpoint, "eventHubResourceURL": eventHubResourceURL, "storageAccountName": "aStorageAccount", "storageEndpointSuffix": storageEndpointSuffix, "consumerGroup": eventHubConsumerGroup, "unprocessedEventThreshold": "15", "eventHubName": testEventHubName, "eventHubNamespace": testEventHubNamespace},
 		resolvedEnv: sampleEventHubResolvedEnv,
 		isError:     false,
+	},
+}
+
+var calculateUnprocessedEventsDataset = []calculateUnprocessedEventsTestData{
+	{
+		checkpoint:        azure.NewCheckpoint("1", 5),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 10, LastEnqueuedOffset: "2"},
+		unprocessedEvents: 5,
+	},
+	{
+		checkpoint:        azure.NewCheckpoint("1002", 4611686018427387903),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905, LastEnqueuedOffset: "1000"},
+		unprocessedEvents: 2,
+	},
+	{
+		checkpoint:        azure.NewCheckpoint("900", 4611686018427387900),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905, LastEnqueuedOffset: "1000"},
+		unprocessedEvents: 5,
+	},
+	{
+		checkpoint:        azure.NewCheckpoint("800", 4000000000000200000),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4000000000000000000, LastEnqueuedOffset: "750"},
+		unprocessedEvents: 9223372036854575807,
+	},
+	// Empty checkpoint
+	{
+		checkpoint:        azure.NewCheckpoint("", 0),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 1, LastEnqueuedOffset: "1"},
+		unprocessedEvents: 2,
+	},
+	// Stale PartitionInfo
+	{
+		checkpoint:        azure.NewCheckpoint("5", 15),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 10, LastEnqueuedOffset: "2"},
+		unprocessedEvents: 0,
+	},
+	{
+		checkpoint:        azure.NewCheckpoint("1000", 4611686018427387910),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905, LastEnqueuedOffset: "900"},
+		unprocessedEvents: 0,
+	},
+	{
+		checkpoint:        azure.NewCheckpoint("1", 5),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 9223372036854775797, LastEnqueuedOffset: "10000"},
+		unprocessedEvents: 0,
+	},
+	// Circular buffer reset
+	{
+		checkpoint:        azure.NewCheckpoint("100000", 9223372036854775797),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 5, LastEnqueuedOffset: "1"},
+		unprocessedEvents: 15,
 	},
 }
 
@@ -603,6 +660,15 @@ func TestEventHubGetMetricSpecForScaling(t *testing.T) {
 		metricName := metricSpec[0].External.Metric.Name
 		if metricName != testData.name {
 			t.Error("Wrong External metric source name:", metricName)
+		}
+	}
+}
+
+func TestCalculateUnprocessedEvents(t *testing.T) {
+	for _, testData := range calculateUnprocessedEventsDataset {
+		v := calculateUnprocessedEvents(context.Background(), testData.partitionInfo, testData.checkpoint, defaultStalePartitionInfoThreshold)
+		if v != testData.unprocessedEvents {
+			t.Errorf("Wrong calculation: expected %d, got %d", testData.unprocessedEvents, v)
 		}
 	}
 }


### PR DESCRIPTION
This PR improves the Event Hub unprocessed event count calculation to prevent negative and large values.

There are two issues in the current implementation:

1. Stale partition runtime information results in very large values:
The scaling calculation uses the **SequenceNumber** from the partition runtime information and the checkpoint store.
Partition information could be stale compared to the checkpoint, for example when the partition runtime information is **10** and the checkpoint is **15**. This should result in **0** and not in **9223372036854775802**.

2. When the sum of all unprocessed events per partition is greater than the Int64 max value the result is negative:
When there are a lot of unprocessed events (mostly caused by the first issue), the sum of all unprocessed events per partition is greater than the Int64 max value, resulting in a negative value.
Using the first example: Partition 1 (9223372036854775802) + Partition 2 (100) = -9223372036854775714
In this case the result should be the Int64 max value, which will result in the max value for `lagRelatedToPartitionCount`: `(partitionCount * threshold)`.

To solve the first issue I introduced a new parameter `stalePartitionInfoThreshold` to configure the stale partition information threshold.
This configures the range to decide if the partition information is stale or if the Event Hub went almost through the full circular buffer.

Using the first example to explain the new implementation:

- Partition information sequence number: **10**
- Checkpoint store sequence number: **15**
- `stalePartitionInfoThreshold`: **10000**
    - Results in 9223372036854765807 (Int64 max value - threshold) max unprocessed events for the partition info not to be considered stale.
- Distance between the checkpoint and the partition info:  **9223372036854775802**
-  **9223372036854775802** > **9223372036854765807**, so the partition info is stale. Return **0** as the unprocessed event count for the partition because all data is processed.

Visualization:
![stalePartitionInfoThreshold](https://github.com/kedacore/keda/assets/17150300/49de56ac-4b3e-46bb-b1e2-7c1754f5eae8)

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #4250