### PR TITLE
feat: Add new alignment parameters 'rate' and 'count' for GCP Stackdriver Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Add GRPC Healthchecks ([#5590](https://github.com/kedacore/keda/issues/5590))
 - **General**: Add OPENTELEMETRY flag in e2e test YAML ([#5375](https://github.com/kedacore/keda/issues/5375))
 - **General**: Add support for cross tenant/cloud authentication when using Azure Workload Identity for TriggerAuthentication ([#5441](https://github.com/kedacore/keda/issues/5441))
+- **GCP Stackdriver Scaler**: Add missing parameters 'rate' and 'count' for GCP Stackdriver Scaler alignment ([#5633](https://github.com/kedacore/keda/issues/5633))
 - **Metrics API Scaler**: Add support for various formats: json, xml, yaml, prometheus ([#2633](https://github.com/kedacore/keda/issues/2633))
 - **MongoDB Scaler**: Add scheme field support srv record ([#5544](https://github.com/kedacore/keda/issues/5544))
 

--- a/pkg/scalers/gcp/gcp_stackdriver_client.go
+++ b/pkg/scalers/gcp/gcp_stackdriver_client.go
@@ -144,6 +144,8 @@ func alignerFromString(aligner string) (monitoringpb.Aggregation_Aligner, error)
 		return monitoringpb.Aggregation_ALIGN_NONE, nil
 	case "delta":
 		return monitoringpb.Aggregation_ALIGN_DELTA, nil
+	case "rate":
+		return monitoringpb.Aggregation_ALIGN_RATE, nil
 	case "interpolate":
 		return monitoringpb.Aggregation_ALIGN_INTERPOLATE, nil
 	case "next_older":
@@ -195,6 +197,8 @@ func reducerFromString(reducer string) (monitoringpb.Aggregation_Reducer, error)
 		return monitoringpb.Aggregation_REDUCE_SUM, nil
 	case "stddev":
 		return monitoringpb.Aggregation_REDUCE_STDDEV, nil
+	case "count":
+		return monitoringpb.Aggregation_REDUCE_COUNT, nil
 	case "count_true":
 		return monitoringpb.Aggregation_REDUCE_COUNT_TRUE, nil
 	case "count_false":


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add new alignment parameters 'rate' and 'count' for GCP Stackdriver Scaler alignment

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([[#1345](https://github.com/kedacore/keda-docs/pull/1345)](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #5633
