### PR TITLE
Add prerun `TestMain` function to test utils

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -208,6 +208,22 @@ func GetKubernetesClient(t *testing.T) *kubernetes.Clientset {
 	return KubeClient
 }
 
+func GetKubernetesClientOrError() (*kubernetes.Clientset, error) {
+	if KubeClient != nil && KubeConfig != nil {
+		return KubeClient, nil
+	}
+	var err error
+	KubeConfig, err = config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	KubeClient, err = kubernetes.NewForConfig(KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return KubeClient, nil
+}
+
 func GetKedaKubernetesClient(t *testing.T) *v1alpha1.KedaV1alpha1Client {
 	if KedaKubeClient != nil && KubeConfig != nil {
 		return KedaKubeClient

--- a/tests/utils/main_test.go
+++ b/tests/utils/main_test.go
@@ -1,0 +1,22 @@
+//go:build e2e
+// +build e2e
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
+)
+
+func TestMain(m *testing.M) {
+	var err error
+	KubeClient, err = GetKubernetesClientOrError()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting kubernetes client - %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -27,10 +27,6 @@ func TestVerifyCommands(t *testing.T) {
 	}
 }
 
-func TestKubernetesConnection(t *testing.T) {
-	KubeClient = GetKubernetesClient(t)
-}
-
 func TestKubernetesVersion(t *testing.T) {
 	out, err := ExecuteCommand("kubectl version")
 	require.NoErrorf(t, err, "error getting kubernetes version - %s", err)
@@ -77,7 +73,6 @@ func TestSetupCertManager(t *testing.T) {
 	_, err = ExecuteCommand("helm repo update jetstack")
 	require.NoErrorf(t, err, "cannot update jetstack helm repo - %s", err)
 
-	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, CertManagerNamespace)
 
 	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install cert-manager jetstack/cert-manager --namespace %s --set installCRDs=true",
@@ -99,7 +94,6 @@ func TestSetupWorkloadIdentityComponents(t *testing.T) {
 	_, err = ExecuteCommand("helm repo update azure-workload-identity")
 	require.NoErrorf(t, err, "cannot update workload identity helm repo - %s", err)
 
-	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, AzureWorkloadIdentityNamespace)
 
 	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install workload-identity-webhook azure-workload-identity/workload-identity-webhook --namespace %s --set azureTenantID=%s",
@@ -121,7 +115,6 @@ func TestSetupAwsIdentityComponents(t *testing.T) {
 	_, err = ExecuteCommand("helm repo update jkroepke")
 	require.NoErrorf(t, err, "cannot update jkroepke helm repo - %s", err)
 
-	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, AwsIdentityNamespace)
 
 	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install aws-identity-webhook jkroepke/amazon-eks-pod-identity-webhook --namespace %s --set fullnameOverride=aws-identity-webhook",
@@ -143,7 +136,6 @@ func TestSetupGcpIdentityComponents(t *testing.T) {
 	_, err = ExecuteCommand("helm repo update gcp-workload-identity-federation-webhook")
 	require.NoErrorf(t, err, "cannot update gcp-workload-identity-federation-webhook helm repo - %s", err)
 
-	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, GcpIdentityNamespace)
 
 	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install gcp-identity-webhook gcp-workload-identity-federation-webhook/gcp-workload-identity-federation-webhook --namespace %s --set fullnameOverride=gcp-identity-webhook --set controllerManager.manager.args[0]=--token-default-mode=0444",
@@ -197,7 +189,6 @@ func TestSetupOpentelemetryComponents(t *testing.T) {
 }
 
 func TestDeployKEDA(t *testing.T) {
-	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, KEDANamespace)
 
 	caCtr, _ := GetTestCA(t)
@@ -244,7 +235,6 @@ func TestSetupAadPodIdentityComponents(t *testing.T) {
 	_, err = ExecuteCommand("helm repo update aad-pod-identity")
 	require.NoErrorf(t, err, "cannot update aad pod identity helm repo - %s", err)
 
-	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, AzureAdPodIdentityNamespace)
 
 	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install "+
@@ -266,8 +256,6 @@ func TestSetUpStrimzi(t *testing.T) {
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 	_, err = ExecuteCommand("helm repo update")
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
-
-	KubeClient = GetKubernetesClient(t)
 
 	CreateNamespace(t, KubeClient, StrimziNamespace)
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

In my individual testing I was using [TestVerifyKEDA](https://github.com/josefkarasek/keda/blob/2bf1dafd55321f5aad06c81a2c63024956206e6d/tests/utils/setup_test.go#L215) to wait for keda cluster to come up, but it didn't work because the test didn't have kubernetes client.

Since  [TestMain](https://pkg.go.dev/testing#hdr-Main) is a standard way in go testing to setup test env before the test suite is executed, I think that this change can be beneficial for other keda users.


### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->


<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
