### PR TITLE
Update GetAzureQueueLength in azure queue scaler, to support different queue length strategies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Here is an overview of all new **experimental** features:
 
 ### Improvements
 
+- **Azure queue scaler**: Added new configuration option 'queueLengthStrategy' ([#4478](https://github.com/kedacore/keda/issues/4478))
 - **Cassandra Scaler**: Add TLS support for cassandra scaler ([#5802](https://github.com/kedacore/keda/issues/5802))
 - **GCP Pub/Sub**: Add optional valueIfNull to allow a default scaling value and prevent errors when GCP metric returns no value. ([#5896](https://github.com/kedacore/keda/issues/5896))
 - **GCP Scalers**: Added custom time horizon in GCP scalers ([#5778](https://github.com/kedacore/keda/issues/5778))


### PR DESCRIPTION
This PR is an attempt to solve https://github.com/kedacore/keda/issues/4478

It adds a new configuration option `queueLengthStrategy` to the Azure Storage Queue scaler, where you can set the value of `default` or `visibleonly`.

`default`: Considers both visible and invisible messages.
`visibleonly`: Uses Peek to count only visible messages. If the count of visible messages is 32 or higher, it falls back to the default strategy, counting both visible and invisible messages.

`visibleonly` will, in practice, use the previous behaviour, as before https://github.com/kedacore/keda/pull/4003 was merged.

Docs PR: https://github.com/kedacore/keda-docs/pull/1406.

I've created this change to the best of my ability. However, it hasn't been tested. I would appreciate if someone could help with testing, or giving directions on how to test.

Thanks!