### PR TITLE
fix: Remove deprecated dependency from devcontainer's Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update \
         github.com/ramya-rao-a/go-outline \
         github.com/acroca/go-symbols \
         github.com/godoctor/godoctor \
-        golang.org/x/tools/cmd/guru \
         golang.org/x/tools/cmd/gorename \
         github.com/rogpeppe/godef \
         github.com/zmb3/gogetdoc \


### PR DESCRIPTION
[golang.org/x/tools/cmd/guru is deprecated](https://pkg.go.dev/golang.org/x/tools/cmd/guru@v0.1.1-deprecated) and raises error during devcontainer generation

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

