### PR TITLE
fix: TriggerAuthentication.podIdentity validation allows 'none'

### DIFF
--- a/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -139,7 +139,7 @@ const (
 // AuthPodIdentity allows users to select the platform native identity
 // mechanism
 type AuthPodIdentity struct {
-	// +kubebuilder:validation:Enum=azure;azure-workload;gcp;aws;aws-eks;aws-kiam
+	// +kubebuilder:validation:Enum=azure;azure-workload;gcp;aws;aws-eks;aws-kiam;none
 	Provider PodIdentityProvider `json:"provider"`
 	// +optional
 	IdentityID *string `json:"identityId"`

--- a/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
@@ -157,6 +157,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -256,6 +257,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -369,6 +371,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -485,6 +488,7 @@ spec:
                     - aws
                     - aws-eks
                     - aws-kiam
+                    - none
                     type: string
                   roleArn:
                     description: RoleArn sets the AWS RoleArn to be used. Mutually

--- a/config/crd/bases/keda.sh_triggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_triggerauthentications.yaml
@@ -156,6 +156,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -255,6 +256,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -368,6 +370,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -484,6 +487,7 @@ spec:
                     - aws
                     - aws-eks
                     - aws-kiam
+                    - none
                     type: string
                   roleArn:
                     description: RoleArn sets the AWS RoleArn to be used. Mutually


### PR DESCRIPTION
As a user reported in helm chart repo, `none` is a valid value (although it's the default value "by omission") but the CRDs don't it

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

