### PR TITLE
chore: e2e test improvements

### DIFF
--- a/config/e2e/patch_operator.yml
+++ b/config/e2e/patch_operator.yml
@@ -26,7 +26,7 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: "http://opentelemetry-collector.default.svc.cluster.local:4318"
+    value: "http://opentelemetry-collector.open-telemetry-system.svc.cluster.local:4318"
 
 - op: add
   path: /spec/template/spec/containers/0/env/-

--- a/tests/clean-crds.sh
+++ b/tests/clean-crds.sh
@@ -3,7 +3,7 @@
 echo "Cleaning up CRDs before undeploying KEDA"
 while read -r namespace
 do
-    resources=$(kubectl get so,sj,ta,cta -n $namespace -o name)
+    resources=$(kubectl get so,sj,ta,cta,cloudeventsource -n $namespace -o name)
     if [[ -n  "$resources" ]]
     then
         kubectl delete $resources -n $namespace

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -153,7 +153,7 @@ func ExecCommandOnSpecificPod(t *testing.T, podName string, namespace string, co
 	}
 	buf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
-	request := KubeClient.CoreV1().RESTClient().Post().
+	request := GetKubernetesClient(t).CoreV1().RESTClient().Post().
 		Resource("pods").Name(podName).Namespace(namespace).
 		SubResource("exec").Timeout(time.Second*20).
 		VersionedParams(&corev1.PodExecOptions{
@@ -243,7 +243,7 @@ func CreateNamespace(t *testing.T, kc *kubernetes.Clientset, nsName string) {
 func DeleteNamespace(t *testing.T, nsName string) {
 	t.Logf("deleting namespace %s", nsName)
 	period := int64(0)
-	err := KubeClient.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{
+	err := GetKubernetesClient(t).CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{
 		GracePeriodSeconds: &period,
 	})
 	if errors.IsNotFound(err) {
@@ -295,7 +295,7 @@ func WaitForAllJobsSuccess(t *testing.T, kc *kubernetes.Clientset, namespace str
 func WaitForNamespaceDeletion(t *testing.T, nsName string) bool {
 	for i := 0; i < 120; i++ {
 		t.Logf("waiting for namespace %s deletion", nsName)
-		_, err := KubeClient.CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
+		_, err := GetKubernetesClient(t).CoreV1().Namespaces().Get(context.Background(), nsName, metav1.GetOptions{})
 		if err != nil && errors.IsNotFound(err) {
 			return true
 		}

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -563,6 +563,27 @@ func KubectlApplyMultipleWithTemplate(t *testing.T, data interface{}, templates 
 	}
 }
 
+func KubectlReplaceWithTemplate(t *testing.T, data interface{}, templateName string, config string) {
+	t.Logf("Applying template: %s", templateName)
+
+	tmpl, err := template.New("kubernetes resource template").Parse(config)
+	assert.NoErrorf(t, err, "cannot parse template - %s", err)
+
+	tempFile, err := os.CreateTemp("", templateName)
+	assert.NoErrorf(t, err, "cannot create temp file - %s", err)
+
+	defer os.Remove(tempFile.Name())
+
+	err = tmpl.Execute(tempFile, data)
+	assert.NoErrorf(t, err, "cannot insert data into template - %s", err)
+
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl replace -f %s --force", tempFile.Name()))
+	assert.NoErrorf(t, err, "cannot replace file - %s", err)
+
+	err = tempFile.Close()
+	assert.NoErrorf(t, err, "cannot close temp file - %s", err)
+}
+
 func KubectlDeleteWithTemplate(t *testing.T, data interface{}, templateName, config string) {
 	t.Logf("Deleting template: %s", templateName)
 

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -648,7 +648,6 @@ func FindPodLogs(kc *kubernetes.Clientset, namespace, label string, includePrevi
 
 	var outputLogs []string
 	for _, pod := range pods.Items {
-
 		getPrevious := false
 		if includePrevious {
 			for _, container := range pod.Status.ContainerStatuses {

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -157,17 +157,18 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 	t.Log("--- test emitting eventsource about scaledobject err---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
 
-	// wait 5 seconds to ensure event propagation
-	time.Sleep(5 * time.Second)
+	// wait 15 seconds to ensure event propagation
+	time.Sleep(15 * time.Second)
 
-	out, _, _ := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
-
-	assert.NotNil(t, out)
+	out, outErr, err := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
+	assert.NotEmpty(t, out)
+	assert.Empty(t, outErr)
+	assert.NoError(t, err)
 
 	cloudEvent := make(map[string]interface{})
-	err := json.Unmarshal([]byte(out), &cloudEvent)
+	err = json.Unmarshal([]byte(out), &cloudEvent)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// check the cloud event content
 	cloudEventData, ok := cloudEvent["data"]

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -34,7 +34,7 @@ var (
 	cloudEventHTTPServiceURL   = fmt.Sprintf("http://%s.%s.svc.cluster.local:8899", cloudEventHTTPServiceName, namespace)
 	clusterName                = "test-cluster"
 	expectedSubject            = fmt.Sprintf("/%s/%s/workload/%s", clusterName, namespace, scaledObjectName)
-	expectedSource             = fmt.Sprintf("/%s/%s/keda/", clusterName, namespace)
+	expectedSource             = fmt.Sprintf("/%s/%s/keda", clusterName, namespace)
 )
 
 type templateData struct {

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -163,12 +163,12 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 	out, outErr, err := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
 	assert.NotEmpty(t, out)
 	assert.Empty(t, outErr)
-	assert.NoError(t, err)
+	assert.NoError(t, err, "dont expect error requesting ")
 
 	cloudEvent := make(map[string]interface{})
 	err = json.Unmarshal([]byte(out), &cloudEvent)
 
-	assert.NoError(t, err)
+	assert.NoError(t, err, "dont expect error unmarshaling the cloudEvent")
 
 	// check the cloud event content
 	cloudEventData, ok := cloudEvent["data"]

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -34,6 +34,7 @@ var (
 	cloudEventHTTPServiceURL   = fmt.Sprintf("http://%s.%s.svc.cluster.local:8899", cloudEventHTTPServiceName, namespace)
 	clusterName                = "test-cluster"
 	expectedSubject            = fmt.Sprintf("/%s/%s/workload/%s", clusterName, namespace, scaledObjectName)
+	expectedSource             = fmt.Sprintf("/%s/%s/keda/", clusterName, namespace)
 )
 
 type templateData struct {
@@ -185,6 +186,7 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 			assert.NoError(t, err)
 			assert.Equal(t, data["message"], "ScaledObject doesn't have correct scaleTargetRef specification")
 			assert.Equal(t, cloudEvent.Type(), "com.cloudeventsource.keda")
+			assert.Equal(t, cloudEvent.Source(), expectedSource)
 			assert.Equal(t, cloudEvent.DataContentType(), "application/json")
 		}
 	}

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -157,6 +157,9 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 	t.Log("--- test emitting eventsource about scaledobject err---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectErrTemplate", scaledObjectErrTemplate)
 
+	// wait 5 seconds to ensure event propagation
+	time.Sleep(5 * time.Second)
+
 	out, _, _ := ExecCommandOnSpecificPod(t, clientName, namespace, fmt.Sprintf("curl -X GET %s/getCloudEvent/%s", cloudEventHTTPServiceURL, "ScaledObjectCheckFailed"))
 
 	assert.NotNil(t, out)
@@ -168,10 +171,10 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 
 	// check the cloud event content
 	cloudEventData, ok := cloudEvent["data"]
-	assert.True(t, ok, "cloudEvent contains data")
+	assert.True(t, ok, "cloudEvent should contain data")
 	if ok {
 		message, ok := cloudEventData.(map[string]interface{})["message"]
-		assert.True(t, ok, "cloudEvent contains message")
+		assert.True(t, ok, "cloudEvent should contain message")
 		if ok {
 			assert.Equal(t, message, "ScaledObject doesn't have correct scaleTargetRef specification")
 		}

--- a/tests/internals/fallback/fallback_test.go
+++ b/tests/internals/fallback/fallback_test.go
@@ -247,7 +247,7 @@ func TestFallback(t *testing.T) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	data.MetricValue = 50
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicas)
@@ -269,7 +269,7 @@ func testRestoreAfterFallback(t *testing.T, kc *kubernetes.Clientset, data templ
 	t.Log("--- testing after fallback ---")
 	KubectlApplyWithTemplate(t, data, "metricsServerDeploymentTemplate", metricsServerDeploymentTemplate)
 	data.MetricValue = 50
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicas)

--- a/tests/internals/global_custom_ca/global_custom_ca_test.go
+++ b/tests/internals/global_custom_ca/global_custom_ca_test.go
@@ -240,7 +240,7 @@ func TestCustomCa(t *testing.T) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	data.MetricValue = 50
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -249,7 +249,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
+++ b/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
@@ -215,7 +215,7 @@ func testPollingIntervalUp(t *testing.T, kc *kubernetes.Clientset, data template
 	t.Log("--- test Polling Interval up ---")
 
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	// wait some seconds to finish the job
 	WaitForJobCount(t, kc, namespace, 0, 15, 2)
@@ -232,7 +232,7 @@ func testPollingIntervalUp(t *testing.T, kc *kubernetes.Clientset, data template
 	assert.NoError(t, err)
 
 	data.MetricValue = maxReplicas
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, minReplicas, 60)
 
@@ -246,7 +246,7 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 	t.Log("--- test Polling Interval down ---")
 
 	data.MetricValue = 1
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	// wait some seconds to finish the job
 	WaitForJobCount(t, kc, namespace, 0, 15, 2)
@@ -264,7 +264,7 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 	assert.NoError(t, err)
 
 	data.MetricValue = minReplicas
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, maxReplicas, 60)
 
@@ -282,7 +282,7 @@ func testCooldownPeriod(t *testing.T, kc *kubernetes.Clientset, data templateDat
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	data.MetricValue = 1
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	// wait some seconds to finish the job
 	WaitForJobCount(t, kc, namespace, 0, 15, 2)
@@ -299,7 +299,7 @@ func testCooldownPeriod(t *testing.T, kc *kubernetes.Clientset, data templateDat
 	assert.NoError(t, err)
 
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, maxReplicas, 60)
 

--- a/tests/internals/replica_update_so/replica_update_so_test.go
+++ b/tests/internals/replica_update_so/replica_update_so_test.go
@@ -215,7 +215,7 @@ func TestScaler(t *testing.T) {
 func scaleMaxReplicasUp(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- scale up after MaxReplicas change ---")
 	data.MetricValue = 100
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
@@ -234,7 +234,7 @@ func scaleMaxReplicasUp(t *testing.T, kc *kubernetes.Clientset, data templateDat
 func scaleMaxReplicasDown(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- scale max replicas down ---")
 	data.MetricValue = 100
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	updatedMaxReplicas := maxReplicas + 10
 	data.MaxReplicas = strconv.Itoa(updatedMaxReplicas)
@@ -254,7 +254,7 @@ func scaleMaxReplicasDown(t *testing.T, kc *kubernetes.Clientset, data templateD
 func scaleMinReplicasUpFromZero(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- scale min replicas up from zero ---")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
@@ -273,7 +273,7 @@ func scaleMinReplicasUpFromZero(t *testing.T, kc *kubernetes.Clientset, data tem
 func scaleMinReplicasDownToZero(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- scale min replicas down to zero ---")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	// set minReplicas to higher number at first
 	updatedMinReplicas := minReplicas + 5

--- a/tests/internals/scaling_modifiers/scaling_modifiers_test.go
+++ b/tests/internals/scaling_modifiers/scaling_modifiers_test.go
@@ -148,6 +148,9 @@ spec:
   cooldownPeriod: 5
   minReplicaCount: 0
   maxReplicaCount: 10
+  fallback:
+    replicas: 5
+    failureThreshold: 3
   triggers:
   - type: metrics-api
     name: metrics_api
@@ -253,7 +256,7 @@ func testFormula(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 3, 12, 10),
 		"replica count should be %d after 2 minutes", 3)
 
-	// apply fallback fallback
+	// apply fallback
 	_, err = ExecuteCommand(fmt.Sprintf("kubectl scale deployment/%s --replicas=0 -n %s", metricsServerDeploymentName, namespace))
 	assert.NoErrorf(t, err, "cannot scale metricsServer deployment - %s", err)
 

--- a/tests/internals/scaling_modifiers/scaling_modifiers_test.go
+++ b/tests/internals/scaling_modifiers/scaling_modifiers_test.go
@@ -241,12 +241,12 @@ func testFormula(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	// formula simply adds 2 metrics together (0+2=2; activationTarget = 2 -> replicas should be 0)
 	KubectlApplyWithTemplate(t, data, "soFallbackTemplate", soFallbackTemplate)
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, 0, 60)
 
 	// formula simply adds 2 metrics together (3+2=5; target = 2 -> 5/2 replicas should be 3)
 	data.MetricValue = 3
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
 	_, err := ExecuteCommand(fmt.Sprintf("kubectl scale deployment/depl-workload-base --replicas=2 -n %s", namespace))
 	assert.NoErrorf(t, err, "cannot scale workload deployment - %s", err)
@@ -268,7 +268,7 @@ func testFormula(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	assert.NoErrorf(t, err, "cannot scale metricsServer deployment - %s", err)
 
 	data.MetricValue = 2
-	KubectlApplyWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 	// 2+2=4; target = 2 -> 4/2 replicas should be 2
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 2, 12, 10),
 		"replica count should be %d after 2 minutes", 2)

--- a/tests/internals/scaling_modifiers/scaling_modifiers_test.go
+++ b/tests/internals/scaling_modifiers/scaling_modifiers_test.go
@@ -148,9 +148,6 @@ spec:
   cooldownPeriod: 5
   minReplicaCount: 0
   maxReplicaCount: 10
-  fallback:
-    replicas: 5
-    failureThreshold: 1
   triggers:
   - type: metrics-api
     name: metrics_api

--- a/tests/internals/trigger_authentication_validation/trigger_authentication_validation_test.go
+++ b/tests/internals/trigger_authentication_validation/trigger_authentication_validation_test.go
@@ -20,7 +20,7 @@ import (
 var _ = godotenv.Load("../../../.env")
 
 const (
-	testName = "azure-aad-pod-identity-test"
+	testName = "trigger-authentication-validation-test"
 )
 
 var (

--- a/tests/internals/trigger_update_so/trigger_update_so_test.go
+++ b/tests/internals/trigger_update_so/trigger_update_so_test.go
@@ -317,21 +317,21 @@ func testTargetValue(t *testing.T, kc *kubernetes.Clientset, data templateData) 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	data.MetricValue = 1
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 1, 180, 3),
 		"replica count should be %d after 3 minutes", 1)
 
 	t.Log("--- test target value 10 ---")
 	data.MetricValue = 10
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
 		"replica count should be %d after 3 minutes", maxReplicas)
 
 	t.Log("--- test target value 0 ---")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
 		"replica count should be %d after 3 minutes", minReplicas)
@@ -343,7 +343,7 @@ func testTwoTriggers(t *testing.T, kc *kubernetes.Clientset, data templateData) 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	data.MetricValue = 1
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 1, 180, 3),
 		"replica count should be %d after 3 minutes", 1)
@@ -362,7 +362,7 @@ func testRemoveTrigger(t *testing.T, kc *kubernetes.Clientset, data templateData
 	t.Log("--- test remove trigger 2 -> 1 ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTwoTriggerTemplate", scaledObjectTwoTriggerTemplate)
 	data.MetricValue = 5 // 3 replicas (midReplicas)
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	KubernetesScaleDeployment(t, kc, workloadDeploymentName, int64(maxReplicas), namespace)
 
@@ -385,7 +385,7 @@ func testThreeTriggersWithCPU(t *testing.T, kc *kubernetes.Clientset, data templ
 
 	// scaling might take longer because of fetching of the cpu metrics (possibly increase iterations if needed)
 	data.MetricValue = 10
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
 		"replica count should be %d after 3 minutes", maxReplicas)
 }

--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -348,7 +348,7 @@ func printKedaLogs() {
 	kubeConfig, _ := config.GetConfig()
 	kubeClient, _ := kubernetes.NewForConfig(kubeConfig)
 
-	operatorLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-operator")
+	operatorLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-operator", true)
 	if err == nil {
 		fmt.Println(">>> KEDA Operator log <<<")
 		fmt.Println(operatorLogs)
@@ -356,7 +356,7 @@ func printKedaLogs() {
 		fmt.Println("##############################################")
 	}
 
-	msLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-metrics-apiserver")
+	msLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-metrics-apiserver", true)
 	if err == nil {
 		fmt.Println(">>> KEDA Metrics Server log <<<")
 		fmt.Println(msLogs)
@@ -364,7 +364,7 @@ func printKedaLogs() {
 		fmt.Println("##############################################")
 	}
 
-	hooksLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-admission-webhooks")
+	hooksLogs, err := helper.FindPodLogs(kubeClient, "keda", "app=keda-admission-webhooks", true)
 	if err == nil {
 		fmt.Println(">>> KEDA Admission Webhooks log <<<")
 		fmt.Println(hooksLogs)

--- a/tests/scalers/apache_kafka/apache_kafka_test.go
+++ b/tests/scalers/apache_kafka/apache_kafka_test.go
@@ -391,7 +391,6 @@ func TestScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
-	defer DeleteKubernetesResources(t, testNamespace, data, templates)
 	addCluster(t, data)
 	addTopic(t, data, topic1, topicPartitions)
 	addTopic(t, data, topic2, topicPartitions)
@@ -408,6 +407,7 @@ func TestScaler(t *testing.T) {
 	testOneOnInvalidOffset(t, kc, data)
 	testPersistentLag(t, kc, data)
 	testScalingOnlyPartitionsWithLag(t, kc, data)
+	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 
 func testEarliestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/scalers/arangodb/arangodb_test.go
+++ b/tests/scalers/arangodb/arangodb_test.go
@@ -249,7 +249,7 @@ func getTemplateData() (templateData, []Template) {
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
 
-	KubectlApplyWithTemplate(t, data, "generateLowLevelDataJobTemplate", generateLowLevelDataJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLowLevelDataJobTemplate", generateLowLevelDataJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, "generate-low-level-data-job", testNamespace, 5, 60), "test activation job failed")
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
@@ -258,7 +258,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 
-	KubectlApplyWithTemplate(t, data, "generateDataJobTemplate", generateDataJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateDataJobTemplate", generateDataJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, "generate-data-job", testNamespace, 5, 60), "test scale-out job failed")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
@@ -268,7 +268,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
 
-	KubectlApplyWithTemplate(t, data, "deleteDataJobTemplate", deleteDataJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "deleteDataJobTemplate", deleteDataJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, "delete-data-job", testNamespace, 5, 60), "test scale-in job failed")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 5),

--- a/tests/scalers/artemis/artemis_test.go
+++ b/tests/scalers/artemis/artemis_test.go
@@ -321,14 +321,14 @@ func TestArtemisScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "triggerJobTemplate", producerJob)
+	KubectlReplaceWithTemplate(t, data, "triggerJobTemplate", producerJob)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "triggerJobTemplate", producerJob)
+	KubectlReplaceWithTemplate(t, data, "triggerJobTemplate", producerJob)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/azure/azure_managed_prometheus/helper/helper.go
+++ b/tests/scalers/azure/azure_managed_prometheus/helper/helper.go
@@ -239,14 +239,14 @@ func TestAzureManagedPrometheusScaler(t *testing.T, data TemplateData) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data TemplateData) {
 	t.Log("--- testing activation ---")
-	helper.KubectlApplyWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generateLowLevelLoadJobTemplate)
+	helper.KubectlReplaceWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generateLowLevelLoadJobTemplate)
 
 	helper.AssertReplicaCountNotChangeDuringTimePeriod(t, kc, data.DeploymentName, data.TestNamespace, MinReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data TemplateData) {
 	t.Log("--- testing scale out ---")
-	helper.KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
+	helper.KubectlReplaceWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
 
 	assert.True(t, helper.WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, MaxReplicaCount, 144, 5),
 		"replica count should be %d after 12 minutes", MaxReplicaCount)

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -200,8 +200,7 @@ func scaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	t.Log("--- applying job ---")
 
-	templateTriggerJob := []Template{{Name: "triggerJobTemplate", Config: triggerJob}}
-	KubectlApplyMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlReplaceWithTemplate(t, data, "triggerJobTemplate", triggerJob)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 180, 1),
 		"Replica count should scale out in next 3 minutes")
@@ -209,7 +208,7 @@ func scaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
 	t.Log("--- deleting job ---")
 
-	KubectlDeleteMultipleWithTemplate(t, data, templateTriggerJob)
+	KubectlDeleteWithTemplate(t, data, "triggerJobTemplate", triggerJob)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 180, 1),
 		"Replica count should be 1 in next 3 minutes")

--- a/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
+++ b/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
@@ -137,7 +137,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	data.Value = 4
 	KubectlApplyWithTemplate(t, data, jobName, setJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, jobName, data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, jobName, setJobTemplate)
+	KubectlReplaceWithTemplate(t, data, jobName, setJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
@@ -145,9 +145,9 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	data.Value = 9
-	KubectlApplyWithTemplate(t, data, jobName, setJobTemplate)
+	KubectlReplaceWithTemplate(t, data, jobName, setJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, jobName, data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, jobName, setJobTemplate)
+	KubectlReplaceWithTemplate(t, data, jobName, setJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -156,9 +156,9 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
 	data.Value = 0
-	KubectlApplyWithTemplate(t, data, jobName, setJobTemplate)
+	KubectlReplaceWithTemplate(t, data, jobName, setJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, jobName, data.TestNamespace, 6, 10), "update job failed")
-	KubectlDeleteWithTemplate(t, data, jobName, setJobTemplate)
+	KubectlReplaceWithTemplate(t, data, jobName, setJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/external_push_scaler/external_push_scaler_test.go
+++ b/tests/scalers/external_push_scaler/external_push_scaler_test.go
@@ -191,7 +191,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to min replicas")
 	data.MetricValue = data.MetricThreshold
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
@@ -199,7 +199,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to max replicas")
 	data.MetricValue = data.MetricThreshold * 2
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
 		"replica count should be 2 after 2 minutes")
@@ -211,7 +211,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to idle replicas")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2),
 		"replica count should be 0 after 2 minutes")

--- a/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
+++ b/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
@@ -170,7 +170,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to max replicas")
 	data.MetricValue = data.MetricThreshold * 3
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 3, 60, 1),
 		"job count should be 3 after 1 minute")
@@ -182,7 +182,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to idle replicas")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 0, 60, 1),
 		"job count should be 0 after 1 minute")

--- a/tests/scalers/external_scaler_so/external_scaler_so_test.go
+++ b/tests/scalers/external_scaler_so/external_scaler_so_test.go
@@ -191,7 +191,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to min replicas")
 	data.MetricValue = data.MetricThreshold
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
@@ -199,7 +199,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to max replicas")
 	data.MetricValue = data.MetricThreshold * 2
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
 		"replica count should be 2 after 2 minutes")
@@ -211,7 +211,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	t.Log("scaling to idle replicas")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2),
 		"replica count should be 0 after 2 minutes")

--- a/tests/scalers/graphite/graphite_test.go
+++ b/tests/scalers/graphite/graphite_test.go
@@ -536,14 +536,14 @@ func TestGraphiteScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "lowLevelRequestsJobTemplate", lowLevelRequestsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "lowLevelRequestsJobTemplate", lowLevelRequestsJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "requestsJobTemplate", requestsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "requestsJobTemplate", requestsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -551,7 +551,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
-	KubectlApplyWithTemplate(t, data, "emptyRequestsJobTemplate", emptyRequestsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "emptyRequestsJobTemplate", emptyRequestsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/influxdb/influxdb_test.go
+++ b/tests/scalers/influxdb/influxdb_test.go
@@ -208,7 +208,7 @@ func TestInfluxScaler(t *testing.T) {
 func runWriteJob(t *testing.T, kc *kubernetes.Clientset) templateData {
 	// run writeJob
 	data, _ := getTemplateData()
-	KubectlApplyWithTemplate(t, data, "influxdbWriteJobTemplate", influxdbWriteJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "influxdbWriteJobTemplate", influxdbWriteJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, influxdbJobName, testNamespace, 30, 2), "Job should run successfully")
 
 	// get pod logs

--- a/tests/scalers/influxdb/influxdb_test.go
+++ b/tests/scalers/influxdb/influxdb_test.go
@@ -186,7 +186,6 @@ spec:
 func TestInfluxScaler(t *testing.T) {
 	// setup
 	t.Log("--- setting up ---")
-
 	// Create kubernetes resources
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
@@ -196,18 +195,20 @@ func TestInfluxScaler(t *testing.T) {
 	assert.True(t, WaitForStatefulsetReplicaReadyCount(t, kc, influxdbStatefulsetName, testNamespace, 1, 60, 1),
 		"replica count should be 0 after a minute")
 
+	// get token
+	updateDataWithInfluxAuth(t, kc, &data)
+
 	// test activation
-	testActivation(t, kc)
+	testActivation(t, kc, data)
 	// test scaling
-	testScaleFloat(t, kc)
+	testScaleFloat(t, kc, data)
 
 	// cleanup
 	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 
-func runWriteJob(t *testing.T, kc *kubernetes.Clientset) templateData {
+func updateDataWithInfluxAuth(t *testing.T, kc *kubernetes.Clientset, data *templateData) {
 	// run writeJob
-	data, _ := getTemplateData()
 	KubectlReplaceWithTemplate(t, data, "influxdbWriteJobTemplate", influxdbWriteJobTemplate)
 	assert.True(t, WaitForJobSuccess(t, kc, influxdbJobName, testNamespace, 30, 2), "Job should run successfully")
 
@@ -222,7 +223,6 @@ func runWriteJob(t *testing.T, kc *kubernetes.Clientset) templateData {
 	}
 	data.AuthToken = (strings.SplitN(lines[0], "=", 2))[1]
 	data.OrgName = (strings.SplitN(lines[1], "=", 2))[1]
-	return data
 }
 
 func getTemplateData() (templateData, []Template) {
@@ -240,17 +240,15 @@ func getTemplateData() (templateData, []Template) {
 		}
 }
 
-func testActivation(t *testing.T, kc *kubernetes.Clientset) {
+func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation---")
-	data := runWriteJob(t, kc)
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectActivationTemplate", scaledObjectActivationTemplate)
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 }
 
-func testScaleFloat(t *testing.T, kc *kubernetes.Clientset) {
+func testScaleFloat(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out float---")
-	data := runWriteJob(t, kc)
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplateFloat", scaledObjectTemplateFloat)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 1),

--- a/tests/scalers/influxdb/influxdb_test.go
+++ b/tests/scalers/influxdb/influxdb_test.go
@@ -212,7 +212,7 @@ func runWriteJob(t *testing.T, kc *kubernetes.Clientset) templateData {
 	assert.True(t, WaitForJobSuccess(t, kc, influxdbJobName, testNamespace, 30, 2), "Job should run successfully")
 
 	// get pod logs
-	log, err := FindPodLogs(kc, testNamespace, label)
+	log, err := FindPodLogs(kc, testNamespace, label, false)
 	assert.NoErrorf(t, err, "cannotget logs - %s", err)
 
 	var lines []string

--- a/tests/scalers/kafka/kafka_test.go
+++ b/tests/scalers/kafka/kafka_test.go
@@ -390,7 +390,6 @@ func TestScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
-	defer DeleteKubernetesResources(t, testNamespace, data, templates)
 	addCluster(t, data)
 	addTopic(t, data, topic1, topicPartitions)
 	addTopic(t, data, topic2, topicPartitions)
@@ -407,6 +406,7 @@ func TestScaler(t *testing.T) {
 	testOneOnInvalidOffset(t, kc, data)
 	testPersistentLag(t, kc, data)
 	testScalingOnlyPartitionsWithLag(t, kc, data)
+	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 
 func testEarliestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/scalers/loki/loki_test.go
+++ b/tests/scalers/loki/loki_test.go
@@ -166,14 +166,14 @@ func TestLokiScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generateLowLevelLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generateLowLevelLoadJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/metrics_api/metrics_api_test.go
+++ b/tests/scalers/metrics_api/metrics_api_test.go
@@ -208,7 +208,7 @@ func TestScaler(t *testing.T) {
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
 	data.MetricValue = 10
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
@@ -216,7 +216,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	data.MetricValue = 50
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -225,7 +225,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
 	data.MetricValue = 0
-	KubectlApplyWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
+	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", minReplicaCount)

--- a/tests/scalers/mssql/mssql_test.go
+++ b/tests/scalers/mssql/mssql_test.go
@@ -282,7 +282,7 @@ func TestMssqlScaler(t *testing.T) {
 // insert 10 records in the table -> activation should not happen (activationTargetValue = 15)
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate1", insertRecordsJobTemplate1)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate1", insertRecordsJobTemplate1)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
@@ -290,7 +290,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 // insert another 10 records in the table, which in total is 20 -> should be scaled up
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate2", insertRecordsJobTemplate2)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate2", insertRecordsJobTemplate2)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/mysql/mysql_test.go
+++ b/tests/scalers/mysql/mysql_test.go
@@ -272,7 +272,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
 	t.Log("--- applying job ---")
 	data.ItemsToWrite = 50
-	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
@@ -281,7 +281,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	t.Log("--- applying job ---")
 	data.ItemsToWrite = 4000
-	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
 	// Check if deployment scale to 2 (the max)
 	maxReplicaCount := 2
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 120, 1),

--- a/tests/scalers/nats_jetstream/nats_jetstream_standalone/nats_jetstream_standalone_test.go
+++ b/tests/scalers/nats_jetstream/nats_jetstream_standalone/nats_jetstream_standalone_test.go
@@ -251,14 +251,14 @@ func removeServerWithJetStream(t *testing.T, namespace string) {
 func testActivation(t *testing.T, kc *k8s.Clientset, data nats.JetStreamDeploymentTemplateData) {
 	t.Log("--- testing activation ---")
 	data.NumberOfMessages = 10
-	KubectlApplyWithTemplate(t, data, "activationPublishJobTemplate", nats.ActivationPublishJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "activationPublishJobTemplate", nats.ActivationPublishJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *k8s.Clientset, data nats.JetStreamDeploymentTemplateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "publishJobTemplate", nats.PublishJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "publishJobTemplate", nats.PublishJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/postgresql/postgresql_high_available/postgresql_ha_test.go
+++ b/tests/scalers/postgresql/postgresql_high_available/postgresql_ha_test.go
@@ -153,14 +153,14 @@ func TestPostreSQLScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "lowLevelRecordsJobTemplate", pg.LowLevelRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "lowLevelRecordsJobTemplate", pg.LowLevelRecordsJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", pg.InsertRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate", pg.InsertRecordsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/postgresql/postgresql_standalone/postgresql_test.go
+++ b/tests/scalers/postgresql/postgresql_standalone/postgresql_test.go
@@ -100,14 +100,14 @@ func TestPostreSQLScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "lowLevelRecordsJobTemplate", pg.LowLevelRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "lowLevelRecordsJobTemplate", pg.LowLevelRecordsJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", pg.InsertRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate", pg.InsertRecordsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/predictkube/predictkube_test.go
+++ b/tests/scalers/predictkube/predictkube_test.go
@@ -233,14 +233,14 @@ func TestScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateLightLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLoadJobTemplate", generateLightLoadJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateHeavyLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLoadJobTemplate", generateHeavyLoadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/prometheus/prometheus_test.go
+++ b/tests/scalers/prometheus/prometheus_test.go
@@ -232,14 +232,14 @@ func TestPrometheusScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generateLowLevelLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generateLowLevelLoadJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/pulsar/helper/helper.go
+++ b/tests/scalers/pulsar/helper/helper.go
@@ -292,7 +292,7 @@ func TestScalerWithConfig(t *testing.T, testName string, numPartitions int) {
 	assert.True(t, helper.WaitForStatefulsetReplicaReadyCount(t, kc, testName, testName, 1, 300, 1),
 		"replica count should be 1 within 5 minutes")
 
-	helper.KubectlApplyWithTemplate(t, data, "topicInitJobTemplate", topicInitJobTemplate)
+	helper.KubectlReplaceWithTemplate(t, data, "topicInitJobTemplate", topicInitJobTemplate)
 
 	assert.True(t, helper.WaitForJobSuccess(t, kc, getTopicInitJobName(testName), testName, 300, 1),
 		"job should succeed within 5 minutes")
@@ -342,14 +342,14 @@ func getTemplateData(testName string, numPartitions int) (templateData, []helper
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
 	// publish message and less than MsgBacklog
-	helper.KubectlApplyWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
+	helper.KubectlReplaceWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
 	helper.AssertReplicaCountNotChangeDuringTimePeriod(t, kc, getConsumerDeploymentName(data.TestName), data.TestName, data.MinReplicaCount, 60)
-	helper.KubectlDeleteWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
+	helper.KubectlReplaceWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	data.MessageCount = 100
-	helper.KubectlApplyWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
+	helper.KubectlReplaceWithTemplate(t, data, "publishJobTemplate", topicPublishJobTemplate)
 	assert.True(t, helper.WaitForDeploymentReplicaReadyCount(t, kc, getConsumerDeploymentName(data.TestName), data.TestName, 5, 300, 1),
 		"replica count should be 5 within 5 minute")
 }

--- a/tests/scalers/redis/redis_cluster_lists/redis_cluster_lists_test.go
+++ b/tests/scalers/redis/redis_cluster_lists/redis_cluster_lists_test.go
@@ -189,7 +189,7 @@ func TestScaler(t *testing.T) {
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
 	data.ItemsToWrite = 5
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
@@ -197,7 +197,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	data.ItemsToWrite = 400
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_cluster_streams_lag/redis_cluster_streams_lag_test.go
+++ b/tests/scalers/redis/redis_cluster_streams_lag/redis_cluster_streams_lag_test.go
@@ -209,7 +209,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int, maxReplicas int) {
 	data.ItemsToWrite = numMessages
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicas, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicas)
@@ -222,7 +222,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, minReplicas int) {
 
 func testActivationValue(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int) {
 	data.ItemsToWrite = numMessages
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 }
 

--- a/tests/scalers/redis/redis_cluster_streams_length/redis_cluster_streams_length_test.go
+++ b/tests/scalers/redis/redis_cluster_streams_length/redis_cluster_streams_length_test.go
@@ -196,7 +196,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_cluster_streams_pending_entries/redis_cluster_streams_pending_entries_test.go
+++ b/tests/scalers/redis/redis_cluster_streams_pending_entries/redis_cluster_streams_pending_entries_test.go
@@ -195,7 +195,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
+++ b/tests/scalers/redis/redis_sentinel_lists/redis_sentinel_lists_test.go
@@ -196,7 +196,7 @@ func TestScaler(t *testing.T) {
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
@@ -204,7 +204,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	data.ItemsToWrite = 400
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_sentinel_streams_lag/redis_sentinel_streams_lag_test.go
+++ b/tests/scalers/redis/redis_sentinel_streams_lag/redis_sentinel_streams_lag_test.go
@@ -223,7 +223,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int, maxReplicas int) {
 	data.ItemsToWrite = numMessages
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicas, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicas)
@@ -236,7 +236,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, minReplicas int) {
 
 func testActivationValue(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int) {
 	data.ItemsToWrite = numMessages
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 }

--- a/tests/scalers/redis/redis_sentinel_streams_length/redis_sentinel_streams_length_test.go
+++ b/tests/scalers/redis/redis_sentinel_streams_length/redis_sentinel_streams_length_test.go
@@ -210,7 +210,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_sentinel_streams_pending_entries/redis_sentinel_streams_pending_entries_test.go
+++ b/tests/scalers/redis/redis_sentinel_streams_pending_entries/redis_sentinel_streams_pending_entries_test.go
@@ -209,7 +209,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
+++ b/tests/scalers/redis/redis_standalone_lists/redis_standalone_lists_test.go
@@ -185,7 +185,7 @@ func TestScaler(t *testing.T) {
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
 	data.ItemsToWrite = 5
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
@@ -193,7 +193,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	data.ItemsToWrite = 400
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_standalone_streams_lag/redis_standalone_streams_lag_test.go
+++ b/tests/scalers/redis/redis_standalone_streams_lag/redis_standalone_streams_lag_test.go
@@ -147,7 +147,7 @@ metadata:
   name: {{.JobName}}
   namespace: {{.TestNamespace}}
 spec:
-  ttlSecondsAfterFinished: 0
+  ttlSecondsAfterFinished: 30
   template:
     spec:
       containers:
@@ -205,7 +205,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int, maxReplicas int) {
 	data.ItemsToWrite = numMessages
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicas, 60, 1),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -218,7 +218,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, minReplicas int) {
 
 func testActivationValue(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int) {
 	data.ItemsToWrite = numMessages
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 30)
 }

--- a/tests/scalers/redis/redis_standalone_streams_length/redis_standalone_streams_length_test.go
+++ b/tests/scalers/redis/redis_standalone_streams_length/redis_standalone_streams_length_test.go
@@ -193,7 +193,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/redis/redis_standalone_streams_pending_entries/redis_standalone_streams_test_pending_entries_test.go
+++ b/tests/scalers/redis/redis_standalone_streams_pending_entries/redis_standalone_streams_test_pending_entries_test.go
@@ -192,7 +192,7 @@ func TestScaler(t *testing.T) {
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/secret-providers/hashicorp_vault/hashicorp_vault_test.go
+++ b/tests/secret-providers/hashicorp_vault/hashicorp_vault_test.go
@@ -639,14 +639,14 @@ func cleanupHashiCorpVault(t *testing.T) {
 
 func testPromActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generatePromLowLevelLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generatePromLowLevelLoadJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testPromScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "generateLoadJobTemplate", generatePromLoadJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "generateLoadJobTemplate", generatePromLoadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)
@@ -654,14 +654,14 @@ func testPromScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData)
 
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlApplyWithTemplate(t, data, "lowLevelRecordsJobTemplate", lowLevelRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "lowLevelRecordsJobTemplate", lowLevelRecordsJobTemplate)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlApplyWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate", insertRecordsJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 5),
 		"replica count should be %d after 5 minutes", maxReplicaCount)

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -231,7 +231,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 }
 
 func saveLogs(t *testing.T, kc *kubernetes.Clientset, logName, selector, namespace string) {
-	logs, err := FindPodLogs(kc, namespace, selector)
+	logs, err := FindPodLogs(kc, namespace, selector, false)
 	assert.NoErrorf(t, err, "cannotget logs - %s", err)
 	f, err := os.Create(fmt.Sprintf("%s-%s.log", logName, time.Now().Format("20060102150405")))
 	assert.NoErrorf(t, err, "cannot create log file - %s", err)

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -40,6 +40,9 @@ var (
 	clientName                               = fmt.Sprintf("%s-client", testName)
 	kedaOperatorCollectorPrometheusExportURL = "http://opentelemetry-collector.open-telemetry-system.svc.cluster.local:8889/metrics"
 	namespaceString                          = "namespace"
+	kedaNamespace                            = "keda"
+	kedaOperatorDeploymentName               = "keda-operator"
+	operatorLabelSelector                    = "app=keda-operator"
 )
 
 type templateData struct {
@@ -267,7 +270,7 @@ spec:
 `
 )
 
-func TestPrometheusMetrics(t *testing.T) {
+func TestOpenTelemetryMetrics(t *testing.T) {
 	// setup
 	t.Log("--- setting up ---")
 
@@ -276,6 +279,11 @@ func TestPrometheusMetrics(t *testing.T) {
 	data, templates := getTemplateData()
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
+
+	// restart KEDA operator to ensure that all the metrics are sent to the collector
+	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, kedaOperatorDeploymentName, kedaNamespace, 1, 60, 2),
+		"replica count should be 1 after 2 minute")
 
 	// scaling to max replica count to ensure the counter is registered before we test it
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
@@ -331,7 +339,9 @@ func testScalerMetricValue(t *testing.T) {
 	t.Log("--- testing scaler metric value ---")
 	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
 
-	if val, ok := family["keda_scaler_metrics_value"]; ok {
+	val, ok := family["keda_scaler_metrics_value"]
+	assert.True(t, ok, "keda_scaler_metrics_value not available")
+	if ok {
 		var found bool
 		metrics := val.GetMetric()
 		for _, metric := range metrics {
@@ -344,8 +354,6 @@ func testScalerMetricValue(t *testing.T) {
 			}
 		}
 		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("metric not available")
 	}
 }
 
@@ -358,22 +366,22 @@ func testScaledObjectErrors(t *testing.T, data templateData) {
 	time.Sleep(20 * time.Second)
 
 	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
-	if val, ok := family["keda_scaledobject_errors_total"]; ok {
+	val, ok := family["keda_scaledobject_errors_total"]
+	assert.True(t, ok, "keda_scaledobject_errors_total not available")
+	if ok {
 		errCounterVal1 := getErrorMetricsValue(val)
 
 		// wait for 2 seconds as pollinginterval is 2
 		time.Sleep(5 * time.Second)
 
 		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
-		if val, ok := family["keda_scaledobject_errors_total"]; ok {
+		val, ok := family["keda_scaledobject_errors_total"]
+		assert.True(t, ok, "keda_scaledobject_errors_total not available")
+		if ok {
 			errCounterVal2 := getErrorMetricsValue(val)
 			assert.NotEqual(t, errCounterVal2, float64(0))
 			assert.GreaterOrEqual(t, errCounterVal2, errCounterVal1)
-		} else {
-			t.Errorf("metric not available")
 		}
-	} else {
-		t.Errorf("metric not available")
 	}
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
@@ -391,22 +399,22 @@ func testScalerErrors(t *testing.T, data templateData) {
 	time.Sleep(15 * time.Second)
 
 	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
-	if val, ok := family["keda_scaler_errors_total"]; ok {
+	val, ok := family["keda_scaler_errors_total"]
+	assert.True(t, ok, "keda_scaler_errors_total not available")
+	if ok {
 		errCounterVal1 := getErrorMetricsValue(val)
 
 		// wait for 10 seconds to correctly fetch metrics.
 		time.Sleep(5 * time.Second)
 
 		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
-		if val, ok := family["keda_scaler_errors_total"]; ok {
+		val, ok := family["keda_scaler_errors_total"]
+		assert.True(t, ok, "keda_scaler_errors_total not available")
+		if ok {
 			errCounterVal2 := getErrorMetricsValue(val)
 			assert.NotEqual(t, errCounterVal2, float64(0))
 			assert.GreaterOrEqual(t, errCounterVal2, errCounterVal1)
-		} else {
-			t.Errorf("metric not available")
 		}
-	} else {
-		t.Errorf("metric not available")
 	}
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
@@ -444,7 +452,9 @@ func testScalerMetricLatency(t *testing.T) {
 
 	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
 
-	if val, ok := family["keda_scaler_metrics_latency"]; ok {
+	val, ok := family["keda_scaler_metrics_latency"]
+	assert.True(t, ok, "keda_scaler_metrics_latency not available")
+	if ok {
 		var found bool
 		metrics := val.GetMetric()
 		for _, metric := range metrics {
@@ -457,8 +467,6 @@ func testScalerMetricLatency(t *testing.T) {
 			}
 		}
 		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("metric not available")
 	}
 }
 
@@ -467,7 +475,9 @@ func testScalableObjectMetrics(t *testing.T) {
 
 	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
 
-	if val, ok := family["keda_internal_scale_loop_latency"]; ok {
+	val, ok := family["keda_internal_scale_loop_latency"]
+	assert.True(t, ok, "keda_internal_scale_loop_latency not available")
+	if ok {
 		var found bool
 		metrics := val.GetMetric()
 
@@ -494,8 +504,6 @@ func testScalableObjectMetrics(t *testing.T) {
 			}
 		}
 		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("scaledobject metric not available")
 	}
 }
 
@@ -504,7 +512,9 @@ func testScalerActiveMetric(t *testing.T) {
 
 	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
 
-	if val, ok := family["keda_scaler_active"]; ok {
+	val, ok := family["keda_scaler_active"]
+	assert.True(t, ok, "keda_scaler_active not available")
+	if ok {
 		var found bool
 		metrics := val.GetMetric()
 		for _, metric := range metrics {
@@ -517,8 +527,6 @@ func testScalerActiveMetric(t *testing.T) {
 			}
 		}
 		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("metric not available")
 	}
 }
 
@@ -629,8 +637,8 @@ func checkBuildInfo(t *testing.T, families map[string]*prommodel.MetricFamily) {
 	t.Log("--- testing build info metric ---")
 
 	family, ok := families["keda_build_info"]
+	assert.True(t, ok, "keda_build_info not available")
 	if !ok {
-		t.Errorf("metric not available")
 		return
 	}
 
@@ -666,8 +674,8 @@ func checkTriggerTotalValues(t *testing.T, families map[string]*prommodel.Metric
 	t.Log("--- testing trigger total metrics ---")
 
 	family, ok := families["keda_trigger_totals"]
+	assert.True(t, ok, "keda_trigger_totals not available")
 	if !ok {
-		t.Errorf("metric not available")
 		return
 	}
 
@@ -695,8 +703,8 @@ func checkCRTotalValues(t *testing.T, families map[string]*prommodel.MetricFamil
 	t.Log("--- testing resource total metrics ---")
 
 	family, ok := families["keda_resource_totals"]
+	assert.True(t, ok, "keda_resource_totals not available")
 	if !ok {
-		t.Errorf("metric not available")
 		return
 	}
 
@@ -722,8 +730,8 @@ func checkCRTotalValues(t *testing.T, families map[string]*prommodel.MetricFamil
 
 func assertScaledObjectPausedMetric(t *testing.T, families map[string]*prommodel.MetricFamily, scaledObjectName string, expected bool) {
 	family, ok := families["keda_scaled_object_paused"]
+	assert.True(t, ok, "keda_scaled_object_paused not available")
 	if !ok {
-		t.Errorf("keda_scaled_object_paused metric not available")
 		return
 	}
 

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -38,7 +38,7 @@ var (
 	wrongScalerName                          = fmt.Sprintf("%s-wrong-scaler", testName)
 	cronScaledJobName                        = fmt.Sprintf("%s-cron-sj", testName)
 	clientName                               = fmt.Sprintf("%s-client", testName)
-	kedaOperatorCollectorPrometheusExportURL = "http://opentelemetry-collector.default.svc.cluster.local:8889/metrics"
+	kedaOperatorCollectorPrometheusExportURL = "http://opentelemetry-collector.open-telemetry-system.svc.cluster.local:8889/metrics"
 	namespaceString                          = "namespace"
 )
 

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -361,6 +361,7 @@ func testScaledObjectErrors(t *testing.T, data templateData) {
 	t.Log("--- testing scaled object errors ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
 
 	time.Sleep(20 * time.Second)
@@ -385,6 +386,7 @@ func testScaledObjectErrors(t *testing.T, data templateData) {
 	}
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	// wait for 10 seconds to correctly fetch metrics.
 	time.Sleep(10 * time.Second)
@@ -394,6 +396,7 @@ func testScalerErrors(t *testing.T, data templateData) {
 	t.Log("--- testing scaler errors ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
 
 	time.Sleep(15 * time.Second)
@@ -418,6 +421,7 @@ func testScalerErrors(t *testing.T, data templateData) {
 	}
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }
 

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -358,6 +358,7 @@ func testScaledObjectErrors(t *testing.T, data templateData) {
 	t.Log("--- testing scaled object errors ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
 
 	// wait for 2 seconds as pollinginterval is 2
@@ -383,6 +384,7 @@ func testScaledObjectErrors(t *testing.T, data templateData) {
 	}
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }
 
@@ -390,6 +392,7 @@ func testScalerErrors(t *testing.T, data templateData) {
 	t.Log("--- testing scaler errors ---")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
 
 	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
@@ -412,6 +415,7 @@ func testScalerErrors(t *testing.T, data templateData) {
 	}
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }
 
@@ -441,6 +445,7 @@ func testScalerErrorsTotal(t *testing.T, data templateData) {
 	}
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	time.Sleep(2 * time.Second)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }
 

--- a/tests/utils/cleanup_test.go
+++ b/tests/utils/cleanup_test.go
@@ -29,8 +29,6 @@ func TestRemoveAadPodIdentityComponents(t *testing.T) {
 	_, err := ExecuteCommand(fmt.Sprintf("helm uninstall aad-pod-identity --namespace %s", AzureAdPodIdentityNamespace))
 	require.NoErrorf(t, err, "cannot uninstall aad pod identity webhook - %s", err)
 
-	KubeClient = GetKubernetesClient(t)
-
 	DeleteNamespace(t, AzureAdPodIdentityNamespace)
 }
 
@@ -41,8 +39,6 @@ func TestRemoveWorkloadIdentityComponents(t *testing.T) {
 
 	_, err := ExecuteCommand(fmt.Sprintf("helm uninstall workload-identity-webhook --namespace %s", AzureWorkloadIdentityNamespace))
 	require.NoErrorf(t, err, "cannot uninstall workload identity webhook - %s", err)
-
-	KubeClient = GetKubernetesClient(t)
 
 	DeleteNamespace(t, AzureWorkloadIdentityNamespace)
 }
@@ -55,8 +51,6 @@ func TestRemoveAwsIdentityComponents(t *testing.T) {
 	_, err := ExecuteCommand(fmt.Sprintf("helm uninstall aws-identity-webhook --namespace %s", AwsIdentityNamespace))
 	require.NoErrorf(t, err, "cannot uninstall workload identity webhook - %s", err)
 
-	KubeClient = GetKubernetesClient(t)
-
 	DeleteNamespace(t, AwsIdentityNamespace)
 }
 
@@ -67,15 +61,13 @@ func TestRemoveGcpIdentityComponents(t *testing.T) {
 
 	_, err := ExecuteCommand(fmt.Sprintf("helm uninstall gcp-identity-webhook --namespace %s", GcpIdentityNamespace))
 	require.NoErrorf(t, err, "cannot uninstall workload identity webhook - %s", err)
-
-	KubeClient = GetKubernetesClient(t)
-
 	DeleteNamespace(t, GcpIdentityNamespace)
 }
 
 func TestRemoveOpentelemetryComponents(t *testing.T) {
-	_, err := ExecuteCommand("helm uninstall opentelemetry-collector")
+	_, err := ExecuteCommand(fmt.Sprintf("helm uninstall opentelemetry-collector --namespace %s", OpentelemetryNamespace))
 	require.NoErrorf(t, err, "cannot uninstall opentelemetry-collector - %s", err)
+	DeleteNamespace(t, OpentelemetryNamespace)
 }
 
 func TestRemoveCertManager(t *testing.T) {
@@ -85,9 +77,6 @@ func TestRemoveCertManager(t *testing.T) {
 
 	_, err := ExecuteCommand(fmt.Sprintf("helm uninstall cert-manager --namespace %s", CertManagerNamespace))
 	require.NoErrorf(t, err, "cannot uninstall cert-manager - %s", err)
-
-	KubeClient = GetKubernetesClient(t)
-
 	DeleteNamespace(t, CertManagerNamespace)
 }
 
@@ -100,8 +89,5 @@ func TestRemoveStrimzi(t *testing.T) {
 		StrimziNamespace,
 		StrimziChartName))
 	require.NoErrorf(t, err, "cannot uninstall strimzi - %s", err)
-
-	KubeClient = GetKubernetesClient(t)
-
 	DeleteNamespace(t, StrimziNamespace)
 }

--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -188,11 +188,14 @@ func TestSetupOpentelemetryComponents(t *testing.T) {
 	_, err = ExecuteCommand("helm repo update open-telemetry")
 	require.NoErrorf(t, err, "cannot update open-telemetry helm repo - %s", err)
 
-	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install opentelemetry-collector open-telemetry/opentelemetry-collector -f %s", otlpTempFileName))
+	KubeClient = GetKubernetesClient(t)
+	CreateNamespace(t, KubeClient, OpentelemetryNamespace)
+
+	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install opentelemetry-collector open-telemetry/opentelemetry-collector -f %s --namespace %s", otlpTempFileName, OpentelemetryNamespace))
 
 	require.NoErrorf(t, err, "cannot install opentelemetry - %s", err)
 
-	_, err = ExecuteCommand(fmt.Sprintf("kubectl apply -f %s", otlpServiceTempFileName))
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl apply -f %s -n %s", otlpServiceTempFileName, OpentelemetryNamespace))
 	require.NoErrorf(t, err, "cannot update opentelemetry ports - %s", err)
 }
 


### PR DESCRIPTION
This PR address some gaps on e2e tests:
- CloudEvents are properly removed as part of CRD cleaning up
- CloudEvents e2e test assertion refactored to prevent panics
- CloudEvents e2e test updated to process and validate all the events and the subject/type/source as well
- OTEL Collector is deployed into its own namespace and cleaned up at the end
- If any KEDA Component has a restart, printKedaLogs shows current and previous container logs
- Explicitly call to resource deletion on Kafka e2e tests because both keep resources alive after the test finishes
- Use Replace instead of apply for load jobs 
- Scaling modifiers: Increased fallback threshold to prevent randome fails

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

