### PR TITLE
Event Hub Scaler: Remove or replace usages of Event Hub offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,11 @@ Here is an overview of all new **experimental** features:
 - **General**: Add GRPC Healthchecks ([#5590](https://github.com/kedacore/keda/issues/5590))
 - **General**: Add OPENTELEMETRY flag in e2e test YAML ([#5375](https://github.com/kedacore/keda/issues/5375))
 - **General**: Add support for cross tenant/cloud authentication when using Azure Workload Identity for TriggerAuthentication ([#5441](https://github.com/kedacore/keda/issues/5441))
+- **Azure Event Hub Scaler**: Remove usage of checkpoint offsets to account for SDK checkpointing implementation changes
 - **GCP Stackdriver Scaler**: Add missing parameters 'rate' and 'count' for GCP Stackdriver Scaler alignment ([#5633](https://github.com/kedacore/keda/issues/5633))
 - **Metrics API Scaler**: Add support for various formats: json, xml, yaml, prometheus ([#2633](https://github.com/kedacore/keda/issues/2633))
 - **MongoDB Scaler**: Add scheme field support srv record ([#5544](https://github.com/kedacore/keda/issues/5544))
+
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,6 @@ Here is an overview of all new **experimental** features:
 - **Metrics API Scaler**: Add support for various formats: json, xml, yaml, prometheus ([#2633](https://github.com/kedacore/keda/issues/2633))
 - **MongoDB Scaler**: Add scheme field support srv record ([#5544](https://github.com/kedacore/keda/issues/5544))
 
-
 ### Fixes
 
 - **General**: Fix CVE-2024-28180 in github.com/go-jose/go-jose/v3 ([#5617](https://github.com/kedacore/keda/pull/5617))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Add GRPC Healthchecks ([#5590](https://github.com/kedacore/keda/issues/5590))
 - **General**: Add OPENTELEMETRY flag in e2e test YAML ([#5375](https://github.com/kedacore/keda/issues/5375))
 - **General**: Add support for cross tenant/cloud authentication when using Azure Workload Identity for TriggerAuthentication ([#5441](https://github.com/kedacore/keda/issues/5441))
-- **Azure Event Hub Scaler**: Remove usage of checkpoint offsets to account for SDK checkpointing implementation changes
+- **Azure Event Hub Scaler**: Remove usage of checkpoint offsets to account for SDK checkpointing implementation changes ([#5574](https://github.com/kedacore/keda/issues/5574))
 - **GCP Stackdriver Scaler**: Add missing parameters 'rate' and 'count' for GCP Stackdriver Scaler alignment ([#5633](https://github.com/kedacore/keda/issues/5633))
 - **Metrics API Scaler**: Add support for various formats: json, xml, yaml, prometheus ([#2633](https://github.com/kedacore/keda/issues/2633))
 - **MongoDB Scaler**: Add scheme field support srv record ([#5544](https://github.com/kedacore/keda/issues/5544))

--- a/pkg/scalers/azure/azure_eventhub_checkpoint.go
+++ b/pkg/scalers/azure/azure_eventhub_checkpoint.go
@@ -35,17 +35,15 @@ import (
 // goCheckpoint struct to adapt goSdk Checkpoint
 type goCheckpoint struct {
 	Checkpoint struct {
-		SequenceNumber int64  `json:"sequenceNumber"`
-		Offset         string `json:"offset"`
+		SequenceNumber int64 `json:"sequenceNumber"`
 	} `json:"checkpoint"`
 	PartitionID string `json:"partitionId"`
 }
 
 type baseCheckpoint struct {
-	Epoch  int64  `json:"Epoch"`
-	Offset string `json:"Offset"`
-	Owner  string `json:"Owner"`
-	Token  string `json:"Token"`
+	Epoch int64  `json:"Epoch"`
+	Owner string `json:"Owner"`
+	Token string `json:"Token"`
 }
 
 // Checkpoint in a common format
@@ -92,8 +90,8 @@ type defaultCheckpointer struct {
 	containerName string
 }
 
-func NewCheckpoint(offset string, sequenceNumber int64) Checkpoint {
-	return Checkpoint{baseCheckpoint: baseCheckpoint{Offset: offset}, SequenceNumber: sequenceNumber}
+func NewCheckpoint(sequenceNumber int64) Checkpoint {
+	return Checkpoint{baseCheckpoint: baseCheckpoint{}, SequenceNumber: sequenceNumber}
 }
 
 // GetCheckpointFromBlobStorage reads depending of the CheckpointStrategy the checkpoint from a azure storage
@@ -222,10 +220,8 @@ func newGoSdkCheckpoint(get *azblob.DownloadResponse) (Checkpoint, error) {
 
 	return Checkpoint{
 		SequenceNumber: checkpoint.Checkpoint.SequenceNumber,
-		baseCheckpoint: baseCheckpoint{
-			Offset: checkpoint.Checkpoint.Offset,
-		},
-		PartitionID: checkpoint.PartitionID,
+		baseCheckpoint: baseCheckpoint{},
+		PartitionID:    checkpoint.PartitionID,
 	}, nil
 }
 
@@ -316,15 +312,6 @@ func getCheckpointFromStorageMetadata(get *azblob.DownloadResponse, partitionID 
 		} else {
 			return Checkpoint{}, fmt.Errorf("sequencenumber is not a valid int64 value: %w", err)
 		}
-	}
-
-	if offset, ok := metadata["offset"]; ok {
-		if !ok {
-			if offset, ok = metadata["Offset"]; !ok {
-				return Checkpoint{}, fmt.Errorf("offset on blob not found")
-			}
-		}
-		checkpoint.Offset = offset
 	}
 
 	return checkpoint, nil

--- a/pkg/scalers/azure/azure_eventhub_checkpoint.go
+++ b/pkg/scalers/azure/azure_eventhub_checkpoint.go
@@ -40,22 +40,14 @@ type goCheckpoint struct {
 	PartitionID string `json:"partitionId"`
 }
 
-type baseCheckpoint struct {
-	Epoch int64  `json:"Epoch"`
-	Owner string `json:"Owner"`
-	Token string `json:"Token"`
-}
-
 // Checkpoint in a common format
 type Checkpoint struct {
-	baseCheckpoint
 	PartitionID    string `json:"PartitionId"`
 	SequenceNumber int64  `json:"SequenceNumber"`
 }
 
 // Older python sdk stores the checkpoint differently
 type pythonCheckpoint struct {
-	baseCheckpoint
 	PartitionID    string `json:"partition_id"`
 	SequenceNumber int64  `json:"sequence_number"`
 }
@@ -91,7 +83,7 @@ type defaultCheckpointer struct {
 }
 
 func NewCheckpoint(sequenceNumber int64) Checkpoint {
-	return Checkpoint{baseCheckpoint: baseCheckpoint{}, SequenceNumber: sequenceNumber}
+	return Checkpoint{SequenceNumber: sequenceNumber}
 }
 
 // GetCheckpointFromBlobStorage reads depending of the CheckpointStrategy the checkpoint from a azure storage
@@ -220,7 +212,6 @@ func newGoSdkCheckpoint(get *azblob.DownloadResponse) (Checkpoint, error) {
 
 	return Checkpoint{
 		SequenceNumber: checkpoint.Checkpoint.SequenceNumber,
-		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    checkpoint.PartitionID,
 	}, nil
 }

--- a/pkg/scalers/azure/azure_eventhub_test.go
+++ b/pkg/scalers/azure/azure_eventhub_test.go
@@ -25,23 +25,20 @@ func TestCheckpointFromBlobStorageAzureFunction(t *testing.T) {
 	}
 
 	partitionID := "0"
-	offset := "1001"
 	consumerGroup := "$Default1"
 
 	sequencenumber := int64(1)
 
 	containerName := "azure-webjobs-eventhub"
-	checkpointFormat := "{\"Offset\":\"%s\",\"SequenceNumber\":%d,\"PartitionId\":\"%s\",\"Owner\":\"\",\"Token\":\"\",\"Epoch\":0}"
-	checkpoint := fmt.Sprintf(checkpointFormat, offset, sequencenumber, partitionID)
+	checkpointFormat := "{\"SequenceNumber\":%d,\"PartitionId\":\"%s\",\"Owner\":\"\",\"Token\":\"\",\"Epoch\":0}"
+	checkpoint := fmt.Sprintf(checkpointFormat, sequencenumber, partitionID)
 	urlPath := fmt.Sprintf("eventhubnamespace.servicebus.windows.net/hub/%s/", consumerGroup)
 
 	ctx, err := createNewCheckpointInStorage(urlPath, containerName, partitionID, checkpoint, nil)
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{
-			Offset: offset,
-		},
+		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -54,8 +51,6 @@ func TestCheckpointFromBlobStorageAzureFunction(t *testing.T) {
 	}
 
 	check, _ := GetCheckpointFromBlobStorage(ctx, http.DefaultClient, eventHubInfo, "0")
-	_ = check.Offset
-	_ = expectedCheckpoint.Offset
 	assert.Equal(t, check, expectedCheckpoint)
 }
 
@@ -65,23 +60,20 @@ func TestCheckpointFromBlobStorageDefault(t *testing.T) {
 	}
 
 	partitionID := "1"
-	offset := "1005"
 	consumerGroup := "$Default2"
 
 	sequencenumber := int64(1)
 
 	containerName := "defaultcontainer"
-	checkpointFormat := "{\"Offset\":\"%s\",\"SequenceNumber\":%d,\"PartitionId\":\"%s\",\"Owner\":\"\",\"Token\":\"\",\"Epoch\":0}"
-	checkpoint := fmt.Sprintf(checkpointFormat, offset, sequencenumber, partitionID)
+	checkpointFormat := "{\"SequenceNumber\":%d,\"PartitionId\":\"%s\",\"Owner\":\"\",\"Token\":\"\",\"Epoch\":0}"
+	checkpoint := fmt.Sprintf(checkpointFormat, sequencenumber, partitionID)
 	urlPath := fmt.Sprintf("%s/", consumerGroup)
 
 	ctx, err := createNewCheckpointInStorage(urlPath, containerName, partitionID, checkpoint, nil)
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{
-			Offset: offset,
-		},
+		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -95,8 +87,6 @@ func TestCheckpointFromBlobStorageDefault(t *testing.T) {
 	}
 
 	check, _ := GetCheckpointFromBlobStorage(ctx, http.DefaultClient, eventHubInfo, partitionID)
-	_ = check.Offset
-	_ = expectedCheckpoint.Offset
 	assert.Equal(t, check, expectedCheckpoint)
 }
 
@@ -106,23 +96,20 @@ func TestCheckpointFromBlobStorageDefaultDeprecatedPythonCheckpoint(t *testing.T
 	}
 
 	partitionID := "2"
-	offset := "1006"
 	consumerGroup := "$Default3"
 
 	sequencenumber := int64(1)
 
 	containerName := "defaultcontainerpython"
-	checkpointFormat := "{\"Offset\":\"%s\",\"sequence_number\":%d,\"partition_id\":\"%s\",\"Owner\":\"\",\"Token\":\"\",\"Epoch\":0}"
-	checkpoint := fmt.Sprintf(checkpointFormat, offset, sequencenumber, partitionID)
+	checkpointFormat := "{\"sequence_number\":%d,\"partition_id\":\"%s\",\"Owner\":\"\",\"Token\":\"\",\"Epoch\":0}"
+	checkpoint := fmt.Sprintf(checkpointFormat, sequencenumber, partitionID)
 	urlPath := fmt.Sprintf("%s/", consumerGroup)
 
 	ctx, err := createNewCheckpointInStorage(urlPath, containerName, partitionID, checkpoint, nil)
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{
-			Offset: offset,
-		},
+		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -136,8 +123,6 @@ func TestCheckpointFromBlobStorageDefaultDeprecatedPythonCheckpoint(t *testing.T
 	}
 
 	check, _ := GetCheckpointFromBlobStorage(ctx, http.DefaultClient, eventHubInfo, partitionID)
-	_ = check.Offset
-	_ = expectedCheckpoint.Offset
 	assert.Equal(t, check, expectedCheckpoint)
 }
 
@@ -147,13 +132,11 @@ func TestCheckpointFromBlobStorageWithBlobMetadata(t *testing.T) {
 	}
 
 	partitionID := "4"
-	offset := "1002"
 	consumerGroup := "$default"
 
 	sequencenumber := int64(1)
 
 	metadata := map[string]string{
-		"offset":         offset,
 		"sequencenumber": strconv.FormatInt(sequencenumber, 10),
 	}
 
@@ -164,9 +147,7 @@ func TestCheckpointFromBlobStorageWithBlobMetadata(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{
-			Offset: offset,
-		},
+		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -181,8 +162,6 @@ func TestCheckpointFromBlobStorageWithBlobMetadata(t *testing.T) {
 	}
 
 	check, _ := GetCheckpointFromBlobStorage(ctx, http.DefaultClient, eventHubInfo, partitionID)
-	_ = check.Offset
-	_ = expectedCheckpoint.Offset
 	assert.Equal(t, check, expectedCheckpoint)
 }
 
@@ -192,13 +171,12 @@ func TestCheckpointFromBlobStorageGoSdk(t *testing.T) {
 	}
 
 	partitionID := "0"
-	offset := "1003"
 
 	sequencenumber := int64(1)
 
 	containerName := "gosdkcontainer"
-	checkpointFormat := "{\"partitionID\":\"%s\",\"epoch\":0,\"owner\":\"\",\"checkpoint\":{\"offset\":\"%s\",\"sequenceNumber\":%d,\"enqueueTime\":\"\"},\"state\":\"\",\"token\":\"\"}"
-	checkpoint := fmt.Sprintf(checkpointFormat, partitionID, offset, sequencenumber)
+	checkpointFormat := "{\"partitionID\":\"%s\",\"epoch\":0,\"owner\":\"\",\"checkpoint\":{\"sequenceNumber\":%d,\"enqueueTime\":\"\"},\"state\":\"\",\"token\":\"\"}"
+	checkpoint := fmt.Sprintf(checkpointFormat, partitionID, sequencenumber)
 
 	urlPath := ""
 
@@ -206,9 +184,7 @@ func TestCheckpointFromBlobStorageGoSdk(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{
-			Offset: offset,
-		},
+		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -222,8 +198,6 @@ func TestCheckpointFromBlobStorageGoSdk(t *testing.T) {
 	}
 
 	check, _ := GetCheckpointFromBlobStorage(ctx, http.DefaultClient, eventHubInfo, partitionID)
-	_ = check.Offset
-	_ = expectedCheckpoint.Offset
 	assert.Equal(t, check, expectedCheckpoint)
 }
 
@@ -233,15 +207,14 @@ func TestCheckpointFromBlobStorageDapr(t *testing.T) {
 	}
 
 	partitionID := "0"
-	offset := "1004"
 	consumerGroup := "$default"
 	eventhubName := "hub"
 
 	sequencenumber := int64(1)
 
 	containerName := fmt.Sprintf("dapr-%s-%s-%s", eventhubName, consumerGroup, partitionID)
-	checkpointFormat := "{\"partitionID\":\"%s\",\"epoch\":0,\"owner\":\"\",\"checkpoint\":{\"offset\":\"%s\",\"sequenceNumber\":%d,\"enqueueTime\":\"\"},\"state\":\"\",\"token\":\"\"}"
-	checkpoint := fmt.Sprintf(checkpointFormat, partitionID, offset, sequencenumber)
+	checkpointFormat := "{\"partitionID\":\"%s\",\"epoch\":0,\"owner\":\"\",\"checkpoint\":{\"sequenceNumber\":%d,\"enqueueTime\":\"\"},\"state\":\"\",\"token\":\"\"}"
+	checkpoint := fmt.Sprintf(checkpointFormat, partitionID, sequencenumber)
 
 	urlPath := ""
 
@@ -249,9 +222,7 @@ func TestCheckpointFromBlobStorageDapr(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{
-			Offset: offset,
-		},
+		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -265,8 +236,6 @@ func TestCheckpointFromBlobStorageDapr(t *testing.T) {
 	}
 
 	check, _ := GetCheckpointFromBlobStorage(ctx, http.DefaultClient, eventHubInfo, partitionID)
-	_ = check.Offset
-	_ = expectedCheckpoint.Offset
 	assert.Equal(t, check, expectedCheckpoint)
 }
 

--- a/pkg/scalers/azure/azure_eventhub_test.go
+++ b/pkg/scalers/azure/azure_eventhub_test.go
@@ -38,7 +38,6 @@ func TestCheckpointFromBlobStorageAzureFunction(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -73,7 +72,6 @@ func TestCheckpointFromBlobStorageDefault(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -109,7 +107,6 @@ func TestCheckpointFromBlobStorageDefaultDeprecatedPythonCheckpoint(t *testing.T
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -147,7 +144,6 @@ func TestCheckpointFromBlobStorageWithBlobMetadata(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -184,7 +180,6 @@ func TestCheckpointFromBlobStorageGoSdk(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}
@@ -222,7 +217,6 @@ func TestCheckpointFromBlobStorageDapr(t *testing.T) {
 	assert.Equal(t, err, nil)
 
 	expectedCheckpoint := Checkpoint{
-		baseCheckpoint: baseCheckpoint{},
 		PartitionID:    partitionID,
 		SequenceNumber: sequencenumber,
 	}

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -280,8 +280,8 @@ func parseAzureEventHubAuthenticationMetadata(logger logr.Logger, config *scaler
 
 // GetUnprocessedEventCountInPartition gets number of unprocessed events in a given partition
 func (s *azureEventHubScaler) GetUnprocessedEventCountInPartition(ctx context.Context, partitionInfo *eventhub.HubPartitionRuntimeInformation) (newEventCount int64, checkpoint azure.Checkpoint, err error) {
-	// if partitionInfo.LastEnqueuedOffset = -1, that means event hub partition is empty
-	if partitionInfo == nil || partitionInfo.LastEnqueuedOffset == "-1" {
+	// if partitionInfo.LastEnqueuedSequenceNumber = -1, that means event hub partition is empty
+	if partitionInfo == nil || partitionInfo.LastEnqueuedSequenceNumber == -1 {
 		return 0, azure.Checkpoint{}, nil
 	}
 
@@ -305,14 +305,6 @@ func (s *azureEventHubScaler) GetUnprocessedEventCountInPartition(ctx context.Co
 
 func calculateUnprocessedEvents(partitionInfo *eventhub.HubPartitionRuntimeInformation, checkpoint azure.Checkpoint, stalePartitionInfoThreshold int64) int64 {
 	unprocessedEventCount := int64(0)
-
-	// If checkpoint.Offset is empty that means no messages has been processed from an event hub partition
-	// And since partitionInfo.LastSequenceNumber = 0 for the very first message hence
-	// total unprocessed message will be partitionInfo.LastSequenceNumber + 1
-	if checkpoint.Offset == "" {
-		unprocessedEventCount = partitionInfo.LastSequenceNumber + 1
-		return unprocessedEventCount
-	}
 
 	if partitionInfo.LastSequenceNumber >= checkpoint.SequenceNumber {
 		unprocessedEventCount = partitionInfo.LastSequenceNumber - checkpoint.SequenceNumber

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -280,8 +280,8 @@ func parseAzureEventHubAuthenticationMetadata(logger logr.Logger, config *scaler
 
 // GetUnprocessedEventCountInPartition gets number of unprocessed events in a given partition
 func (s *azureEventHubScaler) GetUnprocessedEventCountInPartition(ctx context.Context, partitionInfo *eventhub.HubPartitionRuntimeInformation) (newEventCount int64, checkpoint azure.Checkpoint, err error) {
-	// if partitionInfo.LastEnqueuedSequenceNumber = -1, that means event hub partition is empty
-	if partitionInfo == nil || partitionInfo.LastEnqueuedSequenceNumber == -1 {
+	// if partitionInfo.LastSequenceNumber = -1, that means event hub partition is empty
+	if partitionInfo == nil || partitionInfo.LastSequenceNumber == -1 {
 		return 0, azure.Checkpoint{}, nil
 	}
 

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -234,7 +234,7 @@ var calculateUnprocessedEventsDataset = []calculateUnprocessedEventsTestData{
 	{
 		checkpoint:        azure.NewCheckpoint(0),
 		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 1},
-		unprocessedEvents: 2,
+		unprocessedEvents: 1,
 	},
 	// Stale PartitionInfo
 	{

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -211,51 +211,51 @@ var parseEventHubMetadataDatasetWithPodIdentity = []parseEventHubMetadataTestDat
 
 var calculateUnprocessedEventsDataset = []calculateUnprocessedEventsTestData{
 	{
-		checkpoint:        azure.NewCheckpoint("1", 5),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 10, LastEnqueuedOffset: "2"},
+		checkpoint:        azure.NewCheckpoint(5),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 10},
 		unprocessedEvents: 5,
 	},
 	{
-		checkpoint:        azure.NewCheckpoint("1002", 4611686018427387903),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905, LastEnqueuedOffset: "1000"},
+		checkpoint:        azure.NewCheckpoint(4611686018427387903),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905},
 		unprocessedEvents: 2,
 	},
 	{
-		checkpoint:        azure.NewCheckpoint("900", 4611686018427387900),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905, LastEnqueuedOffset: "1000"},
+		checkpoint:        azure.NewCheckpoint(4611686018427387900),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905},
 		unprocessedEvents: 5,
 	},
 	{
-		checkpoint:        azure.NewCheckpoint("800", 4000000000000200000),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4000000000000000000, LastEnqueuedOffset: "750"},
+		checkpoint:        azure.NewCheckpoint(4000000000000200000),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4000000000000000000},
 		unprocessedEvents: 9223372036854575807,
 	},
 	// Empty checkpoint
 	{
-		checkpoint:        azure.NewCheckpoint("", 0),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 1, LastEnqueuedOffset: "1"},
+		checkpoint:        azure.NewCheckpoint(0),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 1},
 		unprocessedEvents: 2,
 	},
 	// Stale PartitionInfo
 	{
-		checkpoint:        azure.NewCheckpoint("5", 15),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 10, LastEnqueuedOffset: "2"},
+		checkpoint:        azure.NewCheckpoint(15),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 10},
 		unprocessedEvents: 0,
 	},
 	{
-		checkpoint:        azure.NewCheckpoint("1000", 4611686018427387910),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905, LastEnqueuedOffset: "900"},
+		checkpoint:        azure.NewCheckpoint(4611686018427387910),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 4611686018427387905},
 		unprocessedEvents: 0,
 	},
 	{
-		checkpoint:        azure.NewCheckpoint("1", 5),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 9223372036854775797, LastEnqueuedOffset: "10000"},
+		checkpoint:        azure.NewCheckpoint(5),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 9223372036854775797},
 		unprocessedEvents: 0,
 	},
 	// Circular buffer reset
 	{
-		checkpoint:        azure.NewCheckpoint("100000", 9223372036854775797),
-		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 5, LastEnqueuedOffset: "1"},
+		checkpoint:        azure.NewCheckpoint(9223372036854775797),
+		partitionInfo:     &eventhub.HubPartitionRuntimeInformation{LastSequenceNumber: 5},
 		unprocessedEvents: 15,
 	},
 }

--- a/vendor/github.com/Azure/azure-event-hubs-go/v3/amqp_mgmt.go
+++ b/vendor/github.com/Azure/azure-event-hubs-go/v3/amqp_mgmt.go
@@ -64,12 +64,12 @@ type (
 
 	// HubPartitionRuntimeInformation provides management node information about a given Event Hub partition
 	HubPartitionRuntimeInformation struct {
-		HubPath                 string    `mapstructure:"name"`
-		PartitionID             string    `mapstructure:"partition"`
-		BeginningSequenceNumber int64     `mapstructure:"begin_sequence_number"`
-		LastSequenceNumber      int64     `mapstructure:"last_enqueued_sequence_number"`
-		LastEnqueuedOffset      string    `mapstructure:"last_enqueued_offset"`
-		LastEnqueuedTimeUtc     time.Time `mapstructure:"last_enqueued_time_utc"`
+		HubPath                    string    `mapstructure:"name"`
+		PartitionID                string    `mapstructure:"partition"`
+		BeginningSequenceNumber    int64     `mapstructure:"begin_sequence_number"`
+		LastSequenceNumber         int64     `mapstructure:"last_enqueued_sequence_number"`
+		LastEnqueuedSequenceNumber int64     `mapstructure:"last_enqueued_sequence_number"`
+		LastEnqueuedTimeUtc        time.Time `mapstructure:"last_enqueued_time_utc"`
 	}
 )
 

--- a/vendor/github.com/Azure/azure-event-hubs-go/v3/amqp_mgmt.go
+++ b/vendor/github.com/Azure/azure-event-hubs-go/v3/amqp_mgmt.go
@@ -64,12 +64,12 @@ type (
 
 	// HubPartitionRuntimeInformation provides management node information about a given Event Hub partition
 	HubPartitionRuntimeInformation struct {
-		HubPath                    string    `mapstructure:"name"`
-		PartitionID                string    `mapstructure:"partition"`
-		BeginningSequenceNumber    int64     `mapstructure:"begin_sequence_number"`
-		LastSequenceNumber         int64     `mapstructure:"last_enqueued_sequence_number"`
-		LastEnqueuedSequenceNumber int64     `mapstructure:"last_enqueued_sequence_number"`
-		LastEnqueuedTimeUtc        time.Time `mapstructure:"last_enqueued_time_utc"`
+		HubPath                 string    `mapstructure:"name"`
+		PartitionID             string    `mapstructure:"partition"`
+		BeginningSequenceNumber int64     `mapstructure:"begin_sequence_number"`
+		LastSequenceNumber      int64     `mapstructure:"last_enqueued_sequence_number"`
+		LastEnqueuedOffset      string    `mapstructure:"last_enqueued_offset"`
+		LastEnqueuedTimeUtc     time.Time `mapstructure:"last_enqueued_time_utc"`
 	}
 )
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR removes or replaces uses of Event Hub offsets, as this is no longer a supported metric to use for determining consumer locations within a partition.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5574

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/Azure/azure-sdk-for-net/issues/42409
