### PR TITLE
fix: Jetstream e2e test uses the right config value

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/kedacore/keda/v2/pkg/generated/clientset/versioned/typed/keda/v1alpha1"
@@ -744,7 +745,9 @@ func FindPodLogs(kc *kubernetes.Clientset, namespace, label string, includePrevi
 // Delete all pods in namespace by selector
 func DeletePodsInNamespaceBySelector(t *testing.T, kc *kubernetes.Clientset, selector, namespace string) {
 	t.Logf("killing all pods in %s namespace with selector %s", namespace, selector)
-	err := kc.CoreV1().Pods(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{
+	err := kc.CoreV1().Pods(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{
+		GracePeriodSeconds: ptr.To(int64(0)),
+	}, metav1.ListOptions{
 		LabelSelector: selector,
 	})
 	assert.NoErrorf(t, err, "cannot delete pods - %s", err)

--- a/tests/scalers/nats_jetstream/nats_jetstream_cluster/nats_jetstream_cluster_test.go
+++ b/tests/scalers/nats_jetstream/nats_jetstream_cluster/nats_jetstream_cluster_test.go
@@ -171,6 +171,7 @@ func removeStreamAndConsumer(t *testing.T, streamReplicas int, stream, namespace
 
 // installClusterWithJetStream install the nats helm chart with clustered jetstream enabled
 func installClusterWithJetStream(t *testing.T, kc *k8s.Clientset, noAdvertise bool) {
+	removeNATSPods(t)
 	CreateNamespace(t, kc, natsNamespace)
 	_, err := ExecuteCommand(fmt.Sprintf("helm repo add %s %s", nats.NatsJetStreamName, natsHelmRepo))
 	require.NoErrorf(t, err, "cannot execute command - %s", err)
@@ -190,6 +191,7 @@ func installClusterWithJetStream(t *testing.T, kc *k8s.Clientset, noAdvertise bo
 
 // installClusterWithJetStreaV2_10 install the nats helm chart with clustered jetstream enabled using v2.10
 func installClusterWithJetStreaV2_10(t *testing.T, kc *k8s.Clientset) {
+	removeNATSPods(t)
 	CreateNamespace(t, kc, natsNamespace)
 	_, err := ExecuteCommand(fmt.Sprintf("helm repo add %s %s", nats.NatsJetStreamName, natsHelmRepo))
 	require.NoErrorf(t, err, "cannot execute command - %s", err)
@@ -213,6 +215,13 @@ func installClusterWithJetStreaV2_10(t *testing.T, kc *k8s.Clientset) {
 func removeClusterWithJetStream(t *testing.T) {
 	_, err := ExecuteCommand(fmt.Sprintf(`helm uninstall --wait --namespace %s %s`, natsNamespace, nats.NatsJetStreamName))
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+	removeNATSPods(t)
+}
+
+// removeNATSPods delete the server pods in case they're stuck
+func removeNATSPods(t *testing.T) {
+	DeletePodsInNamespaceBySelector(t, KubeClient, "app.kubernetes.io/name=nats", natsNamespace)
+	assert.True(t, WaitForPodCountInNamespace(t, KubeClient, natsNamespace, 0, 30, 2))
 }
 
 func testActivation(t *testing.T, kc *k8s.Clientset, data nats.JetStreamDeploymentTemplateData) {

--- a/tests/scalers/nats_jetstream/nats_jetstream_cluster/nats_jetstream_cluster_test.go
+++ b/tests/scalers/nats_jetstream/nats_jetstream_cluster/nats_jetstream_cluster_test.go
@@ -198,7 +198,7 @@ func installClusterWithJetStreaV2_10(t *testing.T, kc *k8s.Clientset) {
 	_, err = ExecuteCommand(fmt.Sprintf(`helm upgrade --install --version %s --set %s --set %s --set %s --set %s --set %s --set %s --set %s --wait --namespace %s %s nats/nats`,
 		nats.Natsv2_10JetStreamChartVersion,
 		"config.jetstream.enabled=true",
-		"config.jetstream.fileStorage.enabled=false",
+		"config.jetstream.fileStore.enabled=false",
 		"config.jetstream.memoryStore.enabled=true",
 		"config.cluster.enabled=true",
 		"service.enabled=true",


### PR DESCRIPTION
### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
