### PR TITLE
fix: Update CloudEvent content to reflect correct emitter and subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Fix CVE-2023-39325 in golang.org/x/net ([#5122](https://github.com/kedacore/keda/issues/5122))
 - **General**: Fix otelgrpc DoS vulnerability ([#5208](https://github.com/kedacore/keda/issues/5208))
 - **General**: Prevented stuck status due to timeouts during scalers generation ([#5083](https://github.com/kedacore/keda/issues/5083))
+- **General**: Update CloudEvent content to reflect correct emitter and subject ([#5278](https://github.com/kedacore/keda/issues/5278))
 - **AWS Scalers**: Ensure session tokens are included when instantiating AWS credentials ([#5156](https://github.com/kedacore/keda/issues/5156))
 - **Azure Pipelines**: No more HTTP 400 errors produced by poolName with spaces ([#5107](https://github.com/kedacore/keda/issues/5107))
 - **GCP pubsub scaler**: Added `project_id` to filter for metrics queries ([#5256](https://github.com/kedacore/keda/issues/5256))

--- a/pkg/eventemitter/cloudevent_http_handler.go
+++ b/pkg/eventemitter/cloudevent_http_handler.go
@@ -32,10 +32,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kedacore/keda/v2/pkg/eventemitter/eventdata"
+	"github.com/kedacore/keda/v2/pkg/util"
 )
 
 const (
 	cloudEventSourceType = "com.cloudeventsource.keda"
+)
+
+var (
+	kedaNamespace, _ = util.GetClusterObjectNamespace()
 )
 
 type CloudEventHTTPHandler struct {
@@ -86,8 +91,8 @@ func (c *CloudEventHTTPHandler) CloseHandler() {
 }
 
 func (c *CloudEventHTTPHandler) EmitEvent(eventData eventdata.EventData, failureFunc func(eventData eventdata.EventData, err error)) {
-	source := "/" + c.clusterName + "/" + eventData.Namespace + "/keda"
-	subject := "/" + c.clusterName + "/" + eventData.Namespace + "/workload/" + eventData.ObjectName
+	source := fmt.Sprintf("/%s/%s/keda", c.clusterName, kedaNamespace)
+	subject := fmt.Sprintf("/%s/%s/%s/%s", c.clusterName, eventData.Namespace, eventData.ObjectType, eventData.ObjectName)
 
 	event := cloudevents.NewEvent()
 	event.SetSource(source)

--- a/pkg/eventemitter/eventdata/eventdata.go
+++ b/pkg/eventemitter/eventdata/eventdata.go
@@ -24,6 +24,7 @@ import (
 type EventData struct {
 	Namespace  string
 	ObjectName string
+	ObjectType string
 	EventType  string
 	Reason     string
 	Message    string

--- a/pkg/eventemitter/eventemitter.go
+++ b/pkg/eventemitter/eventemitter.go
@@ -280,10 +280,12 @@ func (e *EventEmitter) Emit(object runtime.Object, namesapce types.NamespacedNam
 		return
 	}
 
-	name, _ := meta.NewAccessor().Name(object)
+	objectName, _ := meta.NewAccessor().Name(object)
+	objectType, _ := meta.NewAccessor().Kind(object)
 	eventData := eventdata.EventData{
 		Namespace:  namesapce.Namespace,
-		ObjectName: name,
+		ObjectName: strings.ToLower(objectName),
+		ObjectType: strings.ToLower(objectType),
 		EventType:  eventType,
 		Reason:     reason,
 		Message:    message,

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -33,8 +33,8 @@ var (
 	cloudEventHTTPServiceName  = fmt.Sprintf("%s-cloudevent-http-service", testName)
 	cloudEventHTTPServiceURL   = fmt.Sprintf("http://%s.%s.svc.cluster.local:8899", cloudEventHTTPServiceName, namespace)
 	clusterName                = "test-cluster"
-	expectedSubject            = fmt.Sprintf("/%s/%s/workload/%s", clusterName, namespace, scaledObjectName)
-	expectedSource             = fmt.Sprintf("/%s/%s/keda", clusterName, namespace)
+	expectedSubject            = fmt.Sprintf("/%s/%s/scaledobject/%s", clusterName, namespace, scaledObjectName)
+	expectedSource             = fmt.Sprintf("/%s/keda/keda", clusterName)
 )
 
 type templateData struct {


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/5278

