### PR TITLE
fix: Hashicorp Vault PKI doesn't fail with due to KeyPair mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **General**: Hashicorp Vault PKI doesn't fail with due to KeyPair mismatch ([#6028](https://github.com/kedacore/keda/issues/6028))
 
 ### Deprecations
 

--- a/pkg/scaling/resolver/hashicorpvault_handler.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler.go
@@ -277,7 +277,7 @@ func (vh *HashicorpVaultHandler) getSecretValue(secret *kedav1alpha1.VaultSecret
 type SecretGroup struct {
 	path         string
 	secretType   kedav1alpha1.VaultSecretType
-	vaultPkiData *kedav1alpha1.VaultPkiData
+	vaultPkiData kedav1alpha1.VaultPkiData
 }
 
 // fetchSecret returns the vaultSecret at a given vault path. If the secret is a pki, then the secret will use the
@@ -314,7 +314,7 @@ func (vh *HashicorpVaultHandler) ResolveSecrets(secrets []kedav1alpha1.VaultSecr
 	grouped := make(map[SecretGroup][]kedav1alpha1.VaultSecret)
 	vaultSecrets := make(map[SecretGroup]*vaultapi.Secret)
 	for _, e := range secrets {
-		group := SecretGroup{secretType: e.Type, path: e.Path, vaultPkiData: &e.PkiData}
+		group := SecretGroup{secretType: e.Type, path: e.Path, vaultPkiData: e.PkiData}
 		if _, ok := grouped[group]; !ok {
 			grouped[group] = make([]kedav1alpha1.VaultSecret, 0)
 		}
@@ -322,7 +322,7 @@ func (vh *HashicorpVaultHandler) ResolveSecrets(secrets []kedav1alpha1.VaultSecr
 	}
 	// For each group fetch the secret from vault
 	for group := range grouped {
-		vaultSecret, err := vh.fetchSecret(group.secretType, group.path, group.vaultPkiData)
+		vaultSecret, err := vh.fetchSecret(group.secretType, group.path, &group.vaultPkiData)
 		if err != nil {
 			// could not fetch secret, skipping group
 			continue


### PR DESCRIPTION
Read the issue to get the full context 😄 

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/6028


