### PR TITLE
fix: AWS EKS doesn't fail if missing annotation

### DIFF
--- a/pkg/scaling/resolver/aws_secretmanager_handler.go
+++ b/pkg/scaling/resolver/aws_secretmanager_handler.go
@@ -87,7 +87,7 @@ func (ash *AwsSecretManagerHandler) Initialize(ctx context.Context, client clien
 		}
 	case kedav1alpha1.PodIdentityProviderAws:
 		if ash.secretManager.PodIdentity.IsWorkloadIdentityOwner() {
-			awsRoleArn, err := resolveServiceAccountAnnotation(ctx, client, podSpec.ServiceAccountName, triggerNamespace, kedav1alpha1.PodIdentityAnnotationEKS)
+			awsRoleArn, err := resolveServiceAccountAnnotation(ctx, client, podSpec.ServiceAccountName, triggerNamespace, kedav1alpha1.PodIdentityAnnotationEKS, true)
 			if err != nil {
 				return fmt.Errorf("error resolving role arn for aws: %w", err)
 			}


### PR DESCRIPTION
### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/5385
