### PR TITLE
Remove cortexOrgID from Prometheus scaler

### DIFF
--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -32,7 +32,6 @@ const (
 	promThreshold           = "threshold"
 	promActivationThreshold = "activationThreshold"
 	promNamespace           = "namespace"
-	promCortexScopeOrgID    = "cortexOrgID"
 	promCustomHeaders       = "customHeaders"
 	ignoreNullValues        = "ignoreNullValues"
 	unsafeSsl               = "unsafeSsl"
@@ -202,10 +201,6 @@ func parsePrometheusMetadata(config *scalersconfig.ScalerConfig) (meta *promethe
 
 	if val, ok := config.TriggerMetadata[promNamespace]; ok && val != "" {
 		meta.namespace = val
-	}
-
-	if val, ok := config.TriggerMetadata[promCortexScopeOrgID]; ok && val != "" {
-		return nil, fmt.Errorf("cortexOrgID is deprecated, please use customHeaders instead")
 	}
 
 	if val, ok := config.TriggerMetadata[promCustomHeaders]; ok && val != "" {

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -60,8 +60,6 @@ var testPromMetadata = []parsePrometheusMetadataTestData{
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "customHeaders": "key1=value1,key2=value2"}, false},
 	// customHeaders with wrong format
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "customHeaders": "key1=value1,key2"}, true},
-	// deprecated cortexOrgID
-	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "cortexOrgID": "my-org"}, true},
 	// queryParameters
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "queryParameters": "key1=value1,key2=value2"}, false},
 	// queryParameters with wrong format


### PR DESCRIPTION
In line with the deprecation of `cortexOrgID` in v2.10 and its scheduled removal in v2.12, this commit removes all references to `cortexOrgID` within the Prometheus scaler codebase and documentation.
Fixes #5538 