### PR TITLE
[WIP] Generic parameter parser for scalers

### DIFF
--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -189,6 +189,7 @@ func parseApacheKafkaAuthParams(config *ScalerConfig, meta *apacheKafkaMetadata)
 			if err != nil {
 				return fmt.Errorf("%w. No awsRegion given", err)
 			}
+			meta.awsRegion = awsRegion.(string)
 			auth, err := awsutils.GetAwsAuthorization(config.TriggerUniqueKey, config.PodIdentity, config.TriggerMetadata, config.AuthParams, config.ResolvedEnv)
 			if err != nil {
 				return err

--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -119,83 +120,75 @@ func NewApacheKafkaScaler(ctx context.Context, config *ScalerConfig) (Scaler, er
 
 func parseApacheKafkaAuthParams(config *ScalerConfig, meta *apacheKafkaMetadata) error {
 	meta.enableTLS = false
-	enableTLS := false
-	if val, ok := config.TriggerMetadata["tls"]; ok {
-		switch val {
-		case stringEnable:
-			enableTLS = true
-		case stringDisable:
-			enableTLS = false
-		default:
-			return fmt.Errorf("error incorrect TLS value given, got %s", val)
-		}
+	var enableTLS bool
+	tlsString, err := getParameterFromConfigV2(config, "tls", true, true, false, true, "disable", reflect.TypeOf(""))
+	if err != nil {
+		return fmt.Errorf("error incorrect TLS value given. %w", err)
 	}
-
-	if val, ok := config.AuthParams["tls"]; ok {
-		val = strings.TrimSpace(val)
-		if enableTLS {
-			return errors.New("unable to set `tls` in both ScaledObject and TriggerAuthentication together")
-		}
-		switch val {
-		case stringEnable:
-			enableTLS = true
-		case stringDisable:
-			enableTLS = false
-		default:
-			return fmt.Errorf("error incorrect TLS value given, got %s", val)
-		}
+	tlsString = strings.TrimSpace(tlsString.(string))
+	switch tlsString.(string) {
+	case stringEnable:
+		enableTLS = true
+	case stringDisable:
+		enableTLS = false
+	default:
+		return fmt.Errorf("error incorrect TLS value given, got %s", tlsString.(string))
 	}
 
 	if enableTLS {
-		certGiven := config.AuthParams["cert"] != ""
-		keyGiven := config.AuthParams["key"] != ""
-		if certGiven && !keyGiven {
+		certGiven, err := getParameterFromConfigV2(config, "cert", false, true, false, true, "", reflect.TypeOf(""))
+		if err != nil {
+			return err
+		}
+		keyGiven, err := getParameterFromConfigV2(config, "key", false, true, false, true, "", reflect.TypeOf(""))
+		if err != nil {
+			return err
+		}
+		if certGiven == "" && keyGiven != "" {
 			return errors.New("key must be provided with cert")
 		}
-		if keyGiven && !certGiven {
+		if keyGiven == "" && certGiven != "" {
 			return errors.New("cert must be provided with key")
 		}
-		meta.ca = config.AuthParams["ca"]
-		meta.cert = config.AuthParams["cert"]
-		meta.key = config.AuthParams["key"]
-		if value, found := config.AuthParams["keyPassword"]; found {
-			meta.keyPassword = value
-		} else {
-			meta.keyPassword = ""
+		ca, err := getParameterFromConfigV2(config, "ca", false, true, false, true, "", reflect.TypeOf(""))
+		if err != nil {
+			return err
 		}
+		meta.ca = ca.(string)
+		meta.cert = certGiven.(string)
+		meta.key = keyGiven.(string)
+		keyPassword, err := getParameterFromConfigV2(config, "keyPassword", false, true, false, true, "", reflect.TypeOf(""))
+		if err != nil {
+			return err
+		}
+		meta.keyPassword = keyPassword.(string)
 		meta.enableTLS = true
 	}
 
 	meta.saslType = KafkaSASLTypeNone
-	var saslAuthType string
-	switch {
-	case config.TriggerMetadata["sasl"] != "":
-		saslAuthType = config.TriggerMetadata["sasl"]
-	default:
-		saslAuthType = ""
-	}
-	if val, ok := config.AuthParams["sasl"]; ok {
-		if saslAuthType != "" {
-			return errors.New("unable to set `sasl` in both ScaledObject and TriggerAuthentication together")
-		}
-		saslAuthType = val
+	saslAuthType, err := getParameterFromConfigV2(config, "sasl", true, true, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
 	}
 
 	if saslAuthType != "" {
-		saslAuthType = strings.TrimSpace(saslAuthType)
-		switch mode := kafkaSaslType(saslAuthType); mode {
+		saslAuthType = strings.TrimSpace(saslAuthType.(string))
+		switch mode := kafkaSaslType(saslAuthType.(string)); mode {
 		case KafkaSASLTypeMskIam:
 			meta.saslType = mode
-			if val, ok := config.TriggerMetadata["awsEndpoint"]; ok {
-				meta.awsEndpoint = val
+			awsEndpoint, err := getParameterFromConfigV2(config, "awsEndpoint", true, false, false, true, "", reflect.TypeOf(""))
+			if err != nil {
+				return err
+			}
+			if awsEndpoint != "" {
+				meta.awsEndpoint = awsEndpoint.(string)
 			}
 			if !meta.enableTLS {
 				return errors.New("TLS is required for MSK")
 			}
-			if val, ok := config.TriggerMetadata["awsRegion"]; ok && val != "" {
-				meta.awsRegion = val
-			} else {
-				return errors.New("no awsRegion given")
+			awsRegion, err := getParameterFromConfigV2(config, "awsRegion", true, false, false, false, "", reflect.TypeOf(""))
+			if err != nil {
+				return fmt.Errorf("%w. No awsRegion given", err)
 			}
 			auth, err := awsutils.GetAwsAuthorization(config.TriggerUniqueKey, config.PodIdentity, config.TriggerMetadata, config.AuthParams, config.ResolvedEnv)
 			if err != nil {
@@ -207,16 +200,17 @@ func parseApacheKafkaAuthParams(config *ScalerConfig, meta *apacheKafkaMetadata)
 		case KafkaSASLTypeSCRAMSHA256:
 			fallthrough
 		case KafkaSASLTypeSCRAMSHA512:
-			if val, ok := config.AuthParams["username"]; ok {
-				meta.username = strings.TrimSpace(val)
-			} else {
-				return errors.New("no username given")
+			username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
+			if err != nil {
+				return fmt.Errorf("%w. No username given", err)
 			}
-			if val, ok := config.AuthParams["password"]; ok {
-				meta.password = strings.TrimSpace(val)
-			} else {
-				return errors.New("no password given")
+			meta.username = strings.TrimSpace(username.(string))
+
+			password, err := getParameterFromConfigV2(config, "password", false, true, false, false, "", reflect.TypeOf(""))
+			if err != nil {
+				return fmt.Errorf("%w. No password given", err)
 			}
+			meta.password = strings.TrimSpace(password.(string))
 		case KafkaSASLTypeOAuthbearer:
 			return errors.New("SASL/OAUTHBEARER is not implemented yet")
 		default:
@@ -229,42 +223,40 @@ func parseApacheKafkaAuthParams(config *ScalerConfig, meta *apacheKafkaMetadata)
 
 func parseApacheKafkaMetadata(config *ScalerConfig, logger logr.Logger) (apacheKafkaMetadata, error) {
 	meta := apacheKafkaMetadata{}
-	switch {
-	case config.TriggerMetadata["bootstrapServersFromEnv"] != "":
-		meta.bootstrapServers = strings.Split(config.ResolvedEnv[config.TriggerMetadata["bootstrapServersFromEnv"]], ",")
-	case config.TriggerMetadata["bootstrapServers"] != "":
-		meta.bootstrapServers = strings.Split(config.TriggerMetadata["bootstrapServers"], ",")
-	default:
-		return meta, errors.New("no bootstrapServers given")
+	bootstrapServers, err := getParameterFromConfigV2(config, "bootstrapServers", true, false, true, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, fmt.Errorf("no bootstrapServers given. %w", err)
 	}
+	meta.bootstrapServers = strings.Split(bootstrapServers.(string), ",")
 
-	switch {
-	case config.TriggerMetadata["consumerGroupFromEnv"] != "":
-		meta.group = config.ResolvedEnv[config.TriggerMetadata["consumerGroupFromEnv"]]
-	case config.TriggerMetadata["consumerGroup"] != "":
-		meta.group = config.TriggerMetadata["consumerGroup"]
-	default:
-		return meta, errors.New("no consumer group given")
+	consumerGroup, err := getParameterFromConfigV2(config, "consumerGroup", true, false, true, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, fmt.Errorf("no consumer group given. %w", err)
 	}
+	meta.group = consumerGroup.(string)
 
-	switch {
-	case config.TriggerMetadata["topicFromEnv"] != "":
-		meta.topic = strings.Split(config.ResolvedEnv[config.TriggerMetadata["topicFromEnv"]], ",")
-	case config.TriggerMetadata["topic"] != "":
-		meta.topic = strings.Split(config.TriggerMetadata["topic"], ",")
-	default:
+	topic, err := getParameterFromConfigV2(config, "topic", true, false, true, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, err
+	}
+	if topic == "" {
 		meta.topic = []string{}
 		logger.V(1).Info(fmt.Sprintf("consumer group %q has no topics specified, "+
 			"will use all topics subscribed by the consumer group for scaling", meta.group))
+	} else {
+		meta.topic = strings.Split(topic.(string), ",")
 	}
 
 	meta.partitionLimitation = nil
-	partitionLimitationMetadata := strings.TrimSpace(config.TriggerMetadata["partitionLimitation"])
+	partitionLimitationMetadata, err := getParameterFromConfigV2(config, "partitionLimitation", true, false, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, err
+	}
 	if partitionLimitationMetadata != "" {
 		if meta.topic == nil || len(meta.topic) == 0 {
 			logger.V(1).Info("no specific topics set, ignoring partitionLimitation setting")
 		} else {
-			pattern := config.TriggerMetadata["partitionLimitation"]
+			pattern := strings.TrimSpace(partitionLimitationMetadata.(string))
 			parsed, err := kedautil.ParseInt32List(pattern)
 			if err != nil {
 				return meta, fmt.Errorf("error parsing in partitionLimitation '%s': %w", pattern, err)
@@ -275,27 +267,27 @@ func parseApacheKafkaMetadata(config *ScalerConfig, logger logr.Logger) (apacheK
 	}
 
 	meta.offsetResetPolicy = defaultOffsetResetPolicy
-
-	if config.TriggerMetadata["offsetResetPolicy"] != "" {
-		policy := offsetResetPolicy(config.TriggerMetadata["offsetResetPolicy"])
+	offsetResetPolicyRaw, err := getParameterFromConfigV2(config, "offsetResetPolicy", true, false, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, err
+	}
+	if offsetResetPolicyRaw != "" {
+		policy := offsetResetPolicy(offsetResetPolicyRaw.(string))
 		if policy != earliest && policy != latest {
-			return meta, fmt.Errorf("err offsetResetPolicy policy %q given", policy)
+			return meta, fmt.Errorf("err offsetResetPolicy policy %q given", offsetResetPolicyRaw)
 		}
 		meta.offsetResetPolicy = policy
 	}
 
 	meta.lagThreshold = defaultKafkaLagThreshold
-
-	if val, ok := config.TriggerMetadata[lagThresholdMetricName]; ok {
-		t, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing %q: %w", lagThresholdMetricName, err)
-		}
-		if t <= 0 {
-			return meta, fmt.Errorf("%q must be positive number", lagThresholdMetricName)
-		}
-		meta.lagThreshold = t
+	lagThreshold, err := getParameterFromConfigV2(config, lagThresholdMetricName, true, false, false, true, defaultKafkaLagThreshold, reflect.TypeOf(64))
+	if err != nil {
+		return meta, err
 	}
+	if lagThreshold.(int) <= 0 {
+		return meta, fmt.Errorf("%q must be positive number", lagThresholdMetricName)
+	}
+	meta.lagThreshold = int64(lagThreshold.(int))
 
 	meta.activationLagThreshold = defaultKafkaActivationLagThreshold
 

--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -290,63 +289,46 @@ func parseApacheKafkaMetadata(config *ScalerConfig, logger logr.Logger) (apacheK
 	meta.lagThreshold = int64(lagThreshold.(int))
 
 	meta.activationLagThreshold = defaultKafkaActivationLagThreshold
-
-	if val, ok := config.TriggerMetadata[activationLagThresholdMetricName]; ok {
-		t, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing %q: %w", activationLagThresholdMetricName, err)
-		}
-		if t < 0 {
-			return meta, fmt.Errorf("%q must be positive number", activationLagThresholdMetricName)
-		}
-		meta.activationLagThreshold = t
+	activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, int64(defaultKafkaActivationLagThreshold), reflect.TypeOf(int64(64)))
+	if err != nil {
+		return meta, err
+	}
+	if activationLagThreshold.(int64) < 0 {
+		return meta, fmt.Errorf("%q must be positive number", activationLagThresholdMetricName)
 	}
 
 	if err := parseApacheKafkaAuthParams(config, &meta); err != nil {
 		return meta, err
 	}
 
-	meta.allowIdleConsumers = false
-	if val, ok := config.TriggerMetadata["allowIdleConsumers"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing allowIdleConsumers: %w", err)
-		}
-		meta.allowIdleConsumers = t
+	allowIDConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, fmt.Errorf("error parsing allowIdleConsumers: %w", err)
 	}
+	meta.allowIdleConsumers = allowIDConsumers.(bool)
 
-	meta.excludePersistentLag = false
-	if val, ok := config.TriggerMetadata["excludePersistentLag"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing excludePersistentLag: %w", err)
-		}
-		meta.excludePersistentLag = t
+	excludePersistentLag, err := getParameterFromConfigV2(config, "excludePersistentLag", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, fmt.Errorf("error parsing excludePersistentLag: %w", err)
 	}
+	meta.excludePersistentLag = excludePersistentLag.(bool)
 
-	meta.scaleToZeroOnInvalidOffset = false
-	if val, ok := config.TriggerMetadata["scaleToZeroOnInvalidOffset"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing scaleToZeroOnInvalidOffset: %w", err)
-		}
-		meta.scaleToZeroOnInvalidOffset = t
+	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(config, "scaleToZeroOnInvalidOffset", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, fmt.Errorf("error parsing scaleToZeroOnInvalidOffset: %w", err)
 	}
+	meta.scaleToZeroOnInvalidOffset = scaleToZeroOnInvalidOffset.(bool)
 
-	meta.limitToPartitionsWithLag = false
-	if val, ok := config.TriggerMetadata["limitToPartitionsWithLag"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing limitToPartitionsWithLag: %w", err)
-		}
-		meta.limitToPartitionsWithLag = t
-
-		if meta.allowIdleConsumers && meta.limitToPartitionsWithLag {
-			return meta, fmt.Errorf("allowIdleConsumers and limitToPartitionsWithLag cannot be set simultaneously")
-		}
-		if len(meta.topic) == 0 && meta.limitToPartitionsWithLag {
-			return meta, fmt.Errorf("topic must be specified when using limitToPartitionsWithLag")
-		}
+	limitToPartitionsWithLag, err := getParameterFromConfigV2(config, "limitToPartitionsWithLag", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, err
+	}
+	meta.limitToPartitionsWithLag = limitToPartitionsWithLag.(bool)
+	if meta.allowIdleConsumers && meta.limitToPartitionsWithLag {
+		return meta, fmt.Errorf("allowIdleConsumers and limitToPartitionsWithLag cannot be set simultaneously")
+	}
+	if len(meta.topic) == 0 && meta.limitToPartitionsWithLag {
+		return meta, fmt.Errorf("topic must be specified when using limitToPartitionsWithLag")
 	}
 
 	meta.triggerIndex = config.TriggerIndex

--- a/pkg/scalers/apache_kafka_scaler_test.go
+++ b/pkg/scalers/apache_kafka_scaler_test.go
@@ -288,7 +288,6 @@ func getBrokerApacheKafkaTestBase(t *testing.T, meta apacheKafkaMetadata, testDa
 	if er != nil {
 		t.Errorf("Unable to convert test data lagThreshold %s to string", testData.metadata["lagThreshold"])
 	}
-
 	if meta.lagThreshold != expectedLagThreshold && meta.lagThreshold != defaultKafkaLagThreshold {
 		t.Errorf("Expected lagThreshold to be either %v or %v got %v ", meta.lagThreshold, defaultKafkaLagThreshold, expectedLagThreshold)
 	}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -419,7 +419,7 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 		}
 		meta.offsetResetPolicy = policy
 	}
-
+	meta.lagThreshold = defaultKafkaLagThreshold
 	lagThreshold, err := getParameterFromConfigV2(config, lagThresholdMetricName, true, false, false, true, defaultKafkaLagThreshold, reflect.TypeOf(64))
 	if err != nil {
 		return meta, err
@@ -482,6 +482,7 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 	if err != nil {
 		return meta, fmt.Errorf("error parsing kafka version: %w", err)
 	}
+	meta.version = version
 	meta.triggerIndex = config.TriggerIndex
 	return meta, nil
 }

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -155,23 +155,14 @@ func NewKafkaScaler(config *ScalerConfig) (Scaler, error) {
 
 func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	meta.saslType = KafkaSASLTypeNone
-	var saslAuthType string
-	switch {
-	case config.TriggerMetadata["sasl"] != "":
-		saslAuthType = config.TriggerMetadata["sasl"]
-	default:
-		saslAuthType = ""
-	}
-	if val, ok := config.AuthParams["sasl"]; ok {
-		if saslAuthType != "" {
-			return errors.New("unable to set `sasl` in both ScaledObject and TriggerAuthentication together")
-		}
-		saslAuthType = val
+	saslAuthType, err := getParameterFromConfigV2(config, "sasl", true, true, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
 	}
 
 	if saslAuthType != "" {
-		saslAuthType = strings.TrimSpace(saslAuthType)
-		mode := kafkaSaslType(saslAuthType)
+		saslAuthType = strings.TrimSpace(saslAuthType.(string))
+		mode := kafkaSaslType(saslAuthType.(string))
 
 		switch {
 		case mode == KafkaSASLTypePlaintext || mode == KafkaSASLTypeSCRAMSHA256 || mode == KafkaSASLTypeSCRAMSHA512 || mode == KafkaSASLTypeOAuthbearer:
@@ -191,30 +182,18 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 
 	meta.enableTLS = false
 	enableTLS := false
-	if val, ok := config.TriggerMetadata["tls"]; ok {
-		switch val {
-		case stringEnable:
-			enableTLS = true
-		case stringDisable:
-			enableTLS = false
-		default:
-			return fmt.Errorf("error incorrect TLS value given, got %s", val)
-		}
+	tlsString, err := getParameterFromConfigV2(config, "tls", true, false, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return fmt.Errorf("error incorrect TLS value given. %s", err.Error())
 	}
-
-	if val, ok := config.AuthParams["tls"]; ok {
-		val = strings.TrimSpace(val)
-		if enableTLS {
-			return errors.New("unable to set `tls` in both ScaledObject and TriggerAuthentication together")
-		}
-		switch val {
-		case stringEnable:
-			enableTLS = true
-		case stringDisable:
-			enableTLS = false
-		default:
-			return fmt.Errorf("error incorrect TLS value given, got %s", val)
-		}
+	tlsString = strings.TrimSpace(tlsString.(string))
+	switch tlsString.(string) {
+	case stringEnable:
+		enableTLS = true
+	case stringDisable:
+		enableTLS = false
+	default:
+		return fmt.Errorf("error incorrect TLS value given, got %s", tlsString)
 	}
 
 	if enableTLS {
@@ -225,65 +204,95 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 }
 
 func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
-	certGiven := config.AuthParams["cert"] != ""
-	keyGiven := config.AuthParams["key"] != ""
-	if certGiven && !keyGiven {
+	certGiven, err := getParameterFromConfigV2(config, "cert", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
+	}
+	keyGiven, err := getParameterFromConfigV2(config, "key", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
+	}
+
+	if certGiven != "" && keyGiven == "" {
 		return errors.New("key must be provided with cert")
 	}
-	if keyGiven && !certGiven {
+	if keyGiven != "" && certGiven == "" {
 		return errors.New("cert must be provided with key")
 	}
-	meta.ca = config.AuthParams["ca"]
-	meta.cert = config.AuthParams["cert"]
-	meta.key = config.AuthParams["key"]
-	meta.unsafeSsl = defaultUnsafeSsl
 
-	if val, ok := config.TriggerMetadata["unsafeSsl"]; ok {
-		unsafeSsl, err := strconv.ParseBool(val)
-		if err != nil {
-			return fmt.Errorf("error parsing unsafeSsl: %w", err)
-		}
-		meta.unsafeSsl = unsafeSsl
+	ca, err := getParameterFromConfigV2(config, "ca", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
 	}
+	meta.ca = ca.(string)
+	cert, err := getParameterFromConfigV2(config, "cert", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
+	}
+	meta.cert = cert.(string)
+	key, err := getParameterFromConfigV2(config, "key", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
+	}
+	meta.key = key.(string)
 
-	if value, found := config.AuthParams["keyPassword"]; found {
-		meta.keyPassword = value
-	} else {
-		meta.keyPassword = ""
+	unsafeSslRaw, err := getParameterFromConfigV2(config, "unsafeSsl", false, true, false, true, defaultUnsafeSsl, reflect.TypeOf(true))
+	if err != nil {
+		return errors.New(fmt.Sprintf("error parsing unsafeSsl: %s", err.Error()))
 	}
+	meta.unsafeSsl = unsafeSslRaw.(bool)
+
+	keyPassword, err := getParameterFromConfigV2(config, "keyPassword", false, true, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
+	}
+	meta.keyPassword = keyPassword.(string)
+
 	meta.enableTLS = true
 	return nil
 }
 
 func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
-	if config.AuthParams["username"] == "" {
-		return errors.New("no username given")
+	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return errors.New(fmt.Sprintf("no username given. %s", err.Error()))
 	}
-	meta.username = strings.TrimSpace(config.AuthParams["username"])
+	meta.username = strings.TrimSpace(username.(string))
 
-	if (config.AuthParams["password"] == "" && config.AuthParams["keytab"] == "") ||
-		(config.AuthParams["password"] != "" && config.AuthParams["keytab"] != "") {
+	password, err := getParameterFromConfigV2(config, "password", false, true, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
+	}
+	keytab, err := getParameterFromConfigV2(config, "keytab", false, true, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return err
+	}
+	if (password == "" && keytab == "") ||
+		(password != "" && keytab != "") {
 		return errors.New("exactly one of 'password' or 'keytab' must be provided for GSSAPI authentication")
 	}
-	if config.AuthParams["password"] != "" {
-		meta.password = strings.TrimSpace(config.AuthParams["password"])
+
+	if password != "" {
+		meta.password = strings.TrimSpace(password.(string))
 	} else {
-		path, err := saveToFile(config.AuthParams["keytab"])
+		path, err := saveToFile(keytab.(string))
 		if err != nil {
 			return fmt.Errorf("error saving keytab to file: %w", err)
 		}
 		meta.keytabPath = path
 	}
 
-	if config.AuthParams["realm"] == "" {
-		return errors.New("no realm given")
+	realm, err := getParameterFromConfigV2(config, "realm", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return errors.New(fmt.Sprintf("no realm given. %s", err.Error()))
 	}
-	meta.realm = strings.TrimSpace(config.AuthParams["realm"])
+	meta.realm = strings.TrimSpace(realm.(string))
 
-	if config.AuthParams["kerberosConfig"] == "" {
-		return errors.New("no Kerberos configuration file (kerberosConfig) given")
+	kerberosConfig, err := getParameterFromConfigV2(config, "kerberosConfig", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return errors.New(fmt.Sprintf("no Kerberos configuration file (kerberosConfig) given. %s", err.Error()))
 	}
-	path, err := saveToFile(config.AuthParams["kerberosConfig"])
+	path, err := saveToFile(kerberosConfig.(string))
 	if err != nil {
 		return fmt.Errorf("error saving kerberosConfig to file: %w", err)
 	}
@@ -294,34 +303,41 @@ func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSa
 }
 
 func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
-	if config.AuthParams["username"] == "" {
-		return errors.New("no username given")
+	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return errors.New(fmt.Sprintf("no username given. %s", err.Error()))
 	}
-	meta.username = strings.TrimSpace(config.AuthParams["username"])
+	meta.username = strings.TrimSpace(username.(string))
 
-	if config.AuthParams["password"] == "" {
-		return errors.New("no password given")
+	password, err := getParameterFromConfigV2(config, "password", false, true, false, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return errors.New(fmt.Sprintf("no password given. %s", err.Error()))
 	}
-	meta.password = strings.TrimSpace(config.AuthParams["password"])
+	meta.password = strings.TrimSpace(password.(string))
 	meta.saslType = mode
 
 	if mode == KafkaSASLTypeOAuthbearer {
-		meta.scopes = strings.Split(config.AuthParams["scopes"], ",")
-
-		if config.AuthParams["oauthTokenEndpointUri"] == "" {
-			return errors.New("no oauth token endpoint uri given")
+		scopes, err := getParameterFromConfigV2(config, "scopes", false, true, false, false, "", reflect.TypeOf(""))
+		if err != nil {
+			return errors.New(fmt.Sprintf("no scopes given. %s", err.Error()))
 		}
-		meta.oauthTokenEndpointURI = strings.TrimSpace(config.AuthParams["oauthTokenEndpointUri"])
+		meta.scopes = strings.Split(scopes.(string), ",")
+
+		oauthTokenEndpointsURI, err := getParameterFromConfigV2(config, "oauthTokenEndpointUri", false, true, false, false, "", reflect.TypeOf(""))
+		if err != nil {
+			return errors.New(fmt.Sprintf("no oauth token endpoint uri given. %s", err.Error()))
+		}
+		meta.oauthTokenEndpointURI = strings.TrimSpace(oauthTokenEndpointsURI.(string))
 
 		meta.oauthExtensions = make(map[string]string)
-		oauthExtensionsRaw := config.AuthParams["oauthExtensions"]
+		oauthExtensionsRaw, _ := getParameterFromConfigV2(config, "oauthExtensions", false, true, false, true, "", reflect.TypeOf(""))
 		if oauthExtensionsRaw != "" {
-			for _, extension := range strings.Split(oauthExtensionsRaw, ",") {
-				splittedExtension := strings.Split(extension, "=")
-				if len(splittedExtension) != 2 {
+			for _, extension := range strings.Split(oauthExtensionsRaw.(string), ",") {
+				splitExtension := strings.Split(extension, "=")
+				if len(splitExtension) != 2 {
 					return errors.New("invalid OAuthBearer extension, must be of format key=value")
 				}
-				meta.oauthExtensions[splittedExtension[0]] = splittedExtension[1]
+				meta.oauthExtensions[splitExtension[0]] = splitExtension[1]
 			}
 		}
 	}
@@ -357,42 +373,38 @@ func saveToFile(content string) (string, error) {
 
 func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata, error) {
 	meta := kafkaMetadata{}
-	switch {
-	case config.TriggerMetadata["bootstrapServersFromEnv"] != "":
-		meta.bootstrapServers = strings.Split(config.ResolvedEnv[config.TriggerMetadata["bootstrapServersFromEnv"]], ",")
-	case config.TriggerMetadata["bootstrapServers"] != "":
-		meta.bootstrapServers = strings.Split(config.TriggerMetadata["bootstrapServers"], ",")
-	default:
-		return meta, errors.New("no bootstrapServers given")
+	bootstrapServers, err := getParameterFromConfigV2(config, "bootstrapServers", true, false, true, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, errors.New(fmt.Sprintf("no bootstrapServers given. %s", err.Error()))
 	}
+	meta.bootstrapServers = strings.Split(bootstrapServers.(string), ",")
 
-	switch {
-	case config.TriggerMetadata["consumerGroupFromEnv"] != "":
-		meta.group = config.ResolvedEnv[config.TriggerMetadata["consumerGroupFromEnv"]]
-	case config.TriggerMetadata["consumerGroup"] != "":
-		meta.group = config.TriggerMetadata["consumerGroup"]
-	default:
-		return meta, errors.New("no consumer group given")
+	consumerGroup, err := getParameterFromConfigV2(config, "consumerGroup", true, false, true, false, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, errors.New(fmt.Sprintf("no consumer group given. %s", err.Error()))
 	}
+	meta.group = consumerGroup.(string)
 
-	switch {
-	case config.TriggerMetadata["topicFromEnv"] != "":
-		meta.topic = config.ResolvedEnv[config.TriggerMetadata["topicFromEnv"]]
-	case config.TriggerMetadata["topic"] != "":
-		meta.topic = config.TriggerMetadata["topic"]
-	default:
-		meta.topic = ""
+	topic, err := getParameterFromConfigV2(config, "topic", true, false, true, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, err
+	}
+	if topic == "" {
 		logger.V(1).Info(fmt.Sprintf("consumer group %q has no topic specified, "+
 			"will use all topics subscribed by the consumer group for scaling", meta.group))
 	}
+	meta.topic = topic.(string)
 
 	meta.partitionLimitation = nil
-	partitionLimitationMetadata := strings.TrimSpace(config.TriggerMetadata["partitionLimitation"])
+	partitionLimitationMetadata, err := getParameterFromConfigV2(config, "partitionLimitation", true, false, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, err
+	}
 	if partitionLimitationMetadata != "" {
 		if meta.topic == "" {
 			logger.V(1).Info("no specific topic set, ignoring partitionLimitation setting")
 		} else {
-			pattern := config.TriggerMetadata["partitionLimitation"]
+			pattern := strings.TrimSpace(partitionLimitationMetadata.(string))
 			parsed, err := kedautil.ParseInt32List(pattern)
 			if err != nil {
 				return meta, fmt.Errorf("error parsing in partitionLimitation '%s': %w", pattern, err)
@@ -403,96 +415,80 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 	}
 
 	meta.offsetResetPolicy = defaultOffsetResetPolicy
-
-	if config.TriggerMetadata["offsetResetPolicy"] != "" {
-		policy := offsetResetPolicy(config.TriggerMetadata["offsetResetPolicy"])
-		if policy != earliest && policy != latest {
-			return meta, fmt.Errorf("err offsetResetPolicy policy %q given", policy)
+	offsetResetPolicyRaw, err := getParameterFromConfigV2(config, "offsetResetPolicy", true, false, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, err
+	}
+	if offsetResetPolicyRaw != "" {
+		if offsetResetPolicyRaw != earliest && offsetResetPolicyRaw != latest {
+			return meta, fmt.Errorf("err offsetResetPolicy policy %q given", offsetResetPolicyRaw)
 		}
-		meta.offsetResetPolicy = policy
+		meta.offsetResetPolicy = offsetResetPolicy(offsetResetPolicyRaw.(string))
 	}
 
-	meta.lagThreshold = defaultKafkaLagThreshold
-
-	if val, ok := config.TriggerMetadata[lagThresholdMetricName]; ok {
-		t, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing %q: %w", lagThresholdMetricName, err)
-		}
-		if t <= 0 {
-			return meta, fmt.Errorf("%q must be positive number", lagThresholdMetricName)
-		}
-		meta.lagThreshold = t
+	lagThreshold, err := getParameterFromConfigV2(config, lagThresholdMetricName, true, false, false, true, defaultKafkaLagThreshold, reflect.TypeOf(64))
+	if err != nil {
+		return meta, err
 	}
+	if lagThreshold.(int) <= 0 {
+		return meta, fmt.Errorf("%q must be positive number", lagThresholdMetricName)
+	}
+	meta.lagThreshold = int64(lagThreshold.(int))
 
 	meta.activationLagThreshold = defaultKafkaActivationLagThreshold
-
-	if val, ok := config.TriggerMetadata[activationLagThresholdMetricName]; ok {
-		t, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing %q: %w", activationLagThresholdMetricName, err)
-		}
-		if t < 0 {
-			return meta, fmt.Errorf("%q must be positive number", activationLagThresholdMetricName)
-		}
-		meta.activationLagThreshold = t
+	activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, defaultKafkaActivationLagThreshold, reflect.TypeOf(int64(64)))
+	if err != nil {
+		return meta, err
 	}
+	fmt.Println(activationLagThreshold)
+	if int64(activationLagThreshold.(int)) < 0 {
+		return meta, fmt.Errorf("%q must be positive number", activationLagThresholdMetricName)
+	}
+	meta.activationLagThreshold = int64(activationLagThreshold.(int))
 
 	if err := parseKafkaAuthParams(config, &meta); err != nil {
 		return meta, err
 	}
 
-	meta.allowIdleConsumers = false
-	if val, ok := config.TriggerMetadata["allowIdleConsumers"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing allowIdleConsumers: %w", err)
-		}
-		meta.allowIdleConsumers = t
+	allowIdConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, errors.New(fmt.Sprintf("error parsing allowIdleConsumers: %s", err.Error()))
 	}
+	meta.allowIdleConsumers = allowIdConsumers.(bool)
 
-	meta.excludePersistentLag = false
-	if val, ok := config.TriggerMetadata["excludePersistentLag"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing excludePersistentLag: %w", err)
-		}
-		meta.excludePersistentLag = t
+	excludePersistentLag, err := getParameterFromConfigV2(config, "excludePersistentLag", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, errors.New(fmt.Sprintf("error parsing excludePersistentLag: %s", err.Error()))
 	}
+	meta.excludePersistentLag = excludePersistentLag.(bool)
 
-	meta.scaleToZeroOnInvalidOffset = false
-	if val, ok := config.TriggerMetadata["scaleToZeroOnInvalidOffset"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing scaleToZeroOnInvalidOffset: %w", err)
-		}
-		meta.scaleToZeroOnInvalidOffset = t
+	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(config, "scaleToZeroOnInvalidOffset", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, errors.New(fmt.Sprintf("error parsing scaleToZeroOnInvalidOffset: %s", err.Error()))
 	}
+	meta.scaleToZeroOnInvalidOffset = scaleToZeroOnInvalidOffset.(bool)
 
-	meta.limitToPartitionsWithLag = false
-	if val, ok := config.TriggerMetadata["limitToPartitionsWithLag"]; ok {
-		t, err := strconv.ParseBool(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing limitToPartitionsWithLag: %w", err)
-		}
-		meta.limitToPartitionsWithLag = t
-
-		if meta.allowIdleConsumers && meta.limitToPartitionsWithLag {
-			return meta, fmt.Errorf("allowIdleConsumers and limitToPartitionsWithLag cannot be set simultaneously")
-		}
-		if len(meta.topic) == 0 && meta.limitToPartitionsWithLag {
-			return meta, fmt.Errorf("topic must be specified when using limitToPartitionsWithLag")
-		}
+	limitToPartitionsWithLag, err := getParameterFromConfigV2(config, "limitToPartitionsWithLag", true, false, false, true, false, reflect.TypeOf(true))
+	if err != nil {
+		return meta, err
 	}
+	meta.limitToPartitionsWithLag = limitToPartitionsWithLag.(bool)
 
+	if meta.allowIdleConsumers && meta.limitToPartitionsWithLag {
+		return meta, fmt.Errorf("allowIdleConsumers and limitToPartitionsWithLag cannot be set simultaneously")
+	}
+	if len(meta.topic) == 0 && meta.limitToPartitionsWithLag {
+		return meta, fmt.Errorf("topic must be specified when using limitToPartitionsWithLag")
+	}
+	saramaVer, err := getParameterFromConfigV2(config, "version", true, false, false, true, "", reflect.TypeOf(""))
+	if err != nil {
+		return meta, err
+	}
 	meta.version = sarama.V1_0_0_0
-	if val, ok := config.TriggerMetadata["version"]; ok {
-		val = strings.TrimSpace(val)
-		version, err := sarama.ParseKafkaVersion(val)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing kafka version: %w", err)
-		}
-		meta.version = version
+	saramaVer = strings.TrimSpace(saramaVer.(string))
+	version, err := sarama.ParseKafkaVersion(saramaVer.(string))
+	if err != nil {
+		return meta, fmt.Errorf("error parsing kafka version: %w", err)
 	}
 	meta.triggerIndex = config.TriggerIndex
 	return meta, nil

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -184,7 +184,7 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	var enableTLS bool
 	tlsString, err := getParameterFromConfigV2(config, "tls", true, true, false, true, "disable", reflect.TypeOf(""))
 	if err != nil {
-		return fmt.Errorf("error incorrect TLS value given. %s", err.Error())
+		return fmt.Errorf("error incorrect TLS value given. %w", err)
 	}
 	tlsString = strings.TrimSpace(tlsString.(string))
 	switch tlsString.(string) {

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -231,7 +231,7 @@ func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
 
 	unsafeSslRaw, err := getParameterFromConfigV2(config, "unsafeSsl", true, false, false, true, defaultUnsafeSsl, reflect.TypeOf(true))
 	if err != nil {
-		return errors.New(fmt.Sprintf("error parsing unsafeSsl: %s", err.Error()))
+		return fmt.Errorf("error parsing unsafeSsl: %w", err)
 	}
 	meta.unsafeSsl = unsafeSslRaw.(bool)
 
@@ -248,7 +248,7 @@ func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
 func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
 	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no username given. %s", err.Error()))
+		return fmt.Errorf("no username given. %w", err)
 	}
 	meta.username = strings.TrimSpace(username.(string))
 
@@ -277,13 +277,13 @@ func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSa
 
 	realm, err := getParameterFromConfigV2(config, "realm", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no realm given. %s", err.Error()))
+		return fmt.Errorf("no realm given. %w", err)
 	}
 	meta.realm = strings.TrimSpace(realm.(string))
 
 	kerberosConfig, err := getParameterFromConfigV2(config, "kerberosConfig", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no Kerberos configuration file (kerberosConfig) given. %s", err.Error()))
+		return fmt.Errorf("no Kerberos configuration file (kerberosConfig) given. %w", err)
 	}
 	path, err := saveToFile(kerberosConfig.(string))
 	if err != nil {
@@ -298,13 +298,13 @@ func parseKerberosParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSa
 func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslType) error {
 	username, err := getParameterFromConfigV2(config, "username", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no username given. %s", err.Error()))
+		return fmt.Errorf("no username given. %w", err)
 	}
 	meta.username = strings.TrimSpace(username.(string))
 
 	password, err := getParameterFromConfigV2(config, "password", false, true, false, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return errors.New(fmt.Sprintf("no password given. %s", err.Error()))
+		return fmt.Errorf("no password given. %w", err)
 	}
 	meta.password = strings.TrimSpace(password.(string))
 	meta.saslType = mode
@@ -312,13 +312,13 @@ func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslTy
 	if mode == KafkaSASLTypeOAuthbearer {
 		scopes, err := getParameterFromConfigV2(config, "scopes", false, true, false, true, "", reflect.TypeOf(""))
 		if err != nil {
-			return errors.New(fmt.Sprintf("no scopes given. %s", err.Error()))
+			return fmt.Errorf("no scopes given. %w", err)
 		}
 		meta.scopes = strings.Split(scopes.(string), ",")
 
 		oauthTokenEndpointsURI, err := getParameterFromConfigV2(config, "oauthTokenEndpointUri", false, true, false, false, "", reflect.TypeOf(""))
 		if err != nil {
-			return errors.New(fmt.Sprintf("no oauth token endpoint uri given. %s", err.Error()))
+			return fmt.Errorf("no oauth token endpoint uri given. %w", err)
 		}
 		meta.oauthTokenEndpointURI = strings.TrimSpace(oauthTokenEndpointsURI.(string))
 
@@ -368,13 +368,13 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 	meta := kafkaMetadata{}
 	bootstrapServers, err := getParameterFromConfigV2(config, "bootstrapServers", true, false, true, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("no bootstrapServers given. %s", err.Error()))
+		return meta, fmt.Errorf("no bootstrapServers given. %w", err)
 	}
 	meta.bootstrapServers = strings.Split(bootstrapServers.(string), ",")
 
 	consumerGroup, err := getParameterFromConfigV2(config, "consumerGroup", true, false, true, false, "", reflect.TypeOf(""))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("no consumer group given. %s", err.Error()))
+		return meta, fmt.Errorf("no consumer group given. %w", err)
 	}
 	meta.group = consumerGroup.(string)
 
@@ -443,21 +443,21 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 		return meta, err
 	}
 
-	allowIdConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
+	allowIDConsumers, err := getParameterFromConfigV2(config, "allowIdleConsumers", true, false, false, true, false, reflect.TypeOf(true))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("error parsing allowIdleConsumers: %s", err.Error()))
+		return meta, fmt.Errorf("error parsing allowIdleConsumers: %w", err)
 	}
-	meta.allowIdleConsumers = allowIdConsumers.(bool)
+	meta.allowIdleConsumers = allowIDConsumers.(bool)
 
 	excludePersistentLag, err := getParameterFromConfigV2(config, "excludePersistentLag", true, false, false, true, false, reflect.TypeOf(true))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("error parsing excludePersistentLag: %s", err.Error()))
+		return meta, fmt.Errorf("error parsing excludePersistentLag: %w", err)
 	}
 	meta.excludePersistentLag = excludePersistentLag.(bool)
 
 	scaleToZeroOnInvalidOffset, err := getParameterFromConfigV2(config, "scaleToZeroOnInvalidOffset", true, false, false, true, false, reflect.TypeOf(true))
 	if err != nil {
-		return meta, errors.New(fmt.Sprintf("error parsing scaleToZeroOnInvalidOffset: %s", err.Error()))
+		return meta, fmt.Errorf("error parsing scaleToZeroOnInvalidOffset: %w", err)
 	}
 	meta.scaleToZeroOnInvalidOffset = scaleToZeroOnInvalidOffset.(bool)
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -181,8 +181,8 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 	}
 
 	meta.enableTLS = false
-	enableTLS := false
-	tlsString, err := getParameterFromConfigV2(config, "tls", true, false, false, true, "", reflect.TypeOf(""))
+	var enableTLS bool
+	tlsString, err := getParameterFromConfigV2(config, "tls", true, true, false, true, "disable", reflect.TypeOf(""))
 	if err != nil {
 		return fmt.Errorf("error incorrect TLS value given. %s", err.Error())
 	}
@@ -204,14 +204,17 @@ func parseKafkaAuthParams(config *ScalerConfig, meta *kafkaMetadata) error {
 }
 
 func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
-	certGiven, err := getParameterFromConfigV2(config, "cert", false, true, false, false, "", reflect.TypeOf(""))
+	certGiven, err := getParameterFromConfigV2(config, "cert", false, true, false, true, "", reflect.TypeOf(""))
 	if err != nil {
 		return err
 	}
-	keyGiven, err := getParameterFromConfigV2(config, "key", false, true, false, false, "", reflect.TypeOf(""))
+	meta.cert = certGiven.(string)
+
+	keyGiven, err := getParameterFromConfigV2(config, "key", false, true, false, true, "", reflect.TypeOf(""))
 	if err != nil {
 		return err
 	}
+	meta.key = keyGiven.(string)
 
 	if certGiven != "" && keyGiven == "" {
 		return errors.New("key must be provided with cert")
@@ -220,23 +223,13 @@ func parseTLS(config *ScalerConfig, meta *kafkaMetadata) error {
 		return errors.New("cert must be provided with key")
 	}
 
-	ca, err := getParameterFromConfigV2(config, "ca", false, true, false, false, "", reflect.TypeOf(""))
+	ca, err := getParameterFromConfigV2(config, "ca", false, true, false, true, "", reflect.TypeOf(""))
 	if err != nil {
 		return err
 	}
 	meta.ca = ca.(string)
-	cert, err := getParameterFromConfigV2(config, "cert", false, true, false, false, "", reflect.TypeOf(""))
-	if err != nil {
-		return err
-	}
-	meta.cert = cert.(string)
-	key, err := getParameterFromConfigV2(config, "key", false, true, false, false, "", reflect.TypeOf(""))
-	if err != nil {
-		return err
-	}
-	meta.key = key.(string)
 
-	unsafeSslRaw, err := getParameterFromConfigV2(config, "unsafeSsl", false, true, false, true, defaultUnsafeSsl, reflect.TypeOf(true))
+	unsafeSslRaw, err := getParameterFromConfigV2(config, "unsafeSsl", true, false, false, true, defaultUnsafeSsl, reflect.TypeOf(true))
 	if err != nil {
 		return errors.New(fmt.Sprintf("error parsing unsafeSsl: %s", err.Error()))
 	}
@@ -317,7 +310,7 @@ func parseSaslParams(config *ScalerConfig, meta *kafkaMetadata, mode kafkaSaslTy
 	meta.saslType = mode
 
 	if mode == KafkaSASLTypeOAuthbearer {
-		scopes, err := getParameterFromConfigV2(config, "scopes", false, true, false, false, "", reflect.TypeOf(""))
+		scopes, err := getParameterFromConfigV2(config, "scopes", false, true, false, true, "", reflect.TypeOf(""))
 		if err != nil {
 			return errors.New(fmt.Sprintf("no scopes given. %s", err.Error()))
 		}
@@ -420,10 +413,11 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 		return meta, err
 	}
 	if offsetResetPolicyRaw != "" {
-		if offsetResetPolicyRaw != earliest && offsetResetPolicyRaw != latest {
+		policy := offsetResetPolicy(offsetResetPolicyRaw.(string))
+		if policy != earliest && policy != latest {
 			return meta, fmt.Errorf("err offsetResetPolicy policy %q given", offsetResetPolicyRaw)
 		}
-		meta.offsetResetPolicy = offsetResetPolicy(offsetResetPolicyRaw.(string))
+		meta.offsetResetPolicy = policy
 	}
 
 	lagThreshold, err := getParameterFromConfigV2(config, lagThresholdMetricName, true, false, false, true, defaultKafkaLagThreshold, reflect.TypeOf(64))
@@ -436,15 +430,14 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 	meta.lagThreshold = int64(lagThreshold.(int))
 
 	meta.activationLagThreshold = defaultKafkaActivationLagThreshold
-	activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, defaultKafkaActivationLagThreshold, reflect.TypeOf(int64(64)))
+	activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, int64(defaultKafkaActivationLagThreshold), reflect.TypeOf(int64(64)))
 	if err != nil {
 		return meta, err
 	}
-	fmt.Println(activationLagThreshold)
-	if int64(activationLagThreshold.(int)) < 0 {
+	if activationLagThreshold.(int64) < 0 {
 		return meta, fmt.Errorf("%q must be positive number", activationLagThresholdMetricName)
 	}
-	meta.activationLagThreshold = int64(activationLagThreshold.(int))
+	meta.activationLagThreshold = activationLagThreshold.(int64)
 
 	if err := parseKafkaAuthParams(config, &meta); err != nil {
 		return meta, err
@@ -480,11 +473,10 @@ func parseKafkaMetadata(config *ScalerConfig, logger logr.Logger) (kafkaMetadata
 	if len(meta.topic) == 0 && meta.limitToPartitionsWithLag {
 		return meta, fmt.Errorf("topic must be specified when using limitToPartitionsWithLag")
 	}
-	saramaVer, err := getParameterFromConfigV2(config, "version", true, false, false, true, "", reflect.TypeOf(""))
+	saramaVer, err := getParameterFromConfigV2(config, "version", true, false, false, true, "1.0.0", reflect.TypeOf(""))
 	if err != nil {
 		return meta, err
 	}
-	meta.version = sarama.V1_0_0_0
 	saramaVer = strings.TrimSpace(saramaVer.(string))
 	version, err := sarama.ParseKafkaVersion(saramaVer.(string))
 	if err != nil {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -317,7 +317,7 @@ var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
 }
 
 func TestGetBrokers(t *testing.T) {
-	for _, testData := range parseKafkaMetadataTestDataset {
+	for idx, testData := range parseKafkaMetadataTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
 		getBrokerTestBase(t, meta, testData, err)
 
@@ -371,30 +371,30 @@ func getBrokerTestBase(t *testing.T, meta kafkaMetadata, testData parseKafkaMeta
 }
 
 func TestKafkaAuthParamsInTriggerAuthentication(t *testing.T) {
-	for _, testData := range parseKafkaAuthParamsTestDataset {
+	for idx, testData := range parseKafkaAuthParamsTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: validKafkaMetadata, AuthParams: testData.authParams}, logr.Discard())
 
 		if err != nil && !testData.isError {
-			t.Error("Expected success but got error", err)
+			t.Errorf("Test %v: expected success but got error %v", idx, err)
 		}
 		if testData.isError && err == nil {
-			t.Error("Expected error but got success")
+			t.Errorf("Test %v: expected error but got success", idx)
 		}
 		if meta.enableTLS != testData.enableTLS {
-			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
+			t.Errorf("Test %v: expected enableTLS to be set to %v but got %v\n", idx, testData.enableTLS, meta.enableTLS)
 		}
 		if meta.enableTLS {
 			if meta.ca != testData.authParams["ca"] {
-				t.Errorf("Expected ca to be set to %v but got %v\n", testData.authParams["ca"], meta.enableTLS)
+				t.Errorf("Test %v: expected ca to be set to %v but got %v\n", idx, testData.authParams["ca"], meta.enableTLS)
 			}
 			if meta.cert != testData.authParams["cert"] {
-				t.Errorf("Expected cert to be set to %v but got %v\n", testData.authParams["cert"], meta.cert)
+				t.Errorf("Test %v: expected cert to be set to %v but got %v\n", idx, testData.authParams["cert"], meta.cert)
 			}
 			if meta.key != testData.authParams["key"] {
-				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["key"], meta.key)
+				t.Errorf("Test %v: expected key to be set to %v but got %v\n", idx, testData.authParams["key"], meta.key)
 			}
 			if meta.keyPassword != testData.authParams["keyPassword"] {
-				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["keyPassword"], meta.key)
+				t.Errorf("Test %v: expected key to be set to %v but got %v\n", idx, testData.authParams["keyPassword"], meta.key)
 			}
 		}
 		if meta.saslType == KafkaSASLTypeGSSAPI && !testData.isError {

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -317,7 +317,7 @@ var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
 }
 
 func TestGetBrokers(t *testing.T) {
-	for idx, testData := range parseKafkaMetadataTestDataset {
+	for _, testData := range parseKafkaMetadataTestDataset {
 		meta, err := parseKafkaMetadata(&ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: validWithAuthParams}, logr.Discard())
 		getBrokerTestBase(t, meta, testData, err)
 

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -216,7 +216,7 @@ func GenerateMetricInMili(metricName string, value float64) external_metrics.Ext
 }
 
 // getParameterFromConfigV2 returns the value of the parameter from the config
-func getParameterFromConfigV2(config *ScalerConfig, parameter string, useMetadata bool, useAuthentication bool, useResolvedEnv bool, isOptional bool, defaultVal string, targetType reflect.Type) (interface{}, error) {
+func getParameterFromConfigV2(config *ScalerConfig, parameter string, useMetadata bool, useAuthentication bool, useResolvedEnv bool, isOptional bool, defaultVal interface{}, targetType reflect.Type) (interface{}, error) {
 	foundCount := 0
 	var foundVal string
 	var convertedVal interface{}
@@ -257,10 +257,6 @@ func getParameterFromConfigV2(config *ScalerConfig, parameter string, useMetadat
 	default:
 		return "", fmt.Errorf("key not found. Either set the correct key or set isOptional to true and set defaultVal")
 	}
-<<<<<<< HEAD
-=======
-	return "", fmt.Errorf("key %s not found. Either set the correct key or set isOptional to true and set defaultVal", parameter)
->>>>>>> f1c0e241 (First commit)
 }
 
 func convertToType(input interface{}, targetType reflect.Type) (interface{}, error) {

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -257,6 +257,10 @@ func getParameterFromConfigV2(config *ScalerConfig, parameter string, useMetadat
 	default:
 		return "", fmt.Errorf("key not found. Either set the correct key or set isOptional to true and set defaultVal")
 	}
+<<<<<<< HEAD
+=======
+	return "", fmt.Errorf("key %s not found. Either set the correct key or set isOptional to true and set defaultVal", parameter)
+>>>>>>> f1c0e241 (First commit)
 }
 
 func convertToType(input interface{}, targetType reflect.Type) (interface{}, error) {

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -238,7 +238,7 @@ var getParameterFromConfigTestDataset = []getParameterFromConfigTestData{
 		targetType:     reflect.TypeOf(string("")),
 		expectedResult: "default", // Should return empty string
 		isError:        true,
-		errorMessage:   "key not found. Either set the correct key or set isOptional to true and set defaultVal",
+		errorMessage:   "key key2 not found. Either set the correct key or set isOptional to true and set defaultVal",
 	},
 	{
 		name:              "test_authParam_bool",

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -238,7 +238,7 @@ var getParameterFromConfigTestDataset = []getParameterFromConfigTestData{
 		targetType:     reflect.TypeOf(string("")),
 		expectedResult: "default", // Should return empty string
 		isError:        true,
-		errorMessage:   "key key2 not found. Either set the correct key or set isOptional to true and set defaultVal",
+		errorMessage:   "key not found. Either set the correct key or set isOptional to true and set defaultVal",
 	},
 	{
 		name:              "test_authParam_bool",


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR intends to further improve the work related to refactoring of scalers accomplished by https://github.com/kedacore/keda/pull/5319 and https://github.com/kedacore/keda/pull/5228. This depends on https://github.com/kedacore/keda/pull/5319 and requires a rebase after that PR merges first because this contains commits from that PR.

All unique changes proposed here are in the last commit https://github.com/kedacore/keda/pull/5388/commits/f03313c69ce29d56066d8eb896d55acb2c67e46e can be summarized in following points:
* dropping reflections argument from `getParameterFromConfigV2` in favour of generics
* adding a type constraint to catch bugs from calling `getParameterFromConfigV2` with types not supported by `convertToType` during compile time
* implicit type conversion so the rest of the code doesn't need type assertions

this means following invocation changes from
```go
activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, int64(defaultKafkaActivationLagThreshold), reflect.TypeOf(int64(64)))
if activationLagThreshold.(int64) < 0 {
...
}
```
to slightly simpler
```go
activationLagThreshold, err := getParameterFromConfigV2(config, activationLagThresholdMetricName, true, false, false, true, defaultKafkaActivationLagThreshold)
if activationLagThreshold < 0 {
...
}
```


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Relates to https://github.com/kedacore/keda/issues/5037