### PR TITLE
Feat: Enhance podIdentity Role Assumption in AWS by Direct Integration with OIDC/Federation and Implement Credentials Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Here is an overview of all new **experimental** features:
 - **Kafka Scaler**: Add support for Kerberos authentication (SASL / GSSAPI) ([#4836](https://github.com/kedacore/keda/issues/4836))
 - **Prometheus Metrics**: Introduce paused ScaledObjects in Prometheus metrics ([#4430](https://github.com/kedacore/keda/issues/4430))
 - **Pulsar Scaler**: support endpointParams in pulsar oauth ([#5069](https://github.com/kedacore/keda/issues/5069))
+- **General**: Enhance podIdentity Role Assumption in AWS by Direct Integration with OIDC/Federation ([#5178](https://github.com/kedacore/keda/issues/5178))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Here is an overview of all new **experimental** features:
 - **Prometheus Metrics**: Introduce paused ScaledObjects in Prometheus metrics ([#4430](https://github.com/kedacore/keda/issues/4430))
 - **Pulsar Scaler**: support endpointParams in pulsar oauth ([#5069](https://github.com/kedacore/keda/issues/5069))
 - **General**: Enhance podIdentity Role Assumption in AWS by Direct Integration with OIDC/Federation ([#5178](https://github.com/kedacore/keda/issues/5178))
+- **General**: Implement Credentials Cache for AWS Roles to reduce AWS API calls ([#5297](https://github.com/kedacore/keda/issues/5297))
 
 ### Fixes
 

--- a/pkg/scalers/aws_common.go
+++ b/pkg/scalers/aws_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -31,7 +32,85 @@ type awsConfigMetadata struct {
 	awsAuthorization awsAuthorizationMetadata
 }
 
-func getAwsConfig(ctx context.Context, awsRegion string, awsAuthorization awsAuthorizationMetadata) (*aws.Config, error) {
+type CacheEntry struct {
+	credentials *aws.CredentialsCache
+	usages      map[string]bool // Tracks the scaledObjects requested the cache
+}
+
+var (
+	roleCredentialsCache = make(map[string]CacheEntry)
+	mu                   sync.Mutex
+)
+
+func getCredentialsForRole(cfg aws.Config, roleArn string, scalerUniqueKey string) (*aws.CredentialsCache, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if cachedEntry, exists := roleCredentialsCache[roleArn]; exists {
+		cachedEntry.usages[scalerUniqueKey] = true
+		roleCredentialsCache[roleArn] = cachedEntry
+		return cachedEntry.credentials, nil
+	}
+
+	cachedProvider, err := retrieveCredentials(cfg, roleArn)
+	if err != nil {
+		return nil, err
+	}
+
+	newCacheEntry := CacheEntry{
+		credentials: cachedProvider,
+		usages:      map[string]bool{scalerUniqueKey: true},
+	}
+
+	roleCredentialsCache[roleArn] = newCacheEntry
+
+	return cachedProvider, nil
+
+}
+
+func retrieveCredentials(cfg aws.Config, roleArn string) (*aws.CredentialsCache, error) {
+	stsSvc := sts.NewFromConfig(cfg)
+	webIdentityTokenFile := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")
+
+	webIdentityCredentialProvider := stscreds.NewWebIdentityRoleProvider(stsSvc, roleArn, stscreds.IdentityTokenFile(webIdentityTokenFile), func(options *stscreds.WebIdentityRoleOptions) {
+		options.RoleSessionName = "KEDA"
+	})
+	var cachedProvider *aws.CredentialsCache
+
+	_, err := webIdentityCredentialProvider.Retrieve(context.Background())
+	if err != nil {
+		// Fallback to Assume Role
+		assumeRoleCredentialProvider := stscreds.NewAssumeRoleProvider(stsSvc, roleArn, func(options *stscreds.AssumeRoleOptions) {
+			options.RoleSessionName = "KEDA"
+		})
+		cachedProvider = aws.NewCredentialsCache(assumeRoleCredentialProvider)
+	} else {
+		cachedProvider = aws.NewCredentialsCache(webIdentityCredentialProvider)
+	}
+	return cachedProvider, nil
+}
+
+func removeCachedEntry(scalerUniqueKey string, roleArn string) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if cachedEntry, exists := roleCredentialsCache[roleArn]; exists {
+		// Delete the scalerUniqueKey from usages
+		delete(cachedEntry.usages, scalerUniqueKey)
+
+		// If no more usages, delete the entire entry from the cache
+		if len(cachedEntry.usages) == 0 {
+			delete(roleCredentialsCache, roleArn)
+		} else {
+			roleCredentialsCache[roleArn] = cachedEntry
+		}
+	}
+
+	return nil
+
+}
+
+func getAwsConfig(ctx context.Context, awsRegion string, awsAuthorization awsAuthorizationMetadata, scalerUniqueKey string) (*aws.Config, error) {
 	metadata := &awsConfigMetadata{
 		awsRegion:        awsRegion,
 		awsAuthorization: awsAuthorization,
@@ -52,25 +131,7 @@ func getAwsConfig(ctx context.Context, awsRegion string, awsAuthorization awsAut
 	}
 
 	if metadata.awsAuthorization.awsRoleArn != "" {
-		stsSvc := sts.NewFromConfig(cfg)
-
-		// Create the web identity role provider
-		stsCredentialProvider := stscreds.NewWebIdentityRoleProvider(
-			stsSvc,
-			metadata.awsAuthorization.awsRoleArn,
-			stscreds.IdentityTokenFile(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE")),
-		)
-
-		// Attempt to retrieve credentials
-		_, err := stsCredentialProvider.Retrieve(context.Background())
-		if err != nil {
-			// Setup AssumeRoleProvider as a fallback
-			assumeRoleCredentialProvider := stscreds.NewAssumeRoleProvider(stsSvc, metadata.awsAuthorization.awsRoleArn, func(options *stscreds.AssumeRoleOptions) {})
-			cfg.Credentials = aws.NewCredentialsCache(assumeRoleCredentialProvider)
-		} else {
-			// If the retrieval is successful, use the web identity credentials
-			cfg.Credentials = aws.NewCredentialsCache(stsCredentialProvider)
-		}
+		cfg.Credentials, err = getCredentialsForRole(cfg, metadata.awsAuthorization.awsRoleArn, scalerUniqueKey)
 	}
 
 	return &cfg, err

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -102,6 +102,9 @@ type ScalerConfig struct {
 
 	// When we use the scaler for composite scaler, we shouldn't require the value because it'll be ignored
 	AsMetricSource bool
+
+	// UniqueName for the scaler to track things like caching, required for AWS scalers
+	ScalerUniqueKey string
 }
 
 var (

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -65,6 +65,7 @@ func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alp
 				ScalerIndex:             triggerIndex,
 				MetricType:              trigger.MetricType,
 				AsMetricSource:          asMetricSource,
+				ScalerUniqueKey:         trigger.Name + "-" + withTriggers.Name + "-" + withTriggers.Namespace + "-" + withTriggers.Kind,
 			}
 
 			authParams, podIdentity, err := resolver.ResolveAuthRefAndPodIdentity(ctx, h.client, logger, trigger.AuthenticationRef, podTemplateSpec, withTriggers.Namespace, h.secretsLister)


### PR DESCRIPTION
In the existing setup, when AWS roles are overridden through pod identity mechanism or by specifying the awsRoleArn trigger authentication environment variable, KEDA attempts to assume the specified role using its Operator's IAM role. This process necessitates granting the KEDA operator's role the necessary permissions to assume the target role. Additionally, the trust relationship on the target role must be configured to permit this assumption. While this approach aligns well with setups using kube2iam, it introduces a redundant step in environments that utilize IRSA.

The proposed Pull Request (PR) enables KEDA to directly assume AWS roles by using OpenID Connect (OIDC) and federation mechanisms. This direct method bypasses the need to configure additional permissions on the KEDA operator's role. By doing so, it simplifies the role assumption process in IRSA environments, reducing the configuration overhead typically associated with setting up cross-account role permissions and trust policies.
The modification maintains backward compatibility; if role assumption is unsuccessful, it will revert to attempting role assumption via the operator's role

Additionally, this update **introduces a credentials cache for AWS roles**. When multiple ScaledObjects utilize the same AWS role, this cache significantly cuts down on the number of AWS API calls.


### Checklist

- [ ] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #5178
Fixes #5297 

