### PR TITLE
Support metrics externally ScaledJob as well as ScaledObject

### DIFF
--- a/pkg/mock/mock_scaling/mock_interface.go
+++ b/pkg/mock/mock_scaling/mock_interface.go
@@ -64,6 +64,21 @@ func (mr *MockScaleHandlerMockRecorder) DeleteScalableObject(ctx, scalableObject
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScalableObject", reflect.TypeOf((*MockScaleHandler)(nil).DeleteScalableObject), ctx, scalableObject)
 }
 
+// GetScaledJobMetrics mocks base method.
+func (m *MockScaleHandler) GetScaledJobMetrics(ctx context.Context, scaledJobName, scaleJobNamespace, metricName string) (*external_metrics.ExternalMetricValueList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScaledJobMetrics", ctx, scaledJobName, scaleJobNamespace, metricName)
+	ret0, _ := ret[0].(*external_metrics.ExternalMetricValueList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScaledJobMetrics indicates an expected call of GetScaledJobMetrics.
+func (mr *MockScaleHandlerMockRecorder) GetScaledJobMetrics(ctx, scaledJobName, scaleJobNamespace, metricName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScaledJobMetrics", reflect.TypeOf((*MockScaleHandler)(nil).GetScaledJobMetrics), ctx, scaledJobName, scaleJobNamespace, metricName)
+}
+
 // GetScaledObjectMetrics mocks base method.
 func (m *MockScaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectName, scaledObjectNamespace, metricName string) (*external_metrics.ExternalMetricValueList, error) {
 	m.ctrl.T.Helper()

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -35,6 +35,7 @@ var log = logf.Log.WithName("scalers_cache")
 
 type ScalersCache struct {
 	ScaledObject             *kedav1alpha1.ScaledObject
+	ScaledJob                *kedav1alpha1.ScaledJob
 	Scalers                  []ScalerBuilder
 	ScalableObjectGeneration int64
 	Recorder                 record.EventRecorder


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Support metrics externally ScaledJob as well as ScaledObject
This change is related with https://github.com/kedacore/keda/pull/4913

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
