### PR TITLE
Return the error if TLS config fails in Rabbitmq scaler

### DIFF
--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -454,9 +454,10 @@ func getConnectionAndChannel(host string, meta *rabbitMQMetadata) (*amqp.Connect
 	var err error
 	if meta.enableTLS {
 		tlsConfig, configErr := kedautil.NewTLSConfigWithPassword(meta.cert, meta.key, meta.keyPassword, meta.ca, meta.unsafeSsl)
-		if configErr == nil {
-			conn, err = amqp.DialTLS(host, tlsConfig)
+		if configErr != nil {
+			return nil, nil, configErr
 		}
+		conn, err = amqp.DialTLS(host, tlsConfig)
 	} else {
 		conn, err = amqp.Dial(host)
 	}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

It should return the error if the TLS configuration returns an error, to prevent further nil pointer dereference on the `conn` variable.

