### PR TITLE
Make improvement to `getParameterFromConfigV2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ New deprecation(s):
 
 ### Other
 
+- **General**: Create a common utility function to get parameter value from config ([#5037](https://github.com/kedacore/keda/issues/5037))
 - **General**: Minor refactor to reduce copy/paste code in ScaledObject webhook ([#5397](https://github.com/kedacore/keda/issues/5397))
 - **General**: TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
@@ -163,7 +164,6 @@ New deprecation(s):
 ### Other
 
 - **General**: Bump K8s deps to 0.28.5 ([#5346](https://github.com/kedacore/keda/pull/5346))
-- **General**: Create a common utility function to get parameter value from config ([#5037](https://github.com/kedacore/keda/issues/5037))
 - **General**: Fix CVE-2023-45142 in OpenTelemetry ([#5089](https://github.com/kedacore/keda/issues/5089))
 - **General**: Fix logger in OpenTelemetry collector ([#5094](https://github.com/kedacore/keda/issues/5094))
 - **General**: Fix lost commit from the newly created utility function ([#5037](https://github.com/kedacore/keda/issues/5037))
@@ -175,6 +175,7 @@ New deprecation(s):
 - **CPU scaler**: Wait for metrics window during CPU scaler tests ([#5294](https://github.com/kedacore/keda/pull/5294))
 - **Hashicorp Vault**: Improve test coverage in `pkg/scaling/resolver/hashicorpvault_handler`  ([#5195](https://github.com/kedacore/keda/issues/5195))
 - **Kafka Scaler**: Add more test cases for large value of LagThreshold ([#5354](https://github.com/kedacore/keda/issues/5354))
+- **Kafka Scaler**: Improve readability of utility function getParameterFromConfigV2 ([#5037](https://github.com/kedacore/keda/issues/5037))
 - **Openstack Scaler**: Use Gophercloud SDK ([#3439](https://github.com/kedacore/keda/issues/3439))
 
 ## v2.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ New deprecation(s):
 
 ### Other
 
-- **General**: Create a common utility function to get parameter value from config ([#5037](https://github.com/kedacore/keda/issues/5037))
+- **General**: Improve readability of utility function getParameterFromConfigV2 ([#5037](https://github.com/kedacore/keda/issues/5037))
 - **General**: Minor refactor to reduce copy/paste code in ScaledObject webhook ([#5397](https://github.com/kedacore/keda/issues/5397))
 - **General**: TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
@@ -175,7 +175,6 @@ New deprecation(s):
 - **CPU scaler**: Wait for metrics window during CPU scaler tests ([#5294](https://github.com/kedacore/keda/pull/5294))
 - **Hashicorp Vault**: Improve test coverage in `pkg/scaling/resolver/hashicorpvault_handler`  ([#5195](https://github.com/kedacore/keda/issues/5195))
 - **Kafka Scaler**: Add more test cases for large value of LagThreshold ([#5354](https://github.com/kedacore/keda/issues/5354))
-- **Kafka Scaler**: Improve readability of utility function getParameterFromConfigV2 ([#5037](https://github.com/kedacore/keda/issues/5037))
 - **Openstack Scaler**: Use Gophercloud SDK ([#3439](https://github.com/kedacore/keda/issues/3439))
 
 ## v2.12.1

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -168,40 +168,46 @@ func GenerateMetricInMili(metricName string, value float64) external_metrics.Ext
 	}
 }
 
+// Option represents a function type that modifies a configOptions instance.
 type Option func(*configOptions)
 
 type configOptions struct {
-	useMetadata       bool
-	useAuthentication bool
-	useResolvedEnv    bool
-	isOptional        bool
-	defaultVal        interface{}
+	useMetadata       bool        // Indicates whether to use metadata.
+	useAuthentication bool        // Indicates whether to use authentication.
+	useResolvedEnv    bool        // Indicates whether to use resolved environment variables.
+	isOptional        bool        // Indicates whether the configuration is optional.
+	defaultVal        interface{} // Default value for the configuration.
 }
 
+// UseMetadata is an Option function that sets the useMetadata field of configOptions.
 func UseMetadata(metadata bool) Option {
 	return func(opt *configOptions) {
 		opt.useMetadata = metadata
 	}
 }
 
+// UseAuthentication is an Option function that sets the useAuthentication field of configOptions.
 func UseAuthentication(auth bool) Option {
 	return func(opt *configOptions) {
 		opt.useAuthentication = auth
 	}
 }
 
+// UseResolvedEnv is an Option function that sets the useResolvedEnv field of configOptions.
 func UseResolvedEnv(resolvedEnv bool) Option {
 	return func(opt *configOptions) {
 		opt.useResolvedEnv = resolvedEnv
 	}
 }
 
+// IsOptional is an Option function that sets the isOptional field of configOptions.
 func IsOptional(optional bool) Option {
 	return func(opt *configOptions) {
 		opt.isOptional = optional
 	}
 }
 
+// WithDefaultVal is an Option function that sets the defaultVal field of configOptions.
 func WithDefaultVal(defaultVal interface{}) Option {
 	return func(opt *configOptions) {
 		opt.defaultVal = defaultVal

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -208,7 +208,31 @@ func WithDefaultVal(defaultVal interface{}) Option {
 	}
 }
 
-// getParameterFromConfigV2 returns the value of the parameter from the config
+// getParameterFromConfigV2 retrieves a parameter value from the provided ScalerConfig object based on the specified parameter name, target type, and optional configuration options.
+//
+// This method searches for the parameter value in different places within the ScalerConfig object, such as authentication parameters, trigger metadata, and resolved environment variables, based on the provided options.
+// It then attempts to convert the found value to the specified target type and returns it.
+//
+// Parameters:
+//
+//	config: A pointer to a ScalerConfig object from which to retrieve the parameter value.
+//	parameter: A string representing the name of the parameter to retrieve.
+//	targetType: A reflect.Type representing the target type to which the parameter value should be converted.
+//	options: An optional variadic parameter that allows configuring the behavior of the method through Option functions.
+//
+// Returns:
+//   - An interface{} representing the retrieved parameter value, converted to the specified target type.
+//   - An error, if any occurred during the retrieval or conversion process.
+//
+// Example Usage:
+//
+//	To retrieve a parameter value from a ScalerConfig object, you can call this function with the necessary parameters and options
+//
+//	```
+//	val, err := getParameterFromConfigV2(scalerConfig, "parameterName", reflect.TypeOf(int64(0)), UseMetadata(true), UseAuthentication(true))
+//	if err != nil {
+//	    // Handle error
+//	}
 func getParameterFromConfigV2(config *scalersconfig.ScalerConfig, parameter string, targetType reflect.Type, options ...Option) (interface{}, error) {
 	opt := &configOptions{defaultVal: ""}
 	for _, option := range options {

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -257,12 +257,12 @@ func TestGetParameterFromConfigV2(t *testing.T) {
 		val, err := getParameterFromConfigV2(
 			&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams, ResolvedEnv: testData.resolvedEnv},
 			testData.parameter,
-			testData.useMetadata,
-			testData.useAuthentication,
-			testData.useResolvedEnv,
-			testData.isOptional,
-			testData.defaultVal,
 			testData.targetType,
+			UseMetadata(testData.useMetadata),
+			UseAuthentication(testData.useAuthentication),
+			UseResolvedEnv(testData.useResolvedEnv),
+			IsOptional(testData.isOptional),
+			WithDefaultVal(testData.defaultVal),
 		)
 		if testData.isError {
 			assert.NotNilf(t, err, "test %s: expected error but got success, testData - %+v", testData.name, testData)
@@ -466,7 +466,7 @@ func TestConvertStringToType(t *testing.T) {
 
 		if testData.isError {
 			assert.NotNilf(t, err, "test %s: expected error but got success, testData - %+v", testData.name, testData)
-			assert.Containsf(t, err.Error(), testData.errorMessage, "test %s", testData.name, testData.errorMessage)
+			assert.Containsf(t, err.Error(), testData.errorMessage, "test %s: %s", testData.name, testData.errorMessage)
 		} else {
 			assert.Nil(t, err)
 			assert.Equalf(t, testData.expectedOutput, val, "test %s: expected %s but got %s", testData.name, testData.expectedOutput, val)


### PR DESCRIPTION
From the [slack discussion](https://kubernetes.slack.com/archives/C01JGDP8MB8/p1705413854296079?thread_ts=1705333570.247929&cid=C01JGDP8MB8), we should make some improvements to the `getParameterFromConfigV2` util function to make it more readable.
I create a new PR instead of adding on to  https://github.com/kedacore/keda/pull/5319 as I want to make this change modular, just showcasing the alternative without refactoring hundreds of lines on the other PR.
How we use the function would be something like 
```golang
 getParameterFromConfigV2(
			&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams, ResolvedEnv: testData.resolvedEnv},
			testData.parameter,
			testData.targetType,
			UseMetadata(testData.useMetadata),
			UseAuthentication(testData.useAuthentication),
			UseResolvedEnv(testData.useResolvedEnv),
			IsOptional(testData.isOptional),
			WithDefaultVal(testData.defaultVal),
		)
```
### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

