### PR TITLE
fix: consider empty results set from new relic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,10 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
-- **New Relic Scaler**: Consider empty results set from query executer ([#5619](https://github.com/kedacore/keda/pull/5619))
 - **General**: Fix CVE-2024-28180 in github.com/go-jose/go-jose/v3 ([#5617](https://github.com/kedacore/keda/pull/5617))
 - **General**: Prometheus metrics shows errors correctly ([#5597](https://github.com/kedacore/keda/issues/5597))
 - **General**: Validate empty array value of triggers in ScaledObject/ScaledJob creation ([#5520](https://github.com/kedacore/keda/issues/5520))
+- **New Relic Scaler**: Consider empty results set from query executer ([#5619](https://github.com/kedacore/keda/pull/5619))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **New Relic Scaler**: Consider empty results set from query executer ([#5619](https://github.com/kedacore/keda/pull/5619))
 - **General**: Fix CVE-2024-28180 in github.com/go-jose/go-jose/v3 ([#5617](https://github.com/kedacore/keda/pull/5617))
 - **General**: Prometheus metrics shows errors correctly ([#5597](https://github.com/kedacore/keda/issues/5597))
 - **General**: Validate empty array value of triggers in ScaledObject/ScaledJob creation ([#5520](https://github.com/kedacore/keda/issues/5520))

--- a/pkg/scalers/newrelic_scaler.go
+++ b/pkg/scalers/newrelic_scaler.go
@@ -158,6 +158,13 @@ func (s *newrelicScaler) executeNewRelicQuery(ctx context.Context) (float64, err
 	if err != nil {
 		return 0, fmt.Errorf("error running NRQL %s (%s)", s.metadata.nrql, err.Error())
 	}
+	// Check for empty results set, as New Relic lib does not report these as errors
+	if len(resp.Results) == 0 {
+		if s.metadata.noDataError {
+			return 0, fmt.Errorf("query return no results %s", s.metadata.nrql)
+		}
+		return 0, nil
+	}
 	// Only use the first result from the query, as the query should not be multi row
 	for _, v := range resp.Results[0] {
 		val, ok := v.(float64)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Handle empty results set returned by New Relic query executor.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5619
