### PR TITLE
Remove WaitForConnectionReady to fix race condition in connection to LeaderElected Operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Here is an overview of all new **experimental** features:
 - **General**: Fix CVE-2024-28180 in github.com/go-jose/go-jose/v3 ([#5617](https://github.com/kedacore/keda/pull/5617))
 - **General**: Log field `ScaledJob` no longer have conflicting types ([#5592](https://github.com/kedacore/keda/pull/5592))
 - **General**: Prometheus metrics shows errors correctly ([#5597](https://github.com/kedacore/keda/issues/5597)|[#5663](https://github.com/kedacore/keda/issues/5663))
+- **General**: Remove WaitForConnectionReady to fix race condition connection to LeaderElected Operator ([#5680](https://github.com/kedacore/keda/pull/5680))
 - **General**: Validate empty array value of triggers in ScaledObject/ScaledJob creation ([#5520](https://github.com/kedacore/keda/issues/5520))
 - **GitHub Runner Scaler**: Fixed `in_progress` detection on running jobs instead of just `queued` ([#5604](https://github.com/kedacore/keda/issues/5604))
 - **New Relic Scaler**: Consider empty results set from query executer ([#5619](https://github.com/kedacore/keda/pull/5619))

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -19,12 +19,9 @@ package metricsservice
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/go-logr/logr"
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 
@@ -99,29 +96,6 @@ func (c *GrpcClient) GetMetrics(ctx context.Context, scaledObjectName, scaledObj
 	}
 
 	return extMetrics, nil
-}
-
-// WaitForConnectionReady waits for gRPC connection to be ready
-// returns true if the connection was successful, false if we hit a timeut from context
-func (c *GrpcClient) WaitForConnectionReady(ctx context.Context, logger logr.Logger) bool {
-	currentState := c.connection.GetState()
-	if currentState != connectivity.Ready {
-		logger.Info("Waiting for establishing a gRPC connection to KEDA Metrics Server")
-		for {
-			select {
-			case <-ctx.Done():
-				return false
-			default:
-				c.connection.Connect()
-				time.Sleep(500 * time.Millisecond)
-				currentState := c.connection.GetState()
-				if currentState == connectivity.Ready {
-					return true
-				}
-			}
-		}
-	}
-	return true
 }
 
 // GetServerURL returns url of the gRPC server this client is connected to

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -55,15 +55,15 @@ func NewProvider(ctx context.Context, adapterLogger logr.Logger, client client.C
 	logger = adapterLogger.WithName("provider")
 	logger.Info("starting")
 
-	go func() {
-		if !grpcClient.WaitForConnectionReady(ctx, logger) {
-			grpcClientConnected = false
-			logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", grpcClient.GetServerURL())
-		} else if !grpcClientConnected {
-			grpcClientConnected = true
-			logger.Info("Connection to KEDA Metrics Service gRPC server has been successfully established", "server", grpcClient.GetServerURL())
-		}
-	}()
+	// go func() {
+	// 	if !grpcClient.WaitForConnectionReady(ctx, logger) {
+	// 		grpcClientConnected = false
+	// 		logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", grpcClient.GetServerURL())
+	// 	} else if !grpcClientConnected {
+	// 		grpcClientConnected = true
+	// 		logger.Info("Connection to KEDA Metrics Service gRPC server has been successfully established", "server", grpcClient.GetServerURL())
+	// 	}
+	// }()
 
 	return provider
 }
@@ -84,15 +84,15 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 	}
 
 	// Get Metrics from Metrics Service gRPC Server
-	if !p.grpcClient.WaitForConnectionReady(ctx, logger) {
-		grpcClientConnected = false
-		logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", p.grpcClient.GetServerURL())
-		return nil, err
-	}
-	if !grpcClientConnected {
-		grpcClientConnected = true
-		logger.Info("Connection to KEDA Metrics Service gRPC server has been successfully established", "server", p.grpcClient.GetServerURL())
-	}
+	// if !p.grpcClient.WaitForConnectionReady(ctx, logger) {
+	// 	grpcClientConnected = false
+	// 	logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", p.grpcClient.GetServerURL())
+	// 	return nil, err
+	// }
+	// if !grpcClientConnected {
+	// 	grpcClientConnected = true
+	// 	logger.Info("Connection to KEDA Metrics Service gRPC server has been successfully established", "server", p.grpcClient.GetServerURL())
+	// }
 
 	// selector is in form: `scaledobject.keda.sh/name: scaledobject-name`
 	scaledObjectName := selector.Get(kedav1alpha1.ScaledObjectOwnerAnnotation)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -55,16 +55,6 @@ func NewProvider(ctx context.Context, adapterLogger logr.Logger, client client.C
 	logger = adapterLogger.WithName("provider")
 	logger.Info("starting")
 
-	// go func() {
-	// 	if !grpcClient.WaitForConnectionReady(ctx, logger) {
-	// 		grpcClientConnected = false
-	// 		logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", grpcClient.GetServerURL())
-	// 	} else if !grpcClientConnected {
-	// 		grpcClientConnected = true
-	// 		logger.Info("Connection to KEDA Metrics Service gRPC server has been successfully established", "server", grpcClient.GetServerURL())
-	// 	}
-	// }()
-
 	return provider
 }
 
@@ -82,17 +72,6 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 		logger.Error(err, "error converting Selector to Labels Map")
 		return nil, err
 	}
-
-	// Get Metrics from Metrics Service gRPC Server
-	// if !p.grpcClient.WaitForConnectionReady(ctx, logger) {
-	// 	grpcClientConnected = false
-	// 	logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", p.grpcClient.GetServerURL())
-	// 	return nil, err
-	// }
-	// if !grpcClientConnected {
-	// 	grpcClientConnected = true
-	// 	logger.Info("Connection to KEDA Metrics Service gRPC server has been successfully established", "server", p.grpcClient.GetServerURL())
-	// }
 
 	// selector is in form: `scaledobject.keda.sh/name: scaledobject-name`
 	scaledObjectName := selector.Get(kedav1alpha1.ScaledObjectOwnerAnnotation)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR removes `WaitForConnectionReady` as we will instead just rely on the GRPC roundrobin client policy to find a connection that works.

This time, I verified by running two operators and two adapters and verified that the HPA controller was able to fetch metrics from KEDA adapter successfully. Below is my testing matrix:

- Tested with 1 Adapter replica, 1 operator replica: worked
- Tested with 1 Adapter replica, 2 Operator replicas: worked
- Tested with 2 Adapter replicas, 1 operator replicas: worked
- Tested with 2 Adapter replicas, 2 operator replicas: worked.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5680


