### PR TITLE
Refactor get config to `getParameterFromConfigV2` Kafka Scaler

### DIFF
--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -417,6 +417,7 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 	if activationLagThreshold.(int64) < 0 {
 		return meta, fmt.Errorf("%q must be positive number", activationLagThresholdMetricName)
 	}
+	meta.activationLagThreshold = activationLagThreshold.(int64)
 
 	if err := parseApacheKafkaAuthParams(config, &meta); err != nil {
 		return meta, err

--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -121,7 +121,16 @@ func NewApacheKafkaScaler(ctx context.Context, config *scalersconfig.ScalerConfi
 func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apacheKafkaMetadata) error {
 	meta.enableTLS = false
 	var enableTLS bool
-	tlsString, err := getParameterFromConfigV2(config, "tls", true, true, false, true, "disable", reflect.TypeOf(""))
+	tlsString, err := getParameterFromConfigV2(
+		config,
+		"tls",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal("disable"),
+	)
 	if err != nil {
 		return fmt.Errorf("error incorrect TLS value given. %w", err)
 	}
@@ -136,11 +145,29 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 	}
 
 	if enableTLS {
-		certGiven, err := getParameterFromConfigV2(config, "cert", false, true, false, true, "", reflect.TypeOf(""))
+		certGiven, err := getParameterFromConfigV2(
+			config,
+			"cert",
+			reflect.TypeOf(""),
+			UseMetadata(false),
+			UseAuthentication(true),
+			UseResolvedEnv(false),
+			IsOptional(true),
+			WithDefaultVal(""),
+		)
 		if err != nil {
 			return err
 		}
-		keyGiven, err := getParameterFromConfigV2(config, "key", false, true, false, true, "", reflect.TypeOf(""))
+		keyGiven, err := getParameterFromConfigV2(
+			config,
+			"key",
+			reflect.TypeOf(""),
+			UseMetadata(false),
+			UseAuthentication(true),
+			UseResolvedEnv(false),
+			IsOptional(true),
+			WithDefaultVal(""),
+		)
 		if err != nil {
 			return err
 		}
@@ -150,14 +177,32 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 		if keyGiven == "" && certGiven != "" {
 			return errors.New("cert must be provided with key")
 		}
-		ca, err := getParameterFromConfigV2(config, "ca", false, true, false, true, "", reflect.TypeOf(""))
+		ca, err := getParameterFromConfigV2(
+			config,
+			"ca",
+			reflect.TypeOf(""),
+			UseMetadata(false),
+			UseAuthentication(true),
+			UseResolvedEnv(false),
+			IsOptional(true),
+			WithDefaultVal(""),
+		)
 		if err != nil {
 			return err
 		}
 		meta.ca = ca.(string)
 		meta.cert = certGiven.(string)
 		meta.key = keyGiven.(string)
-		keyPassword, err := getParameterFromConfigV2(config, "keyPassword", false, true, false, true, "", reflect.TypeOf(""))
+		keyPassword, err := getParameterFromConfigV2(
+			config,
+			"keyPassword",
+			reflect.TypeOf(""),
+			UseMetadata(false),
+			UseAuthentication(true),
+			UseResolvedEnv(false),
+			IsOptional(true),
+			WithDefaultVal(""),
+		)
 		if err != nil {
 			return err
 		}
@@ -166,7 +211,16 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 	}
 
 	meta.saslType = KafkaSASLTypeNone
-	saslAuthType, err := getParameterFromConfigV2(config, "sasl", true, true, false, true, "", reflect.TypeOf(""))
+	saslAuthType, err := getParameterFromConfigV2(
+		config,
+		"sasl",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
@@ -176,7 +230,16 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 		switch mode := kafkaSaslType(saslAuthType.(string)); mode {
 		case KafkaSASLTypeMskIam:
 			meta.saslType = mode
-			awsEndpoint, err := getParameterFromConfigV2(config, "awsEndpoint", true, false, false, true, "", reflect.TypeOf(""))
+			awsEndpoint, err := getParameterFromConfigV2(
+				config,
+				"awsEndpoint",
+				reflect.TypeOf(""),
+				UseMetadata(true),
+				UseAuthentication(true),
+				UseResolvedEnv(false),
+				IsOptional(true),
+				WithDefaultVal(""),
+			)
 			if err != nil {
 				return err
 			}
@@ -186,7 +249,15 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 			if !meta.enableTLS {
 				return errors.New("TLS is required for MSK")
 			}
-			awsRegion, err := getParameterFromConfigV2(config, "awsRegion", true, false, false, false, "", reflect.TypeOf(""))
+			awsRegion, err := getParameterFromConfigV2(
+				config,
+				"awsRegion",
+				reflect.TypeOf(""),
+				UseMetadata(true),
+				UseAuthentication(false),
+				UseResolvedEnv(false),
+				IsOptional(false),
+			)
 			if err != nil {
 				return fmt.Errorf("%w. No awsRegion given", err)
 			}
@@ -201,13 +272,30 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 		case KafkaSASLTypeSCRAMSHA256:
 			fallthrough
 		case KafkaSASLTypeSCRAMSHA512:
-			username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
+			username, err := getParameterFromConfigV2(
+				config,
+				"username",
+				reflect.TypeOf(""),
+				UseMetadata(false),
+				UseAuthentication(true),
+				UseResolvedEnv(false),
+				IsOptional(false),
+				WithDefaultVal(""),
+			)
 			if err != nil {
 				return fmt.Errorf("%w. No username given", err)
 			}
 			meta.username = strings.TrimSpace(username.(string))
-
-			password, err := getParameterFromConfigV2(config, "password", false, true, false, false, "", reflect.TypeOf(""))
+			password, err := getParameterFromConfigV2(
+				config,
+				"password",
+				reflect.TypeOf(""),
+				UseMetadata(false),
+				UseAuthentication(true),
+				UseResolvedEnv(false),
+				IsOptional(false),
+				WithDefaultVal(""),
+			)
 			if err != nil {
 				return fmt.Errorf("%w. No password given", err)
 			}
@@ -224,19 +312,45 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 
 func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) (apacheKafkaMetadata, error) {
 	meta := apacheKafkaMetadata{}
-	bootstrapServers, err := getParameterFromConfigV2(config, "bootstrapServers", true, false, true, false, "", reflect.TypeOf(""))
+	bootstrapServers, err := getParameterFromConfigV2(
+		config,
+		"bootstrapServers",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(true),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("no bootstrapServers given. %w", err)
 	}
 	meta.bootstrapServers = strings.Split(bootstrapServers.(string), ",")
 
-	consumerGroup, err := getParameterFromConfigV2(config, "consumerGroup", true, false, true, false, "", reflect.TypeOf(""))
+	consumerGroup, err := getParameterFromConfigV2(
+		config,
+		"consumerGroup",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(true),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("no consumer group given. %w", err)
 	}
 	meta.group = consumerGroup.(string)
-
-	topic, err := getParameterFromConfigV2(config, "topic", true, false, true, true, "", reflect.TypeOf(""))
+	topic, err := getParameterFromConfigV2(
+		config,
+		"topic",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(true),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -249,7 +363,17 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 	}
 
 	meta.partitionLimitation = nil
-	partitionLimitationMetadata, err := getParameterFromConfigV2(config, "partitionLimitation", true, false, false, true, "", reflect.TypeOf(""))
+	partitionLimitationMetadata, err := getParameterFromConfigV2(
+		config,
+		"partitionLimitation",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
+
 	if err != nil {
 		return meta, err
 	}
@@ -268,7 +392,16 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 	}
 
 	meta.offsetResetPolicy = defaultOffsetResetPolicy
-	offsetResetPolicyRaw, err := getParameterFromConfigV2(config, "offsetResetPolicy", true, false, false, true, "", reflect.TypeOf(""))
+	offsetResetPolicyRaw, err := getParameterFromConfigV2(
+		config,
+		"offsetResetPolicy",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -281,7 +414,17 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 	}
 
 	meta.lagThreshold = defaultKafkaLagThreshold
-	lagThreshold, err := getParameterFromConfigV2(config, lagThresholdMetricName, true, false, false, true, defaultKafkaLagThreshold, reflect.TypeOf(64))
+	lagThreshold, err := getParameterFromConfigV2(
+		config,
+		lagThresholdMetricName,
+		reflect.TypeOf(64),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(defaultKafkaLagThreshold),
+	)
+
 	if err != nil {
 		return meta, err
 	}
@@ -291,7 +434,16 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 	meta.lagThreshold = int64(lagThreshold.(int))
 
 	meta.activationLagThreshold = defaultKafkaActivationLagThreshold
-	activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, int64(defaultKafkaActivationLagThreshold), reflect.TypeOf(int64(64)))
+	activationLagThreshold, err := getParameterFromConfigV2(
+		config,
+		activationLagThresholdMetricName,
+		reflect.TypeOf(int64(64)),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(int64(defaultKafkaActivationLagThreshold)),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -303,25 +455,61 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		return meta, err
 	}
 
-	allowIDConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
+	allowIDConsumers, err := getParameterFromConfigV2(
+		config,
+		"allowIdleConsumers",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("error parsing allowIdleConsumers: %w", err)
 	}
 	meta.allowIdleConsumers = allowIDConsumers.(bool)
 
-	excludePersistentLag, err := getParameterFromConfigV2(config, "excludePersistentLag", true, false, false, true, false, reflect.TypeOf(true))
+	excludePersistentLag, err := getParameterFromConfigV2(
+		config,
+		"excludePersistentLag",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("error parsing excludePersistentLag: %w", err)
 	}
 	meta.excludePersistentLag = excludePersistentLag.(bool)
 
-	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(config, "scaleToZeroOnInvalidOffset", true, false, false, true, false, reflect.TypeOf(true))
+	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(
+		config,
+		"scaleToZeroOnInvalidOffset",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("error parsing scaleToZeroOnInvalidOffset: %w", err)
 	}
 	meta.scaleToZeroOnInvalidOffset = scaleToZeroOnInvalidOffset.(bool)
 
-	limitToPartitionsWithLag, err := getParameterFromConfigV2(config, "limitToPartitionsWithLag", true, false, false, true, false, reflect.TypeOf(true))
+	limitToPartitionsWithLag, err := getParameterFromConfigV2(
+		config,
+		"limitToPartitionsWithLag",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -426,7 +614,7 @@ func (s *apacheKafkaScaler) getTopicPartitions(ctx context.Context) (map[string]
 		for _, topic := range metadata.Topics {
 			partitions := make([]int, 0)
 			for _, partition := range topic.Partitions {
-				// if no partitions limitatitions are specified, all partitions are considered
+				// if no partitions limitations are specified, all partitions are considered
 				if (len(s.metadata.partitionLimitation) == 0) ||
 					(len(s.metadata.partitionLimitation) > 0 && kedautil.Contains(s.metadata.partitionLimitation, int32(partition.ID))) {
 					partitions = append(partitions, partition.ID)

--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -125,10 +125,9 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 		config,
 		"tls",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal("disable"),
 	)
 	if err != nil {
@@ -149,10 +148,8 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 			config,
 			"cert",
 			reflect.TypeOf(""),
-			UseMetadata(false),
-			UseAuthentication(true),
-			UseResolvedEnv(false),
-			IsOptional(true),
+			UseAuthentication(),
+			IsOptional(),
 			WithDefaultVal(""),
 		)
 		if err != nil {
@@ -162,10 +159,8 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 			config,
 			"key",
 			reflect.TypeOf(""),
-			UseMetadata(false),
-			UseAuthentication(true),
-			UseResolvedEnv(false),
-			IsOptional(true),
+			UseAuthentication(),
+			IsOptional(),
 			WithDefaultVal(""),
 		)
 		if err != nil {
@@ -181,10 +176,8 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 			config,
 			"ca",
 			reflect.TypeOf(""),
-			UseMetadata(false),
-			UseAuthentication(true),
-			UseResolvedEnv(false),
-			IsOptional(true),
+			UseAuthentication(),
+			IsOptional(),
 			WithDefaultVal(""),
 		)
 		if err != nil {
@@ -197,10 +190,8 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 			config,
 			"keyPassword",
 			reflect.TypeOf(""),
-			UseMetadata(false),
-			UseAuthentication(true),
-			UseResolvedEnv(false),
-			IsOptional(true),
+			UseAuthentication(),
+			IsOptional(),
 			WithDefaultVal(""),
 		)
 		if err != nil {
@@ -215,10 +206,9 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 		config,
 		"sasl",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -234,10 +224,9 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 				config,
 				"awsEndpoint",
 				reflect.TypeOf(""),
-				UseMetadata(true),
-				UseAuthentication(true),
-				UseResolvedEnv(false),
-				IsOptional(true),
+				UseMetadata(),
+				UseAuthentication(),
+				IsOptional(),
 				WithDefaultVal(""),
 			)
 			if err != nil {
@@ -253,10 +242,7 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 				config,
 				"awsRegion",
 				reflect.TypeOf(""),
-				UseMetadata(true),
-				UseAuthentication(false),
-				UseResolvedEnv(false),
-				IsOptional(false),
+				UseMetadata(),
 			)
 			if err != nil {
 				return fmt.Errorf("%w. No awsRegion given", err)
@@ -276,10 +262,7 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 				config,
 				"username",
 				reflect.TypeOf(""),
-				UseMetadata(false),
-				UseAuthentication(true),
-				UseResolvedEnv(false),
-				IsOptional(false),
+				UseAuthentication(),
 				WithDefaultVal(""),
 			)
 			if err != nil {
@@ -290,10 +273,7 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 				config,
 				"password",
 				reflect.TypeOf(""),
-				UseMetadata(false),
-				UseAuthentication(true),
-				UseResolvedEnv(false),
-				IsOptional(false),
+				UseAuthentication(),
 				WithDefaultVal(""),
 			)
 			if err != nil {
@@ -316,10 +296,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"bootstrapServers",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(true),
-		IsOptional(false),
+		UseMetadata(),
+		UseResolvedEnv(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -331,10 +309,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"consumerGroup",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(true),
-		IsOptional(false),
+		UseMetadata(),
+		UseResolvedEnv(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -345,10 +321,9 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"topic",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(true),
-		IsOptional(true),
+		UseMetadata(),
+		UseResolvedEnv(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -367,10 +342,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"partitionLimitation",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 
@@ -396,10 +369,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"offsetResetPolicy",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -418,10 +389,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		lagThresholdMetricName,
 		reflect.TypeOf(64),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(defaultKafkaLagThreshold),
 	)
 
@@ -438,10 +407,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		activationLagThresholdMetricName,
 		reflect.TypeOf(int64(64)),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(int64(defaultKafkaActivationLagThreshold)),
 	)
 	if err != nil {
@@ -459,10 +426,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"allowIdleConsumers",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 	if err != nil {
@@ -474,10 +439,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"excludePersistentLag",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 	if err != nil {
@@ -489,10 +452,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"scaleToZeroOnInvalidOffset",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 	if err != nil {
@@ -504,10 +465,8 @@ func parseApacheKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Lo
 		config,
 		"limitToPartitionsWithLag",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 	if err != nil {

--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -190,6 +190,7 @@ func parseApacheKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *apache
 			if err != nil {
 				return fmt.Errorf("%w. No awsRegion given", err)
 			}
+			meta.awsRegion = awsRegion.(string)
 			auth, err := awsutils.GetAwsAuthorization(config.TriggerUniqueKey, config.PodIdentity, config.TriggerMetadata, config.AuthParams, config.ResolvedEnv)
 			if err != nil {
 				return err

--- a/pkg/scalers/apache_kafka_scaler_test.go
+++ b/pkg/scalers/apache_kafka_scaler_test.go
@@ -290,7 +290,6 @@ func getBrokerApacheKafkaTestBase(t *testing.T, meta apacheKafkaMetadata, testDa
 	if er != nil {
 		t.Errorf("Unable to convert test data lagThreshold %s to string", testData.metadata["lagThreshold"])
 	}
-
 	if meta.lagThreshold != expectedLagThreshold && meta.lagThreshold != defaultKafkaLagThreshold {
 		t.Errorf("Expected lagThreshold to be either %v or %v got %v ", meta.lagThreshold, defaultKafkaLagThreshold, expectedLagThreshold)
 	}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -426,7 +426,7 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		}
 		meta.offsetResetPolicy = policy
 	}
-
+	meta.lagThreshold = defaultKafkaLagThreshold
 	lagThreshold, err := getParameterFromConfigV2(config, lagThresholdMetricName, true, false, false, true, defaultKafkaLagThreshold, reflect.TypeOf(64))
 	if err != nil {
 		return meta, err
@@ -489,6 +489,7 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 	if err != nil {
 		return meta, fmt.Errorf("error parsing kafka version: %w", err)
 	}
+	meta.version = version
 	meta.triggerIndex = config.TriggerIndex
 	return meta, nil
 }

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -158,7 +158,16 @@ func NewKafkaScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 
 func parseKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata) error {
 	meta.saslType = KafkaSASLTypeNone
-	saslAuthType, err := getParameterFromConfigV2(config, "sasl", true, true, false, true, "", reflect.TypeOf(""))
+	saslAuthType, err := getParameterFromConfigV2(
+		config,
+		"sasl",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(true),
+		UseResolvedEnv(true),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
@@ -185,7 +194,16 @@ func parseKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadat
 
 	meta.enableTLS = false
 	var enableTLS bool
-	tlsString, err := getParameterFromConfigV2(config, "tls", true, true, false, true, "disable", reflect.TypeOf(""))
+	tlsString, err := getParameterFromConfigV2(
+		config,
+		"tls",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal("disable"),
+	)
 	if err != nil {
 		return fmt.Errorf("error incorrect TLS value given. %w", err)
 	}
@@ -206,14 +224,32 @@ func parseKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadat
 	return nil
 }
 
-func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
-	certGiven, err := getParameterFromConfigV2(config, "cert", false, true, false, true, "", reflect.TypeOf(""))
+func parseTLS(config *scalersconfig.ScalerConfig, meta *kafkaMetadata) error {
+	certGiven, err := getParameterFromConfigV2(
+		config,
+		"cert",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
 	meta.cert = certGiven.(string)
 
-	keyGiven, err := getParameterFromConfigV2(config, "key", false, true, false, true, "", reflect.TypeOf(""))
+	keyGiven, err := getParameterFromConfigV2(
+		config,
+		"key",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
@@ -226,19 +262,46 @@ func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
 		return errors.New("cert must be provided with key")
 	}
 
-	ca, err := getParameterFromConfigV2(config, "ca", false, true, false, true, "", reflect.TypeOf(""))
+	ca, err := getParameterFromConfigV2(
+		config,
+		"ca",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
 	meta.ca = ca.(string)
 
-	unsafeSslRaw, err := getParameterFromConfigV2(config, "unsafeSsl", true, false, false, true, defaultUnsafeSsl, reflect.TypeOf(true))
+	unsafeSslRaw, err := getParameterFromConfigV2(
+		config,
+		"unsafeSsl",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(defaultUnsafeSsl),
+	)
 	if err != nil {
 		return fmt.Errorf("error parsing unsafeSsl: %w", err)
 	}
 	meta.unsafeSsl = unsafeSslRaw.(bool)
 
-	keyPassword, err := getParameterFromConfigV2(config, "keyPassword", false, true, false, true, "", reflect.TypeOf(""))
+	keyPassword, err := getParameterFromConfigV2(
+		config,
+		"keyPassword",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
@@ -248,18 +311,45 @@ func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
 	return nil
 }
 
-func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
-	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
+func parseKerberosParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
+	username, err := getParameterFromConfigV2(
+		config,
+		"username",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return fmt.Errorf("no username given. %w", err)
 	}
 	meta.username = strings.TrimSpace(username.(string))
 
-	password, err := getParameterFromConfigV2(config, "password", false, true, false, true, "", reflect.TypeOf(""))
+	password, err := getParameterFromConfigV2(
+		config,
+		"password",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
-	keytab, err := getParameterFromConfigV2(config, "keytab", false, true, false, true, "", reflect.TypeOf(""))
+	keytab, err := getParameterFromConfigV2(
+		config,
+		"keytab",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return err
 	}
@@ -278,13 +368,31 @@ func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSa
 		meta.keytabPath = path
 	}
 
-	realm, err := getParameterFromConfigV2(config, "realm", false, true, false, false, "", reflect.TypeOf(""))
+	realm, err := getParameterFromConfigV2(
+		config,
+		"realm",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return fmt.Errorf("no realm given. %w", err)
 	}
 	meta.realm = strings.TrimSpace(realm.(string))
 
-	kerberosConfig, err := getParameterFromConfigV2(config, "kerberosConfig", false, true, false, false, "", reflect.TypeOf(""))
+	kerberosConfig, err := getParameterFromConfigV2(
+		config,
+		"kerberosConfig",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return fmt.Errorf("no Kerberos configuration file (kerberosConfig) given. %w", err)
 	}
@@ -302,14 +410,32 @@ func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSa
 	return nil
 }
 
-func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
-	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
+func parseSaslParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
+	username, err := getParameterFromConfigV2(
+		config,
+		"username",
+		reflect.TypeOf(""),
+		UseMetadata(false),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return fmt.Errorf("no username given. %w", err)
 	}
 	meta.username = strings.TrimSpace(username.(string))
 
-	password, err := getParameterFromConfigV2(config, "password", false, true, false, false, "", reflect.TypeOf(""))
+	password, err := getParameterFromConfigV2(
+		config,
+		"password",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(true),
+		UseResolvedEnv(false),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return fmt.Errorf("no password given. %w", err)
 	}
@@ -317,20 +443,47 @@ func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslTy
 	meta.saslType = mode
 
 	if mode == KafkaSASLTypeOAuthbearer {
-		scopes, err := getParameterFromConfigV2(config, "scopes", false, true, false, true, "", reflect.TypeOf(""))
+		scopes, err := getParameterFromConfigV2(
+			config,
+			"scopes",
+			reflect.TypeOf(""),
+			UseMetadata(false),
+			UseAuthentication(true),
+			UseResolvedEnv(false),
+			IsOptional(true),
+			WithDefaultVal(""),
+		)
 		if err != nil {
 			return fmt.Errorf("no scopes given. %w", err)
 		}
 		meta.scopes = strings.Split(scopes.(string), ",")
 
-		oauthTokenEndpointsURI, err := getParameterFromConfigV2(config, "oauthTokenEndpointUri", false, true, false, false, "", reflect.TypeOf(""))
+		oauthTokenEndpointsURI, err := getParameterFromConfigV2(
+			config,
+			"oauthTokenEndpointUri",
+			reflect.TypeOf(""),
+			UseMetadata(false),
+			UseAuthentication(true),
+			UseResolvedEnv(false),
+			IsOptional(false),
+			WithDefaultVal(""),
+		)
 		if err != nil {
 			return fmt.Errorf("no oauth token endpoint uri given. %w", err)
 		}
 		meta.oauthTokenEndpointURI = strings.TrimSpace(oauthTokenEndpointsURI.(string))
 
 		meta.oauthExtensions = make(map[string]string)
-		oauthExtensionsRaw, _ := getParameterFromConfigV2(config, "oauthExtensions", false, true, false, true, "", reflect.TypeOf(""))
+		oauthExtensionsRaw, _ := getParameterFromConfigV2(
+			config,
+			"oauthExtensions",
+			reflect.TypeOf(""),
+			UseMetadata(false),
+			UseAuthentication(true),
+			UseResolvedEnv(false),
+			IsOptional(true),
+			WithDefaultVal(""),
+		)
 		if oauthExtensionsRaw != "" {
 			for _, extension := range strings.Split(oauthExtensionsRaw.(string), ",") {
 				splitExtension := strings.Split(extension, "=")
@@ -373,19 +526,46 @@ func saveToFile(content string) (string, error) {
 
 func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) (kafkaMetadata, error) {
 	meta := kafkaMetadata{}
-	bootstrapServers, err := getParameterFromConfigV2(config, "bootstrapServers", true, false, true, false, "", reflect.TypeOf(""))
+	bootstrapServers, err := getParameterFromConfigV2(
+		config,
+		"bootstrapServers",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(true),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("no bootstrapServers given. %w", err)
 	}
 	meta.bootstrapServers = strings.Split(bootstrapServers.(string), ",")
 
-	consumerGroup, err := getParameterFromConfigV2(config, "consumerGroup", true, false, true, false, "", reflect.TypeOf(""))
+	consumerGroup, err := getParameterFromConfigV2(
+		config,
+		"consumerGroup",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(true),
+		IsOptional(false),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("no consumer group given. %w", err)
 	}
 	meta.group = consumerGroup.(string)
 
-	topic, err := getParameterFromConfigV2(config, "topic", true, false, true, true, "", reflect.TypeOf(""))
+	topic, err := getParameterFromConfigV2(
+		config,
+		"topic",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(true),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -396,7 +576,16 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 	meta.topic = topic.(string)
 
 	meta.partitionLimitation = nil
-	partitionLimitationMetadata, err := getParameterFromConfigV2(config, "partitionLimitation", true, false, false, true, "", reflect.TypeOf(""))
+	partitionLimitationMetadata, err := getParameterFromConfigV2(
+		config,
+		"partitionLimitation",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -415,7 +604,16 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 	}
 
 	meta.offsetResetPolicy = defaultOffsetResetPolicy
-	offsetResetPolicyRaw, err := getParameterFromConfigV2(config, "offsetResetPolicy", true, false, false, true, "", reflect.TypeOf(""))
+	offsetResetPolicyRaw, err := getParameterFromConfigV2(
+		config,
+		"offsetResetPolicy",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(""),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -427,7 +625,16 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		meta.offsetResetPolicy = policy
 	}
 	meta.lagThreshold = defaultKafkaLagThreshold
-	lagThreshold, err := getParameterFromConfigV2(config, lagThresholdMetricName, true, false, false, true, defaultKafkaLagThreshold, reflect.TypeOf(64))
+	lagThreshold, err := getParameterFromConfigV2(
+		config,
+		lagThresholdMetricName,
+		reflect.TypeOf(64),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(defaultKafkaLagThreshold),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -437,7 +644,16 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 	meta.lagThreshold = int64(lagThreshold.(int))
 
 	meta.activationLagThreshold = defaultKafkaActivationLagThreshold
-	activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, int64(defaultKafkaActivationLagThreshold), reflect.TypeOf(int64(64)))
+	activationLagThreshold, err := getParameterFromConfigV2(
+		config,
+		activationLagThresholdMetricName,
+		reflect.TypeOf(int64(64)),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(int64(defaultKafkaActivationLagThreshold)),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -449,26 +665,62 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 	if err := parseKafkaAuthParams(config, &meta); err != nil {
 		return meta, err
 	}
-
-	allowIDConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
+	allowIDConsumers, err := getParameterFromConfigV2(
+		config,
+		"allowIdleConsumers",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("error parsing allowIdleConsumers: %w", err)
 	}
 	meta.allowIdleConsumers = allowIDConsumers.(bool)
 
-	excludePersistentLag, err := getParameterFromConfigV2(config, "excludePersistentLag", true, false, false, true, false, reflect.TypeOf(true))
+	excludePersistentLag, err := getParameterFromConfigV2(
+		config,
+		"excludePersistentLag",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
 	if err != nil {
 		return meta, fmt.Errorf("error parsing excludePersistentLag: %w", err)
 	}
 	meta.excludePersistentLag = excludePersistentLag.(bool)
 
-	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(config, "scaleToZeroOnInvalidOffset", true, false, false, true, false, reflect.TypeOf(true))
+	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(
+		config,
+		"scaleToZeroOnInvalidOffset",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
+
 	if err != nil {
 		return meta, fmt.Errorf("error parsing scaleToZeroOnInvalidOffset: %w", err)
 	}
 	meta.scaleToZeroOnInvalidOffset = scaleToZeroOnInvalidOffset.(bool)
 
-	limitToPartitionsWithLag, err := getParameterFromConfigV2(config, "limitToPartitionsWithLag", true, false, false, true, false, reflect.TypeOf(true))
+	limitToPartitionsWithLag, err := getParameterFromConfigV2(
+		config,
+		"limitToPartitionsWithLag",
+		reflect.TypeOf(true),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal(false),
+	)
 	if err != nil {
 		return meta, err
 	}
@@ -480,7 +732,16 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 	if len(meta.topic) == 0 && meta.limitToPartitionsWithLag {
 		return meta, fmt.Errorf("topic must be specified when using limitToPartitionsWithLag")
 	}
-	saramaVer, err := getParameterFromConfigV2(config, "version", true, false, false, true, "1.0.0", reflect.TypeOf(""))
+	saramaVer, err := getParameterFromConfigV2(
+		config,
+		"version",
+		reflect.TypeOf(""),
+		UseMetadata(true),
+		UseAuthentication(false),
+		UseResolvedEnv(false),
+		IsOptional(true),
+		WithDefaultVal("1.0.0"),
+	)
 	if err != nil {
 		return meta, err
 	}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -162,10 +162,10 @@ func parseKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadat
 		config,
 		"sasl",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(true),
-		UseResolvedEnv(true),
-		IsOptional(true),
+		UseMetadata(),
+		UseAuthentication(),
+		UseResolvedEnv(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -198,10 +198,9 @@ func parseKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadat
 		config,
 		"tls",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal("disable"),
 	)
 	if err != nil {
@@ -229,10 +228,8 @@ func parseTLS(config *scalersconfig.ScalerConfig, meta *kafkaMetadata) error {
 		config,
 		"cert",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -244,10 +241,8 @@ func parseTLS(config *scalersconfig.ScalerConfig, meta *kafkaMetadata) error {
 		config,
 		"key",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -266,10 +261,8 @@ func parseTLS(config *scalersconfig.ScalerConfig, meta *kafkaMetadata) error {
 		config,
 		"ca",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -281,10 +274,8 @@ func parseTLS(config *scalersconfig.ScalerConfig, meta *kafkaMetadata) error {
 		config,
 		"unsafeSsl",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(defaultUnsafeSsl),
 	)
 	if err != nil {
@@ -296,10 +287,8 @@ func parseTLS(config *scalersconfig.ScalerConfig, meta *kafkaMetadata) error {
 		config,
 		"keyPassword",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -316,10 +305,7 @@ func parseKerberosParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata
 		config,
 		"username",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(false),
+		UseAuthentication(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -331,10 +317,8 @@ func parseKerberosParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata
 		config,
 		"password",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -344,10 +328,8 @@ func parseKerberosParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata
 		config,
 		"keytab",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseAuthentication(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -372,10 +354,7 @@ func parseKerberosParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata
 		config,
 		"realm",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(false),
+		UseAuthentication(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -387,10 +366,7 @@ func parseKerberosParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata
 		config,
 		"kerberosConfig",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(false),
+		UseAuthentication(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -415,10 +391,7 @@ func parseSaslParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata, mo
 		config,
 		"username",
 		reflect.TypeOf(""),
-		UseMetadata(false),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(false),
+		UseAuthentication(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -430,10 +403,8 @@ func parseSaslParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata, mo
 		config,
 		"password",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(true),
-		UseResolvedEnv(false),
-		IsOptional(false),
+		UseMetadata(),
+		UseAuthentication(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -447,10 +418,8 @@ func parseSaslParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata, mo
 			config,
 			"scopes",
 			reflect.TypeOf(""),
-			UseMetadata(false),
-			UseAuthentication(true),
-			UseResolvedEnv(false),
-			IsOptional(true),
+			UseAuthentication(),
+			IsOptional(),
 			WithDefaultVal(""),
 		)
 		if err != nil {
@@ -462,10 +431,7 @@ func parseSaslParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata, mo
 			config,
 			"oauthTokenEndpointUri",
 			reflect.TypeOf(""),
-			UseMetadata(false),
-			UseAuthentication(true),
-			UseResolvedEnv(false),
-			IsOptional(false),
+			UseAuthentication(),
 			WithDefaultVal(""),
 		)
 		if err != nil {
@@ -478,10 +444,8 @@ func parseSaslParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadata, mo
 			config,
 			"oauthExtensions",
 			reflect.TypeOf(""),
-			UseMetadata(false),
-			UseAuthentication(true),
-			UseResolvedEnv(false),
-			IsOptional(true),
+			UseAuthentication(),
+			IsOptional(),
 			WithDefaultVal(""),
 		)
 		if oauthExtensionsRaw != "" {
@@ -530,10 +494,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"bootstrapServers",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(true),
-		IsOptional(false),
+		UseMetadata(),
+		UseResolvedEnv(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -545,10 +507,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"consumerGroup",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(true),
-		IsOptional(false),
+		UseMetadata(),
+		UseResolvedEnv(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -560,10 +520,9 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"topic",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(true),
-		IsOptional(true),
+		UseMetadata(),
+		UseResolvedEnv(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -580,10 +539,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"partitionLimitation",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -608,10 +565,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"offsetResetPolicy",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(""),
 	)
 	if err != nil {
@@ -629,10 +584,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		lagThresholdMetricName,
 		reflect.TypeOf(64),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(defaultKafkaLagThreshold),
 	)
 	if err != nil {
@@ -648,10 +601,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		activationLagThresholdMetricName,
 		reflect.TypeOf(int64(64)),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(int64(defaultKafkaActivationLagThreshold)),
 	)
 	if err != nil {
@@ -669,10 +620,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"allowIdleConsumers",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 	if err != nil {
@@ -684,10 +633,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"excludePersistentLag",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 	if err != nil {
@@ -699,10 +646,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"scaleToZeroOnInvalidOffset",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 
@@ -715,10 +660,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"limitToPartitionsWithLag",
 		reflect.TypeOf(true),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal(false),
 	)
 	if err != nil {
@@ -736,10 +679,8 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		config,
 		"version",
 		reflect.TypeOf(""),
-		UseMetadata(true),
-		UseAuthentication(false),
-		UseResolvedEnv(false),
-		IsOptional(true),
+		UseMetadata(),
+		IsOptional(),
 		WithDefaultVal("1.0.0"),
 	)
 	if err != nil {

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -234,7 +234,7 @@ func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
 
 	unsafeSslRaw, err := getParameterFromConfigV2(config, "unsafeSsl", true, false, false, true, defaultUnsafeSsl, reflect.TypeOf(true))
 	if err != nil {
-		return errors.New(fmt.Sprintf("error parsing unsafeSsl: %s", err.Error()))
+		return fmt.Errorf("error parsing unsafeSsl: %w", err)
 	}
 	meta.unsafeSsl = unsafeSslRaw.(bool)
 
@@ -251,7 +251,7 @@ func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
 func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
 	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no username given. %s", err.Error()))
+		return fmt.Errorf("no username given. %w", err)
 	}
 	meta.username = strings.TrimSpace(username.(string))
 
@@ -280,13 +280,13 @@ func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSa
 
 	realm, err := getParameterFromConfigV2(config, "realm", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no realm given. %s", err.Error()))
+		return fmt.Errorf("no realm given. %w", err)
 	}
 	meta.realm = strings.TrimSpace(realm.(string))
 
 	kerberosConfig, err := getParameterFromConfigV2(config, "kerberosConfig", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no Kerberos configuration file (kerberosConfig) given. %s", err.Error()))
+		return fmt.Errorf("no Kerberos configuration file (kerberosConfig) given. %w", err)
 	}
 	path, err := saveToFile(kerberosConfig.(string))
 	if err != nil {
@@ -305,13 +305,13 @@ func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSa
 func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
 	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no username given. %s", err.Error()))
+		return fmt.Errorf("no username given. %w", err)
 	}
 	meta.username = strings.TrimSpace(username.(string))
 
 	password, err := getParameterFromConfigV2(config, "password", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no password given. %s", err.Error()))
+		return fmt.Errorf("no password given. %w", err)
 	}
 	meta.password = strings.TrimSpace(password.(string))
 	meta.saslType = mode
@@ -319,13 +319,13 @@ func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslTy
 	if mode == KafkaSASLTypeOAuthbearer {
 		scopes, err := getParameterFromConfigV2(config, "scopes", false, true, false, true, "", reflect.TypeOf(""))
 		if err != nil {
-			return errors.New(fmt.Sprintf("no scopes given. %s", err.Error()))
+			return fmt.Errorf("no scopes given. %w", err)
 		}
 		meta.scopes = strings.Split(scopes.(string), ",")
 
 		oauthTokenEndpointsURI, err := getParameterFromConfigV2(config, "oauthTokenEndpointUri", false, true, false, false, "", reflect.TypeOf(""))
 		if err != nil {
-			return errors.New(fmt.Sprintf("no oauth token endpoint uri given. %s", err.Error()))
+			return fmt.Errorf("no oauth token endpoint uri given. %w", err)
 		}
 		meta.oauthTokenEndpointURI = strings.TrimSpace(oauthTokenEndpointsURI.(string))
 
@@ -375,13 +375,13 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 	meta := kafkaMetadata{}
 	bootstrapServers, err := getParameterFromConfigV2(config, "bootstrapServers", true, false, true, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("no bootstrapServers given. %s", err.Error()))
+		return meta, fmt.Errorf("no bootstrapServers given. %w", err)
 	}
 	meta.bootstrapServers = strings.Split(bootstrapServers.(string), ",")
 
 	consumerGroup, err := getParameterFromConfigV2(config, "consumerGroup", true, false, true, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("no consumer group given. %s", err.Error()))
+		return meta, fmt.Errorf("no consumer group given. %w", err)
 	}
 	meta.group = consumerGroup.(string)
 
@@ -450,21 +450,21 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		return meta, err
 	}
 
-	allowIdConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
+	allowIDConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("error parsing allowIdleConsumers: %s", err.Error()))
+		return meta, fmt.Errorf("error parsing allowIdleConsumers: %w", err)
 	}
-	meta.allowIdleConsumers = allowIdConsumers.(bool)
+	meta.allowIdleConsumers = allowIDConsumers.(bool)
 
 	excludePersistentLag, err := getParameterFromConfigV2(config, "excludePersistentLag", true, false, false, true, false, reflect.TypeOf(true))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("error parsing excludePersistentLag: %s", err.Error()))
+		return meta, fmt.Errorf("error parsing excludePersistentLag: %w", err)
 	}
 	meta.excludePersistentLag = excludePersistentLag.(bool)
 
 	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(config, "scaleToZeroOnInvalidOffset", true, false, false, true, false, reflect.TypeOf(true))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("error parsing scaleToZeroOnInvalidOffset: %s", err.Error()))
+		return meta, fmt.Errorf("error parsing scaleToZeroOnInvalidOffset: %w", err)
 	}
 	meta.scaleToZeroOnInvalidOffset = scaleToZeroOnInvalidOffset.(bool)
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -187,7 +187,7 @@ func parseKafkaAuthParams(config *scalersconfig.ScalerConfig, meta *kafkaMetadat
 	var enableTLS bool
 	tlsString, err := getParameterFromConfigV2(config, "tls", true, true, false, true, "disable", reflect.TypeOf(""))
 	if err != nil {
-		return fmt.Errorf("error incorrect TLS value given. %s", err.Error())
+		return fmt.Errorf("error incorrect TLS value given. %w", err)
 	}
 	tlsString = strings.TrimSpace(tlsString.(string))
 	switch tlsString.(string) {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -321,8 +321,8 @@ var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
 }
 
 func TestGetBrokers(t *testing.T) {
-	for _, testData := range parseKafkaMetadataTestDataset {
-		meta, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
+	for idx, testData := range parseKafkaMetadataTestDataset {
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
 		getBrokerTestBase(t, meta, testData, err)
 
 		meta, err = parseKafkaMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithoutAuthParams}, logr.Discard())
@@ -375,30 +375,30 @@ func getBrokerTestBase(t *testing.T, meta kafkaMetadata, testData parseKafkaMeta
 }
 
 func TestKafkaAuthParamsInTriggerAuthentication(t *testing.T) {
-	for _, testData := range parseKafkaAuthParamsTestDataset {
-		meta, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
+	for idx, testData := range parseKafkaAuthParamsTestDataset {
+		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
-			t.Error("Expected success but got error", err)
+			t.Errorf("Test %v: expected success but got error %v", idx, err)
 		}
 		if testData.isError && err == nil {
-			t.Error("Expected error but got success")
+			t.Errorf("Test %v: expected error but got success", idx)
 		}
 		if meta.enableTLS != testData.enableTLS {
-			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
+			t.Errorf("Test %v: expected enableTLS to be set to %v but got %v\n", idx, testData.enableTLS, meta.enableTLS)
 		}
 		if meta.enableTLS {
 			if meta.ca != testData.authParams["ca"] {
-				t.Errorf("Expected ca to be set to %v but got %v\n", testData.authParams["ca"], meta.enableTLS)
+				t.Errorf("Test %v: expected ca to be set to %v but got %v\n", idx, testData.authParams["ca"], meta.enableTLS)
 			}
 			if meta.cert != testData.authParams["cert"] {
-				t.Errorf("Expected cert to be set to %v but got %v\n", testData.authParams["cert"], meta.cert)
+				t.Errorf("Test %v: expected cert to be set to %v but got %v\n", idx, testData.authParams["cert"], meta.cert)
 			}
 			if meta.key != testData.authParams["key"] {
-				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["key"], meta.key)
+				t.Errorf("Test %v: expected key to be set to %v but got %v\n", idx, testData.authParams["key"], meta.key)
 			}
 			if meta.keyPassword != testData.authParams["keyPassword"] {
-				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["keyPassword"], meta.key)
+				t.Errorf("Test %v: expected key to be set to %v but got %v\n", idx, testData.authParams["keyPassword"], meta.key)
 			}
 		}
 		if meta.saslType == KafkaSASLTypeGSSAPI && !testData.isError {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -321,7 +321,7 @@ var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
 }
 
 func TestGetBrokers(t *testing.T) {
-	for idx, testData := range parseKafkaMetadataTestDataset {
+	for _, testData := range parseKafkaMetadataTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
 		getBrokerTestBase(t, meta, testData, err)
 

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -322,7 +322,7 @@ var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
 
 func TestGetBrokers(t *testing.T) {
 	for _, testData := range parseKafkaMetadataTestDataset {
-		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
+		meta, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
 		getBrokerTestBase(t, meta, testData, err)
 
 		meta, err = parseKafkaMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithoutAuthParams}, logr.Discard())
@@ -376,7 +376,7 @@ func getBrokerTestBase(t *testing.T, meta kafkaMetadata, testData parseKafkaMeta
 
 func TestKafkaAuthParamsInTriggerAuthentication(t *testing.T) {
 	for idx, testData := range parseKafkaAuthParamsTestDataset {
-		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
+		meta, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Errorf("Test %v: expected success but got error %v", idx, err)

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -182,28 +182,28 @@ type configOptions struct {
 // UseMetadata is an Option function that sets the useMetadata field of configOptions.
 func UseMetadata() Option {
 	return func(opt *configOptions) {
-		opt.useMetadata = true 
+		opt.useMetadata = true
 	}
 }
 
 // UseAuthentication is an Option function that sets the useAuthentication field of configOptions.
 func UseAuthentication() Option {
 	return func(opt *configOptions) {
-		opt.useAuthentication = true 
+		opt.useAuthentication = true
 	}
 }
 
 // UseResolvedEnv is an Option function that sets the useResolvedEnv field of configOptions.
 func UseResolvedEnv() Option {
 	return func(opt *configOptions) {
-		opt.useResolvedEnv = true 
+		opt.useResolvedEnv = true
 	}
 }
 
 // IsOptional is an Option function that sets the isOptional field of configOptions.
 func IsOptional() Option {
 	return func(opt *configOptions) {
-		opt.isOptional = true 
+		opt.isOptional = true
 	}
 }
 

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -180,30 +180,30 @@ type configOptions struct {
 }
 
 // UseMetadata is an Option function that sets the useMetadata field of configOptions.
-func UseMetadata(metadata bool) Option {
+func UseMetadata() Option {
 	return func(opt *configOptions) {
-		opt.useMetadata = metadata
+		opt.useMetadata = true 
 	}
 }
 
 // UseAuthentication is an Option function that sets the useAuthentication field of configOptions.
-func UseAuthentication(auth bool) Option {
+func UseAuthentication() Option {
 	return func(opt *configOptions) {
-		opt.useAuthentication = auth
+		opt.useAuthentication = true 
 	}
 }
 
 // UseResolvedEnv is an Option function that sets the useResolvedEnv field of configOptions.
-func UseResolvedEnv(resolvedEnv bool) Option {
+func UseResolvedEnv() Option {
 	return func(opt *configOptions) {
-		opt.useResolvedEnv = resolvedEnv
+		opt.useResolvedEnv = true 
 	}
 }
 
 // IsOptional is an Option function that sets the isOptional field of configOptions.
-func IsOptional(optional bool) Option {
+func IsOptional() Option {
 	return func(opt *configOptions) {
-		opt.isOptional = optional
+		opt.isOptional = true 
 	}
 }
 
@@ -235,7 +235,7 @@ func WithDefaultVal(defaultVal interface{}) Option {
 //	To retrieve a parameter value from a ScalerConfig object, you can call this function with the necessary parameters and options
 //
 //	```
-//	val, err := getParameterFromConfigV2(scalerConfig, "parameterName", reflect.TypeOf(int64(0)), UseMetadata(true), UseAuthentication(true))
+//	val, err := getParameterFromConfigV2(scalerConfig, "parameterName", reflect.TypeOf(int64(0)), UseMetadata(), UseAuthentication())
 //	if err != nil {
 //	    // Handle error
 //	}

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -254,15 +254,28 @@ var getParameterFromConfigTestDataset = []getParameterFromConfigTestData{
 
 func TestGetParameterFromConfigV2(t *testing.T) {
 	for _, testData := range getParameterFromConfigTestDataset {
+		options := []Option{
+			WithDefaultVal(testData.defaultVal),
+		}
+
+		if testData.useMetadata {
+			options = append(options, UseMetadata())
+		}
+		if testData.useAuthentication {
+			options = append(options, UseAuthentication())
+		}
+		if testData.useResolvedEnv {
+			options = append(options, UseResolvedEnv())
+		}
+		if testData.isOptional {
+			options = append(options, IsOptional())
+		}
+
 		val, err := getParameterFromConfigV2(
 			&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams, ResolvedEnv: testData.resolvedEnv},
 			testData.parameter,
 			testData.targetType,
-			UseMetadata(testData.useMetadata),
-			UseAuthentication(testData.useAuthentication),
-			UseResolvedEnv(testData.useResolvedEnv),
-			IsOptional(testData.isOptional),
-			WithDefaultVal(testData.defaultVal),
+			options...,
 		)
 		if testData.isError {
 			assert.NotNilf(t, err, "test %s: expected error but got success, testData - %+v", testData.name, testData)

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -240,7 +240,7 @@ var getParameterFromConfigTestDataset = []getParameterFromConfigTestData{
 		targetType:     reflect.TypeOf(string("")),
 		expectedResult: "default", // Should return empty string
 		isError:        true,
-		errorMessage:   "key key2 not found. Either set the correct key or set isOptional to true and set defaultVal",
+		errorMessage:   "key not found. Either set the correct key or set isOptional to true and set defaultVal",
 	},
 	{
 		name:              "test_authParam_bool",

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -240,7 +240,7 @@ var getParameterFromConfigTestDataset = []getParameterFromConfigTestData{
 		targetType:     reflect.TypeOf(string("")),
 		expectedResult: "default", // Should return empty string
 		isError:        true,
-		errorMessage:   "key not found. Either set the correct key or set isOptional to true and set defaultVal",
+		errorMessage:   "key key2 not found. Either set the correct key or set isOptional to true and set defaultVal",
 	},
 	{
 		name:              "test_authParam_bool",


### PR DESCRIPTION
Hi team,

I did the refactor for 1 scaler first to get your opinion on this. Chose Kafka because imo its the most complexed :sweat: so its worth a try

### Checklist


- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/5037
