### PR TITLE
chore: Introduce KEDA v2.13 and estimate v2.16 in roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,14 +14,15 @@ Here is an overview of our current release estimations:
 
 | Version | Estimated Release Date                               |
 |:--------|:-----------------------------------------------------|
-| v2.13   | January 11th, 2024 *(planned later due to holidays)* |
 | v2.14   | April 12th, 2024                                     |
 | v2.15   | July 9th, 2024                                       |
+| v2.16   | Oct 3rd, 2024                                        |
 
 Here is an overview of our previous releases:
 
 | Version | Release Date      | Links                                                                  |
 |:--------|:------------------|:-----------------------------------------------------------------------|
+| v2.13   | Jan 19th, 2024   | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.13.0) |
 | v2.12   | Sept 28th, 2023   | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.12.0) |
 | v2.11   | June 22nd, 2023   | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.11.0) |
 | v2.10   | March 9th, 2023   | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.10.0) |


### PR DESCRIPTION
Introduce KEDA v2.13 and estimate v2.16 in roadmap.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/5275
