### PR TITLE
chore: Increase minimum supported Kubernetes version for KEDA v2.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -93,6 +93,7 @@ body:
     label: Kubernetes Version
     description: What version of Kubernetes that are you running?
     options:
+    - "1.30"
     - "1.29"
     - "1.28"
     - "1.27"

--- a/pkg/util/welcome.go
+++ b/pkg/util/welcome.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	minSupportedVersion = 27
-	maxSupportedVersion = 29
+	maxSupportedVersion = 30
 )
 
 func PrintWelcome(logger logr.Logger, kubeVersion K8sVersion, component string) {


### PR DESCRIPTION
chore: Increase minimum supported Kubernetes version for KEDA v2.14

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
# https://github.com/kedacore/keda/issues/5671
