### PR TITLE
Fix e2e test in non-opentelemetry case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ New deprecation(s):
 ### Other
 
 - **General**: Improve readability of utility function getParameterFromConfigV2 ([#5037](https://github.com/kedacore/keda/issues/5037))
-- **General**: Introduce ENABLE_OPENTELEMETRY in deploying/testing process  ([#5375](https://github.com/kedacore/keda/issues/5375))
+- **General**: Introduce ENABLE_OPENTELEMETRY in deploying/testing process  ([#5375](https://github.com/kedacore/keda/issues/5375)|[#5578](https://github.com/kedacore/keda/issues/5578))
 - **General**: Migrate away from unmaintained golang/mock and use uber/gomock ([#5440](https://github.com/kedacore/keda/issues/5440))
 - **General**: Minor refactor to reduce copy/paste code in ScaledObject webhook ([#5397](https://github.com/kedacore/keda/issues/5397))
 

--- a/tests/utils/cleanup_test.go
+++ b/tests/utils/cleanup_test.go
@@ -65,6 +65,10 @@ func TestRemoveGcpIdentityComponents(t *testing.T) {
 }
 
 func TestRemoveOpentelemetryComponents(t *testing.T) {
+	if EnableOpentelemetry == "" || EnableOpentelemetry == StringFalse {
+		t.Skip("skipping uninstall of opentelemetry")
+	}
+
 	_, err := ExecuteCommand(fmt.Sprintf("helm uninstall opentelemetry-collector --namespace %s", OpentelemetryNamespace))
 	require.NoErrorf(t, err, "cannot uninstall opentelemetry-collector - %s", err)
 	DeleteNamespace(t, OpentelemetryNamespace)


### PR DESCRIPTION
If running e2e tests without `ENABLE_OPENTELEMETRY=true`, the tests fail during teardown when it tries to remove opentelemetry-related test items. This PR skips the removal when the setup was skipped.

### Checklist

- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #5375, #5436