### PR TITLE
doc: remind about dependency version bumps before releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_release_tracker.md
+++ b/.github/ISSUE_TEMPLATE/4_release_tracker.md
@@ -23,6 +23,11 @@ We aim to release this release in the week of <week range, example March 27-31>.
 - [ ] Prepare changelog
 - [ ] [Welcome message supported versions](https://github.com/kedacore/keda/blob/main/pkg/util/welcome.go#L29-L30) are up-to-date
 - [ ] Add the new version to [GitHub Bug report](https://github.com/kedacore/keda/blob/main/.github/ISSUE_TEMPLATE/3_bug_report.yml) template
+- [ ] Best effort version bump for dependencies, example: [#5400](https://github.com/kedacore/keda/pull/5400)
+  - [ ] Update k8s go modules and pin to the 2nd most recent minor version
+  - [ ] Check if new Go has been released and if KEDA can be safely built by it
+  - [ ] Update linters and build pipelines if Go has been bumped, example: [#5399](https://github.com/kedacore/keda/pull/5399)
+- [ ] Best effort changelog cleanup, sometimes the notes can be a little inconsistent, example: [#5398](https://github.com/kedacore/keda/pull/5398)
 - [ ] Create KEDA release
 - [ ] Publish new documentation version
 - [ ] Setup continuous container scanning with Snyk


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Document a reminder about dependency version bumps before releases in the release tracker issue template.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


