### PR TITLE
Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Add parameter queryParameters to prometheus-scaler ([#4962](https://github.com/kedacore/keda/issues/4962))
 - **General**: Support TriggerAuthentication properties from ConfigMap ([#4830](https://github.com/kedacore/keda/issues/4830))
-- **Hashicorp Vault*: Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set ([#4964](https://github.com/kedacore/keda/issues/4964))
+- **Hashicorp Vault**: Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set ([#4964](https://github.com/kedacore/keda/issues/4964))
 - **Hashicorp Vault**: Add support to get secret that needs write operation (e.g. pki) ([#5067](https://github.com/kedacore/keda/issues/5067))
 - **Kafka Scaler**: Ability to set upper bound to the number of partitions with lag ([#3997](https://github.com/kedacore/keda/issues/3997))
 - **Kafka Scaler**: Add more logging to check Sarama DescribeTopics method ([#5102](https://github.com/kedacore/keda/issues/5102))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Add parameter queryParameters to prometheus-scaler ([#4962](https://github.com/kedacore/keda/issues/4962))
 - **General**: Support TriggerAuthentication properties from ConfigMap ([#4830](https://github.com/kedacore/keda/issues/4830))
+- **Hashicorp Vault*: Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set ([#4964](https://github.com/kedacore/keda/issues/4964))
 - **Hashicorp Vault**: Add support to get secret that needs write operation (e.g. pki) ([#5067](https://github.com/kedacore/keda/issues/5067))
 - **Kafka Scaler**: Ability to set upper bound to the number of partitions with lag ([#3997](https://github.com/kedacore/keda/issues/3997))
 - **Kafka Scaler**: Add more logging to check Sarama DescribeTopics method ([#5102](https://github.com/kedacore/keda/issues/5102))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,8 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Add parameter queryParameters to prometheus-scaler ([#4962](https://github.com/kedacore/keda/issues/4962))
 - **General**: Support TriggerAuthentication properties from ConfigMap ([#4830](https://github.com/kedacore/keda/issues/4830))
-- **Hashicorp Vault**: Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set ([#4964](https://github.com/kedacore/keda/issues/4964))
 - **Hashicorp Vault**: Add support to get secret that needs write operation (e.g. pki) ([#5067](https://github.com/kedacore/keda/issues/5067))
+- **Hashicorp Vault**: Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set ([#4964](https://github.com/kedacore/keda/issues/4964))
 - **Kafka Scaler**: Ability to set upper bound to the number of partitions with lag ([#3997](https://github.com/kedacore/keda/issues/3997))
 - **Kafka Scaler**: Add more logging to check Sarama DescribeTopics method ([#5102](https://github.com/kedacore/keda/issues/5102))
 - **Kafka Scaler**: Add support for Kerberos authentication (SASL / GSSAPI) ([#4836](https://github.com/kedacore/keda/issues/4836))

--- a/pkg/scaling/resolver/hashicorpvault_handler.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler.go
@@ -110,6 +110,13 @@ func (vh *HashicorpVaultHandler) token(client *vaultapi.Client) (string, error) 
 			return token, errors.New("k8s role not in config")
 		}
 
+		if vh.vault.Credential == nil {
+			defaultCred := kedav1alpha1.Credential{
+				ServiceAccount: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+			}
+			vh.vault.Credential = &defaultCred
+		}
+
 		if len(vh.vault.Credential.ServiceAccount) == 0 {
 			return token, errors.New("k8s SA file not in config")
 		}

--- a/pkg/scaling/resolver/hashicorpvault_handler_test.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler_test.go
@@ -345,6 +345,25 @@ func TestHashicorpVaultHandler_ResolveSecret(t *testing.T) {
 	}
 }
 
+func TestHashicorpVaultHandler_DefaultKubernetesVaultRole(t *testing.T) {
+	defaultServiceAccountPath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	server := mockVault(t)
+	defer server.Close()
+
+	vault := kedav1alpha1.HashiCorpVault{
+		Address:        server.URL,
+		Authentication: kedav1alpha1.VaultAuthenticationKubernetes,
+		Mount:          "my-mount",
+		Role:           "my-role",
+	}
+
+	vaultHandler := NewHashicorpVaultHandler(&vault)
+	err := vaultHandler.Initialize(logf.Log.WithName("test"))
+	defer vaultHandler.Stop()
+	assert.Errorf(t, err, "open %s : no such file or directory", defaultServiceAccountPath)
+	assert.Equal(t, vaultHandler.vault.Credential.ServiceAccount, defaultServiceAccountPath)
+}
+
 func TestHashicorpVaultHandler_ResolveSecrets_SameCertAndKey(t *testing.T) {
 	server := mockVault(t)
 	defer server.Close()


### PR DESCRIPTION
Hi team,
This PR fixes the issue where the operator panics when `spec.hashiCorpVault.credential.serviceAccount` is not set
There are two ways we can fix this:
- One way is to throw out error
- Another way is to set a default value to `spec.hashiCorpVault.credential.serviceAccount=/var/run/secrets/kubernetes.io/serviceaccount/token`

Personally I prefer the second option. Please let me know your preference so that I can make changes to the documentation repo accordingly.
### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/4964

