### PR TITLE
chore: Add more granular control to E2E test setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ New deprecation(s):
 
 ### Other
 
+- **General**: Allow E2E tests to be run against existing KEDA and/or Kafka installation ([#5595](https://github.com/kedacore/keda/pull/5595))
 - **General**: Improve readability of utility function getParameterFromConfigV2 ([#5037](https://github.com/kedacore/keda/issues/5037))
 - **General**: Introduce ENABLE_OPENTELEMETRY in deploying/testing process  ([#5375](https://github.com/kedacore/keda/issues/5375)|[#5578](https://github.com/kedacore/keda/issues/5578))
 - **General**: Migrate away from unmaintained golang/mock and use uber/gomock ([#5440](https://github.com/kedacore/keda/issues/5440))

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -83,6 +83,8 @@ var (
 	GcpIdentityTests              = os.Getenv("GCP_RUN_IDENTITY_TESTS")
 	EnableOpentelemetry           = os.Getenv("ENABLE_OPENTELEMETRY")
 	InstallCertManager            = AwsIdentityTests == StringTrue || GcpIdentityTests == StringTrue
+	InstallKeda                   = os.Getenv("E2E_INSTALL_KEDA")
+	InstallKafka                  = os.Getenv("E2E_INSTALL_KAFKA")
 )
 
 var (

--- a/tests/utils/cleanup_test.go
+++ b/tests/utils/cleanup_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestRemoveKEDA(t *testing.T) {
+	// default to true
+	if InstallKeda == StringFalse {
+		t.Skip("skipping as requested -- KEDA not installed via these tests")
+	}
 	out, err := ExecuteCommandWithDir("make undeploy", "../..")
 	require.NoErrorf(t, err, "error removing KEDA - %s", err)
 
@@ -89,6 +93,10 @@ func TestRemoveAzureManagedPrometheusComponents(t *testing.T) {
 }
 
 func TestRemoveStrimzi(t *testing.T) {
+	// default to true
+	if InstallKafka == StringFalse {
+		t.Skip("skipping as requested -- Kafka not managed by E2E tests")
+	}
 	_, err := ExecuteCommand(fmt.Sprintf(`helm uninstall --namespace %s %s`,
 		StrimziNamespace,
 		StrimziChartName))

--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -204,6 +204,10 @@ func TestSetupOpentelemetryComponents(t *testing.T) {
 }
 
 func TestDeployKEDA(t *testing.T) {
+	// default to true
+	if InstallKeda == StringFalse {
+		t.Skip("skipping as requested -- KEDA assumed to be already installed")
+	}
 	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, KEDANamespace)
 
@@ -229,6 +233,10 @@ func TestDeployKEDA(t *testing.T) {
 }
 
 func TestVerifyKEDA(t *testing.T) {
+	// default to true
+	if InstallKeda == StringFalse {
+		t.Skip("skipping as requested -- KEDA assumed to be already installed")
+	}
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, KubeClient, KEDAOperator, KEDANamespace, 1, 30, 6),
 		"replica count should be 1 after 3 minutes")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, KubeClient, KEDAMetricsAPIServer, KEDANamespace, 1, 30, 6),
@@ -268,6 +276,10 @@ func TestSetupAadPodIdentityComponents(t *testing.T) {
 }
 
 func TestSetUpStrimzi(t *testing.T) {
+	// default to true
+	if InstallKafka == StringFalse {
+		t.Skip("skipping as requested -- Kafka assumed to be unneeded or already installed")
+	}
 	t.Log("--- installing kafka operator ---")
 	_, err := ExecuteCommand("helm repo add strimzi https://strimzi.io/charts/")
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)


### PR DESCRIPTION
Allow the test setup to skip the installation of KEDA and/or Kafka so that tests can run even if they were installed via other methods, such as OLM operators.

### Checklist

- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))