### PR TITLE
Fix scaler leak during cache refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **General**: Scalers are properly closed after being refreshed ([#5806](https://github.com/kedacore/keda/issues/5806))
 - **MongoDB Scaler**:  MongoDB url parses correctly `+srv` scheme ([#5760](https://github.com/kedacore/keda/issues/5760))
 
 ### Deprecations

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -293,7 +293,7 @@ func (h *scaleHandler) getScalersCacheForScaledObject(ctx context.Context, scale
 // performGetScalersCache returns cache for input scalableObject, it is common code used by GetScalersCache() and getScalersCacheForScaledObject() methods
 func (h *scaleHandler) performGetScalersCache(ctx context.Context, key string, scalableObject interface{}, scalableObjectGeneration *int64, scalableObjectKind, scalableObjectNamespace, scalableObjectName string) (*cache.ScalersCache, error) {
 	h.scalerCachesLock.RLock()
-	regenerateCache := false
+
 	if cache, ok := h.scalerCaches[key]; ok {
 		// generation was specified -> let's include it in the check as well
 		if scalableObjectGeneration != nil {
@@ -301,15 +301,12 @@ func (h *scaleHandler) performGetScalersCache(ctx context.Context, key string, s
 				h.scalerCachesLock.RUnlock()
 				return cache, nil
 			}
-			// object was found in cache, but the generation is not correct,
-			// we'll need to close scalers in the cache and
-			// proceed further to recreate the cache
-			regenerateCache = false
 		} else {
 			h.scalerCachesLock.RUnlock()
 			return cache, nil
 		}
 	}
+
 	h.scalerCachesLock.RUnlock()
 
 	if scalableObject == nil {
@@ -379,17 +376,17 @@ func (h *scaleHandler) performGetScalersCache(ctx context.Context, key string, s
 	default:
 	}
 
-	// Scalers Close() could be impacted by timeouts, blocking the mutex
-	// until the timeout happens. Instead of locking the mutex, we take
-	// the old cache item and we close it in another goroutine, not locking
-	// the cache: https://github.com/kedacore/keda/issues/5083
-	if regenerateCache {
-		oldCache := h.scalerCaches[key]
+	h.scalerCachesLock.Lock()
+	defer h.scalerCachesLock.Unlock()
+
+	if oldCache, ok := h.scalerCaches[key]; ok {
+		// Scalers Close() could be impacted by timeouts, blocking the mutex
+		// until the timeout happens. Instead of locking the mutex, we take
+		// the old cache item and we close it in another goroutine, not locking
+		// the cache: https://github.com/kedacore/keda/issues/5083
 		go oldCache.Close(ctx)
 	}
 
-	h.scalerCachesLock.Lock()
-	defer h.scalerCachesLock.Unlock()
 	h.scalerCaches[key] = newCache
 	return h.scalerCaches[key], nil
 }


### PR DESCRIPTION
Fixes scaler not being properly closed in `performGetScalerCache`:
* Fix logic to close scaler when out of date
* Fix race confition

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5806

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->

