### PR TITLE
Pulsar: remove deprecated trigger name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ New deprecation(s):
 
 ### Breaking Changes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- Pulsar: remove `msgBacklog` trigger name #6059
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ New deprecation(s):
 
 ### Breaking Changes
 
-- Pulsar: remove `msgBacklog` trigger name #6059
+- **Pulsar Scaler**: remove `msgBacklog` trigger name ([#6059](https://github.com/kedacore/keda/issues/6059))
 
 ### Other
 

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -132,7 +132,7 @@ func NewPulsarScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	}, nil
 }
 
-func parsePulsarMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) (pulsarMetadata, error) {
+func parsePulsarMetadata(config *scalersconfig.ScalerConfig, _ logr.Logger) (pulsarMetadata, error) {
 	meta := pulsarMetadata{}
 	switch {
 	case config.TriggerMetadata["adminURLFromEnv"] != "":

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -43,7 +43,6 @@ type pulsarMetadata struct {
 }
 
 const (
-	msgBacklogMetricName       = "msgBacklog"
 	pulsarMetricType           = "External"
 	defaultMsgBacklogThreshold = 10
 	enable                     = "enable"
@@ -182,23 +181,13 @@ func parsePulsarMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger)
 
 	meta.msgBacklogThreshold = defaultMsgBacklogThreshold
 
-	// FIXME: msgBacklog support DEPRECATED to be removed in v2.14
-	fmt.Println(config.TriggerMetadata)
-	if val, ok := config.TriggerMetadata[msgBacklogMetricName]; ok {
-		logger.V(1).Info("\"msgBacklog\" is deprecated and will be removed in v2.14, please use \"msgBacklogThreshold\" instead")
+	if val, ok := config.TriggerMetadata["msgBacklogThreshold"]; ok {
 		t, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
-			return meta, fmt.Errorf("error parsing %s: %w", msgBacklogMetricName, err)
-		}
-		meta.msgBacklogThreshold = t
-	} else if val, ok := config.TriggerMetadata["msgBacklogThreshold"]; ok {
-		t, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return meta, fmt.Errorf("error parsing %s: %w", msgBacklogMetricName, err)
+			return meta, fmt.Errorf("error parsing %s: %w", "msgBacklogThreshold", err)
 		}
 		meta.msgBacklogThreshold = t
 	}
-	// END FIXME
 
 	// For backwards compatibility, we need to map "tls: enable" to
 	if tls, ok := config.TriggerMetadata["tls"]; ok {
@@ -212,7 +201,7 @@ func parsePulsarMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger)
 	}
 	auth, err := authentication.GetAuthConfigs(config.TriggerMetadata, config.AuthParams)
 	if err != nil {
-		return meta, fmt.Errorf("error parsing %s: %w", msgBacklogMetricName, err)
+		return meta, fmt.Errorf("error parsing %s: %w", "msgBacklogThreshold", err)
 	}
 
 	if auth != nil && auth.EnableOAuth {

--- a/pkg/scalers/pulsar_scaler_test.go
+++ b/pkg/scalers/pulsar_scaler_test.go
@@ -156,14 +156,7 @@ func TestParsePulsarMetadata(t *testing.T) {
 		}
 
 		var testDataMsgBacklogThreshold int64
-		// FIXME: msgBacklog support DEPRECATED to be removed in v2.14
-		if val, ok := testData.metadata["msgBacklog"]; ok {
-			testDataMsgBacklogThreshold, err = strconv.ParseInt(val, 10, 64)
-			if err != nil {
-				t.Errorf("error parseing msgBacklog: %v", err)
-			}
-			// END FiXME
-		} else if val, ok := testData.metadata["msgBacklogThreshold"]; ok {
+		if val, ok := testData.metadata["msgBacklogThreshold"]; ok {
 			testDataMsgBacklogThreshold, err = strconv.ParseInt(val, 10, 64)
 			if err != nil {
 				t.Errorf("error parseing msgBacklogThreshold: %v", err)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This commit removes the deprecated trigger name `msgBacklog` in Pulsar scaler. `msgBacklogThreshold` should be used instead.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6059
(The original issue was intended to introduce a scaler to non-persistent Pulsar topics. But after some research, I found out that the proposed metric is infeasible)
<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
