### PR TITLE
fix: Do not disable fallback if the metric type is not explicitly configured

### DIFF
--- a/pkg/fallback/fallback.go
+++ b/pkg/fallback/fallback.go
@@ -29,6 +29,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/scalers"
 )
 
 var log = logf.Log.WithName("fallback")
@@ -38,7 +39,8 @@ func isFallbackEnabled(scaledObject *kedav1alpha1.ScaledObject, metricSpec v2.Me
 		return false
 	}
 
-	if metricSpec.External.Target.Type != v2.AverageValueMetricType {
+	metricType := scalers.GetMetricTargetTypeOrDefault(metricSpec.External.Target.Type)
+	if metricType != v2.AverageValueMetricType {
 		log.V(0).Info("Fallback can only be enabled for triggers with metric of type AverageValue", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
 		return false
 	}

--- a/pkg/fallback/fallback_test.go
+++ b/pkg/fallback/fallback_test.go
@@ -234,6 +234,28 @@ var _ = Describe("fallback", func() {
 		Expect(isEnabled).Should(BeFalse())
 	})
 
+	It("should behave as if fallback is enabled when the metrics spec target type is not explicitly declared", func() {
+		so := buildScaledObject(
+			&kedav1alpha1.Fallback{
+				FailureThreshold: int32(3),
+				Replicas:         int32(10),
+			}, nil,
+		)
+
+		qty := resource.NewQuantity(int64(3), resource.DecimalSI)
+		metricsSpec := v2.MetricSpec{
+			External: &v2.ExternalMetricSource{
+				Target: v2.MetricTarget{
+					Type:  "",
+					Value: qty,
+				},
+			},
+		}
+
+		isEnabled := isFallbackEnabled(so, metricsSpec)
+		Expect(isEnabled).Should(BeTrue())
+	})
+
 	It("should ignore error if we fail to update kubernetes status", func() {
 		scaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Eq(metricName)).Return(nil, false, errors.New("some error"))
 		startingNumberOfFailures := int32(3)

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -115,12 +115,19 @@ func GetMetricTargetType(config *scalersconfig.ScalerConfig) (v2.MetricTargetTyp
 	switch config.MetricType {
 	case v2.UtilizationMetricType:
 		return "", ErrScalerUnsupportedUtilizationMetricType
-	case "":
-		// Use AverageValue if no metric type was provided
-		return v2.AverageValueMetricType, nil
 	default:
-		return config.MetricType, nil
+		return GetMetricTargetTypeOrDefault(config.MetricType), nil
 	}
+}
+
+// GetMetricTargetTypeOrDefault helps get the metric target type of the scaler or return AverageValue if not provided
+func GetMetricTargetTypeOrDefault(metricType v2.MetricTargetType) v2.MetricTargetType {
+	if metricType == "" {
+		// Use AverageValue if no metric type was provided
+		return v2.AverageValueMetricType
+	}
+
+	return metricType
 }
 
 // GetMetricTarget returns a metric target for a valid given metric target type (Value or AverageValue) and value


### PR DESCRIPTION
The fallback mechanism should only work if the metric type is `AverageValue`, which is the default (according to the [docs](https://keda.sh/docs/2.14/concepts/scaling-deployments/#triggers)). 

Problem is, if you do not explicitly declare the metric type, KEDA prints the following error and disables the fallback mechanism:

> `2024-08-02T15:01:04Z	ERROR	scaledobject-validation-webhook	validation error	{"name": "foo", "error": "MetricType=, but Fallback can only be enabled for triggers with metric of type AverageValue"}`

This PR fixes this by checking if the metric type is empty, in which case it's evaluated as `AverageValue`.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
