### PR TITLE
Declarative scaler config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### New
 
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **General**: Declarative scaler config parsing ([#5037](https://github.com/kedacore/keda/issues/5037))
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### New
 
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
-- **General**: Declarative scaler config parsing ([#5037](https://github.com/kedacore/keda/issues/5037))
+- **General**: Declarative parsing of scaler config ([#5037](https://github.com/kedacore/keda/issues/5037))
 
 #### Experimental
 

--- a/pkg/scalers/authentication/authentication_types.go
+++ b/pkg/scalers/authentication/authentication_types.go
@@ -66,37 +66,37 @@ type AuthMeta struct {
 
 // BasicAuth is a basic authentication type
 type BasicAuth struct {
-	Username string `keda:"name=username, parsingOrder=authParams"`
-	Password string `keda:"name=password, parsingOrder=authParams"`
+	Username string `keda:"name=username, order=authParams"`
+	Password string `keda:"name=password, order=authParams"`
 }
 
 // CertAuth is a client certificate authentication type
 type CertAuth struct {
-	Cert string `keda:"name=cert, parsingOrder=authParams"`
-	Key  string `keda:"name=key, parsingOrder=authParams"`
-	CA   string `keda:"name=ca, parsingOrder=authParams"`
+	Cert string `keda:"name=cert, order=authParams"`
+	Key  string `keda:"name=key, order=authParams"`
+	CA   string `keda:"name=ca, order=authParams"`
 }
 
 // OAuth is an oAuth2 authentication type
 type OAuth struct {
-	OauthTokenURI  string     `keda:"name=oauthTokenURI,  parsingOrder=authParams"`
-	Scopes         []string   `keda:"name=scopes,         parsingOrder=authParams"`
-	ClientID       string     `keda:"name=clientID,       parsingOrder=authParams"`
-	ClientSecret   string     `keda:"name=clientSecret,   parsingOrder=authParams"`
-	EndpointParams url.Values `keda:"name=endpointParams, parsingOrder=authParams"`
+	OauthTokenURI  string     `keda:"name=oauthTokenURI,  order=authParams"`
+	Scopes         []string   `keda:"name=scopes,         order=authParams"`
+	ClientID       string     `keda:"name=clientID,       order=authParams"`
+	ClientSecret   string     `keda:"name=clientSecret,   order=authParams"`
+	EndpointParams url.Values `keda:"name=endpointParams, order=authParams"`
 }
 
 // CustomAuth is a custom header authentication type
 type CustomAuth struct {
-	CustomAuthHeader string `keda:"name=customAuthHeader, parsingOrder=authParams"`
-	CustomAuthValue  string `keda:"name=customAuthValue,  parsingOrder=authParams"`
+	CustomAuthHeader string `keda:"name=customAuthHeader, order=authParams"`
+	CustomAuthValue  string `keda:"name=customAuthValue,  order=authParams"`
 }
 
 // Config is the configuration for the authentication types
 type Config struct {
-	Modes []Type `keda:"name=authModes, parsingOrder=triggerMetadata, enum=apiKey;basic;tls;bearer;custom;oauth, exclusive=bearer;basic;oauth, optional"`
+	Modes []Type `keda:"name=authModes, order=triggerMetadata, enum=apiKey;basic;tls;bearer;custom;oauth, exclusiveSet=bearer;basic;oauth, optional"`
 
-	BearerToken string `keda:"name=bearerToken, parsingOrder=authParams, optional"`
+	BearerToken string `keda:"name=bearerToken, order=authParams, optional"`
 	BasicAuth   `keda:"optional"`
 	CertAuth    `keda:"optional"`
 	OAuth       `keda:"optional"`

--- a/pkg/scalers/authentication/authentication_types.go
+++ b/pkg/scalers/authentication/authentication_types.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"fmt"
 	"net/url"
 	"time"
 )
@@ -31,6 +32,8 @@ const (
 	FastHTTP                      // FastHTTP Fast http client.
 )
 
+// AuthMeta is the metadata for the authentication types
+// Deprecated: use Config instead
 type AuthMeta struct {
 	// bearer auth
 	EnableBearerAuth bool
@@ -59,6 +62,131 @@ type AuthMeta struct {
 	EnableCustomAuth bool
 	CustomAuthHeader string
 	CustomAuthValue  string
+}
+
+// BasicAuth is a basic authentication type
+type BasicAuth struct {
+	Username string `keda:"name=username, parsingOrder=authParams"`
+	Password string `keda:"name=password, parsingOrder=authParams"`
+}
+
+// CertAuth is a client certificate authentication type
+type CertAuth struct {
+	Cert string `keda:"name=cert, parsingOrder=authParams"`
+	Key  string `keda:"name=key, parsingOrder=authParams"`
+	CA   string `keda:"name=ca, parsingOrder=authParams"`
+}
+
+// OAuth is an oAuth2 authentication type
+type OAuth struct {
+	OauthTokenURI  string     `keda:"name=oauthTokenURI,  parsingOrder=authParams"`
+	Scopes         []string   `keda:"name=scopes,         parsingOrder=authParams"`
+	ClientID       string     `keda:"name=clientID,       parsingOrder=authParams"`
+	ClientSecret   string     `keda:"name=clientSecret,   parsingOrder=authParams"`
+	EndpointParams url.Values `keda:"name=endpointParams, parsingOrder=authParams"`
+}
+
+// CustomAuth is a custom header authentication type
+type CustomAuth struct {
+	CustomAuthHeader string `keda:"name=customAuthHeader, parsingOrder=authParams"`
+	CustomAuthValue  string `keda:"name=customAuthValue,  parsingOrder=authParams"`
+}
+
+// Config is the configuration for the authentication types
+type Config struct {
+	Modes []Type `keda:"name=authModes, parsingOrder=triggerMetadata, enum=apiKey;basic;tls;bearer;custom;oauth, exclusive=bearer;basic;oauth, optional"`
+
+	BearerToken string `keda:"name=bearerToken, parsingOrder=authParams, optional"`
+	BasicAuth   `keda:"optional"`
+	CertAuth    `keda:"optional"`
+	OAuth       `keda:"optional"`
+	CustomAuth  `keda:"optional"`
+}
+
+// Disabled returns true if no auth modes are enabled
+func (c *Config) Disabled() bool {
+	return c == nil || len(c.Modes) == 0
+}
+
+// Enabled returns true if given auth mode is enabled
+func (c *Config) Enabled(mode Type) bool {
+	for _, m := range c.Modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}
+
+// helpers for checking enabled auth modes
+func (c *Config) EnabledTLS() bool        { return c.Enabled(TLSAuthType) }
+func (c *Config) EnabledBasicAuth() bool  { return c.Enabled(BasicAuthType) }
+func (c *Config) EnabledBearerAuth() bool { return c.Enabled(BearerAuthType) }
+func (c *Config) EnabledOAuth() bool      { return c.Enabled(OAuthType) }
+func (c *Config) EnabledCustomAuth() bool { return c.Enabled(CustomAuthType) }
+
+// GetBearerToken returns the bearer token with the Bearer prefix
+func (c *Config) GetBearerToken() string {
+	return fmt.Sprintf("Bearer %s", c.BearerToken)
+}
+
+// Validate validates the Config and returns an error if it is invalid
+func (c *Config) Validate() error {
+	if c.Disabled() {
+		return nil
+	}
+	if c.EnabledBearerAuth() && c.BearerToken == "" {
+		return fmt.Errorf("bearer token is required when bearer auth is enabled")
+	}
+	if c.EnabledBasicAuth() && c.Username == "" {
+		return fmt.Errorf("username is required when basic auth is enabled")
+	}
+	if c.EnabledTLS() && (c.Cert == "" || c.Key == "") {
+		return fmt.Errorf("cert and key are required when tls auth is enabled")
+	}
+	if c.EnabledOAuth() && (c.OauthTokenURI == "" || c.ClientID == "" || c.ClientSecret == "") {
+		return fmt.Errorf("oauthTokenURI, clientID and clientSecret are required when oauth is enabled")
+	}
+	if c.EnabledCustomAuth() && (c.CustomAuthHeader == "" || c.CustomAuthValue == "") {
+		return fmt.Errorf("customAuthHeader and customAuthValue are required when custom auth is enabled")
+	}
+	return nil
+}
+
+// ToAuthMeta converts the Config to deprecated AuthMeta
+func (c *Config) ToAuthMeta() *AuthMeta {
+	if c.Disabled() {
+		return nil
+	}
+	return &AuthMeta{
+		// bearer auth
+		EnableBearerAuth: c.EnabledBearerAuth(),
+		BearerToken:      c.BearerToken,
+
+		// basic auth
+		EnableBasicAuth: c.EnabledBasicAuth(),
+		Username:        c.Username,
+		Password:        c.Password,
+
+		// client certification
+		EnableTLS: c.EnabledTLS(),
+		Cert:      c.Cert,
+		Key:       c.Key,
+		CA:        c.CA,
+
+		// oAuth2
+		EnableOAuth:    c.EnabledOAuth(),
+		OauthTokenURI:  c.OauthTokenURI,
+		Scopes:         c.Scopes,
+		ClientID:       c.ClientID,
+		ClientSecret:   c.ClientSecret,
+		EndpointParams: c.EndpointParams,
+
+		// custom auth header
+		EnableCustomAuth: c.EnabledCustomAuth(),
+		CustomAuthHeader: c.CustomAuthHeader,
+		CustomAuthValue:  c.CustomAuthValue,
+	}
 }
 
 type HTTPTransport struct {

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -45,7 +45,7 @@ type prometheusScaler struct {
 	logger     logr.Logger
 }
 
-// sometimes should consider there is an error we can accept
+// IgnoreNullValues - sometimes should consider there is an error we can accept
 // default value is true/t, to ignore the null value return from prometheus
 // change to false/f if can not accept prometheus return null values
 // https://github.com/kedacore/keda/issues/3065
@@ -53,18 +53,18 @@ type prometheusMetadata struct {
 	triggerIndex int
 
 	PrometheusAuth      *authentication.Config `keda:"optional"`
-	ServerAddress       string                 `keda:"name=serverAddress,       parsingOrder=triggerMetadata"`
-	Query               string                 `keda:"name=query,               parsingOrder=triggerMetadata"`
-	QueryParameters     map[string]string      `keda:"name=queryParameters,     parsingOrder=triggerMetadata, optional"`
-	Threshold           float64                `keda:"name=threshold,           parsingOrder=triggerMetadata"`
-	ActivationThreshold float64                `keda:"name=activationThreshold, parsingOrder=triggerMetadata, optional"`
-	Namespace           string                 `keda:"name=namespace,           parsingOrder=triggerMetadata, optional"`
-	CustomHeaders       map[string]string      `keda:"name=customHeaders,       parsingOrder=triggerMetadata, optional"`
-	IgnoreNullValues    bool                   `keda:"name=ignoreNullValues,    parsingOrder=triggerMetadata, optional, default=true"`
-	UnsafeSSL           bool                   `keda:"name=unsafeSsl,           parsingOrder=triggerMetadata, optional"`
+	ServerAddress       string                 `keda:"name=serverAddress,       order=triggerMetadata"`
+	Query               string                 `keda:"name=query,               order=triggerMetadata"`
+	QueryParameters     map[string]string      `keda:"name=queryParameters,     order=triggerMetadata, optional"`
+	Threshold           float64                `keda:"name=threshold,           order=triggerMetadata"`
+	ActivationThreshold float64                `keda:"name=activationThreshold, order=triggerMetadata, optional"`
+	Namespace           string                 `keda:"name=namespace,           order=triggerMetadata, optional"`
+	CustomHeaders       map[string]string      `keda:"name=customHeaders,       order=triggerMetadata, optional"`
+	IgnoreNullValues    bool                   `keda:"name=ignoreNullValues,    order=triggerMetadata, optional, default=true"`
+	UnsafeSSL           bool                   `keda:"name=unsafeSsl,           order=triggerMetadata, optional"`
 
 	// deprecated
-	CortexOrgID string `keda:"name=cortexOrgID,         parsingOrder=triggerMetadata, optional, deprecated=use customHeaders instead"`
+	CortexOrgID string `keda:"name=cortexOrgID, order=triggerMetadata, optional, deprecated=use customHeaders instead"`
 }
 
 type promQueryResult struct {

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -317,9 +317,9 @@ func TestPrometheusScalerExecutePromQuery(t *testing.T) {
 
 			scaler := prometheusScaler{
 				metadata: &prometheusMetadata{
-					serverAddress:    server.URL,
-					ignoreNullValues: testData.ignoreNullValues,
-					unsafeSsl:        testData.unsafeSsl,
+					ServerAddress:    server.URL,
+					IgnoreNullValues: testData.ignoreNullValues,
+					UnsafeSSL:        testData.unsafeSsl,
 				},
 				httpClient: http.DefaultClient,
 				logger:     logr.Discard(),
@@ -366,9 +366,9 @@ func TestPrometheusScalerCustomHeaders(t *testing.T) {
 
 	scaler := prometheusScaler{
 		metadata: &prometheusMetadata{
-			serverAddress:    server.URL,
-			customHeaders:    customHeadersValue,
-			ignoreNullValues: testData.ignoreNullValues,
+			ServerAddress:    server.URL,
+			CustomHeaders:    customHeadersValue,
+			IgnoreNullValues: testData.ignoreNullValues,
 		},
 		httpClient: http.DefaultClient,
 	}
@@ -410,9 +410,9 @@ func TestPrometheusScalerExecutePromQueryParameters(t *testing.T) {
 	}))
 	scaler := prometheusScaler{
 		metadata: &prometheusMetadata{
-			serverAddress:    server.URL,
-			queryParameters:  queryParametersValue,
-			ignoreNullValues: testData.ignoreNullValues,
+			ServerAddress:    server.URL,
+			QueryParameters:  queryParametersValue,
+			IgnoreNullValues: testData.ignoreNullValues,
 		},
 		httpClient: http.DefaultClient,
 	}

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -162,11 +162,11 @@ func TestPrometheusScalerAuthParams(t *testing.T) {
 		}
 
 		if err == nil {
-			if meta.prometheusAuth != nil {
-				if (meta.prometheusAuth.EnableBearerAuth && !strings.Contains(testData.metadata["authModes"], "bearer")) ||
-					(meta.prometheusAuth.EnableBasicAuth && !strings.Contains(testData.metadata["authModes"], "basic")) ||
-					(meta.prometheusAuth.EnableTLS && !strings.Contains(testData.metadata["authModes"], "tls")) ||
-					(meta.prometheusAuth.EnableCustomAuth && !strings.Contains(testData.metadata["authModes"], "custom")) {
+			if !meta.PrometheusAuth.Disabled() {
+				if (meta.PrometheusAuth.EnabledBearerAuth() && !strings.Contains(testData.metadata["authModes"], "bearer")) ||
+					(meta.PrometheusAuth.EnabledBasicAuth() && !strings.Contains(testData.metadata["authModes"], "basic")) ||
+					(meta.PrometheusAuth.EnabledTLS() && !strings.Contains(testData.metadata["authModes"], "tls")) ||
+					(meta.PrometheusAuth.EnabledCustomAuth() && !strings.Contains(testData.metadata["authModes"], "custom")) {
 					t.Error("wrong auth mode detected")
 				}
 			}

--- a/pkg/scalers/scalersconfig/typed_config.go
+++ b/pkg/scalers/scalersconfig/typed_config.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scalersconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+// CustomValidator is an interface that can be implemented to validate the configuration of the typed config
+type CustomValidator interface {
+	Validate() error
+}
+
+// ParsingOrder is a type that represents the order in which the parameters are parsed
+type ParsingOrder string
+
+// Constants that represent the order in which the parameters are parsed
+const (
+	TriggerMetadata ParsingOrder = "triggerMetadata"
+	ResolvedEnv     ParsingOrder = "resolvedEnv"
+	AuthParams      ParsingOrder = "authParams"
+)
+
+// separators for field tag structure
+// e.g. name=stringVal,parsingOrder=triggerMetadata;resolvedEnv;authParams,optional
+const (
+	tagSeparator      = ","
+	tagKeySeparator   = "="
+	tagValueSeparator = ";"
+)
+
+// separators for map and slice elements
+const (
+	elemSeparator       = ","
+	elemKeyValSeparator = "="
+)
+
+// field tag parameters
+const (
+	optionalTag     = "optional"
+	deprecatedTag   = "deprecated"
+	defaultTag      = "default"
+	parsingOrderTag = "parsingOrder"
+	nameTag         = "name"
+	enumTag         = "enum"
+	exclusiveTag    = "exclusive"
+)
+
+// Params is a struct that represents the parameter list that can be used in the keda tag
+type Params struct {
+	// FieldName is the name of the field in the struct
+	FieldName string
+
+	// Name is the 'name' tag parameter defining the key in triggerMetadata, resolvedEnv or authParams
+	Name string
+
+	// Optional is the 'optional' tag parameter defining if the parameter is optional
+	Optional bool
+
+	// ParsingOrder is the 'parsingOrder' tag parameter defining the order in which the parameter is looked up
+	// in the triggerMetadata, resolvedEnv or authParams maps
+	ParsingOrder []ParsingOrder
+
+	// Default is the 'default' tag parameter defining the default value of the parameter if it's not found
+	// in any of the maps from ParsingOrder
+	Default string
+
+	// Deprecated is the 'deprecated' tag parameter, if the map contain this parameter, it is considered
+	// as an error and the DeprecatedMessage should be returned to the user
+	Deprecated string
+
+	// Enum is the 'enum' tag parameter defining the list of possible values for the parameter
+	Enum []string
+
+	// Exclusive is the 'exclusive' tag parameter defining the list of values that are mutually exclusive
+	Exclusive []string
+}
+
+// IsNested is a function that returns true if the parameter is nested
+func (p Params) IsNested() bool {
+	return p.Name == ""
+}
+
+// IsDeprecated is a function that returns true if the parameter is deprecated
+func (p Params) IsDeprecated() bool {
+	return p.Deprecated != ""
+}
+
+// DeprecatedMessage is a function that returns the optional deprecated message if the parameter is deprecated
+func (p Params) DeprecatedMessage() string {
+	if p.Deprecated == deprecatedTag {
+		return ""
+	}
+	return fmt.Sprintf(": %s", p.Deprecated)
+}
+
+// TypedConfig is a function that is used to unmarshal the TriggerMetadata, ResolvedEnv and AuthParams
+// populating the provided typedConfig where structure fields along with complementary field tags define
+// declaratively the parsing rules
+func (sc *ScalerConfig) TypedConfig(typedConfig any) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// this shouldn't happen, but calling certain reflection functions may result in panic
+			// if it does, it's better to return a error with stacktrace and reject parsing config
+			// rather than crashing KEDA
+			err = fmt.Errorf("failed to parse typed config %T resulted in panic\n%v", r, debug.Stack())
+		}
+	}()
+	err = sc.parseTypedConfig(typedConfig, false)
+	return
+}
+
+// parseTypedConfig is a function that is used to unmarshal the TriggerMetadata, ResolvedEnv and AuthParams
+// this can be called recursively to parse nested structures
+func (sc *ScalerConfig) parseTypedConfig(typedConfig any, parentOptional bool) error {
+	t := reflect.TypeOf(typedConfig)
+	if t.Kind() != reflect.Pointer {
+		return fmt.Errorf("typedConfig must be a pointer")
+	}
+	t = t.Elem()
+	v := reflect.ValueOf(typedConfig).Elem()
+
+	errs := []error{}
+	for i := 0; i < t.NumField(); i++ {
+		fieldType := t.Field(i)
+		fieldValue := v.Field(i)
+		tag, exists := fieldType.Tag.Lookup("keda")
+		if !exists {
+			continue
+		}
+		tagParams, err := paramsFromTag(tag, fieldType)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		tagParams.Optional = tagParams.Optional || parentOptional
+		if err := sc.setValue(fieldValue, tagParams); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if validator, ok := typedConfig.(CustomValidator); ok {
+		if err := validator.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// setValue is a function that sets the value of the field based on the provided params
+func (sc *ScalerConfig) setValue(field reflect.Value, params Params) error {
+	valFromConfig, exists := sc.configParamValue(params)
+	if exists && params.IsDeprecated() {
+		return fmt.Errorf("parameter %q is deprecated%v", params.Name, params.DeprecatedMessage())
+	}
+	if !exists && params.Default != "" {
+		exists = true
+		valFromConfig = params.Default
+	}
+	if !exists && (params.Optional || params.IsDeprecated()) {
+		return nil
+	}
+	if !exists && !(params.Optional || params.IsDeprecated()) {
+		return fmt.Errorf("missing required parameter %q in %v", params.Name, params.ParsingOrder)
+	}
+	if params.Enum != nil {
+		enumMap := make(map[string]bool)
+		for _, e := range params.Enum {
+			enumMap[e] = true
+		}
+		missingMap := make(map[string]bool)
+		split := strings.Split(valFromConfig, elemSeparator)
+		for _, s := range split {
+			s := strings.TrimSpace(s)
+			if !enumMap[s] {
+				missingMap[s] = true
+			}
+		}
+		if len(missingMap) > 0 {
+			return fmt.Errorf("parameter %q value %q must be one of %v", params.Name, valFromConfig, params.Enum)
+		}
+	}
+	if params.Exclusive != nil {
+		exclusiveMap := make(map[string]bool)
+		for _, e := range params.Exclusive {
+			exclusiveMap[e] = true
+		}
+		split := strings.Split(valFromConfig, elemSeparator)
+		exclusiveCount := 0
+		for _, s := range split {
+			s := strings.TrimSpace(s)
+			if exclusiveMap[s] {
+				exclusiveCount++
+			}
+		}
+		if exclusiveCount > 1 {
+			return fmt.Errorf("parameter %q value %q must contain only one of %v", params.Name, valFromConfig, params.Exclusive)
+		}
+	}
+	if params.IsNested() {
+		for field.Kind() == reflect.Ptr {
+			field.Set(reflect.New(field.Type().Elem()))
+			field = field.Elem()
+		}
+		if field.Kind() != reflect.Struct {
+			return fmt.Errorf("nested parameter %q must be a struct, has kind %q", params.FieldName, field.Kind())
+		}
+		return sc.parseTypedConfig(field.Addr().Interface(), params.Optional)
+	}
+	if err := setConfigValueHelper(valFromConfig, field); err != nil {
+		return fmt.Errorf("unable to set param %q value %q: %w", params.Name, valFromConfig, err)
+	}
+	return nil
+}
+
+// setConfigValueURLParams is a function that sets the value of the url.Values field
+func setConfigValueURLParams(valFromConfig string, field reflect.Value) error {
+	field.Set(reflect.MakeMap(reflect.MapOf(field.Type().Key(), field.Type().Elem())))
+	vals, err := url.ParseQuery(valFromConfig)
+	if err != nil {
+		return fmt.Errorf("expected url.Values, unable to parse query %q: %w", valFromConfig, err)
+	}
+	for k, vs := range vals {
+		ifcMapKeyElem := reflect.New(field.Type().Key()).Elem()
+		ifcMapValueElem := reflect.New(field.Type().Elem()).Elem()
+		if err := setConfigValueHelper(k, ifcMapKeyElem); err != nil {
+			return fmt.Errorf("map key %q: %w", k, err)
+		}
+		for _, v := range vs {
+			ifcMapValueElem.Set(reflect.Append(ifcMapValueElem, reflect.ValueOf(v)))
+		}
+		field.SetMapIndex(ifcMapKeyElem, ifcMapValueElem)
+	}
+	return nil
+}
+
+// setConfigValueMap is a function that sets the value of the map field
+func setConfigValueMap(valFromConfig string, field reflect.Value) error {
+	field.Set(reflect.MakeMap(reflect.MapOf(field.Type().Key(), field.Type().Elem())))
+	split := strings.Split(valFromConfig, elemSeparator)
+	for _, s := range split {
+		s := strings.TrimSpace(s)
+		kv := strings.Split(s, elemKeyValSeparator)
+		if len(kv) != 2 {
+			return fmt.Errorf("expected format key%vvalue, got %q", elemKeyValSeparator, s)
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.TrimSpace(kv[1])
+		ifcKeyElem := reflect.New(field.Type().Key()).Elem()
+		if err := setConfigValueHelper(key, ifcKeyElem); err != nil {
+			return fmt.Errorf("map key %q: %w", key, err)
+		}
+		ifcValueElem := reflect.New(field.Type().Elem()).Elem()
+		if err := setConfigValueHelper(val, ifcValueElem); err != nil {
+			return fmt.Errorf("map key %q, value %q: %w", key, val, err)
+		}
+		field.SetMapIndex(ifcKeyElem, ifcValueElem)
+	}
+	return nil
+}
+
+// setConfigValueSlice is a function that sets the value of the slice field
+func setConfigValueSlice(valFromConfig string, field reflect.Value) error {
+	elemIfc := reflect.New(field.Type().Elem()).Interface()
+	split := strings.Split(valFromConfig, elemSeparator)
+	for i, s := range split {
+		s := strings.TrimSpace(s)
+		if err := setConfigValueHelper(s, reflect.ValueOf(elemIfc).Elem()); err != nil {
+			return fmt.Errorf("slice element %d: %w", i, err)
+		}
+		field.Set(reflect.Append(field, reflect.ValueOf(elemIfc).Elem()))
+	}
+	return nil
+}
+
+// setParamValueHelper is a function that sets the value of the parameter
+func setConfigValueHelper(valFromConfig string, field reflect.Value) error {
+	paramValue := reflect.ValueOf(valFromConfig)
+	if paramValue.Type().AssignableTo(field.Type()) {
+		field.SetString(valFromConfig)
+		return nil
+	}
+	if paramValue.Type().ConvertibleTo(field.Type()) {
+		field.Set(paramValue.Convert(field.Type()))
+		return nil
+	}
+	if field.Type() == reflect.TypeOf(url.Values{}) {
+		return setConfigValueURLParams(valFromConfig, field)
+	}
+	if field.Kind() == reflect.Map {
+		return setConfigValueMap(valFromConfig, field)
+	}
+	if field.Kind() == reflect.Slice {
+		return setConfigValueSlice(valFromConfig, field)
+	}
+	if field.CanInterface() {
+		ifc := reflect.New(field.Type()).Interface()
+		if err := json.Unmarshal([]byte(valFromConfig), &ifc); err != nil {
+			return fmt.Errorf("unable to unmarshal to field type %v: %w", field.Type(), err)
+		}
+		field.Set(reflect.ValueOf(ifc).Elem())
+		return nil
+	}
+	return fmt.Errorf("unable to find matching parser for field type %v", field.Type())
+}
+
+// configParamValue is a function that returns the value of the parameter based on the parsing order
+func (sc *ScalerConfig) configParamValue(params Params) (string, bool) {
+	for _, po := range params.ParsingOrder {
+		var m map[string]string
+		key := params.Name
+		switch po {
+		case TriggerMetadata:
+			m = sc.TriggerMetadata
+		case AuthParams:
+			m = sc.AuthParams
+		case ResolvedEnv:
+			m = sc.ResolvedEnv
+			key = sc.TriggerMetadata[fmt.Sprintf("%sFromEnv", params.Name)]
+		default:
+			m = sc.TriggerMetadata
+		}
+		if param, ok := m[key]; ok && param != "" {
+			return strings.TrimSpace(param), true
+		}
+	}
+	return "", params.IsNested()
+}
+
+// paramsFromTag is a function that returns the Params struct based on the field tag
+func paramsFromTag(tag string, field reflect.StructField) (Params, error) {
+	params := Params{FieldName: field.Name}
+	tagSplit := strings.Split(tag, tagSeparator)
+	for _, ts := range tagSplit {
+		tsplit := strings.Split(ts, tagKeySeparator)
+		tsplit[0] = strings.TrimSpace(tsplit[0])
+		switch tsplit[0] {
+		case optionalTag:
+			if len(tsplit) == 1 {
+				params.Optional = true
+			}
+			if len(tsplit) > 1 {
+				params.Optional, _ = strconv.ParseBool(strings.TrimSpace(tsplit[1]))
+			}
+		case parsingOrderTag:
+			if len(tsplit) > 1 {
+				parsingOrder := strings.Split(tsplit[1], tagValueSeparator)
+				for _, po := range parsingOrder {
+					poTyped := ParsingOrder(strings.TrimSpace(po))
+					params.ParsingOrder = append(params.ParsingOrder, poTyped)
+				}
+			}
+		case nameTag:
+			if len(tsplit) > 1 {
+				params.Name = strings.TrimSpace(tsplit[1])
+			}
+		case deprecatedTag:
+			if len(tsplit) == 1 {
+				params.Deprecated = deprecatedTag
+			} else {
+				params.Deprecated = strings.TrimSpace(tsplit[1])
+			}
+		case defaultTag:
+			if len(tsplit) > 1 {
+				params.Default = strings.TrimSpace(tsplit[1])
+			}
+		case enumTag:
+			if len(tsplit) > 1 {
+				params.Enum = strings.Split(tsplit[1], tagValueSeparator)
+			}
+		case exclusiveTag:
+			if len(tsplit) > 1 {
+				params.Exclusive = strings.Split(tsplit[1], tagValueSeparator)
+			}
+		case "":
+			continue
+		default:
+			return params, fmt.Errorf("unknown tag param %s: %s", tsplit[0], tag)
+		}
+	}
+	return params, nil
+}

--- a/pkg/scalers/scalersconfig/typed_config_test.go
+++ b/pkg/scalers/scalersconfig/typed_config_test.go
@@ -44,11 +44,11 @@ func TestBasicTypedConfig(t *testing.T) {
 	}
 
 	type testStruct struct {
-		StringVal string  `keda:"name=stringVal, parsingOrder=triggerMetadata"`
-		IntVal    int     `keda:"name=intVal,    parsingOrder=triggerMetadata"`
-		BoolVal   bool    `keda:"name=boolVal,   parsingOrder=resolvedEnv"`
-		FloatVal  float64 `keda:"name=floatVal,  parsingOrder=resolvedEnv"`
-		AuthVal   string  `keda:"name=auth,      parsingOrder=authParams"`
+		StringVal string  `keda:"name=stringVal, order=triggerMetadata"`
+		IntVal    int     `keda:"name=intVal,    order=triggerMetadata"`
+		BoolVal   bool    `keda:"name=boolVal,   order=resolvedEnv"`
+		FloatVal  float64 `keda:"name=floatVal,  order=resolvedEnv"`
+		AuthVal   string  `keda:"name=auth,      order=authParams"`
 	}
 
 	ts := testStruct{}
@@ -82,9 +82,9 @@ func TestParsingOrder(t *testing.T) {
 	}
 
 	type testStruct struct {
-		StringVal string  `keda:"name=stringVal, parsingOrder=resolvedEnv;triggerMetadata"`
-		IntVal    int     `keda:"name=intVal,    parsingOrder=triggerMetadata;resolvedEnv"`
-		FloatVal  float64 `keda:"name=floatVal,  parsingOrder=resolvedEnv;triggerMetadata"`
+		StringVal string  `keda:"name=stringVal, order=resolvedEnv;triggerMetadata"`
+		IntVal    int     `keda:"name=intVal,    order=triggerMetadata;resolvedEnv"`
+		FloatVal  float64 `keda:"name=floatVal,  order=resolvedEnv;triggerMetadata"`
 	}
 
 	ts := testStruct{}
@@ -107,9 +107,9 @@ func TestOptional(t *testing.T) {
 	}
 
 	type testStruct struct {
-		StringVal          string `keda:"name=stringVal, parsingOrder=triggerMetadata"`
-		IntValOptional     int    `keda:"name=intVal,    parsingOrder=triggerMetadata, optional"`
-		IntValAlsoOptional int    `keda:"name=intVal,    parsingOrder=triggerMetadata, optional=true"`
+		StringVal          string `keda:"name=stringVal, order=triggerMetadata"`
+		IntValOptional     int    `keda:"name=intVal,    order=triggerMetadata, optional"`
+		IntValAlsoOptional int    `keda:"name=intVal,    order=triggerMetadata, optional=true"`
 	}
 
 	ts := testStruct{}
@@ -128,7 +128,7 @@ func TestMissing(t *testing.T) {
 	sc := &ScalerConfig{}
 
 	type testStruct struct {
-		StringVal string `keda:"name=stringVal, parsingOrder=triggerMetadata"`
+		StringVal string `keda:"name=stringVal, order=triggerMetadata"`
 	}
 
 	ts := testStruct{}
@@ -147,7 +147,7 @@ func TestDeprecated(t *testing.T) {
 	}
 
 	type testStruct struct {
-		StringVal string `keda:"name=stringVal, parsingOrder=triggerMetadata, deprecated=deprecated"`
+		StringVal string `keda:"name=stringVal, order=triggerMetadata, deprecated=deprecated"`
 	}
 
 	ts := testStruct{}
@@ -174,9 +174,9 @@ func TestDefaultValue(t *testing.T) {
 	}
 
 	type testStruct struct {
-		BoolVal    bool   `keda:"name=boolVal,    parsingOrder=triggerMetadata, optional, default=true"`
-		StringVal  string `keda:"name=stringVal,  parsingOrder=triggerMetadata, optional, default=d"`
-		StringVal2 string `keda:"name=stringVal2, parsingOrder=triggerMetadata, optional, default=d"`
+		BoolVal    bool   `keda:"name=boolVal,    order=triggerMetadata, optional, default=true"`
+		StringVal  string `keda:"name=stringVal,  order=triggerMetadata, optional, default=d"`
+		StringVal2 string `keda:"name=stringVal2, order=triggerMetadata, optional, default=d"`
 	}
 
 	ts := testStruct{}
@@ -199,7 +199,7 @@ func TestMap(t *testing.T) {
 	}
 
 	type testStruct struct {
-		MapVal map[string]int `keda:"name=mapVal, parsingOrder=triggerMetadata"`
+		MapVal map[string]int `keda:"name=mapVal, order=triggerMetadata"`
 	}
 
 	ts := testStruct{}
@@ -222,8 +222,8 @@ func TestSlice(t *testing.T) {
 	}
 
 	type testStruct struct {
-		SliceVal           []int `keda:"name=sliceVal, parsingOrder=triggerMetadata"`
-		SliceValWithSpaces []int `keda:"name=sliceValWithSpaces, parsingOrder=triggerMetadata"`
+		SliceVal           []int `keda:"name=sliceVal, order=triggerMetadata"`
+		SliceValWithSpaces []int `keda:"name=sliceValWithSpaces, order=triggerMetadata"`
 	}
 
 	ts := testStruct{}
@@ -251,8 +251,8 @@ func TestEnum(t *testing.T) {
 	}
 
 	type testStruct struct {
-		EnumVal   string   `keda:"name=enumVal,   parsingOrder=triggerMetadata, enum=value1;value2"`
-		EnumSlice []string `keda:"name=enumSlice, parsingOrder=triggerMetadata, enum=value1;value2, optional"`
+		EnumVal   string   `keda:"name=enumVal,   order=triggerMetadata, enum=value1;value2"`
+		EnumSlice []string `keda:"name=enumSlice, order=triggerMetadata, enum=value1;value2, optional"`
 	}
 
 	ts := testStruct{}
@@ -273,12 +273,12 @@ func TestEnum(t *testing.T) {
 	Expect(err).To(MatchError(`parameter "enumVal" value "value3" must be one of [value1 value2]`))
 }
 
-// TestExclusive tests the exclusive type
+// TestExclusive tests the exclusiveSet type
 func TestExclusive(t *testing.T) {
 	RegisterTestingT(t)
 
 	type testStruct struct {
-		IntVal []int `keda:"name=intVal,    parsingOrder=triggerMetadata, exclusive=1;4;5"`
+		IntVal []int `keda:"name=intVal, order=triggerMetadata, exclusiveSet=1;4;5"`
 	}
 
 	sc := &ScalerConfig{
@@ -313,7 +313,7 @@ func TestURLValues(t *testing.T) {
 	}
 
 	type testStruct struct {
-		EndpointParams url.Values `keda:"name=endpointParams, parsingOrder=authParams"`
+		EndpointParams url.Values `keda:"name=endpointParams, order=authParams"`
 	}
 
 	ts := testStruct{}
@@ -338,7 +338,7 @@ func TestGenericMap(t *testing.T) {
 
 	// structurally similar to url.Values but should behave as generic map
 	type testStruct struct {
-		EndpointParams map[string][]string `keda:"name=endpointParams, parsingOrder=authParams"`
+		EndpointParams map[string][]string `keda:"name=endpointParams, order=authParams"`
 	}
 
 	ts := testStruct{}
@@ -365,8 +365,8 @@ func TestNestedStruct(t *testing.T) {
 	}
 
 	type basicAuth struct {
-		Username string `keda:"name=username, parsingOrder=authParams"`
-		Password string `keda:"name=password, parsingOrder=authParams"`
+		Username string `keda:"name=username, order=authParams"`
+		Password string `keda:"name=password, order=authParams"`
 	}
 
 	type testStruct struct {
@@ -393,8 +393,8 @@ func TestEmbeddedStruct(t *testing.T) {
 
 	type testStruct struct {
 		BasicAuth struct {
-			Username string `keda:"name=username, parsingOrder=authParams"`
-			Password string `keda:"name=password, parsingOrder=authParams"`
+			Username string `keda:"name=username, order=authParams"`
+			Password string `keda:"name=password, order=authParams"`
 		} `keda:""`
 	}
 
@@ -436,9 +436,9 @@ func TestNestedOptional(t *testing.T) {
 	}
 
 	type basicAuth struct {
-		Username                   string `keda:"name=username, parsingOrder=authParams"`
-		Password                   string `keda:"name=password, parsingOrder=authParams, optional"`
-		AlsoOptionalThanksToParent string `keda:"name=optional, parsingOrder=authParams"`
+		Username                   string `keda:"name=username, order=authParams"`
+		Password                   string `keda:"name=password, order=authParams, optional"`
+		AlsoOptionalThanksToParent string `keda:"name=optional, order=authParams"`
 	}
 
 	type testStruct struct {
@@ -465,8 +465,8 @@ func TestNestedPointer(t *testing.T) {
 	}
 
 	type basicAuth struct {
-		Username string `keda:"name=username, parsingOrder=authParams"`
-		Password string `keda:"name=password, parsingOrder=authParams"`
+		Username string `keda:"name=username, order=authParams"`
+		Password string `keda:"name=password, order=authParams"`
 	}
 
 	type testStruct struct {
@@ -479,4 +479,39 @@ func TestNestedPointer(t *testing.T) {
 	Expect(ts.BA).ToNot(BeNil())
 	Expect(ts.BA.Username).To(Equal("user"))
 	Expect(ts.BA.Password).To(Equal("pass"))
+}
+
+// TestNoParsingOrder tests when no parsing order is provided
+func TestNoParsingOrder(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"strVal":     "value1",
+			"defaultVal": "value2",
+		},
+	}
+
+	type testStructMissing struct {
+		StrVal string `keda:"name=strVal, enum=value1;value2"`
+	}
+	tsm := testStructMissing{}
+	err := sc.TypedConfig(&tsm)
+	Expect(err).To(MatchError(`missing required parameter "strVal", no 'order' tag, provide any from [authParams resolvedEnv triggerMetadata]`))
+
+	type testStructDefault struct {
+		DefaultVal string `keda:"name=defaultVal, default=dv"`
+	}
+	tsd := testStructDefault{}
+	err = sc.TypedConfig(&tsd)
+	Expect(err).To(BeNil())
+	Expect(tsd.DefaultVal).To(Equal("dv"))
+
+	type testStructDefaultMissing struct {
+		DefaultVal2 string `keda:"name=defaultVal2, default=dv"`
+	}
+	tsdm := testStructDefaultMissing{}
+	err = sc.TypedConfig(&tsdm)
+	Expect(err).To(BeNil())
+	Expect(tsdm.DefaultVal2).To(Equal("dv"))
 }

--- a/pkg/scalers/scalersconfig/typed_config_test.go
+++ b/pkg/scalers/scalersconfig/typed_config_test.go
@@ -1,0 +1,482 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scalersconfig
+
+import (
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestBasicTypedConfig tests the basic types for typed config
+func TestBasicTypedConfig(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"stringVal":       "value1",
+			"intVal":          "1",
+			"boolValFromEnv":  "boolVal",
+			"floatValFromEnv": "floatVal",
+		},
+		ResolvedEnv: map[string]string{
+			"boolVal":  "true",
+			"floatVal": "1.1",
+		},
+		AuthParams: map[string]string{
+			"auth": "authValue",
+		},
+	}
+
+	type testStruct struct {
+		StringVal string  `keda:"name=stringVal, parsingOrder=triggerMetadata"`
+		IntVal    int     `keda:"name=intVal,    parsingOrder=triggerMetadata"`
+		BoolVal   bool    `keda:"name=boolVal,   parsingOrder=resolvedEnv"`
+		FloatVal  float64 `keda:"name=floatVal,  parsingOrder=resolvedEnv"`
+		AuthVal   string  `keda:"name=auth,      parsingOrder=authParams"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+
+	Expect(ts.StringVal).To(Equal("value1"))
+	Expect(ts.IntVal).To(Equal(1))
+	Expect(ts.BoolVal).To(BeTrue())
+	Expect(ts.FloatVal).To(Equal(1.1))
+	Expect(ts.AuthVal).To(Equal("authValue"))
+}
+
+// TestParsingOrder tests the parsing order
+func TestParsingOrder(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"stringVal":       "value1",
+			"intVal":          "1",
+			"intValFromEnv":   "intVal",
+			"floatVal":        "1.1",
+			"floatValFromEnv": "floatVal",
+		},
+		ResolvedEnv: map[string]string{
+			"stringVal": "value2",
+			"intVal":    "2",
+			"floatVal":  "2.2",
+		},
+	}
+
+	type testStruct struct {
+		StringVal string  `keda:"name=stringVal, parsingOrder=resolvedEnv;triggerMetadata"`
+		IntVal    int     `keda:"name=intVal,    parsingOrder=triggerMetadata;resolvedEnv"`
+		FloatVal  float64 `keda:"name=floatVal,  parsingOrder=resolvedEnv;triggerMetadata"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+
+	Expect(ts.StringVal).To(Equal("value1"))
+	Expect(ts.IntVal).To(Equal(1))
+	Expect(ts.FloatVal).To(Equal(2.2))
+}
+
+// TestOptional tests the optional tag
+func TestOptional(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"stringVal": "value1",
+		},
+	}
+
+	type testStruct struct {
+		StringVal          string `keda:"name=stringVal, parsingOrder=triggerMetadata"`
+		IntValOptional     int    `keda:"name=intVal,    parsingOrder=triggerMetadata, optional"`
+		IntValAlsoOptional int    `keda:"name=intVal,    parsingOrder=triggerMetadata, optional=true"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+
+	Expect(ts.StringVal).To(Equal("value1"))
+	Expect(ts.IntValOptional).To(Equal(0))
+	Expect(ts.IntValAlsoOptional).To(Equal(0))
+}
+
+// TestMissing tests the missing parameter for compulsory tag
+func TestMissing(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{}
+
+	type testStruct struct {
+		StringVal string `keda:"name=stringVal, parsingOrder=triggerMetadata"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(MatchError(`missing required parameter "stringVal" in [triggerMetadata]`))
+}
+
+// TestDeprecated tests the deprecated tag
+func TestDeprecated(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"stringVal": "value1",
+		},
+	}
+
+	type testStruct struct {
+		StringVal string `keda:"name=stringVal, parsingOrder=triggerMetadata, deprecated=deprecated"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(MatchError(`parameter "stringVal" is deprecated`))
+
+	sc2 := &ScalerConfig{
+		TriggerMetadata: map[string]string{},
+	}
+
+	ts2 := testStruct{}
+	err = sc2.TypedConfig(&ts2)
+	Expect(err).To(BeNil())
+}
+
+// TestDefaultValue tests the default tag
+func TestDefaultValue(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"stringVal": "value1",
+		},
+	}
+
+	type testStruct struct {
+		BoolVal    bool   `keda:"name=boolVal,    parsingOrder=triggerMetadata, optional, default=true"`
+		StringVal  string `keda:"name=stringVal,  parsingOrder=triggerMetadata, optional, default=d"`
+		StringVal2 string `keda:"name=stringVal2, parsingOrder=triggerMetadata, optional, default=d"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+
+	Expect(ts.BoolVal).To(Equal(true))
+	Expect(ts.StringVal).To(Equal("value1"))
+	Expect(ts.StringVal2).To(Equal("d"))
+}
+
+// TestMap tests the map type
+func TestMap(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"mapVal": "key1=1,key2=2",
+		},
+	}
+
+	type testStruct struct {
+		MapVal map[string]int `keda:"name=mapVal, parsingOrder=triggerMetadata"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.MapVal).To(HaveLen(2))
+	Expect(ts.MapVal["key1"]).To(Equal(1))
+	Expect(ts.MapVal["key2"]).To(Equal(2))
+}
+
+// TestSlice tests the slice type
+func TestSlice(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"sliceVal":           "1,2,3",
+			"sliceValWithSpaces": "1, 2, 3",
+		},
+	}
+
+	type testStruct struct {
+		SliceVal           []int `keda:"name=sliceVal, parsingOrder=triggerMetadata"`
+		SliceValWithSpaces []int `keda:"name=sliceValWithSpaces, parsingOrder=triggerMetadata"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.SliceVal).To(HaveLen(3))
+	Expect(ts.SliceVal[0]).To(Equal(1))
+	Expect(ts.SliceVal[1]).To(Equal(2))
+	Expect(ts.SliceVal[2]).To(Equal(3))
+	Expect(ts.SliceValWithSpaces).To(HaveLen(3))
+	Expect(ts.SliceValWithSpaces[0]).To(Equal(1))
+	Expect(ts.SliceValWithSpaces[1]).To(Equal(2))
+	Expect(ts.SliceValWithSpaces[2]).To(Equal(3))
+}
+
+// TestEnum tests the enum type
+func TestEnum(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"enumVal":   "value1",
+			"enumSlice": "value1, value2",
+		},
+	}
+
+	type testStruct struct {
+		EnumVal   string   `keda:"name=enumVal,   parsingOrder=triggerMetadata, enum=value1;value2"`
+		EnumSlice []string `keda:"name=enumSlice, parsingOrder=triggerMetadata, enum=value1;value2, optional"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.EnumVal).To(Equal("value1"))
+	Expect(ts.EnumSlice).To(HaveLen(2))
+	Expect(ts.EnumSlice).To(ConsistOf("value1", "value2"))
+
+	sc2 := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"enumVal": "value3",
+		},
+	}
+
+	ts2 := testStruct{}
+	err = sc2.TypedConfig(&ts2)
+	Expect(err).To(MatchError(`parameter "enumVal" value "value3" must be one of [value1 value2]`))
+}
+
+// TestExclusive tests the exclusive type
+func TestExclusive(t *testing.T) {
+	RegisterTestingT(t)
+
+	type testStruct struct {
+		IntVal []int `keda:"name=intVal,    parsingOrder=triggerMetadata, exclusive=1;4;5"`
+	}
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"intVal": "1,2,3",
+		},
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+
+	sc2 := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"intVal": "1,4",
+		},
+	}
+
+	ts2 := testStruct{}
+	err = sc2.TypedConfig(&ts2)
+	Expect(err).To(MatchError(`parameter "intVal" value "1,4" must contain only one of [1 4 5]`))
+}
+
+// TestURLValues tests the url.Values type
+func TestURLValues(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		AuthParams: map[string]string{
+			"endpointParams": "key1=value1&key2=value2&key1=value3",
+		},
+	}
+
+	type testStruct struct {
+		EndpointParams url.Values `keda:"name=endpointParams, parsingOrder=authParams"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.EndpointParams).To(HaveLen(2))
+	Expect(ts.EndpointParams).To(HaveKey("key1"))
+	Expect(ts.EndpointParams).To(HaveKey("key2"))
+	Expect(ts.EndpointParams["key1"]).To(ConsistOf("value1", "value3"))
+	Expect(ts.EndpointParams["key2"]).To(ConsistOf("value2"))
+}
+
+// TestGenericMap tests the generic map type that is structurally similar to url.Values
+func TestGenericMap(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		AuthParams: map[string]string{
+			"endpointParams": "key1=value1,key2=value2,key3=value3",
+		},
+	}
+
+	// structurally similar to url.Values but should behave as generic map
+	type testStruct struct {
+		EndpointParams map[string][]string `keda:"name=endpointParams, parsingOrder=authParams"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.EndpointParams).To(HaveLen(3))
+	Expect(ts.EndpointParams).To(HaveKey("key1"))
+	Expect(ts.EndpointParams).To(HaveKey("key2"))
+	Expect(ts.EndpointParams).To(HaveKey("key3"))
+	Expect(ts.EndpointParams["key1"]).To(ConsistOf("value1"))
+	Expect(ts.EndpointParams["key2"]).To(ConsistOf("value2"))
+	Expect(ts.EndpointParams["key3"]).To(ConsistOf("value3"))
+}
+
+// TestNestedStruct tests the nested struct type
+func TestNestedStruct(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		AuthParams: map[string]string{
+			"username": "user",
+			"password": "pass",
+		},
+	}
+
+	type basicAuth struct {
+		Username string `keda:"name=username, parsingOrder=authParams"`
+		Password string `keda:"name=password, parsingOrder=authParams"`
+	}
+
+	type testStruct struct {
+		BA basicAuth `keda:""`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.BA.Username).To(Equal("user"))
+	Expect(ts.BA.Password).To(Equal("pass"))
+}
+
+// TestEmbeddedStruct tests the embedded struct type
+func TestEmbeddedStruct(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		AuthParams: map[string]string{
+			"username": "user",
+			"password": "pass",
+		},
+	}
+
+	type testStruct struct {
+		BasicAuth struct {
+			Username string `keda:"name=username, parsingOrder=authParams"`
+			Password string `keda:"name=password, parsingOrder=authParams"`
+		} `keda:""`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.BasicAuth.Username).To(Equal("user"))
+	Expect(ts.BasicAuth.Password).To(Equal("pass"))
+}
+
+// TestWrongNestedStruct tests the wrong nested type
+func TestWrongNestedStruct(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		AuthParams: map[string]string{
+			"username": "user",
+			"password": "pass",
+		},
+	}
+
+	type testStruct struct {
+		WrongNesting int `keda:""`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(MatchError(`nested parameter "WrongNesting" must be a struct, has kind "int"`))
+}
+
+// TestNestedOptional tests the nested optional type
+func TestNestedOptional(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		AuthParams: map[string]string{
+			"username": "user",
+		},
+	}
+
+	type basicAuth struct {
+		Username                   string `keda:"name=username, parsingOrder=authParams"`
+		Password                   string `keda:"name=password, parsingOrder=authParams, optional"`
+		AlsoOptionalThanksToParent string `keda:"name=optional, parsingOrder=authParams"`
+	}
+
+	type testStruct struct {
+		BA basicAuth `keda:"optional"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.BA.Username).To(Equal("user"))
+	Expect(ts.BA.Password).To(Equal(""))
+	Expect(ts.BA.AlsoOptionalThanksToParent).To(Equal(""))
+}
+
+// TestNestedPointer tests the nested pointer type
+func TestNestedPointer(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		AuthParams: map[string]string{
+			"username": "user",
+			"password": "pass",
+		},
+	}
+
+	type basicAuth struct {
+		Username string `keda:"name=username, parsingOrder=authParams"`
+		Password string `keda:"name=password, parsingOrder=authParams"`
+	}
+
+	type testStruct struct {
+		BA *basicAuth `keda:""`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+	Expect(ts.BA).ToNot(BeNil())
+	Expect(ts.BA.Username).To(Equal("user"))
+	Expect(ts.BA.Password).To(Equal("pass"))
+}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Various scaler configurations are inconsistent in implementation as discussed in https://github.com/kedacore/keda/issues/5037. There has been a great effort in improving the situation with `getParameterFromConfigV2()` in https://github.com/kedacore/keda/pull/5228 (with further enhancements in https://github.com/kedacore/keda/pull/5319 and https://github.com/kedacore/keda/pull/5314).

There are likely always going to be some situations that require imperative parsing of the provided configs and the helper `getParameterFromConfigV2()`, but for the majority of cases, I believe we can implement an even more generic, more convenient and declarative algorithm, similar for example to the API of well known `json.Unmarshal()`.

My desired goal is to allow each scaler to define the configuration struct with proper field tags to fine-tune the parsing algorithm, call a single helper method `TypedConfig()` defined on `ScalerConfig` struct and consume unmarshalled typed config without the need for explicit typecasting.

#### Example:
```go
type MyConfigXYZ struct {
  Flag    bool           `keda:"name=flag,    parsingOrder=triggerMetadata"`
  Addr    string         `keda:"name=addr,    parsingOrder=triggerMetadata;resolvedEnv, optional, default=d"`
  Headers map[string]int `keda:"name=headers, parsingOrder=triggerMetadata,             optional, default=d"`
}

sc := &scalerconfig.ScalerConfig{ ... }
conf := MyConfigXYZ{}
if err := sc.TypedConfig(conf); err != nil {
   ...
}
```
Where the `MyConfigXYZ` is an arbitrary structure with fields containing properly formatted `keda` tag. Callers can control
* where to obtain the value from - `triggerMetadata`, `resolvedEnv`, `authParams`, and which map has a precedence
* whether it's `optional` or `deprecated`
* what is `default` value
* `name` as a key to the map
* allowed values with `enum`
* mutually exclusive values with `exclusive`

The algorithm is based on go `reflections` and dynamic parsing of a structure, natively supports `slices` and `maps` and `url.Values` so it might eventually supersede helpers in [`pkg/util/parse_string.go`](https://github.com/kedacore/keda/blob/cfc1bfc4052c3061b21e98935cbffa1b0fdd9aef/pkg/util/parse_string.go#L67-L87)

#### PR structure
* 4475519ea750590eaa319a25a05f449f867cf9df core implementation 
* d5d0b102de8f2862f0fa9e4022a435693a016565 sample conversion of prometheus scaler
* 43b6c10c56a105492d38b88bd1362b77340a0a8e implementation of prometheus auth parsing

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/5037
