### PR TITLE
Add GRPC Healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Here is an overview of all new **experimental** features:
 ### Improvements
 
 - **General**: Add command-line flag in Adapter to allow override of gRPC Authority Header ([#5449](https://github.com/kedacore/keda/issues/5449))
+- **General**: Add GRPC Healthchecks ([#5590](https://github.com/kedacore/keda/issues/5590))
 - **General**: Add OPENTELEMETRY flag in e2e test YAML ([#5375](https://github.com/kedacore/keda/issues/5375))
 - **General**: Add support for cross tenant/cloud authentication when using Azure Workload Identity for TriggerAuthentication ([#5441](https://github.com/kedacore/keda/issues/5441))
 - **MongoDB Scaler**: Add scheme field support srv record ([#5544](https://github.com/kedacore/keda/issues/5544))

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -300,13 +300,7 @@ func main() {
 		close(certReady)
 	}
 
-	grpcServer := metricsservice.NewGrpcServer(&scaledHandler, metricsServiceAddr, certDir, certReady)
-
-	if err := grpcServer.StartGrpcServer(); err != nil {
-		setupLog.Error(err, "unable to start Metrics Service gRPC server")
-		os.Exit(1)
-	}
-
+	grpcServer := metricsservice.NewGrpcServer(&scaledHandler, metricsServiceAddr, certDir, certReady, mgr.Elected())
 	if err := mgr.Add(&grpcServer); err != nil {
 		setupLog.Error(err, "unable to set up Metrics Service gRPC server")
 		os.Exit(1)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -301,6 +301,12 @@ func main() {
 	}
 
 	grpcServer := metricsservice.NewGrpcServer(&scaledHandler, metricsServiceAddr, certDir, certReady)
+
+	if err := grpcServer.StartGrpcServer(ctx); err != nil {
+		setupLog.Error(err, "unable to start Metrics Service gRPC server")
+		os.Exit(1)
+	}
+
 	if err := mgr.Add(&grpcServer); err != nil {
 		setupLog.Error(err, "unable to set up Metrics Service gRPC server")
 		os.Exit(1)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -302,7 +302,7 @@ func main() {
 
 	grpcServer := metricsservice.NewGrpcServer(&scaledHandler, metricsServiceAddr, certDir, certReady)
 
-	if err := grpcServer.StartGrpcServer(ctx); err != nil {
+	if err := grpcServer.StartGrpcServer(); err != nil {
 		setupLog.Error(err, "unable to start Metrics Service gRPC server")
 		os.Exit(1)
 	}

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -48,10 +48,10 @@ func NewGrpcClient(url, certDir, authority string) (*GrpcClient, error) {
 				"RetryableStatusCodes": [ "UNAVAILABLE" ]
 			}
 			}],
+			"loadBalancingPolicy": "round_robin",
 			"healthCheckConfig": {
 				"serviceName": "%s"
 			},
-			"loadBalancingPolicy": "round_robin",
 		}`,
 		api.MetricsService_ServiceDesc.ServiceName)
 

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -50,7 +50,8 @@ func NewGrpcClient(url, certDir, authority string) (*GrpcClient, error) {
 			}],
 			"healthCheckConfig": {
 				"serviceName": "%s"
-			}
+			},
+			"loadBalancingPolicy": "round_robin",
 		}`,
 		api.MetricsService_ServiceDesc.ServiceName)
 

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -37,17 +37,22 @@ type GrpcClient struct {
 }
 
 func NewGrpcClient(url, certDir, authority string) (*GrpcClient, error) {
-	defaultConfig := `{
-		"methodConfig": [{
-		  "timeout": "3s",
-		  "waitForReady": true,
-		  "retryPolicy": {
-			  "InitialBackoff": ".25s",
-			  "MaxBackoff": "2.0s",
-			  "BackoffMultiplier": 2,
-			  "RetryableStatusCodes": [ "UNAVAILABLE" ]
-		  }
-		}]}`
+	defaultConfig := fmt.Sprintf(`{
+			"methodConfig": [{
+			"timeout": "3s",
+			"waitForReady": true,
+			"retryPolicy": {
+				"InitialBackoff": ".25s",
+				"MaxBackoff": "2.0s",
+				"BackoffMultiplier": 2,
+				"RetryableStatusCodes": [ "UNAVAILABLE" ]
+			}
+			}],
+			"healthCheckConfig": {
+				"serviceName": "%s"
+			}
+		}`,
+		api.MetricsService_ServiceDesc.ServiceName)
 
 	creds, err := utils.LoadGrpcTLSCredentials(certDir, false)
 	if err != nil {

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -39,19 +39,19 @@ type GrpcClient struct {
 func NewGrpcClient(url, certDir, authority string) (*GrpcClient, error) {
 	defaultConfig := fmt.Sprintf(`{
 			"methodConfig": [{
-			"timeout": "3s",
-			"waitForReady": true,
-			"retryPolicy": {
-				"InitialBackoff": ".25s",
-				"MaxBackoff": "2.0s",
-				"BackoffMultiplier": 2,
-				"RetryableStatusCodes": [ "UNAVAILABLE" ]
-			}
+				"timeout": "3s",
+				"waitForReady": true,
+				"retryPolicy": {
+					"InitialBackoff": ".25s",
+					"MaxBackoff": "2.0s",
+					"BackoffMultiplier": 2,
+					"RetryableStatusCodes": [ "UNAVAILABLE" ]
+				}
 			}],
 			"loadBalancingPolicy": "round_robin",
 			"healthCheckConfig": {
 				"serviceName": "%s"
-			},
+			}
 		}`,
 		api.MetricsService_ServiceDesc.ServiceName)
 

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -87,7 +87,8 @@ func (s *GrpcServer) startServer() error {
 	return nil
 }
 
-// StartGrpcServer starts the grpc server in non-serving mode
+// StartGrpcServer starts the grpc server in non-serving mode and when the controller is elected leader
+// sets the status of the server to Serving.
 func (s *GrpcServer) Start(ctx context.Context) error {
 	<-s.certsReady
 	if s.server == nil {

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -87,7 +87,7 @@ func (s *GrpcServer) startServer() error {
 }
 
 // StartGrpcServer starts the grpc server in non-serving mode
-func (s *GrpcServer) StartGrpcServer(ctx context.Context) error {
+func (s *GrpcServer) StartGrpcServer() error {
 	<-s.certsReady
 	if s.server == nil {
 		creds, err := utils.LoadGrpcTLSCredentials(s.certDir, true)

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -120,6 +120,8 @@ func (s *GrpcServer) StartGrpcServer(ctx context.Context) error {
 func (s *GrpcServer) Start(ctx context.Context) error {
 	s.healthServer.SetServingStatus(api.MetricsService_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
 
+	log.Info("Setting server status to Serving")
+
 	select {
 	case err := <-s.errChan:
 		return err

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -126,6 +126,9 @@ func (s *GrpcServer) Start(ctx context.Context) error {
 	case err := <-s.errChan:
 		return err
 	case <-ctx.Done():
+		log.Info("Shutting down grpc server")
+		s.healthServer.SetServingStatus(api.MetricsService_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+		s.server.GracefulStop()
 		return nil
 	}
 }

--- a/vendor/google.golang.org/grpc/health/client.go
+++ b/vendor/google.golang.org/grpc/health/client.go
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/backoff"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	backoffStrategy = backoff.DefaultExponential
+	backoffFunc     = func(ctx context.Context, retries int) bool {
+		d := backoffStrategy.Backoff(retries)
+		timer := time.NewTimer(d)
+		select {
+		case <-timer.C:
+			return true
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		}
+	}
+)
+
+func init() {
+	internal.HealthCheckFunc = clientHealthCheck
+}
+
+const healthCheckMethod = "/grpc.health.v1.Health/Watch"
+
+// This function implements the protocol defined at:
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+func clientHealthCheck(ctx context.Context, newStream func(string) (any, error), setConnectivityState func(connectivity.State, error), service string) error {
+	tryCnt := 0
+
+retryConnection:
+	for {
+		// Backs off if the connection has failed in some way without receiving a message in the previous retry.
+		if tryCnt > 0 && !backoffFunc(ctx, tryCnt-1) {
+			return nil
+		}
+		tryCnt++
+
+		if ctx.Err() != nil {
+			return nil
+		}
+		setConnectivityState(connectivity.Connecting, nil)
+		rawS, err := newStream(healthCheckMethod)
+		if err != nil {
+			continue retryConnection
+		}
+
+		s, ok := rawS.(grpc.ClientStream)
+		// Ideally, this should never happen. But if it happens, the server is marked as healthy for LBing purposes.
+		if !ok {
+			setConnectivityState(connectivity.Ready, nil)
+			return fmt.Errorf("newStream returned %v (type %T); want grpc.ClientStream", rawS, rawS)
+		}
+
+		if err = s.SendMsg(&healthpb.HealthCheckRequest{Service: service}); err != nil && err != io.EOF {
+			// Stream should have been closed, so we can safely continue to create a new stream.
+			continue retryConnection
+		}
+		s.CloseSend()
+
+		resp := new(healthpb.HealthCheckResponse)
+		for {
+			err = s.RecvMsg(resp)
+
+			// Reports healthy for the LBing purposes if health check is not implemented in the server.
+			if status.Code(err) == codes.Unimplemented {
+				setConnectivityState(connectivity.Ready, nil)
+				return err
+			}
+
+			// Reports unhealthy if server's Watch method gives an error other than UNIMPLEMENTED.
+			if err != nil {
+				setConnectivityState(connectivity.TransientFailure, fmt.Errorf("connection active but received health check RPC error: %v", err))
+				continue retryConnection
+			}
+
+			// As a message has been received, removes the need for backoff for the next retry by resetting the try count.
+			tryCnt = 0
+			if resp.Status == healthpb.HealthCheckResponse_SERVING {
+				setConnectivityState(connectivity.Ready, nil)
+			} else {
+				setConnectivityState(connectivity.TransientFailure, fmt.Errorf("connection active but health check failed. status=%s", resp.Status))
+			}
+		}
+	}
+}

--- a/vendor/google.golang.org/grpc/health/logging.go
+++ b/vendor/google.golang.org/grpc/health/logging.go
@@ -1,0 +1,23 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package health
+
+import "google.golang.org/grpc/grpclog"
+
+var logger = grpclog.Component("health_service")

--- a/vendor/google.golang.org/grpc/health/server.go
+++ b/vendor/google.golang.org/grpc/health/server.go
@@ -1,0 +1,163 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package health provides a service that exposes server's health and it must be
+// imported to enable support for client-side health checks.
+package health
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// Server implements `service Health`.
+type Server struct {
+	healthgrpc.UnimplementedHealthServer
+	mu sync.RWMutex
+	// If shutdown is true, it's expected all serving status is NOT_SERVING, and
+	// will stay in NOT_SERVING.
+	shutdown bool
+	// statusMap stores the serving status of the services this Server monitors.
+	statusMap map[string]healthpb.HealthCheckResponse_ServingStatus
+	updates   map[string]map[healthgrpc.Health_WatchServer]chan healthpb.HealthCheckResponse_ServingStatus
+}
+
+// NewServer returns a new Server.
+func NewServer() *Server {
+	return &Server{
+		statusMap: map[string]healthpb.HealthCheckResponse_ServingStatus{"": healthpb.HealthCheckResponse_SERVING},
+		updates:   make(map[string]map[healthgrpc.Health_WatchServer]chan healthpb.HealthCheckResponse_ServingStatus),
+	}
+}
+
+// Check implements `service Health`.
+func (s *Server) Check(ctx context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if servingStatus, ok := s.statusMap[in.Service]; ok {
+		return &healthpb.HealthCheckResponse{
+			Status: servingStatus,
+		}, nil
+	}
+	return nil, status.Error(codes.NotFound, "unknown service")
+}
+
+// Watch implements `service Health`.
+func (s *Server) Watch(in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
+	service := in.Service
+	// update channel is used for getting service status updates.
+	update := make(chan healthpb.HealthCheckResponse_ServingStatus, 1)
+	s.mu.Lock()
+	// Puts the initial status to the channel.
+	if servingStatus, ok := s.statusMap[service]; ok {
+		update <- servingStatus
+	} else {
+		update <- healthpb.HealthCheckResponse_SERVICE_UNKNOWN
+	}
+
+	// Registers the update channel to the correct place in the updates map.
+	if _, ok := s.updates[service]; !ok {
+		s.updates[service] = make(map[healthgrpc.Health_WatchServer]chan healthpb.HealthCheckResponse_ServingStatus)
+	}
+	s.updates[service][stream] = update
+	defer func() {
+		s.mu.Lock()
+		delete(s.updates[service], stream)
+		s.mu.Unlock()
+	}()
+	s.mu.Unlock()
+
+	var lastSentStatus healthpb.HealthCheckResponse_ServingStatus = -1
+	for {
+		select {
+		// Status updated. Sends the up-to-date status to the client.
+		case servingStatus := <-update:
+			if lastSentStatus == servingStatus {
+				continue
+			}
+			lastSentStatus = servingStatus
+			err := stream.Send(&healthpb.HealthCheckResponse{Status: servingStatus})
+			if err != nil {
+				return status.Error(codes.Canceled, "Stream has ended.")
+			}
+		// Context done. Removes the update channel from the updates map.
+		case <-stream.Context().Done():
+			return status.Error(codes.Canceled, "Stream has ended.")
+		}
+	}
+}
+
+// SetServingStatus is called when need to reset the serving status of a service
+// or insert a new service entry into the statusMap.
+func (s *Server) SetServingStatus(service string, servingStatus healthpb.HealthCheckResponse_ServingStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutdown {
+		logger.Infof("health: status changing for %s to %v is ignored because health service is shutdown", service, servingStatus)
+		return
+	}
+
+	s.setServingStatusLocked(service, servingStatus)
+}
+
+func (s *Server) setServingStatusLocked(service string, servingStatus healthpb.HealthCheckResponse_ServingStatus) {
+	s.statusMap[service] = servingStatus
+	for _, update := range s.updates[service] {
+		// Clears previous updates, that are not sent to the client, from the channel.
+		// This can happen if the client is not reading and the server gets flow control limited.
+		select {
+		case <-update:
+		default:
+		}
+		// Puts the most recent update to the channel.
+		update <- servingStatus
+	}
+}
+
+// Shutdown sets all serving status to NOT_SERVING, and configures the server to
+// ignore all future status changes.
+//
+// This changes serving status for all services. To set status for a particular
+// services, call SetServingStatus().
+func (s *Server) Shutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.shutdown = true
+	for service := range s.statusMap {
+		s.setServingStatusLocked(service, healthpb.HealthCheckResponse_NOT_SERVING)
+	}
+}
+
+// Resume sets all serving status to SERVING, and configures the server to
+// accept all future status changes.
+//
+// This changes serving status for all services. To set status for a particular
+// services, call SetServingStatus().
+func (s *Server) Resume() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.shutdown = false
+	for service := range s.statusMap {
+		s.setServingStatusLocked(service, healthpb.HealthCheckResponse_SERVING)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1754,6 +1754,7 @@ google.golang.org/grpc/encoding
 google.golang.org/grpc/encoding/gzip
 google.golang.org/grpc/encoding/proto
 google.golang.org/grpc/grpclog
+google.golang.org/grpc/health
 google.golang.org/grpc/health/grpc_health_v1
 google.golang.org/grpc/internal
 google.golang.org/grpc/internal/backoff


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR adds a GRPC healthcheck server to the operator and returns `SERVING` status only if the server is the leader elected instance.

To do this, I refactored the GRPCServer class to be a non-leader elected runnable (returning `false` for `NeedsLeaderElection`) and instead listen to the `Elected` channel from the manager in the select statement to set the server state to serving.

This also needed the addition client-side health checking to ensure that the GRPC client checks the health of the endpoint its connected to and ensure it is connected to the serving client. Additionally, this required changing the load balancing behavior of the client from `pick_first` to `round_robin` so that the client internally watches the state of the health checks and selects a server that is in the serving state, per docs in https://grpc.io/docs/guides/health-checking/

I also added a graceful shutdown of the GRPC server when `ctx.Done()` is closed as there was none previously. 

Verified by running in our Kubernetes cluster in 1 and 2 replica modes. Verified that server shuts down cleanly when pod is selected by monitoring logs.

Leader-elected:

```
2024/03/20 21:37:34 maxprocs: Updating GOMAXPROCS=1: determined from CPU quota
...
2024-03-20T21:37:34Z	INFO	starting server	{"kind": "health probe", "addr": "[::]:8081"}
I0320 21:37:34.629844      13 leaderelection.go:250] attempting to acquire leader lease keda/operator.keda.sh...
2024-03-20T21:37:34Z	INFO	grpc_server	Starting Metrics Service gRPC Server	{"address": ":9666"}
I0320 21:38:05.572556      13 leaderelection.go:260] successfully acquired lease keda/operator.keda.sh
2024-03-20T21:38:05Z	INFO	Starting EventSource	{"controller": "scaledobject", "controllerGroup": "keda.sh", "controllerKind": "ScaledObject", "source": "kind source: *v1alpha1.ScaledObject"}
...
2024-03-20T21:41:42Z	INFO	Stopping and waiting for non leader election runnables
2024-03-20T21:41:42Z	INFO	grpc_server	Shutting down gRPC server
2024-03-20T21:41:42Z	INFO	Stopping and waiting for leader election runnables
2024-03-20T21:41:42Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "cloudeventsource", "controllerGroup": "eventing.keda.sh", "controllerKind": "CloudEventSource"}
2024-03-20T21:41:42Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "clustertriggerauthentication", "controllerGroup": "keda.sh", "controllerKind": "ClusterTriggerAuthentication"}
2024-03-20T21:41:42Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "scaledjob", "controllerGroup": "keda.sh", "controllerKind": "ScaledJob"}
2024-03-20T21:41:42Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "scaledobject", "controllerGroup": "keda.sh", "controllerKind": "ScaledObject"}
2024-03-20T21:41:42Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "triggerauthentication", "controllerGroup": "keda.sh", "controllerKind": "TriggerAuthentication"}
2024-03-20T21:41:42Z	INFO	All workers finished	{"controller": "clustertriggerauthentication", "controllerGroup": "keda.sh", "controllerKind": "ClusterTriggerAuthentication"}
2024-03-20T21:41:42Z	INFO	All workers finished	{"controller": "cloudeventsource", "controllerGroup": "eventing.keda.sh", "controllerKind": "CloudEventSource"}
2024-03-20T21:41:42Z	INFO	All workers finished	{"controller": "scaledjob", "controllerGroup": "keda.sh", "controllerKind": "ScaledJob"}
2024-03-20T21:41:42Z	INFO	All workers finished	{"controller": "triggerauthentication", "controllerGroup": "keda.sh", "controllerKind": "TriggerAuthentication"}
2024-03-20T21:41:42Z	INFO	All workers finished	{"controller": "scaledobject", "controllerGroup": "keda.sh", "controllerKind": "ScaledObject"}
2024-03-20T21:41:42Z	INFO	Stopping and waiting for caches
W0320 21:41:42.719516      13 reflector.go:458] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: watch of *v1.Deployment ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W0320 21:41:42.719677      13 reflector.go:458] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: watch of *v1alpha1.ClusterTriggerAuthentication ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W0320 21:41:42.719778      13 reflector.go:458] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: watch of *v1alpha1.CloudEventSource ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W0320 21:41:42.719869      13 reflector.go:458] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: watch of *v1alpha1.ScaledJob ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W0320 21:41:42.719968      13 reflector.go:458] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: watch of *v1alpha1.ScaledObject ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W0320 21:41:42.720065      13 reflector.go:458] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: watch of *v1alpha1.TriggerAuthentication ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W0320 21:41:42.720222      13 reflector.go:458] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:105: watch of *v2.HorizontalPodAutoscaler ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
2024-03-20T21:41:42Z	INFO	Stopping and waiting for webhooks
2024-03-20T21:41:42Z	INFO	Stopping and waiting for HTTP servers
2024-03-20T21:41:42Z	INFO	shutting down server	{"kind": "health probe", "addr": "[::]:8081"}
2024-03-20T21:41:42Z	INFO	controller-runtime.metrics	Shutting down metrics server with timeout of 1 minute
2024-03-20T21:41:42Z	INFO	Wait completed, proceeding to shutdown the manager
```

Non-leader instance: 
```
2024/03/20 21:32:57 maxprocs: Updating GOMAXPROCS=1: determined from CPU quota
...
2024-03-20T21:32:57Z	INFO	starting server	{"kind": "health probe", "addr": "[::]:8081"}
I0320 21:32:57.488369      14 leaderelection.go:250] attempting to acquire leader lease keda/operator.keda.sh...
2024-03-20T21:32:57Z	INFO	grpc_server	Starting Metrics Service gRPC Server	{"address": ":9666"}
2024-03-20T21:45:18Z	INFO	Stopping and waiting for non leader election runnables
2024-03-20T21:45:18Z	INFO	grpc_server	Shutting down gRPC server
2024-03-20T21:45:18Z	INFO	Stopping and waiting for leader election runnables
...
2024-03-20T21:45:18Z	INFO	Stopping and waiting for webhooks
2024-03-20T21:45:18Z	INFO	Stopping and waiting for HTTP servers
2024-03-20T21:45:18Z	INFO	shutting down server	{"kind": "health probe", "addr": "[::]:8081"}
2024-03-20T21:45:18Z	INFO	controller-runtime.metrics	Shutting down metrics server with timeout of 1 minute
2024-03-20T21:45:18Z	INFO	Wait completed, proceeding to shutdown the manager
```


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5590 
