### PR TITLE
refactor: Simplify cron scaler code

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -60,7 +60,7 @@ jobs:
         run: make clientset-verify
 
       - name: Verify generated Manifests are up to date
-        run: make verify-manifests
+        run: rm -f bin/controller-gen && make verify-manifests
 
       - name: Build
         run: make build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ New deprecation(s):
 
 ### Other
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **Cron Scaler**: Simplify code to determine next start and stop times ([#6056](https://github.com/kedacore/keda/pull/6056))
 
 ## v2.15.1
 


### PR DESCRIPTION
The current cron scaler code creates a cron object and starts it (which creates a goroutine and a lot of data to manage a cron engine) just so that it can find the next activation time. It also re-parses the cron strings on each iteration. This update only parses on creation of the trigger, then uses the cron schedule object directly to get the next activation time.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))