### PR TITLE
add tls authentication for NATS Streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### New
 
 - **General**: TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
-- **NATS Scaler** Add TLS authentication ([#2296](https://github.com/kedacore/keda/issues/2296))
+- **NATS Scaler**: Add TLS authentication ([#2296](https://github.com/kedacore/keda/issues/2296))
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### New
 
 - **General**: TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **NATS Scaler** Add TLS authentication ([#2296](https://github.com/kedacore/keda/issues/2296))
 
 #### Experimental
 

--- a/pkg/scalers/stan_scaler.go
+++ b/pkg/scalers/stan_scaler.go
@@ -82,7 +82,14 @@ func NewStanScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error parsing stan metadata: %w", err)
 	}
-	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, stanMetadata.enableTLS)
+	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
+	if stanMetadata.enableTLS {
+		config, err := kedautil.NewTLSConfig(stanMetadata.cert, stanMetadata.key, stanMetadata.ca, false)
+		if err != nil {
+			return nil, err
+		}
+		httpClient.Transport = kedautil.CreateHTTPTransportWithTLSConfig(config)
+	}
 	return &stanScaler{
 		channelInfo: &monitorChannelInfo{},
 		metricType:  metricType,

--- a/pkg/scalers/stan_scaler_test.go
+++ b/pkg/scalers/stan_scaler_test.go
@@ -114,7 +114,6 @@ func TestParseStanAuthParams(t *testing.T) {
 			if meta.key != testData.authParams["key"] {
 				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["key"], meta.key)
 			}
-
 		}
 	}
 }

--- a/pkg/scalers/stan_scaler_test.go
+++ b/pkg/scalers/stan_scaler_test.go
@@ -17,10 +17,27 @@ type parseStanMetadataTestData struct {
 	isError    bool
 }
 
+type parseStanTLSTestData struct {
+	metadata   map[string]string
+	authParams map[string]string
+	isError    bool
+	enableTLS  bool
+}
+
 type stanMetricIdentifier struct {
 	metadataTestData *parseStanMetadataTestData
 	triggerIndex     int
 	name             string
+}
+
+var validStanMetadata = map[string]string{
+	"natsServerMonitoringEndpoint": "stan-nats-ss.stan.svc.cluster.local:8222",
+	"queueGroup":                   "grp1",
+	"durableName":                  "ImDurable",
+	"subject":                      "Test",
+	"lagThreshold":                 "10",
+	"activationLagThreshold":       "5",
+	"useHttps":                     "true",
 }
 
 var testStanMetadata = []parseStanMetadataTestData{
@@ -44,6 +61,20 @@ var testStanMetadata = []parseStanMetadataTestData{
 	{map[string]string{"natsServerMonitoringEndpoint": "stan-nats-ss", "queueGroup": "grp1", "durableName": "ImDurable", "subject": "mySubject", "useHttps": "error"}, map[string]string{}, true},
 }
 
+var parseStanAuthParamsTestDataset = []parseStanTLSTestData{
+	// success
+	{map[string]string{"natsServerMonitoringEndpoint": "stan-nats-ss", "queueGroup": "grp1", "durableName": "ImDurable", "subject": "mySubject", "useHttps": "true"}, map[string]string{"tls": "enable", "ca": "caaa", "cert": "ceert", "key": "keey"}, false, true},
+	// success, TLS cert/key and assumed public CA
+	{map[string]string{"natsServerMonitoringEndpoint": "stan-nats-ss", "queueGroup": "grp1", "durableName": "ImDurable", "subject": "mySubject", "useHttps": "true"}, map[string]string{"tls": "enable", "cert": "ceert", "key": "keey"}, false, true},
+	// success, TLS CA only
+	{map[string]string{"natsServerMonitoringEndpoint": "stan-nats-ss", "queueGroup": "grp1", "durableName": "ImDurable", "subject": "mySubject", "useHttps": "true"}, map[string]string{"tls": "enable", "ca": "caa"}, false, true},
+	// Missing TLS key, should fail.
+	{map[string]string{"natsServerMonitoringEndpoint": "stan-nats-ss", "queueGroup": "grp1", "durableName": "ImDurable", "subject": "mySubject", "useHttps": "true"}, map[string]string{"tls": "enable", "cert": "ceert"}, true, false},
+	// Missing TLS cert, should fail.
+	{map[string]string{"natsServerMonitoringEndpoint": "stan-nats-ss", "queueGroup": "grp1", "durableName": "ImDurable", "subject": "mySubject", "useHttps": "true"}, map[string]string{"tls": "enable", "key": "keey"}, true, false},
+	// TLS invalid, should fail.
+	{map[string]string{"natsServerMonitoringEndpoint": "stan-nats-ss", "queueGroup": "grp1", "durableName": "ImDurable", "subject": "mySubject", "useHttps": "true"}, map[string]string{"tls": "yes", "ca": "caa", "cert": "ceert", "key": "keey"}, true, false},
+}
 var stanMetricIdentifiers = []stanMetricIdentifier{
 	{&testStanMetadata[4], 0, "s0-stan-mySubject"},
 	{&testStanMetadata[4], 1, "s1-stan-mySubject"},
@@ -56,6 +87,34 @@ func TestStanParseMetadata(t *testing.T) {
 			t.Error("Expected success but got error", err)
 		} else if testData.isError && err == nil {
 			t.Error("Expected error but got success")
+		}
+	}
+}
+
+func TestParseStanAuthParams(t *testing.T) {
+	for _, testData := range parseStanAuthParamsTestDataset {
+		meta, err := parseStanMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: validStanMetadata, AuthParams: testData.authParams})
+
+		if err != nil && !testData.isError {
+			t.Error("Expected success but got error", err)
+		}
+		if testData.isError && err == nil {
+			t.Error("Expected error but got success")
+		}
+		if meta.enableTLS != testData.enableTLS {
+			t.Errorf("Expected enableTLS to be set to %v but got %v\n", testData.enableTLS, meta.enableTLS)
+		}
+		if meta.enableTLS {
+			if meta.ca != testData.authParams["ca"] {
+				t.Errorf("Expected ca to be set to %v but got %v\n", testData.authParams["ca"], meta.enableTLS)
+			}
+			if meta.cert != testData.authParams["cert"] {
+				t.Errorf("Expected cert to be set to %v but got %v\n", testData.authParams["cert"], meta.cert)
+			}
+			if meta.key != testData.authParams["key"] {
+				t.Errorf("Expected key to be set to %v but got %v\n", testData.authParams["key"], meta.key)
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Add tls authentication for NATS Streaming scaler.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #2296 

