### PR TITLE
fix(gcp scalers): Restore previous time horizon to fix missing metrics and properly close the connecctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **GCP Scalers**: Restore previous time horizon to prevent querying issues ([#5429](https://github.com/kedacore/keda/issues/5429))
 - **Prometheus Scaler**: Fix for missing AWS region from metadata ([#5419](https://github.com/kedacore/keda/issues/5419))
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **GCP Scalers**: Properly close the connection during the scaler cleaning process ([#5448](https://github.com/kedacore/keda/issues/5448))
 - **GCP Scalers**: Restore previous time horizon to prevent querying issues ([#5429](https://github.com/kedacore/keda/issues/5429))
 - **Prometheus Scaler**: Fix for missing AWS region from metadata ([#5419](https://github.com/kedacore/keda/issues/5419))
 

--- a/pkg/scalers/gcp/gcp_stackdriver_client.go
+++ b/pkg/scalers/gcp/gcp_stackdriver_client.go
@@ -20,7 +20,12 @@ import (
 )
 
 const (
-	defaultTimeHorizon = "1m"
+	// Although the "common" value could be 1m
+	// before v2.13 it was 2m, so we need to
+	// keep that value to not break the behaviour
+	// We need to revisit this in KEDA v3
+	// https://github.com/kedacore/keda/issues/5429
+	defaultTimeHorizon = "2m"
 
 	// Visualization of aggregation window:
 	// aggregationTimeHorizon: [- - - - -]

--- a/pkg/scalers/gcp/gcp_stackdriver_client.go
+++ b/pkg/scalers/gcp/gcp_stackdriver_client.go
@@ -371,7 +371,6 @@ func (s *StackDriverClient) Close() error {
 		metricsClientError = s.metricsClient.Close()
 	}
 	return errors.Join(queryClientError, metricsClientError)
-
 }
 
 // buildAggregation builds the aggregation part of a Monitoring Query Language (MQL) query

--- a/pkg/scalers/gcp/gcp_stackdriver_client_test.go
+++ b/pkg/scalers/gcp/gcp_stackdriver_client_test.go
@@ -28,7 +28,7 @@ func TestBuildMQLQuery(t *testing.T) {
 			"topic without aggregation",
 			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "",
 			"fetch pubsub_topic | metric 'pubsub.googleapis.com/topic/x' | filter (resource.project_id == 'myproject' && resource.topic_id == 'mytopic')" +
-				" | within 1m",
+				" | within 2m",
 			false,
 		},
 		{
@@ -42,7 +42,7 @@ func TestBuildMQLQuery(t *testing.T) {
 			"subscription without aggregation",
 			"subscription", "pubsub.googleapis.com/subscription/x", "mysubscription", "",
 			"fetch pubsub_subscription | metric 'pubsub.googleapis.com/subscription/x' | filter (resource.project_id == 'myproject' && resource.subscription_id == 'mysubscription')" +
-				" | within 1m",
+				" | within 2m",
 			false,
 		},
 		{

--- a/pkg/scalers/gcp_cloud_tasks_scaler.go
+++ b/pkg/scalers/gcp_cloud_tasks_scaler.go
@@ -110,13 +110,12 @@ func parseGcpCloudTasksMetadata(config *scalersconfig.ScalerConfig) (*gcpCloudTa
 
 func (s *gcpCloudTasksScaler) Close(context.Context) error {
 	if s.client != nil {
-		err := s.client.MetricsClient.Close()
+		err := s.client.Close()
 		s.client = nil
 		if err != nil {
 			s.logger.Error(err, "error closing StackDriver client")
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -148,13 +148,12 @@ func parsePubSubMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger)
 
 func (s *pubsubScaler) Close(context.Context) error {
 	if s.client != nil {
-		err := s.client.MetricsClient.Close()
+		err := s.client.Close()
 		s.client = nil
 		if err != nil {
 			s.logger.Error(err, "error closing StackDriver client")
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/scalers/gcp_stackdriver_scaler.go
+++ b/pkg/scalers/gcp_stackdriver_scaler.go
@@ -175,13 +175,12 @@ func initializeStackdriverClient(ctx context.Context, gcpAuthorization *gcp.Auth
 
 func (s *stackdriverScaler) Close(context.Context) error {
 	if s.client != nil {
-		err := s.client.MetricsClient.Close()
+		err := s.client.Close()
 		s.client = nil
 		if err != nil {
 			s.logger.Error(err, "error closing StackDriver client")
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Before changes in v2.13 related with GCP client, the time horizon for queries was 2m. We changed it by mistake and this PR restores the previous behaviour.

As customizing the value could make sense for different scenarios, I've created another issue to track supporting it (for next version): https://github.com/kedacore/keda/issues/5453

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/5429
Fixes https://github.com/kedacore/keda/issues/5448
