### PR TITLE
Fix Finalization when other finalizers are in place

### DIFF
--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -124,7 +124,7 @@ func isRemovingFinalizer(so *ScaledObject, old runtime.Object) bool {
 	soSpecString := string(soSpec)
 	oldSoSpecString := string(oldSoSpec)
 
-	return len(so.ObjectMeta.Finalizers) == 0 && len(oldSo.ObjectMeta.Finalizers) == 1 && soSpecString == oldSoSpecString
+	return len(so.ObjectMeta.Finalizers) < len(oldSo.ObjectMeta.Finalizers) && soSpecString == oldSoSpecString
 }
 
 func validateWorkload(so *ScaledObject, action string, dryRun bool) (admission.Warnings, error) {


### PR DESCRIPTION
The webhook's `isRemovingFinalizer` func should check whether the change is **less** finalizers, obviously, and not specifically check whether the old Scaledobject has **exactly** 1 finalizer AND the new Scaled object has exactly 0.
This is to fix a use case in which ArgoCD performs cascading deletion which translates to a `foregroundDeletion` finalizer being added to the object, causing the current webhook implementation enter a loop of update-validate ("if not isRemovingFinalizer then update") instead of proceeding with deletion.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

