### PR TITLE
Add config as parameter to help validate scaler meta data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### New
 
+
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 - **General**: Declarative parsing of scaler config ([#5037](https://github.com/kedacore/keda/issues/5037)|[#5797](https://github.com/kedacore/keda/issues/5797))
 

--- a/pkg/scalers/activemq_scaler.go
+++ b/pkg/scalers/activemq_scaler.go
@@ -46,7 +46,7 @@ type activeMQMetadata struct {
 	ActivationTargetQueueSize int64  `keda:"name=activationTargetQueueSize, order=triggerMetadata, optional, default=0"`
 }
 
-func (a *activeMQMetadata) Validate() error {
+func (a *activeMQMetadata) Validate(_ scalersconfig.ScalerConfig) error {
 	if a.RestAPITemplate != "" {
 		// parse restAPITemplate to provide managementEndpoint, brokerName, destinationName
 		u, err := url.ParseRequestURI(a.RestAPITemplate)

--- a/pkg/scalers/authentication/authentication_types.go
+++ b/pkg/scalers/authentication/authentication_types.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/url"
 	"time"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
 
 // Type describes the authentication type used in a scaler
@@ -131,7 +133,7 @@ func (c *Config) GetBearerToken() string {
 }
 
 // Validate validates the Config and returns an error if it is invalid
-func (c *Config) Validate() error {
+func (c *Config) Validate(_ scalersconfig.ScalerConfig) error {
 	if c.Disabled() {
 		return nil
 	}

--- a/pkg/scalers/scalersconfig/typed_config.go
+++ b/pkg/scalers/scalersconfig/typed_config.go
@@ -32,7 +32,7 @@ import (
 
 // CustomValidator is an interface that can be implemented to validate the configuration of the typed config
 type CustomValidator interface {
-	Validate() error
+	Validate(sc ScalerConfig) error
 }
 
 // ParsingOrder is a type that represents the order in which the parameters are parsed
@@ -170,7 +170,7 @@ func (sc *ScalerConfig) parseTypedConfig(typedConfig any, parentOptional bool) e
 		}
 	}
 	if validator, ok := typedConfig.(CustomValidator); ok {
-		if err := validator.Validate(); err != nil {
+		if err := validator.Validate(*sc); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
Add config as parameter in the Validator func so that we can move all validator into this func, such as checking some situation under config.AsMetricSource. https://github.com/kedacore/keda/pull/5808#discussion_r1607789376

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to # https://github.com/kedacore/keda/issues/5037
