### PR TITLE
Add additional manifest checks to detect missing CRDs & CRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,11 +19,15 @@ jobs:
         - runner: ubuntu-latest
           name: amd64
     steps:
-
       - name: Check out code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 1
+
+      - name: Install prerequisites
+        run: |
+          apt-get update
+          apt-get install -y jq python3-yaml
 
       - name: Register workspace path
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **General**: Check for missing CRD references and sample CRs ([#5920](https://github.com/kedacore/keda/issues/5920))
 - **General**: Scalers are properly closed after being refreshed ([#5806](https://github.com/kedacore/keda/issues/5806))
 - **MongoDB Scaler**:  MongoDB url parses correctly `+srv` scheme ([#5760](https://github.com/kedacore/keda/issues/5760))
 

--- a/config/samples/keda_v1alpha1_clustertriggerauthentication.yaml
+++ b/config/samples/keda_v1alpha1_clustertriggerauthentication.yaml
@@ -1,0 +1,9 @@
+apiVersion: keda.sh/v1alpha1
+kind: ClusterTriggerAuthentication
+metadata:
+  name: example-clustertriggerauthentication
+spec:
+  secretTargetRef:
+    - parameter: example-secret-parameter
+      name: example-secret-name
+      key: example-role-key

--- a/config/samples/keda_v1alpha1_triggerauthentication.yaml
+++ b/config/samples/keda_v1alpha1_triggerauthentication.yaml
@@ -1,4 +1,4 @@
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: example-triggerauthentication

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,7 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
+- eventing_v1alpha1_cloudeventsource.yaml
+- keda_v1alpha1_clustertriggerauthentication.yaml
 - keda_v1alpha1_scaledobject.yaml
 - keda_v1alpha1_scaledjob.yaml
 - keda_v1alpha1_triggerauthentication.yaml


### PR DESCRIPTION
This PR has three parts:
1. Add additional PR checks to make sure that every CRD is listed in the CRD `kustomize.yaml` file and that every CRD also has a sample CR for each of its API versions and is similarly listed in the `kustomize.yaml` file for sample CR files.
2. Add missing sample CRs, CRDs and references.
3. Update existing sample CR for `triggerauthentication` which had the old API group of `keda.k8s.io` instead of the new `keda.sh`

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #5920