### PR TITLE
fix: Use correct otel-collector distro

### DIFF
--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -47,6 +47,8 @@ data:
         target_label: kubernetes_pod_name
 `
 	OtlpConfig = `mode: deployment
+image:
+  repository: "otel/opentelemetry-collector-contrib"
 config:
   exporters:
     logging:


### PR DESCRIPTION
There is a potential breaking change that requires this change during the dep installation (just for testing, nothing to users)
https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md#0880-to-0890

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
