### PR TITLE
Remove deprecated cortexOrgId in prometheus scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ Here is an overview of all new **experimental** features:
 
 ### Deprecations
 
-You can find all deprecations in [this overview](https://github.com/kedacore/keda/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Abreaking-change) and [join the discussion here](https://github.com/kedacore/keda/discussions/categories/deprecations).
+- **Prometheus Scaler**: Remove deprecated field `cortexOrgID` from Prometheus scaler ([#5538](https://github.com/kedacore/keda/issues/5538))
 
 New deprecation(s):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,11 +94,13 @@ Here is an overview of all new **experimental** features:
 
 ### Deprecations
 
-- **Prometheus Scaler**: Remove deprecated field `cortexOrgID` from Prometheus scaler ([#5538](https://github.com/kedacore/keda/issues/5538))
-
 New deprecation(s):
 
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+
+### Breaking Changes
+
+- **Prometheus Scaler**: Remove deprecated field `cortexOrgID` from Prometheus scaler ([#5538](https://github.com/kedacore/keda/issues/5538))
 
 ### Other
 

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -32,7 +32,6 @@ const (
 	promThreshold           = "threshold"
 	promActivationThreshold = "activationThreshold"
 	promNamespace           = "namespace"
-	promCortexScopeOrgID    = "cortexOrgID"
 	promCustomHeaders       = "customHeaders"
 	ignoreNullValues        = "ignoreNullValues"
 	unsafeSsl               = "unsafeSsl"
@@ -62,9 +61,6 @@ type prometheusMetadata struct {
 	CustomHeaders       map[string]string      `keda:"name=customHeaders,       order=triggerMetadata, optional"`
 	IgnoreNullValues    bool                   `keda:"name=ignoreNullValues,    order=triggerMetadata, optional, default=true"`
 	UnsafeSSL           bool                   `keda:"name=unsafeSsl,           order=triggerMetadata, optional"`
-
-	// deprecated
-	CortexOrgID string `keda:"name=cortexOrgID, order=triggerMetadata, optional, deprecated=use customHeaders instead"`
 }
 
 type promQueryResult struct {

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -60,8 +60,6 @@ var testPromMetadata = []parsePrometheusMetadataTestData{
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "customHeaders": "key1=value1,key2=value2"}, false},
 	// customHeaders with wrong format
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "customHeaders": "key1=value1,key2"}, true},
-	// deprecated cortexOrgID
-	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "cortexOrgID": "my-org"}, true},
 	// queryParameters
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "queryParameters": "key1=value1,key2=value2"}, false},
 	// queryParameters with wrong format
@@ -174,7 +172,7 @@ func TestPrometheusScalerAuthParams(t *testing.T) {
 	}
 }
 
-type prometheusQromQueryResultTestData struct {
+type prometheusPromQueryResultTestData struct {
 	name             string
 	bodyStr          string
 	responseStatus   int
@@ -184,7 +182,7 @@ type prometheusQromQueryResultTestData struct {
 	unsafeSsl        bool
 }
 
-var testPromQueryResult = []prometheusQromQueryResultTestData{
+var testPromQueryResult = []prometheusPromQueryResultTestData{
 	{
 		name:             "no results",
 		bodyStr:          `{}`,
@@ -339,7 +337,7 @@ func TestPrometheusScalerExecutePromQuery(t *testing.T) {
 }
 
 func TestPrometheusScalerCustomHeaders(t *testing.T) {
-	testData := prometheusQromQueryResultTestData{
+	testData := prometheusPromQueryResultTestData{
 		name:             "no values",
 		bodyStr:          `{"data":{"result":[]}}`,
 		responseStatus:   http.StatusOK,
@@ -379,7 +377,7 @@ func TestPrometheusScalerCustomHeaders(t *testing.T) {
 }
 
 func TestPrometheusScalerExecutePromQueryParameters(t *testing.T) {
-	testData := prometheusQromQueryResultTestData{
+	testData := prometheusPromQueryResultTestData{
 		name:             "no values",
 		bodyStr:          `{"data":{"result":[]}}`,
 		responseStatus:   http.StatusOK,


### PR DESCRIPTION



_Provide a description of what has been changed_

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/5538

