### PR TITLE
chore: Automatically close stale PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -42,6 +42,3 @@ closeComment: >
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30
-
-# Limit to only `issues` or `pulls`
-only: issues


### PR DESCRIPTION
Automatically close stale PRs to aim for 0 open PRs

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
