### PR TITLE
General: use client-side round-robin load balancing for grpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Add parameter queryParameters to prometheus-scaler ([#4962](https://github.com/kedacore/keda/issues/4962))
 - **General**: Support TriggerAuthentication properties from ConfigMap ([#4830](https://github.com/kedacore/keda/issues/4830))
+- **General**: Use client-side round-robin load balancing for grpc calls ([#5224](https://github.com/kedacore/keda/issues/5224))
 - **GCP pubsub scaler**: Support distribution-valued metrics and metrics from topics ([#5070](https://github.com/kedacore/keda/issues/5070))
 - **Hashicorp Vault**: Add support to get secret that needs write operation (e.g. pki) ([#5067](https://github.com/kedacore/keda/issues/5067))
 - **Hashicorp Vault**: Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set ([#4964](https://github.com/kedacore/keda/issues/4964))

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -37,7 +37,8 @@ type GrpcClient struct {
 }
 
 func NewGrpcClient(url, certDir string) (*GrpcClient, error) {
-	retryPolicy := `{
+	defaultConfig := `{
+		"loadBalancingConfig": [{"round_robin":{}}],
 		"methodConfig": [{
 		  "timeout": "3s",
 		  "waitForReady": true,
@@ -55,7 +56,7 @@ func NewGrpcClient(url, certDir string) (*GrpcClient, error) {
 	}
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
-		grpc.WithDefaultServiceConfig(retryPolicy),
+		grpc.WithDefaultServiceConfig(defaultConfig),
 	}
 	conn, err := grpc.Dial(url, opts...)
 	if err != nil {

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -38,7 +38,6 @@ type GrpcClient struct {
 
 func NewGrpcClient(url, certDir string) (*GrpcClient, error) {
 	defaultConfig := `{
-		"loadBalancingConfig": [{"round_robin":{}}],
 		"methodConfig": [{
 		  "timeout": "3s",
 		  "waitForReady": true,

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -50,6 +50,8 @@ type connectionGroup struct {
 // a pool of connectionGroup per metadata hash
 var connectionPool sync.Map
 
+const grpcConfig = `{"loadBalancingConfig": [{"round_robin":{}}]}`
+
 // NewExternalScaler creates a new external scaler - calls the GRPC interface
 // to create a new scaler
 func NewExternalScaler(config *ScalerConfig) (Scaler, error) {
@@ -302,7 +304,6 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 	connectionPoolMutex.Lock()
 	defer connectionPoolMutex.Unlock()
 
-	defaultConfig := `{"loadBalancingConfig": [{"round_robin":{}}]}`
 	buildGRPCConnection := func(metadata externalScalerMetadata) (*grpc.ClientConn, error) {
 		// FIXME: DEPRECATED to be removed in v2.13 https://github.com/kedacore/keda/issues/4549
 		if metadata.tlsCertFile != "" {
@@ -313,7 +314,7 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 				return nil, err
 			}
 			return grpc.Dial(metadata.scalerAddress,
-				grpc.WithDefaultServiceConfig(defaultConfig),
+				grpc.WithDefaultServiceConfig(grpcConfig),
 				grpc.WithTransportCredentials(creds))
 		}
 
@@ -325,12 +326,12 @@ func getClientForConnectionPool(metadata externalScalerMetadata, logger logr.Log
 		if len(tlsConfig.Certificates) > 0 || metadata.caCert != "" {
 			// nosemgrep: go.grpc.ssrf.grpc-tainted-url-host.grpc-tainted-url-host
 			return grpc.Dial(metadata.scalerAddress,
-				grpc.WithDefaultServiceConfig(defaultConfig),
+				grpc.WithDefaultServiceConfig(grpcConfig),
 				grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		}
 
 		return grpc.Dial(metadata.scalerAddress,
-			grpc.WithDefaultServiceConfig(defaultConfig),
+			grpc.WithDefaultServiceConfig(grpcConfig),
 			grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -246,7 +246,10 @@ func TestWaitForState(t *testing.T) {
 	}()
 
 	// build client connect to server
-	grpcClient, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	defaultConfig := `{"loadBalancingConfig": [{"round_robin":{}}]}`
+	grpcClient, err := grpc.Dial(address,
+		grpc.WithDefaultServiceConfig(defaultConfig),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Errorf("connect grpc server %s failed:%s", address, err)
 		return

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -246,9 +246,8 @@ func TestWaitForState(t *testing.T) {
 	}()
 
 	// build client connect to server
-	defaultConfig := `{"loadBalancingConfig": [{"round_robin":{}}]}`
 	grpcClient, err := grpc.Dial(address,
-		grpc.WithDefaultServiceConfig(defaultConfig),
+		grpc.WithDefaultServiceConfig(grpcConfig),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		t.Errorf("connect grpc server %s failed:%s", address, err)

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -68,10 +68,9 @@ func NewLiiklusScaler(config *ScalerConfig) (Scaler, error) {
 	if err != nil {
 		return nil, err
 	}
-	defaultConfig := `{"loadBalancingConfig": [{"round_robin":{}}]}`
 
 	conn, err := grpc.Dial(lm.address,
-		grpc.WithDefaultServiceConfig(defaultConfig),
+		grpc.WithDefaultServiceConfig(grpcConfig),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -68,8 +68,11 @@ func NewLiiklusScaler(config *ScalerConfig) (Scaler, error) {
 	if err != nil {
 		return nil, err
 	}
+	defaultConfig := `{"loadBalancingConfig": [{"round_robin":{}}]}`
 
-	conn, err := grpc.Dial(lm.address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(lm.address,
+		grpc.WithDefaultServiceConfig(defaultConfig),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Use Client-side grpc round-robin load balancing to better spread the load when using the external scaler;

**Scenario A:**
keda operator makes a grpc call to a Service with a clusterIP. There's only 1 clusterIP. This PR won't affect this setup. Load balancing (within k8s/iptables) only happens when new connections or a connection failure. Requests are hitting the same underlying pod; Users should migrate to headless service.

**Scenario B:**
Keda operator makes a grpc call to a headless service & DNS randomizes the pod IP order. load balancing happens whenever there's a connection failure or if the server set a MaxConnectionAge, otherwise 1 pod is going to be receiving the all of the load. This PR fixes this

**Scenario C:**
Keda operator makes a grpc call to a headless service & DNS doesn't randomize the pod IP order. load balancing currently never happens, 1 pod will be receiving all the load. This PR fixes this. 

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes # https://github.com/kedacore/keda/issues/5224
