### PR TITLE
Add missing TestNamespace to ScaledJob validation test template

### DIFF
--- a/tests/internals/scaled_job_validation/scaled_job_validation_test.go
+++ b/tests/internals/scaled_job_validation/scaled_job_validation_test.go
@@ -32,6 +32,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
   name: {{.EmptyTriggersSjName}}
+  namespace: {{.TestNamespace}}
 spec:
   jobTargetRef:
     template:


### PR DESCRIPTION
This scaledjob test template was missing its namespace.
- It doesn't generally matter for the test -- the test is just checking if the webhook works. It doesn't care where the scaledjob ends up
- It _does_ matter though if you run this test in a more restrictive environment where you can't write to the default namespace  --  it fails with a namespace-related creation error instead of the expected _no triggers defined in the ScaledObject/ScaledJob_ error 

This just adds the namespace to the template so it's consistent with the other ones in the test suite.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

