### PR TITLE
feat(gcp-stackdriver): handling value if no timeseries is return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Support TriggerAuthentication properties from ConfigMap ([#4830](https://github.com/kedacore/keda/issues/4830))
 - **General**: Use client-side round-robin load balancing for grpc calls ([#5224](https://github.com/kedacore/keda/issues/5224))
 - **GCP pubsub scaler**: Support distribution-valued metrics and metrics from topics ([#5070](https://github.com/kedacore/keda/issues/5070))
+- **GCP stackdriver scaler**: Support valueIfNull parameter ([#5345](https://github.com/kedacore/keda/pull/5345))
 - **Hashicorp Vault**: Add support to get secret that needs write operation (e.g. pki) ([#5067](https://github.com/kedacore/keda/issues/5067))
 - **Hashicorp Vault**: Fix operator panic when spec.hashiCorpVault.credential.serviceAccount is not set ([#4964](https://github.com/kedacore/keda/issues/4964))
 - **Hashicorp Vault**: Fix operator panic when using root token to authenticate to vault server ([#5192](https://github.com/kedacore/keda/issues/5192))

--- a/pkg/scalers/gcp_cloud_tasks_scaler.go
+++ b/pkg/scalers/gcp_cloud_tasks_scaler.go
@@ -179,5 +179,5 @@ func (s *gcpCloudTasksScaler) getMetrics(ctx context.Context, metricType string)
 
 	// Cloud Tasks metrics are collected every 60 seconds so no need to aggregate them.
 	// See: https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudtasks
-	return s.client.GetMetrics(ctx, filter, s.metadata.projectID, nil)
+	return s.client.GetMetrics(ctx, filter, s.metadata.projectID, nil, nil)
 }

--- a/pkg/scalers/gcp_stackdriver_client.go
+++ b/pkg/scalers/gcp_stackdriver_client.go
@@ -213,7 +213,8 @@ func (s StackDriverClient) GetMetrics(
 	ctx context.Context,
 	filter string,
 	projectID string,
-	aggregation *monitoringpb.Aggregation) (float64, error) {
+	aggregation *monitoringpb.Aggregation,
+	valueIfNull *float64) (float64, error) {
 	// Set the start time to 1 minute ago
 	startTime := time.Now().UTC().Add(time.Minute * -2)
 
@@ -246,7 +247,10 @@ func (s StackDriverClient) GetMetrics(
 	resp, err := it.Next()
 
 	if err == iterator.Done {
-		return value, fmt.Errorf("could not find stackdriver metric with filter %s", filter)
+		if valueIfNull == nil {
+			return value, fmt.Errorf("could not find stackdriver metric with filter %s", filter)
+		}
+		return *valueIfNull, nil
 	}
 
 	if err != nil {

--- a/pkg/scalers/gcp_stackdriver_scaler.go
+++ b/pkg/scalers/gcp_stackdriver_scaler.go
@@ -110,16 +110,12 @@ func parseStackdriverMetadata(config *ScalerConfig, logger logr.Logger) (*stackd
 		meta.activationTargetValue = activationTargetValue
 	}
 
-	if val, ok := config.TriggerMetadata["valueIfNull"]; ok {
-		if val == "" {
-			meta.valueIfNull = nil
-		} else {
-			valueIfNull, err := strconv.ParseFloat(val, 64)
-			if err != nil {
-				return nil, fmt.Errorf("valueIfNull parsing error %w", err)
-			}
-			meta.valueIfNull = &valueIfNull
+	if val, ok := config.TriggerMetadata["valueIfNull"]; ok && val != "" {
+		valueIfNull, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return nil, fmt.Errorf("valueIfNull parsing error %w", err)
 		}
+		meta.valueIfNull = &valueIfNull
 	}
 
 	auth, err := getGCPAuthorization(config)

--- a/pkg/scalers/gcp_stackdriver_scaler_test.go
+++ b/pkg/scalers/gcp_stackdriver_scaler_test.go
@@ -55,6 +55,10 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "alignmentPeriodSeconds": "a"}, true},
 	// properly formed float targetValue and activationTargetValue
 	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "targetValue": "1.1", "activationTargetValue": "2.1"}, false},
+	//properly formed float valueIfNull
+	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "targetValue": "1.1", "activationTargetValue": "2.1", "valueIfNull": "1.0"}, false},
+	// With bad valueIfNull
+	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "targetValue": "1.1", "activationTargetValue": "2.1", "valueIfNull": "toto"}, true},
 }
 
 var gcpStackdriverMetricIdentifiers = []gcpStackdriverMetricIdentifier{

--- a/pkg/scalers/gcp_stackdriver_scaler_test.go
+++ b/pkg/scalers/gcp_stackdriver_scaler_test.go
@@ -55,7 +55,7 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "alignmentPeriodSeconds": "a"}, true},
 	// properly formed float targetValue and activationTargetValue
 	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "targetValue": "1.1", "activationTargetValue": "2.1"}, false},
-	//properly formed float valueIfNull
+	// properly formed float valueIfNull
 	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "targetValue": "1.1", "activationTargetValue": "2.1", "valueIfNull": "1.0"}, false},
 	// With bad valueIfNull
 	{nil, map[string]string{"projectId": "myProject", "filter": sdFilter, "credentialsFromEnv": "SAMPLE_CREDS", "targetValue": "1.1", "activationTargetValue": "2.1", "valueIfNull": "toto"}, true},


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

Context: it's pretty common to see metric that have no value during some period that can be interpretate by 0.

So this pulling request adding an optional metadata `valueIfNull`. This value (if not empty) that will be used if there is no timeseries return by the gcp monitoring query.



### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
https://github.com/kedacore/keda-docs/pull/1285
