### PR TITLE
Added ScaledObject parameter StartReplicaCount to scale from 0 to N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Here is an overview of all new **experimental** features:
 ### Improvements
 
 - **General**: Add OPENTELEMETRY flag in e2e test YAML ([#5375](https://github.com/kedacore/keda/issues/5375))
+- **General**: Add startReplicaCount parameter to ScaledObject for scaling from 0 to N replicas
 
 ### Fixes
 

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -96,8 +96,8 @@ type ScaledObjectSpec struct {
 	// +optional
 	MaxReplicaCount *int32 `json:"maxReplicaCount,omitempty"`
 	// +optional
-        StartReplicaCount *int32 `json:"startReplicaCount,omitempty"`
-        // +optional
+	StartReplicaCount *int32 `json:"startReplicaCount,omitempty"`
+	// +optional
 	Advanced *AdvancedConfig `json:"advanced,omitempty"`
 
 	Triggers []ScaleTriggers `json:"triggers"`
@@ -259,8 +259,8 @@ func CheckReplicaCountBoundsAreValid(scaledObject *ScaledObject) error {
 	}
 	max := scaledObject.GetHPAMaxReplicas()
 
-        if scaledObject.Spec.StartReplicaCount != nil && (*scaledObject.Spec.StartReplicaCount > max || *scaledObject.Spec.StartReplicaCount < min) {
-                return fmt.Errorf("StartReplicaCount=%d must be less than or equal to MaxReplicaCount=%d and greater than or equal to MinReplicaCount=%d", *scaledObject.Spec.StartReplicaCount, max, min)
+	if scaledObject.Spec.StartReplicaCount != nil && (*scaledObject.Spec.StartReplicaCount > max || *scaledObject.Spec.StartReplicaCount < min) {
+		return fmt.Errorf("StartReplicaCount=%d must be less than or equal to MaxReplicaCount=%d and greater than or equal to MinReplicaCount=%d", *scaledObject.Spec.StartReplicaCount, max, min)
 	}
 
 	if min > max {

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:printcolumn:name="ScaleTargetName",type="string",JSONPath=".spec.scaleTargetRef.name"
 // +kubebuilder:printcolumn:name="Min",type="integer",JSONPath=".spec.minReplicaCount"
 // +kubebuilder:printcolumn:name="Max",type="integer",JSONPath=".spec.maxReplicaCount"
+// +kubebuilder:printcolumn:name="Start",type="integer",JSONPath=".spec.startReplicaCount"
 // +kubebuilder:printcolumn:name="Triggers",type="string",JSONPath=".spec.triggers[*].type"
 // +kubebuilder:printcolumn:name="Authentication",type="string",JSONPath=".spec.triggers[*].authenticationRef.name"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
@@ -95,6 +96,8 @@ type ScaledObjectSpec struct {
 	// +optional
 	MaxReplicaCount *int32 `json:"maxReplicaCount,omitempty"`
 	// +optional
+        StartReplicaCount *int32 `json:"startReplicaCount,omitempty"`
+        // +optional
 	Advanced *AdvancedConfig `json:"advanced,omitempty"`
 
 	Triggers []ScaleTriggers `json:"triggers"`
@@ -255,6 +258,10 @@ func CheckReplicaCountBoundsAreValid(scaledObject *ScaledObject) error {
 		min = *scaledObject.GetHPAMinReplicas()
 	}
 	max := scaledObject.GetHPAMaxReplicas()
+
+        if scaledObject.Spec.StartReplicaCount != nil && (*scaledObject.Spec.StartReplicaCount > max || *scaledObject.Spec.StartReplicaCount < min) {
+                return fmt.Errorf("StartReplicaCount=%d must be less than or equal to MaxReplicaCount=%d and greater than or equal to MinReplicaCount=%d", *scaledObject.Spec.StartReplicaCount, max, min)
+	}
 
 	if min > max {
 		return fmt.Errorf("MinReplicaCount=%d must be less than MaxReplicaCount=%d", min, max)

--- a/config/crd/bases/keda.sh_scaledobjects.yaml
+++ b/config/crd/bases/keda.sh_scaledobjects.yaml
@@ -29,6 +29,9 @@ spec:
     - jsonPath: .spec.maxReplicaCount
       name: Max
       type: integer
+    - jsonPath: .spec.startReplicaCount
+      name: Start
+      type: integer
     - jsonPath: .spec.triggers[*].type
       name: Triggers
       type: string
@@ -242,6 +245,9 @@ spec:
                 format: int32
                 type: integer
               minReplicaCount:
+                format: int32
+                type: integer
+              startReplicaCount:
                 format: int32
                 type: integer
               pollingInterval:

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -297,8 +297,8 @@ func (e *scaleExecutor) scaleToZeroOrIdle(ctx context.Context, logger logr.Logge
 
 func (e *scaleExecutor) scaleFromZeroOrIdle(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, scale *autoscalingv1.Scale) {
 	var replicas int32
-        if scaledObject.Spec.StartReplicaCount != nil && scaledObject.Spec.MinReplicaCount != nil && *scaledObject.Spec.StartReplicaCount > *scaledObject.Spec.MinReplicaCount {
-                replicas = *scaledObject.Spec.StartReplicaCount
+	if scaledObject.Spec.StartReplicaCount != nil && scaledObject.Spec.MinReplicaCount != nil && *scaledObject.Spec.StartReplicaCount > *scaledObject.Spec.MinReplicaCount {
+		replicas = *scaledObject.Spec.StartReplicaCount
 	} else if scaledObject.Spec.MinReplicaCount != nil && *scaledObject.Spec.MinReplicaCount > 0 {
 		replicas = *scaledObject.Spec.MinReplicaCount
 	} else {

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -297,7 +297,9 @@ func (e *scaleExecutor) scaleToZeroOrIdle(ctx context.Context, logger logr.Logge
 
 func (e *scaleExecutor) scaleFromZeroOrIdle(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, scale *autoscalingv1.Scale) {
 	var replicas int32
-	if scaledObject.Spec.MinReplicaCount != nil && *scaledObject.Spec.MinReplicaCount > 0 {
+        if scaledObject.Spec.StartReplicaCount != nil && scaledObject.Spec.MinReplicaCount != nil && *scaledObject.Spec.StartReplicaCount > *scaledObject.Spec.MinReplicaCount {
+                replicas = *scaledObject.Spec.StartReplicaCount
+	} else if scaledObject.Spec.MinReplicaCount != nil && *scaledObject.Spec.MinReplicaCount > 0 {
 		replicas = *scaledObject.Spec.MinReplicaCount
 	} else {
 		replicas = 1


### PR DESCRIPTION
This pull request introduces a new parameter, startReplicaCount, to the ScaledObject in order to change the scaling behavior from 0. The goal is to facilitate scaling from 0 to N replicas, instead of the default 0 to 1.
This change can be useful in scenarios where applications need fast responsiveness when is activated.

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart 
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs))
- [ ] Commits are signed with Developer Certificate of Origin

Relates to #

PR Helm chart: https://github.com/kedacore/charts/pull/606
PR Documentation: https://github.com/kedacore/keda-docs/pull/1308
