### PR TITLE
chore: Enable cherry-pick-bot

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,2 @@
+enabled: true
+preservePullRequestTitle: true


### PR DESCRIPTION
This PR enables a [cherry-pick-bot](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot?rgh-link-date=2023-02-23T20%3A52%3A43Z) that will automate cherry picks into a PR. This will further increase our supply chain security by not requiring an approver to commit a cherry-pick directly to a release branch. Note: merge conflicts will still require manual intervention.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
