### PR TITLE
remove kustomize commonLabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 - **General**: Add --ca-dir flag to KEDA operator to specify directories with CA certificates for scalers to authenticate TLS connections (defaults to /custom/ca) ([#5860](https://github.com/kedacore/keda/issues/5860))
 - **General**: Declarative parsing of scaler config ([#5037](https://github.com/kedacore/keda/issues/5037)|[#5797](https://github.com/kedacore/keda/issues/5797))
+- **General**: Remove deprecated Kustomize commonLabels ([#5888](https://github.com/kedacore/keda/pull/5888))
 - **General**: Support for Kubernetes v1.30 ([#5828](https://github.com/kedacore/keda/issues/5828))
 
 #### Experimental

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,10 @@
 #namePrefix: keda-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+# labels:
+#   - pairs:
+#       someName: someValue
+#     includeSelectors: true
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/minimal/kustomization.yaml
+++ b/config/minimal/kustomization.yaml
@@ -9,8 +9,10 @@
 #namePrefix: keda-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+# labels:
+#   - pairs:
+#       someName: someValue
+#     includeSelectors: true
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,8 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  app.kubernetes.io/name: keda-operator
-  app.kubernetes.io/part-of: keda-operator
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: keda-operator
+      app.kubernetes.io/part-of: keda-operator
+    includeSelectors: true
 
 resources:
 - role.yaml


### PR DESCRIPTION
Signed-off-by: Daniel Wright <dan@dwright.io>

Remove `commonLabels` in favour of the more modern kustomize approach.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #5887

