### PR TITLE
Add TLS support for cassandra scaler. Signed-off-by: Ranjith Gopal Reddy Developer <ranjith.reddy.mscs@gmail.com>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Add command-line flag in Adapter to allow override of gRPC Authority Header ([#5449](https://github.com/kedacore/keda/issues/5449))
 - **General**: Add OPENTELEMETRY flag in e2e test YAML ([#5375](https://github.com/kedacore/keda/issues/5375))
+- **Cassandra**: Add TLS support for cassandra scaler
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Here is an overview of all new **experimental** features:
 
 - **General**: Add command-line flag in Adapter to allow override of gRPC Authority Header ([#5449](https://github.com/kedacore/keda/issues/5449))
 - **General**: Add OPENTELEMETRY flag in e2e test YAML ([#5375](https://github.com/kedacore/keda/issues/5375))
-- **Cassandra**: Add TLS support for cassandra scaler
+- **Cassandra Scaler**: Add TLS support for cassandra scaler
 
 ### Fixes
 

--- a/pkg/scalers/cassandra_scaler_test.go
+++ b/pkg/scalers/cassandra_scaler_test.go
@@ -16,12 +16,19 @@ type parseCassandraMetadataTestData struct {
 	authParams map[string]string
 }
 
+type parseCassandraTLSTestData struct {
+	authParams map[string]string
+	isError    bool
+	enableTLS  bool
+}
+
 type cassandraMetricIdentifier struct {
 	metadataTestData *parseCassandraMetadataTestData
 	triggerIndex     int
 	name             string
 }
 
+// Assuming TLS details in not passed. TLS is set to false by default
 var testCassandraMetadata = []parseCassandraMetadataTestData{
 	// nothing passed
 	{map[string]string{}, true, map[string]string{}},
@@ -45,6 +52,17 @@ var testCassandraMetadata = []parseCassandraMetadataTestData{
 	{map[string]string{"query": "SELECT COUNT(*) FROM test_keyspace.test_table;", "targetQueryValue": "1", "username": "cassandra", "clusterIPAddress": "cassandra.test:9042", "keyspace": "test_keyspace", "TriggerIndex": "0"}, true, map[string]string{}},
 	// fix issue[4110] passed
 	{map[string]string{"query": "SELECT COUNT(*) FROM test_keyspace.test_table;", "targetQueryValue": "1", "username": "cassandra", "port": "9042", "clusterIPAddress": "https://cassandra.test", "keyspace": "test_keyspace", "TriggerIndex": "0"}, false, map[string]string{"password": "Y2Fzc2FuZHJhCg=="}},
+}
+
+var tlsAuthParamsTestData = []parseCassandraTLSTestData{
+	// success, TLS cert/key
+	{map[string]string{"tls": "enable", "cert": "ceert", "key": "keey", "password": "Y2Fzc2FuZHJhCg=="}, false, true},
+	// failure, TLS missing cert
+	{map[string]string{"tls": "enable", "key": "keey", "password": "Y2Fzc2FuZHJhCg=="}, true, false},
+	// failure, TLS missing key
+	{map[string]string{"tls": "enable", "cert": "ceert", "password": "Y2Fzc2FuZHJhCg=="}, true, false},
+	// failure, TLS invalid
+	{map[string]string{"tls": "yes", "cert": "ceert", "key": "keey", "password": "Y2Fzc2FuZHJhCg=="}, true, false},
 }
 
 var cassandraMetricIdentifiers = []cassandraMetricIdentifier{
@@ -80,6 +98,32 @@ func TestCassandraGetMetricSpecForScaling(t *testing.T) {
 		metricName := metricSpec[0].External.Metric.Name
 		if metricName != testData.name {
 			t.Errorf("Wrong External metric source name: %s, expected: %s", metricName, testData.name)
+		}
+	}
+}
+
+var successMetaData = map[string]string{"query": "SELECT COUNT(*) FROM test_keyspace.test_table;", "targetQueryValue": "1", "username": "cassandra", "clusterIPAddress": "cassandra.test:9042", "keyspace": "test_keyspace", "TriggerIndex": "0"}
+
+func TestParseCassandraTLS(t *testing.T) {
+	for _, testData := range tlsAuthParamsTestData {
+		meta, err := parseCassandraMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: successMetaData, AuthParams: testData.authParams})
+
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+		if meta.enableTLS != testData.enableTLS {
+			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
+		}
+		if meta.enableTLS {
+			if meta.cert != testData.authParams["cert"] {
+				t.Errorf("Expected cert to be set to %v but got %v\n", testData.authParams["cert"], meta.cert)
+			}
+			if meta.key != testData.authParams["key"] {
+				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["key"], meta.key)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
