### PR TITLE
TriggerAuth-podIdentity.identityId - validation removed (operator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Fix CVE-2023-39325 in golang.org/x/net ([#5122](https://github.com/kedacore/keda/issues/5122))
 - **General**: Prevented stuck status due to timeouts during scalers generation ([#5083](https://github.com/kedacore/keda/issues/5083))
+- **General**: TriggerAuthentication - validation `identityId` removed from the operator ([#5109](https://github.com/kedacore/keda/issues/5109))
 - **Azure Pipelines**: No more HTTP 400 errors produced by poolName with spaces ([#5107](https://github.com/kedacore/keda/issues/5107))
 - **ScaledJobs**: Copy ScaledJob annotations to child Jobs ([#4594](https://github.com/kedacore/keda/issues/4594))
 

--- a/apis/keda/v1alpha1/triggerauthentication_webhook.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook.go
@@ -107,11 +107,11 @@ func isTriggerAuthenticationRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1
 }
 
 func validateSpec(spec *TriggerAuthenticationSpec) (admission.Warnings, error) {
-	err := validatePodIdentityId(spec.PodIdentity)
+	err := validatePodIdentityID(spec.PodIdentity)
 	return nil, err
 }
 
-func validatePodIdentityId(podIdentity *AuthPodIdentity) error {
+func validatePodIdentityID(podIdentity *AuthPodIdentity) error {
 	if podIdentity != nil {
 		switch podIdentity.Provider {
 		case PodIdentityProviderAzure, PodIdentityProviderAzureWorkload:

--- a/apis/keda/v1alpha1/triggerauthentication_webhook.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook.go
@@ -108,10 +108,7 @@ func isTriggerAuthenticationRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1
 
 func validateSpec(spec *TriggerAuthenticationSpec) (admission.Warnings, error) {
 	err := validatePodIdentityId(spec.PodIdentity)
-	if err != nil {
-		return nil, err
-	}
-	return nil, nil
+	return nil, err
 }
 
 func validatePodIdentityId(podIdentity *AuthPodIdentity) error {

--- a/apis/keda/v1alpha1/triggerauthentication_webhook.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook.go
@@ -107,15 +107,27 @@ func isTriggerAuthenticationRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1
 }
 
 func validateSpec(spec *TriggerAuthenticationSpec) (admission.Warnings, error) {
-	if spec.PodIdentity != nil {
-		switch spec.PodIdentity.Provider {
-		case PodIdentityProviderAzure, PodIdentityProviderAzureWorkload:
-			if spec.PodIdentity.IdentityID != nil && *spec.PodIdentity.IdentityID == "" {
-				return nil, fmt.Errorf("identityid of PodIdentity should not be empty. If it's set, identityId has to be different than \"\"")
-			}
-		default:
-			return nil, nil
-		}
+	err := validatePodIdentityId(spec.PodIdentity)
+	if err != nil {
+		return nil, err
 	}
 	return nil, nil
+}
+
+func validatePodIdentityId(podIdentity *AuthPodIdentity) error {
+	if podIdentity != nil {
+		switch podIdentity.Provider {
+		case PodIdentityProviderAzure, PodIdentityProviderAzureWorkload:
+			if isEmptyString(podIdentity.IdentityID) {
+				return fmt.Errorf("identityid of PodIdentity should not be empty. If it's set, identityId has to be different than \"\"")
+			}
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+func isEmptyString(str *string) bool {
+	return str != nil && *str == ""
 }

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -202,9 +202,6 @@ func ResolveAuthRefAndPodIdentity(ctx context.Context, client client.Client, log
 				// FIXME: Delete this for v2.15
 				logger.Info("WARNING: Azure AD Pod Identity has been archived (https://github.com/Azure/aad-pod-identity#-announcement) and will be removed from KEDA on v2.15")
 			}
-			if podIdentity.IdentityID != nil && *podIdentity.IdentityID == "" {
-				return nil, kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderNone}, fmt.Errorf("IdentityID of PodIdentity should not be empty")
-			}
 		default:
 		}
 		return authParams, podIdentity, nil


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

TriggerAuthentication.podIdentity - validation of `identityId` (empty string "") removed (operator)
- validation remains only in webhook

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/5109

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
