### PR TITLE
chore: golangci-lint: `run.skip-dirs` is deprecated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,9 +7,6 @@ run:
   - e2e
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m
-  # skip vendor directory
-  skip-dirs:
-    - vendor
   modules-download-mode: vendor
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
@@ -49,6 +46,9 @@ linters:
 issues:
   include:
   - EXC0002 # disable excluding of issues about comments from golint
+  exclude-dirs:
+    # skip vendor directory
+    - vendor
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: _test\.go


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

```
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. 
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

