### PR TITLE
revert: Go back to supporting Kubernetes 1.27 to 1.29 for KEDA v2.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -93,10 +93,11 @@ body:
     label: Kubernetes Version
     description: What version of Kubernetes that are you running?
     options:
-    - "1.30"
     - "1.29"
     - "1.28"
-    - "< 1.28"
+    - "1.27"
+    - "1.26"
+    - "< 1.26"
     - "Other"
   validations:
     required: false

--- a/pkg/util/welcome.go
+++ b/pkg/util/welcome.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	minSupportedVersion = 28
-	maxSupportedVersion = 30
+	minSupportedVersion = 27
+	maxSupportedVersion = 29
 )
 
 func PrintWelcome(logger logr.Logger, kubeVersion K8sVersion, component string) {


### PR DESCRIPTION
Go back to supporting Kubernetes 1.27 to 1.29 for KEDA v2.14 given we cannot properly guarantee quality on 1.30.

Reverts kedacore/keda#5736
Relates to https://github.com/kedacore/keda/issues/5671