### PR TITLE
fix: Reconcile SO's status.GVKR if there is any mismatch

### DIFF
--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -353,9 +353,12 @@ func (r *ScaledObjectReconciler) checkTargetResourceIsScalable(ctx context.Conte
 	gvkString := gvkr.GVKString()
 	logger.V(1).Info("Parsed Group, Version, Kind, Resource", "GVK", gvkString, "Resource", gvkr.Resource)
 
-	statusGvkr, _ := kedav1alpha1.ParseGVKR(r.restMapper, scaledObject.Status.ScaleTargetGVKR.Version, scaledObject.Status.ScaleTargetGVKR.Kind)
-	statusGvkString := statusGvkr.GVKString()
-	logger.V(1).Info("Status Group, Version, Kind, Resource", "GVK", statusGvkString, "Resource", statusGvkr.Resource)
+	statusGvkString := ""
+	if scaledObject.Status.ScaleTargetGVKR != nil {
+		statusGvkr, _ := kedav1alpha1.ParseGVKR(r.restMapper, scaledObject.Status.ScaleTargetGVKR.Version, scaledObject.Status.ScaleTargetGVKR.Kind)
+		statusGvkString = statusGvkr.GVKString()
+		logger.V(1).Info("Status Group, Version, Kind, Resource", "GVK", statusGvkString, "Resource", statusGvkr.Resource)
+	}
 
 	// do we need the scale to update the status later?
 	present := scaledObject.HasPausedAnnotation()

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -353,10 +353,17 @@ func (r *ScaledObjectReconciler) checkTargetResourceIsScalable(ctx context.Conte
 	gvkString := gvkr.GVKString()
 	logger.V(1).Info("Parsed Group, Version, Kind, Resource", "GVK", gvkString, "Resource", gvkr.Resource)
 
+	statusGvkr, _ := kedav1alpha1.ParseGVKR(r.restMapper, scaledObject.Status.ScaleTargetGVKR.Version, scaledObject.Status.ScaleTargetGVKR.Kind)
+	statusGvkString := statusGvkr.GVKString()
+	logger.V(1).Info("Status Group, Version, Kind, Resource", "GVK", statusGvkString, "Resource", statusGvkr.Resource)
+
 	// do we need the scale to update the status later?
 	present := scaledObject.HasPausedAnnotation()
 	removePausedStatus := scaledObject.Status.PausedReplicaCount != nil && !present
-	wantStatusUpdate := scaledObject.Status.ScaleTargetKind != gvkString || scaledObject.Status.OriginalReplicaCount == nil || removePausedStatus
+	wantStatusUpdate := scaledObject.Status.ScaleTargetKind != gvkString ||
+		statusGvkString != gvkString ||
+		scaledObject.Status.OriginalReplicaCount == nil ||
+		removePausedStatus
 
 	// check if we already know.
 	var scale *autoscalingv1.Scale
@@ -390,7 +397,7 @@ func (r *ScaledObjectReconciler) checkTargetResourceIsScalable(ctx context.Conte
 	// - store original scaleTarget's replica count (before scaling with KEDA)
 	if wantStatusUpdate {
 		status := scaledObject.Status.DeepCopy()
-		if scaledObject.Status.ScaleTargetKind != gvkString {
+		if scaledObject.Status.ScaleTargetKind != gvkString || gvkString != statusGvkString {
 			status.ScaleTargetKind = gvkString
 			status.ScaleTargetGVKR = &gvkr
 		}


### PR DESCRIPTION
[As the OP reported by Slack](https://kubernetes.slack.com/archives/CKZJ36A5D/p1702842214573499), during the migration process from v2.8 to v2.12, `.status.scaleTargetGVKR` has become inconsistent and KEDA didn't reconcile it but shows an error related with missing status files. 
This PR adds a check to validate the section and reconcile it in case of mismatch


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

