### PR TITLE
Move to getParameterFromConfigV2 for input, excluding auth

### DIFF
--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -83,7 +83,6 @@ func NewAwsCloudwatchScaler(ctx context.Context, config *scalersconfig.ScalerCon
 
 func createCloudwatchClient(ctx context.Context, metadata *awsCloudwatchMetadata) (*cloudwatch.Client, error) {
 	cfg, err := awsutils.GetAwsConfig(ctx, metadata.awsRegion, metadata.awsAuthorization)
-
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +105,8 @@ func getCloudWatchExpression(config *scalersconfig.ScalerConfig) (string, error)
 
 // parseAwsCloudwatchMetadata parses the metric query parameters from the metadata, returning the namespace, metric name,
 // metric unit, dimension names, dimension values, or error if the metadata was not parseable.
-func parseCloudWatchMetricQuery(config *scalersconfig.ScalerConfig) (string, string, string, []string, []string, error) {
-	// namespace is a required parameter, that is a single string
+func getCloudWatchMetricQuery(config *scalersconfig.ScalerConfig) (string, string, string, []string, []string, error) {
+	// namespace isa required parameter, that is a single string
 	namespaceUntyped, err := getParameterFromConfigV2(config, "namespace", reflect.TypeOf(""), IsOptional(false), UseMetadata(true))
 	if err != nil {
 		return "", "", "", nil, nil, fmt.Errorf("error parsing namespace: %w", err)
@@ -170,7 +169,7 @@ func parseAwsCloudwatchMetadata(config *scalersconfig.ScalerConfig) (*awsCloudwa
 	// if the expression is empty, try to get the metric query. The parameters in the query are now
 	// required, as the expression is not present.
 	if meta.expression == "" {
-		meta.namespace, meta.metricsName, meta.metricUnit, meta.dimensionName, meta.dimensionValue, err = parseCloudWatchMetricQuery(config)
+		meta.namespace, meta.metricsName, meta.metricUnit, meta.dimensionName, meta.dimensionValue, err = getCloudWatchMetricQuery(config)
 		if err != nil {
 			return nil, err
 		}
@@ -314,7 +313,6 @@ func computeQueryWindow(current time.Time, metricPeriodSec, metricEndTimeOffsetS
 
 func (s *awsCloudwatchScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
 	metricValue, err := s.GetCloudwatchMetrics(ctx)
-
 	if err != nil {
 		s.logger.Error(err, "Error getting metric value")
 		return []external_metrics.ExternalMetricValue{}, false, err
@@ -397,7 +395,6 @@ func (s *awsCloudwatchScaler) GetCloudwatchMetrics(ctx context.Context) (float64
 	}
 
 	output, err := s.cwClient.GetMetricData(ctx, &input)
-
 	if err != nil {
 		s.logger.Error(err, "Failed to get output")
 		return -1, err

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -253,7 +253,6 @@ func parseAwsCloudwatchMetadata(config *scalersconfig.ScalerConfig) (*awsCloudwa
 	}
 	meta.awsEndpoint = awsEndpoint.(string)
 
-	// TODO: Move awsAuthorization to getParameterFromConfigV2
 	awsAuthorization, err := awsutils.GetAwsAuthorization(config.TriggerUniqueKey, config.PodIdentity, config.TriggerMetadata, config.AuthParams, config.ResolvedEnv)
 	if err != nil {
 		return nil, err

--- a/pkg/scalers/aws_cloudwatch_scaler_test.go
+++ b/pkg/scalers/aws_cloudwatch_scaler_test.go
@@ -50,312 +50,382 @@ type awsCloudwatchMetricIdentifier struct {
 var testAWSCloudwatchMetadata = []parseAWSCloudwatchMetadataTestData{
 	{map[string]string{}, testAWSAuthentication, true, "Empty structures"},
 	// properly formed cloudwatch query and awsRegion
-	{map[string]string{
-		"namespace":                   "AWS/SQS",
-		"dimensionName":               "QueueName",
-		"dimensionValue":              "keda",
-		"metricName":                  "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":           "2",
-		"activationTargetMetricValue": "0",
-		"minMetricValue":              "0",
-		"awsRegion":                   "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":                   "AWS/SQS",
+			"dimensionName":               "QueueName",
+			"dimensionValue":              "keda",
+			"metricName":                  "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":           "2",
+			"activationTargetMetricValue": "0",
+			"minMetricValue":              "0",
+			"awsRegion":                   "eu-west-1",
+		},
 		testAWSAuthentication,
 		false,
-		"properly formed cloudwatch query and awsRegion"},
+		"properly formed cloudwatch query and awsRegion",
+	},
 	// properly formed cloudwatch expression query and awsRegion
-	{map[string]string{
-		"namespace":                   "AWS/SQS",
-		"expression":                  "SELECT MIN(MessageCount) FROM \"AWS/AmazonMQ\" WHERE Broker = 'production' and Queue = 'worker'",
-		"metricName":                  "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":           "2",
-		"activationTargetMetricValue": "0",
-		"minMetricValue":              "0",
-		"awsRegion":                   "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":                   "AWS/SQS",
+			"expression":                  "SELECT MIN(MessageCount) FROM \"AWS/AmazonMQ\" WHERE Broker = 'production' and Queue = 'worker'",
+			"metricName":                  "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":           "2",
+			"activationTargetMetricValue": "0",
+			"minMetricValue":              "0",
+			"awsRegion":                   "eu-west-1",
+		},
 		testAWSAuthentication,
 		false,
-		"properly formed cloudwatch expression query and awsRegion"},
+		"properly formed cloudwatch expression query and awsRegion",
+	},
 	// Properly formed cloudwatch query with optional parameters
-	{map[string]string{
-		"namespace":                   "AWS/SQS",
-		"dimensionName":               "QueueName",
-		"dimensionValue":              "keda",
-		"metricName":                  "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":           "2",
-		"activationTargetMetricValue": "0",
-		"minMetricValue":              "0",
-		"metricCollectionTime":        "300",
-		"metricStat":                  "Average",
-		"metricStatPeriod":            "300",
-		"awsRegion":                   "eu-west-1",
-		"awsEndpoint":                 "http://localhost:4566"},
+	{
+		map[string]string{
+			"namespace":                   "AWS/SQS",
+			"dimensionName":               "QueueName",
+			"dimensionValue":              "keda",
+			"metricName":                  "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":           "2",
+			"activationTargetMetricValue": "0",
+			"minMetricValue":              "0",
+			"metricCollectionTime":        "300",
+			"metricStat":                  "Average",
+			"metricStatPeriod":            "300",
+			"awsRegion":                   "eu-west-1",
+			"awsEndpoint":                 "http://localhost:4566",
+		},
 		testAWSAuthentication, false,
-		"Properly formed cloudwatch query with optional parameters"},
+		"Properly formed cloudwatch query with optional parameters",
+	},
 	// properly formed cloudwatch query but Region is empty
-	{map[string]string{
-		"namespace":                   "AWS/SQS",
-		"dimensionName":               "QueueName",
-		"dimensionValue":              "keda",
-		"metricName":                  "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":           "2",
-		"activationTargetMetricValue": "0",
-		"minMetricValue":              "0",
-		"awsRegion":                   ""},
+	{
+		map[string]string{
+			"namespace":                   "AWS/SQS",
+			"dimensionName":               "QueueName",
+			"dimensionValue":              "keda",
+			"metricName":                  "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":           "2",
+			"activationTargetMetricValue": "0",
+			"minMetricValue":              "0",
+			"awsRegion":                   "",
+		},
 		testAWSAuthentication,
 		true,
-		"properly formed cloudwatch query but Region is empty"},
+		"properly formed cloudwatch query but Region is empty",
+	},
 	// Missing namespace
-	{map[string]string{"dimensionName": "QueueName",
-		"dimensionValue":    "keda",
-		"metricName":        "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"awsRegion":         "eu-west-1"},
+	{
+		map[string]string{
+			"dimensionName":     "QueueName",
+			"dimensionValue":    "keda",
+			"metricName":        "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication,
 		true,
-		"Missing namespace"},
+		"Missing namespace",
+	},
 	// Missing dimensionName
-	{map[string]string{
-		"namespace":         "AWS/SQS",
-		"dimensionValue":    "keda",
-		"metricName":        "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"awsRegion":         "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":         "AWS/SQS",
+			"dimensionValue":    "keda",
+			"metricName":        "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication,
 		true,
-		"Missing dimensionName"},
+		"Missing dimensionName",
+	},
 	// Missing dimensionValue
-	{map[string]string{
-		"namespace":         "AWS/SQS",
-		"dimensionName":     "QueueName",
-		"metricName":        "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"awsRegion":         "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":         "AWS/SQS",
+			"dimensionName":     "QueueName",
+			"metricName":        "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication,
 		true,
-		"Missing dimensionValue"},
+		"Missing dimensionValue",
+	},
 	// Missing metricName
-	{map[string]string{
-		"namespace":         "AWS/SQS",
-		"dimensionName":     "QueueName",
-		"dimensionValue":    "keda",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"awsRegion":         "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":         "AWS/SQS",
+			"dimensionName":     "QueueName",
+			"dimensionValue":    "keda",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication,
 		true,
-		"Missing metricName"},
+		"Missing metricName",
+	},
 	// with static "aws_credentials" from TriggerAuthentication
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStat":           "Average",
-		"metricStatPeriod":     "300",
-		"awsRegion":            "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStat":           "Average",
+			"metricStatPeriod":     "300",
+			"awsRegion":            "eu-west-1",
+		},
 		map[string]string{
 			"awsAccessKeyId":     testAWSCloudwatchAccessKeyID,
 			"awsSecretAccessKey": testAWSCloudwatchSecretAccessKey,
 		},
 		false,
-		"with AWS Credentials from TriggerAuthentication"},
+		"with AWS Credentials from TriggerAuthentication",
+	},
 	// with temporary "aws_credentials" from TriggerAuthentication
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStat":           "Average",
-		"metricStatPeriod":     "300",
-		"awsRegion":            "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStat":           "Average",
+			"metricStatPeriod":     "300",
+			"awsRegion":            "eu-west-1",
+		},
 		map[string]string{
 			"awsAccessKeyId":     testAWSCloudwatchAccessKeyID,
 			"awsSecretAccessKey": testAWSCloudwatchSecretAccessKey,
 			"awsSessionToken":    testAWSCloudwatchSessionToken,
 		},
 		false,
-		"with AWS Credentials from TriggerAuthentication"},
+		"with AWS Credentials from TriggerAuthentication",
+	},
 	// with "aws_role" from TriggerAuthentication
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStat":           "Average",
-		"metricStatPeriod":     "300",
-		"awsRegion":            "eu-west-1"},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStat":           "Average",
+			"metricStatPeriod":     "300",
+			"awsRegion":            "eu-west-1",
+		},
 		map[string]string{
 			"awsRoleArn": testAWSCloudwatchRoleArn,
 		},
 		false,
-		"with AWS Role from TriggerAuthentication"},
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStat":           "Average",
-		"metricStatPeriod":     "300",
-		"awsRegion":            "eu-west-1",
-		"identityOwner":        "operator"},
+		"with AWS Role from TriggerAuthentication",
+	},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStat":           "Average",
+			"metricStatPeriod":     "300",
+			"awsRegion":            "eu-west-1",
+			"identityOwner":        "operator",
+		},
 		map[string]string{},
 		false,
-		"with AWS Role assigned on KEDA operator itself"},
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "a",
-		"metricStat":           "Average",
-		"metricStatPeriod":     "300",
-		"awsRegion":            "eu-west-1",
-		"identityOwner":        "operator"},
+		"with AWS Role assigned on KEDA operator itself",
+	},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "a",
+			"metricStat":           "Average",
+			"metricStatPeriod":     "300",
+			"awsRegion":            "eu-west-1",
+			"identityOwner":        "operator",
+		},
 		map[string]string{},
 		true,
-		"if metricCollectionTime assigned with a string, need to be a number"},
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStat":           "Average",
-		"metricStatPeriod":     "a",
-		"awsRegion":            "eu-west-1",
-		"identityOwner":        "operator"},
+		"if metricCollectionTime assigned with a string, need to be a number",
+	},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStat":           "Average",
+			"metricStatPeriod":     "a",
+			"awsRegion":            "eu-west-1",
+			"identityOwner":        "operator",
+		},
 		map[string]string{},
 		true,
-		"if metricStatPeriod assigned with a string, need to be a number"},
-	{map[string]string{
-		"namespace":         "AWS/SQS",
-		"dimensionName":     "QueueName",
-		"dimensionValue":    "keda",
-		"metricName":        "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"metricStat":        "Average",
-		"metricStatPeriod":  "300",
-		"awsRegion":         "eu-west-1"},
+		"if metricStatPeriod assigned with a string, need to be a number",
+	},
+	{
+		map[string]string{
+			"namespace":         "AWS/SQS",
+			"dimensionName":     "QueueName",
+			"dimensionValue":    "keda",
+			"metricName":        "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"metricStat":        "Average",
+			"metricStatPeriod":  "300",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication, false,
-		"Missing metricCollectionTime not generate error because will get the default value"},
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStatPeriod":     "300",
-		"awsRegion":            "eu-west-1"},
+		"Missing metricCollectionTime not generate error because will get the default value",
+	},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStatPeriod":     "300",
+			"awsRegion":            "eu-west-1",
+		},
 		testAWSAuthentication, false,
-		"Missing metricStat not generate error because will get the default value"},
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStat":           "Average",
-		"awsRegion":            "eu-west-1"},
+		"Missing metricStat not generate error because will get the default value",
+	},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStat":           "Average",
+			"awsRegion":            "eu-west-1",
+		},
 		testAWSAuthentication, false,
-		"Missing metricStatPeriod not generate error because will get the default value"},
-	{map[string]string{
-		"namespace":           "AWS/SQS",
-		"dimensionName":       "QueueName",
-		"dimensionValue":      "keda",
-		"metricName":          "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":   "2",
-		"minMetricValue":      "0",
-		"metricStat":          "Average",
-		"metricUnit":          "Count",
-		"metricEndTimeOffset": "60",
-		"awsRegion":           "eu-west-1"},
+		"Missing metricStatPeriod not generate error because will get the default value",
+	},
+	{
+		map[string]string{
+			"namespace":           "AWS/SQS",
+			"dimensionName":       "QueueName",
+			"dimensionValue":      "keda",
+			"metricName":          "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":   "2",
+			"minMetricValue":      "0",
+			"metricStat":          "Average",
+			"metricUnit":          "Count",
+			"metricEndTimeOffset": "60",
+			"awsRegion":           "eu-west-1",
+		},
 		testAWSAuthentication, false,
-		"set a supported metricUnit"},
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricCollectionTime": "300",
-		"metricStat":           "SomeStat",
-		"awsRegion":            "eu-west-1"},
+		"set a supported metricUnit",
+	},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricCollectionTime": "300",
+			"metricStat":           "SomeStat",
+			"awsRegion":            "eu-west-1",
+		},
 		testAWSAuthentication, true,
-		"metricStat is not supported"},
-	{map[string]string{
-		"namespace":            "AWS/SQS",
-		"dimensionName":        "QueueName",
-		"dimensionValue":       "keda",
-		"metricName":           "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue":    "2",
-		"minMetricValue":       "0",
-		"metricStatPeriod":     "300",
-		"metricCollectionTime": "100",
-		"metricStat":           "Average",
-		"awsRegion":            "eu-west-1"},
+		"metricStat is not supported",
+	},
+	{
+		map[string]string{
+			"namespace":            "AWS/SQS",
+			"dimensionName":        "QueueName",
+			"dimensionValue":       "keda",
+			"metricName":           "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue":    "2",
+			"minMetricValue":       "0",
+			"metricStatPeriod":     "300",
+			"metricCollectionTime": "100",
+			"metricStat":           "Average",
+			"awsRegion":            "eu-west-1",
+		},
 		testAWSAuthentication, true,
-		"metricCollectionTime smaller than metricStatPeriod"},
-	{map[string]string{
-		"namespace":         "AWS/SQS",
-		"dimensionName":     "QueueName",
-		"dimensionValue":    "keda",
-		"metricName":        "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"metricStatPeriod":  "250",
-		"metricStat":        "Average",
-		"awsRegion":         "eu-west-1"},
+		"metricCollectionTime smaller than metricStatPeriod",
+	},
+	{
+		map[string]string{
+			"namespace":         "AWS/SQS",
+			"dimensionName":     "QueueName",
+			"dimensionValue":    "keda",
+			"metricName":        "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"metricStatPeriod":  "250",
+			"metricStat":        "Average",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication, true,
-		"unsupported metricStatPeriod"},
-	{map[string]string{
-		"namespace":         "AWS/SQS",
-		"dimensionName":     "QueueName",
-		"dimensionValue":    "keda",
-		"metricName":        "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"metricStatPeriod":  "25",
-		"metricStat":        "Average",
-		"awsRegion":         "eu-west-1"},
+		"unsupported metricStatPeriod",
+	},
+	{
+		map[string]string{
+			"namespace":         "AWS/SQS",
+			"dimensionName":     "QueueName",
+			"dimensionValue":    "keda",
+			"metricName":        "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"metricStatPeriod":  "25",
+			"metricStat":        "Average",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication, true,
-		"unsupported metricStatPeriod"},
-	{map[string]string{
-		"namespace":         "AWS/SQS",
-		"dimensionName":     "QueueName",
-		"dimensionValue":    "keda",
-		"metricName":        "ApproximateNumberOfMessagesVisible",
-		"targetMetricValue": "2",
-		"minMetricValue":    "0",
-		"metricStatPeriod":  "25",
-		"metricStat":        "Average",
-		"metricUnit":        "Hour",
-		"awsRegion":         "eu-west-1"},
+		"unsupported metricStatPeriod",
+	},
+	{
+		map[string]string{
+			"namespace":         "AWS/SQS",
+			"dimensionName":     "QueueName",
+			"dimensionValue":    "keda",
+			"metricName":        "ApproximateNumberOfMessagesVisible",
+			"targetMetricValue": "2",
+			"minMetricValue":    "0",
+			"metricStatPeriod":  "25",
+			"metricStat":        "Average",
+			"metricUnit":        "Hour",
+			"awsRegion":         "eu-west-1",
+		},
 		testAWSAuthentication, true,
-		"unsupported metricUnit"},
+		"unsupported metricUnit",
+	},
 }
 
 var awsCloudwatchMetricIdentifiers = []awsCloudwatchMetricIdentifier{
@@ -446,8 +516,7 @@ var awsCloudwatchGetMetricTestData = []awsCloudwatchMetadata{
 	},
 }
 
-type mockCloudwatch struct {
-}
+type mockCloudwatch struct{}
 
 func (m *mockCloudwatch) GetMetricData(_ context.Context, input *cloudwatch.GetMetricDataInput, _ ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
 	if input.MetricDataQueries[0].MetricStat != nil {
@@ -554,5 +623,158 @@ func TestComputeQueryWindow(t *testing.T) {
 		startTime, endTime := computeQueryWindow(current, testData.metricPeriodSec, testData.metricEndTimeOffsetSec, testData.metricCollectionTimeSec)
 		assert.Equal(t, testData.expectedStartTime, startTime.UTC().Format(time.RFC3339Nano), "unexpected startTime", "name", testData.name)
 		assert.Equal(t, testData.expectedEndTime, endTime.UTC().Format(time.RFC3339Nano), "unexpected endTime", "name", testData.name)
+	}
+}
+
+func TestGetExpression(t *testing.T) {
+	tests := map[string]struct {
+		expression string
+		want       string
+	}{
+		"normal": {
+			expression: "SELECT MIN(MessageCount) FROM \"AWS/AmazonMQ\" WHERE Broker = 'production' and Queue = 'worker'",
+			want:       "SELECT MIN(MessageCount) FROM \"AWS/AmazonMQ\" WHERE Broker = 'production' and Queue = 'worker'",
+		},
+		"empty": {
+			expression: "",
+			want:       "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := &scalersconfig.ScalerConfig{
+				TriggerMetadata: map[string]string{
+					"expression": tc.expression,
+				},
+			}
+			expression, err := getCloudWatchExpression(config)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			assert.Equal(t, tc.want, expression)
+		})
+	}
+}
+
+func TestGetCloudWatchMetricQuery(t *testing.T) {
+	tests := map[string]struct {
+		metadata       map[string]string
+		namespace      string
+		metricName     string
+		metricUnit     string
+		dimensionName  []string
+		dimensionValue []string
+		wantErr        bool
+	}{
+		"normal": {
+			metadata: map[string]string{
+				"namespace":      "AWS/SQS",
+				"metricName":     "ApproximateNumberOfMessagesVisible",
+				"metricUnit":     "Count",
+				"dimensionName":  "QueueName",
+				"dimensionValue": "keda",
+			},
+			namespace:      "AWS/SQS",
+			metricName:     "ApproximateNumberOfMessagesVisible",
+			metricUnit:     "Count",
+			dimensionName:  []string{"QueueName"},
+			dimensionValue: []string{"keda"},
+			wantErr:        false,
+		},
+		"missing namespace": {
+			metadata: map[string]string{
+				"metricName":     "ApproximateNumberOfMessagesVisible",
+				"metricUnit":     "Count",
+				"dimensionName":  "QueueName",
+				"dimensionValue": "keda",
+			},
+			wantErr: true,
+		},
+		"missing metricName": {
+			metadata: map[string]string{
+				"namespace":      "AWS/SQS",
+				"metricUnit":     "Count",
+				"dimensionName":  "QueueName",
+				"dimensionValue": "keda",
+			},
+			wantErr: true,
+		},
+		"missing dimensionName": {
+			metadata: map[string]string{
+				"namespace":      "AWS/SQS",
+				"metricName":     "ApproximateNumberOfMessagesVisible",
+				"metricUnit":     "Count",
+				"dimensionValue": "keda",
+			},
+			wantErr: true,
+		},
+		"missing dimensionValue": {
+			metadata: map[string]string{
+				"namespace":     "AWS/SQS",
+				"metricName":    "ApproximateNumberOfMessagesVisible",
+				"metricUnit":    "Count",
+				"dimensionName": "QueueName",
+			},
+			wantErr: true,
+		},
+		"missing metricUnit": {
+			metadata: map[string]string{
+				"namespace":      "AWS/SQS",
+				"metricName":     "ApproximateNumberOfMessagesVisible",
+				"dimensionName":  "QueueName",
+				"dimensionValue": "keda",
+			},
+			namespace:      "AWS/SQS",
+			metricName:     "ApproximateNumberOfMessagesVisible",
+			metricUnit:     "",
+			dimensionName:  []string{"QueueName"},
+			dimensionValue: []string{"keda"},
+			wantErr:        false,
+		},
+		"different length dimensions": {
+			metadata: map[string]string{
+				"namespace":      "AWS/SQS",
+				"metricName":     "ApproximateNumberOfMessagesVisible",
+				"metricUnit":     "Count",
+				"dimensionName":  "QueueName,QueueType",
+				"dimensionValue": "keda",
+			},
+			wantErr: true,
+		},
+		"invalid metricUnit": {
+			metadata: map[string]string{
+				"namespace":      "AWS/SQS",
+				"metricName":     "ApproximateNumberOfMessagesVisible",
+				"metricUnit":     "Invalid",
+				"dimensionName":  "QueueName",
+				"dimensionValue": "keda",
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := &scalersconfig.ScalerConfig{
+				TriggerMetadata: tc.metadata,
+			}
+			namespace, metricName, metricUnit, dimensionNames, dimensionValues, err := getCloudWatchMetricQuery(config)
+
+			// if we expect an error, check if it's not nil
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			// else, check if the values are as expected
+			assert.NoError(t, err)
+			assert.Equal(t, tc.namespace, namespace)
+			assert.Equal(t, tc.metricName, metricName)
+			assert.Equal(t, tc.metricUnit, metricUnit)
+			assert.Equal(t, tc.dimensionName, dimensionNames)
+			assert.Equal(t, tc.dimensionValue, dimensionValues)
+		})
 	}
 }


### PR DESCRIPTION
Moves the AWS CloudWatch scaler to use getParameterFromConfigV2 for input. 

Context is from a conversation started here: https://github.com/kedacore/keda/pull/5635#discussion_r1545724939

There is one TODO here, which is to move authorization over. I'll present that in a separate PR to avoid a large PR landing, and I can spend more time to read through the authorization code.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
