### PR TITLE
fix: e2e test regex check tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ scale-node-pool: az-login ## Scale nodepool.
 
 .PHONY: e2e-regex-check
 e2e-regex-check:
-	go run -tags e2e-regex ./tests/run-all.go regex-check
+	go run -tags e2e ./tests/run-all.go regex-check
 
 .PHONY: e2e-test
 e2e-test: get-cluster-context ## Run e2e tests against Azure cluster.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
https://github.com/kedacore/keda/pull/5783 has introduced validation on e2e trigger regex. In the `Makefile` label, it executes go with invalid tag resulting in failed e2e tests
* https://github.com/kedacore/keda/pull/5804#issuecomment-2134660847
```
$ make e2e-regex-check
go run -tags e2e-regex ./tests/run-all.go regex-check
package command-line-arguments
        imports github.com/kedacore/keda/v2/tests/helper: build constraints exclude all Go files in /home/wozy/projects/go/src/github.com/kedacore/keda/tests/helper
make: *** [Makefile:103: e2e-regex-check] Error
```

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5783 
