### PR TITLE
由于公司业务原因，需要的pod比较多，从0到300花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 由于公司业务原因，需要的pod比较多，从0到300花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩
 
+示例：
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {scaled-object-name}  # ScaledObject 对象的名称
+  annotations:
+    minReplicaCountStart："07:00"    # 可选。代表minReplicaCount的开始时间
+    minReplicaCountEnd: "19:00"      # 可选。代表minReplicaCount的结束时间
+    minReplicaCountStr: "100"        # 可选。代表minReplicaCount的值，注，上面三个值都设置才生效
+spec:
+  scaleTargetRef:
+    其他内容略
+---
 <p align="center"><img src="images/logos/keda-word-colour.png" width="300"/></p>
 <p style="font-size: 25px" align="center"><b>Kubernetes-based Event Driven Autoscaling</b></p>
 <p style="font-size: 25px" align="center">
@@ -24,17 +38,18 @@ We are a Cloud Native Computing Foundation (CNCF) graduated project.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of contents**
 
+- [示例：](#示例)
 - [Getting started](#getting-started)
   - [Deploying KEDA](#deploying-keda)
 - [Documentation](#documentation)
 - [Community](#community)
 - [Adopters - Become a listed KEDA user!](#adopters---become-a-listed-keda-user)
-- [Governance & Policies](#governance--policies)
+- [Governance \& Policies](#governance--policies)
 - [Support](#support)
 - [Roadmap](#roadmap)
 - [Releases](#releases)
 - [Contributing](#contributing)
-  - [Building & deploying locally](#building--deploying-locally)
+  - [Building \& deploying locally](#building--deploying-locally)
   - [Testing strategy](#testing-strategy)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 由于公司业务原因，需要的pod比较多，从0到300花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩  
   
 示例：  
----  
+```
 apiVersion: keda.sh/v1alpha1  
 kind: ScaledObject  
 metadata:  
@@ -13,7 +13,7 @@ metadata:
 spec:  
   scaleTargetRef:  
     其他内容略  
----  
+```
 
 <p align="center"><img src="images/logos/keda-word-colour.png" width="300"/></p>
 <p style="font-size: 25px" align="center"><b>Kubernetes-based Event Driven Autoscaling</b></p>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-由于公司业务原因，需要的pod比较多，从0到300花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩
+由于公司业务原因，需要的pod比较多，从0到300花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩  
+  
+示例：  
+---  
+apiVersion: keda.sh/v1alpha1  
+kind: ScaledObject  
+metadata:  
+  name: {scaled-object-name}  # ScaledObject 对象的名称  
+  annotations:  
+    minReplicaCountStart："07:00"    # 可选。代表minReplicaCount的开始时间  
+    minReplicaCountEnd: "19:00"      # 可选。代表minReplicaCount的结束时间  
+    minReplicaCountStr: "100"        # 可选。代表minReplicaCount的值，注，上面三个值都设置才生效  
+spec:  
+  scaleTargetRef:  
+    其他内容略  
+---  
 
-示例：
----
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: {scaled-object-name}  # ScaledObject 对象的名称
-  annotations:
-    minReplicaCountStart："07:00"    # 可选。代表minReplicaCount的开始时间
-    minReplicaCountEnd: "19:00"      # 可选。代表minReplicaCount的结束时间
-    minReplicaCountStr: "100"        # 可选。代表minReplicaCount的值，注，上面三个值都设置才生效
-spec:
-  scaleTargetRef:
-    其他内容略
----
 <p align="center"><img src="images/logos/keda-word-colour.png" width="300"/></p>
 <p style="font-size: 25px" align="center"><b>Kubernetes-based Event Driven Autoscaling</b></p>
 <p style="font-size: 25px" align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-由于公司业务原因，业务需要的pod比较多，从0到200花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩
+由于公司业务原因，需要的pod比较多，从0到300花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩
 
 <p align="center"><img src="images/logos/keda-word-colour.png" width="300"/></p>
 <p style="font-size: 25px" align="center"><b>Kubernetes-based Event Driven Autoscaling</b></p>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+由于公司业务原因，业务需要的pod比较多，从0到200花费时间太长，所以给柯达增加时间段伸缩功能，晚上的0-100之间伸缩，白天在100-300之间伸缩
+
 <p align="center"><img src="images/logos/keda-word-colour.png" width="300"/></p>
 <p style="font-size: 25px" align="center"><b>Kubernetes-based Event Driven Autoscaling</b></p>
 <p style="font-size: 25px" align="center">

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -167,6 +168,54 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	reqLogger.Info("Reconciling ScaledObject")
+
+    // 解析注释
+    minReplicaCountStart, ok := scaledObject.Annotations["minReplicaCountStart"]
+    minReplicaCountEnd, ook := scaledObject.Annotations["minReplicaCountEnd"]
+    minReplicaCountStr, oook := scaledObject.Annotations["minReplicaCountStr"]
+
+    // 如果三个字段都不为空,才进行后续的处理
+    if ok && ook && oook {
+        var minReplicaCountInt int
+		priMinReplicaCountInt32 := scaledObject.Spec.MinReplicaCount
+        minReplicaCountInt, err = strconv.Atoi(minReplicaCountStr)
+        if err != nil {
+            // 如果 minReplicaCount 格式不正确,返回错误
+            return ctrl.Result{}, err
+        }
+
+        // 检查当前时间是否在指定的时间范围内
+        now := time.Now()
+        startTime, err := time.Parse("15:04", minReplicaCountStart)
+        if err != nil {
+            // 如果 minReplicaCountStart 格式不正确,返回错误
+            return ctrl.Result{}, err
+        }
+        endTime, err := time.Parse("15:04", minReplicaCountEnd)
+        if err != nil {
+            // 如果 minReplicaCountEnd 格式不正确,返回错误
+            return ctrl.Result{}, err
+        }
+        inTimeRange := now.After(startTime.Add(-1 * time.Minute)) && now.Before(endTime.Add(time.Minute))
+
+        // 如果当前时间在指定的时间范围内,并且不相等，更新 ScaledObject 的 MaxReplicaCount 字段
+        if inTimeRange {
+			minReplicaCountInt32 := int32(minReplicaCountInt)
+			if scaledObject.Spec.MinReplicaCount != &minReplicaCountInt32 {
+				scaledObject.Spec.MinReplicaCount = &minReplicaCountInt32
+				err = r.Client.Update(ctx, scaledObject)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+        } else {
+			scaledObject.Spec.MinReplicaCount = priMinReplicaCountInt32
+			err = r.Client.Update(ctx, scaledObject)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+    }
 
 	// Check if the ScaledObject instance is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -177,7 +177,7 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
     // 如果三个字段都不为空,才进行后续的处理
     if ok && ook && oook {
         var minReplicaCountInt int
-		priMinReplicaCountInt32 := scaledObject.Spec.MinReplicaCount
+	priMinReplicaCountInt32 := scaledObject.Spec.MinReplicaCount
         minReplicaCountInt, err = strconv.Atoi(minReplicaCountStr)
         if err != nil {
             // 如果 minReplicaCount 格式不正确,返回错误
@@ -200,21 +200,23 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
         // 如果当前时间在指定的时间范围内,并且不相等，更新 ScaledObject 的 MaxReplicaCount 字段
         if inTimeRange {
-			minReplicaCountInt32 := int32(minReplicaCountInt)
-			if scaledObject.Spec.MinReplicaCount != &minReplicaCountInt32 {
-				scaledObject.Spec.MinReplicaCount = &minReplicaCountInt32
-				err = r.Client.Update(ctx, scaledObject)
-				if err != nil {
-					return ctrl.Result{}, err
-				}
+		minReplicaCountInt32 := int32(minReplicaCountInt)
+		if scaledObject.Spec.MinReplicaCount != &minReplicaCountInt32 {
+			scaledObject.Spec.MinReplicaCount = &minReplicaCountInt32
+			err = r.Client.Update(ctx, scaledObject)
+			if err != nil {
+				return ctrl.Result{}, err
 			}
+		}
         } else {
+		if scaledObject.Spec.MinReplicaCount != priMinReplicaCountInt32 {
 			scaledObject.Spec.MinReplicaCount = priMinReplicaCountInt32
 			err = r.Client.Update(ctx, scaledObject)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 		}
+	}
     }
 
 	// Check if the ScaledObject instance is marked to be deleted, which is


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
