### PR TITLE
chore(e2e): Print KEDA logs despite installation fails

### DIFF
--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -52,6 +52,7 @@ func main() {
 	installation := executeTest(ctx, "tests/utils/setup_test.go", "15m", 1)
 	fmt.Print(installation.Attempts[0])
 	if !installation.Passed {
+		printKedaLogs()
 		uninstallKeda(ctx)
 		os.Exit(1)
 	}
@@ -225,32 +226,7 @@ func executeRegularTests(ctx context.Context, testCases []string) []TestResult {
 	}
 
 	if len(testResults) > 0 {
-		kubeConfig, _ := config.GetConfig()
-		kubeClient, _ := kubernetes.NewForConfig(kubeConfig)
-
-		operatorLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-operator")
-		if err == nil {
-			fmt.Println(">>> KEDA Operator log <<<")
-			fmt.Println(operatorLogs)
-			fmt.Println("##############################################")
-			fmt.Println("##############################################")
-		}
-
-		msLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-metrics-apiserver")
-		if err == nil {
-			fmt.Println(">>> KEDA Metrics Server log <<<")
-			fmt.Println(msLogs)
-			fmt.Println("##############################################")
-			fmt.Println("##############################################")
-		}
-
-		hooksLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-admission-webhooks")
-		if err == nil {
-			fmt.Println(">>> KEDA Admission Webhooks log <<<")
-			fmt.Println(hooksLogs)
-			fmt.Println("##############################################")
-			fmt.Println("##############################################")
-		}
+		printKedaLogs()
 	}
 	return testResults
 }
@@ -366,4 +342,33 @@ func numberToWord(num int) string {
 		return words[num]
 	}
 	return fmt.Sprintf("%d", num)
+}
+
+func printKedaLogs() {
+	kubeConfig, _ := config.GetConfig()
+	kubeClient, _ := kubernetes.NewForConfig(kubeConfig)
+
+	operatorLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-operator")
+	if err == nil {
+		fmt.Println(">>> KEDA Operator log <<<")
+		fmt.Println(operatorLogs)
+		fmt.Println("##############################################")
+		fmt.Println("##############################################")
+	}
+
+	msLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-metrics-apiserver")
+	if err == nil {
+		fmt.Println(">>> KEDA Metrics Server log <<<")
+		fmt.Println(msLogs)
+		fmt.Println("##############################################")
+		fmt.Println("##############################################")
+	}
+
+	hooksLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-admission-webhooks")
+	if err == nil {
+		fmt.Println(">>> KEDA Admission Webhooks log <<<")
+		fmt.Println(hooksLogs)
+		fmt.Println("##############################################")
+		fmt.Println("##############################################")
+	}
 }


### PR DESCRIPTION
Currently [we don't have info if KEDA installation fails during e2e tests.](https://github.com/kedacore/keda/actions/runs/7008809642) This PR exposes the logs if KEDA fails during the installation process.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
