### PR TITLE
chore: Use CNCF runner for e2e tests

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -146,7 +146,7 @@ jobs:
 
   run-test:
     needs: [triage, build-test-images]
-    runs-on: e2e
+    runs-on: equinix-keda-runner
     name: Execute e2e tests
     container: ghcr.io/kedacore/keda-tools:1.22.5
     if: needs.triage.outputs.run-e2e == 'true'


### PR DESCRIPTION

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
