### PR TITLE
fix: unnecessary HPA updates when cpu utilization trigger is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Here is an overview of all new **experimental** features:
 ### Fixes
 
 - **General**: Check for missing CRD references and sample CRs ([#5920](https://github.com/kedacore/keda/issues/5920))
+- **General**: Continuous HPA updates with CPU Utilization trigger ([#5821](https://github.com/kedacore/keda/issues/5821))
 - **General**: Scalers are properly closed after being refreshed ([#5806](https://github.com/kedacore/keda/issues/5806))
 - **MongoDB Scaler**:  MongoDB url parses correctly `+srv` scheme ([#5760](https://github.com/kedacore/keda/issues/5760))
 - **New Relic Scaler**: Fix CVE-2024-6104 in github.com/hashicorp/go-retryablehttp ([#5944](https://github.com/kedacore/keda/issues/5944))


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

To address the issue of continuous updates triggered by discrepancies between the ScaledObject and Kubernetes HPA v2 when using CPU utilization triggers, I have implemented a logic similar to the conversion logic used for  HPA v1.

This change ensures that the handling of CPU utilization triggers is consistent and prevents the KEDA operator from continuously detecting differences and updating the HPA. The solution mimics the behavior observed when converting HPA v1, thus maintaining stability and expected behavior within the system.

However, this change may cause discrepancies in the latest version (Kubernetes version >= 1.27) of ScaledObject compared to user expectations. Specifically, when users configure CPU utilization triggers, the generated HPA places the CPU utilization metric last. If multiple CPU utilization triggers are configured, only the first one will take effect.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5821 

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->

