### PR TITLE
WIP: Refactor elasticsearch scaler config

### DIFF
--- a/pkg/scalers/elasticsearch_scaler.go
+++ b/pkg/scalers/elasticsearch_scaler.go
@@ -27,15 +27,15 @@ type elasticsearchScaler struct {
 }
 
 type elasticsearchMetadata struct {
-	Addresses             []string `keda:"name=address;addresses,     order=authParams;triggerMetadata, optional"`
+	Addresses             []string `keda:"name=address,               order=authParams;triggerMetadata, optional"`
 	UnsafeSsl             bool     `keda:"name=unsafeSsl,             order=triggerMetadata, default=false"`
 	Username              string   `keda:"name=username,              order=authParams;triggerMetadata, optional"`
 	Password              string   `keda:"name=password,              order=authParams;resolvedEnv;triggerMetadata, optional"`
 	CloudID               string   `keda:"name=cloudID,               order=authParams;triggerMetadata, optional"`
 	APIKey                string   `keda:"name=apiKey,                order=authParams;triggerMetadata, optional"`
-	Indexes               []string `keda:"name=index;indexes,         order=authParams;triggerMetadata"`
+	Index                 []string `keda:"name=index,                 order=authParams;triggerMetadata"`
 	SearchTemplateName    string   `keda:"name=searchTemplateName,    order=authParams;triggerMetadata"`
-	Parameters            []string `keda:"name=parameter;parameters,  order=triggerMetadata, optional"`
+	Parameters            []string `keda:"name=parameters,            order=triggerMetadata, optional"`
 	ValueLocation         string   `keda:"name=valueLocation,         order=authParams;triggerMetadata"`
 	TargetValue           float64  `keda:"name=targetValue,           order=authParams;triggerMetadata"`
 	ActivationTargetValue float64  `keda:"name=activationTargetValue, order=triggerMetadata, default=0"`
@@ -50,6 +50,9 @@ func (m *elasticsearchMetadata) Validate() error {
 	}
 	if (m.CloudID == "" && m.APIKey == "") && (len(m.Addresses) == 0 && m.Username == "" && m.Password == "") {
 		return fmt.Errorf("must provide either cloud config or endpoint addresses")
+	}
+	if (m.CloudID != "" && m.APIKey == "") || (m.CloudID == "" && m.APIKey != "") {
+		return fmt.Errorf("both cloudID and apiKey must be provided when cloudID or apiKey is used")
 	}
 	return nil
 }

--- a/pkg/scalers/elasticsearch_scaler.go
+++ b/pkg/scalers/elasticsearch_scaler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -22,28 +21,39 @@ import (
 
 type elasticsearchScaler struct {
 	metricType v2.MetricTargetType
-	metadata   *elasticsearchMetadata
+	metadata   elasticsearchMetadata
 	esClient   *elasticsearch.Client
 	logger     logr.Logger
 }
 
 type elasticsearchMetadata struct {
-	addresses             []string
-	unsafeSsl             bool
-	username              string
-	password              string
-	cloudID               string
-	apiKey                string
-	indexes               []string
-	searchTemplateName    string
-	parameters            []string
-	valueLocation         string
-	targetValue           float64
-	activationTargetValue float64
-	metricName            string
+	Addresses             []string `keda:"name=address;addresses,     order=authParams;triggerMetadata, optional"`
+	UnsafeSsl             bool     `keda:"name=unsafeSsl,             order=triggerMetadata, default=false"`
+	Username              string   `keda:"name=username,              order=authParams;triggerMetadata, optional"`
+	Password              string   `keda:"name=password,              order=authParams;resolvedEnv;triggerMetadata, optional"`
+	CloudID               string   `keda:"name=cloudID,               order=authParams;triggerMetadata, optional"`
+	APIKey                string   `keda:"name=apiKey,                order=authParams;triggerMetadata, optional"`
+	Indexes               []string `keda:"name=index;indexes,         order=authParams;triggerMetadata"`
+	SearchTemplateName    string   `keda:"name=searchTemplateName,    order=authParams;triggerMetadata"`
+	Parameters            []string `keda:"name=parameter;parameters,  order=triggerMetadata, optional"`
+	ValueLocation         string   `keda:"name=valueLocation,         order=authParams;triggerMetadata"`
+	TargetValue           float64  `keda:"name=targetValue,           order=authParams;triggerMetadata"`
+	ActivationTargetValue float64  `keda:"name=activationTargetValue, order=triggerMetadata, default=0"`
+	MetricName            string   `keda:"name=metricName,            order=triggerMetadata, optional"`
+
+	TriggerIndex int
 }
 
-// NewElasticsearchScaler creates a new elasticsearch scaler
+func (m *elasticsearchMetadata) Validate() error {
+	if (m.CloudID != "" || m.APIKey != "") && (len(m.Addresses) > 0 || m.Username != "" || m.Password != "") {
+		return fmt.Errorf("can't provide both cloud config and endpoint addresses")
+	}
+	if (m.CloudID == "" && m.APIKey == "") && (len(m.Addresses) == 0 && m.Username == "" && m.Password == "") {
+		return fmt.Errorf("must provide either cloud config or endpoint addresses")
+	}
+	return nil
+}
+
 func NewElasticsearchScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	metricType, err := GetMetricTargetType(config)
 	if err != nil {
@@ -69,184 +79,37 @@ func NewElasticsearchScaler(config *scalersconfig.ScalerConfig) (Scaler, error) 
 	}, nil
 }
 
-const defaultUnsafeSsl = false
-
-func hasCloudConfig(meta *elasticsearchMetadata) bool {
-	if meta.cloudID != "" {
-		return true
-	}
-	if meta.apiKey != "" {
-		return true
-	}
-	return false
-}
-
-func hasEndpointsConfig(meta *elasticsearchMetadata) bool {
-	if len(meta.addresses) > 0 {
-		return true
-	}
-	if meta.username != "" {
-		return true
-	}
-	if meta.password != "" {
-		return true
-	}
-	return false
-}
-
-func extractEndpointsConfig(config *scalersconfig.ScalerConfig, meta *elasticsearchMetadata) error {
-	addresses, err := GetFromAuthOrMeta(config, "addresses")
-	if err != nil {
-		return err
-	}
-
-	meta.addresses = splitAndTrimBySep(addresses, ",")
-	if val, ok := config.AuthParams["username"]; ok {
-		meta.username = val
-	} else if val, ok := config.TriggerMetadata["username"]; ok {
-		meta.username = val
-	}
-
-	if config.AuthParams["password"] != "" {
-		meta.password = config.AuthParams["password"]
-	} else if config.TriggerMetadata["passwordFromEnv"] != "" {
-		meta.password = config.ResolvedEnv[config.TriggerMetadata["passwordFromEnv"]]
-	}
-
-	return nil
-}
-
-func extractCloudConfig(config *scalersconfig.ScalerConfig, meta *elasticsearchMetadata) error {
-	cloudID, err := GetFromAuthOrMeta(config, "cloudID")
-	if err != nil {
-		return err
-	}
-	meta.cloudID = cloudID
-
-	apiKey, err := GetFromAuthOrMeta(config, "apiKey")
-	if err != nil {
-		return err
-	}
-	meta.apiKey = apiKey
-	return nil
-}
-
-var (
-	// ErrElasticsearchMissingAddressesOrCloudConfig is returned when endpoint addresses or cloud config is missing.
-	ErrElasticsearchMissingAddressesOrCloudConfig = errors.New("must provide either endpoint addresses or cloud config")
-
-	// ErrElasticsearchConfigConflict is returned when both endpoint addresses and cloud config are provided.
-	ErrElasticsearchConfigConflict = errors.New("can't provide endpoint addresses and cloud config at the same time")
-)
-
-func parseElasticsearchMetadata(config *scalersconfig.ScalerConfig) (*elasticsearchMetadata, error) {
+func parseElasticsearchMetadata(config *scalersconfig.ScalerConfig) (elasticsearchMetadata, error) {
 	meta := elasticsearchMetadata{}
+	err := config.TypedConfig(&meta)
 
-	var err error
-	addresses, err := GetFromAuthOrMeta(config, "addresses")
-	cloudID, errCloudConfig := GetFromAuthOrMeta(config, "cloudID")
-	if err != nil && errCloudConfig != nil {
-		return nil, ErrElasticsearchMissingAddressesOrCloudConfig
-	}
-
-	if err == nil && addresses != "" {
-		err = extractEndpointsConfig(config, &meta)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if errCloudConfig == nil && cloudID != "" {
-		err = extractCloudConfig(config, &meta)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if hasEndpointsConfig(&meta) && hasCloudConfig(&meta) {
-		return nil, ErrElasticsearchConfigConflict
-	}
-
-	if val, ok := config.TriggerMetadata["unsafeSsl"]; ok {
-		unsafeSsl, err := strconv.ParseBool(val)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing unsafeSsl: %w", err)
-		}
-		meta.unsafeSsl = unsafeSsl
-	} else {
-		meta.unsafeSsl = defaultUnsafeSsl
-	}
-
-	index, err := GetFromAuthOrMeta(config, "index")
 	if err != nil {
-		return nil, err
-	}
-	meta.indexes = splitAndTrimBySep(index, ";")
-
-	searchTemplateName, err := GetFromAuthOrMeta(config, "searchTemplateName")
-	if err != nil {
-		return nil, err
-	}
-	meta.searchTemplateName = searchTemplateName
-
-	if val, ok := config.TriggerMetadata["parameters"]; ok {
-		meta.parameters = splitAndTrimBySep(val, ";")
+		return meta, err
 	}
 
-	valueLocation, err := GetFromAuthOrMeta(config, "valueLocation")
-	if err != nil {
-		return nil, err
-	}
-	meta.valueLocation = valueLocation
+	meta.MetricName = GenerateMetricNameWithIndex(config.TriggerIndex, util.NormalizeString(fmt.Sprintf("elasticsearch-%s", meta.SearchTemplateName)))
+	meta.TriggerIndex = config.TriggerIndex
 
-	targetValueString, err := GetFromAuthOrMeta(config, "targetValue")
-	if err != nil {
-		if config.AsMetricSource {
-			targetValueString = "0"
-		} else {
-			return nil, err
-		}
-	}
-	targetValue, err := strconv.ParseFloat(targetValueString, 64)
-	if err != nil {
-		return nil, fmt.Errorf("targetValue parsing error: %w", err)
-	}
-	meta.targetValue = targetValue
-
-	meta.activationTargetValue = 0
-	if val, ok := config.TriggerMetadata["activationTargetValue"]; ok {
-		activationTargetValue, err := strconv.ParseFloat(val, 64)
-		if err != nil {
-			return nil, fmt.Errorf("activationTargetValue parsing error: %w", err)
-		}
-		meta.activationTargetValue = activationTargetValue
-	}
-
-	meta.metricName = GenerateMetricNameWithIndex(config.TriggerIndex, util.NormalizeString(fmt.Sprintf("elasticsearch-%s", meta.searchTemplateName)))
-	return &meta, nil
+	return meta, nil
 }
 
-// newElasticsearchClient creates elasticsearch db connection
-func newElasticsearchClient(meta *elasticsearchMetadata, logger logr.Logger) (*elasticsearch.Client, error) {
+func newElasticsearchClient(meta elasticsearchMetadata, logger logr.Logger) (*elasticsearch.Client, error) {
 	var config elasticsearch.Config
 
-	if hasCloudConfig(meta) {
+	if meta.CloudID != "" {
 		config = elasticsearch.Config{
-			CloudID: meta.cloudID,
-			APIKey:  meta.apiKey,
+			CloudID: meta.CloudID,
+			APIKey:  meta.APIKey,
 		}
 	} else {
 		config = elasticsearch.Config{
-			Addresses: meta.addresses,
-		}
-		if meta.username != "" {
-			config.Username = meta.username
-		}
-		if meta.password != "" {
-			config.Password = meta.password
+			Addresses: meta.Addresses,
+			Username:  meta.Username,
+			Password:  meta.Password,
 		}
 	}
 
-	config.Transport = util.CreateHTTPTransport(meta.unsafeSsl)
+	config.Transport = util.CreateHTTPTransport(meta.UnsafeSsl)
 	esClient, err := elasticsearch.NewClient(config)
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Found error when creating client: %s", err))
@@ -269,14 +132,14 @@ func (s *elasticsearchScaler) Close(_ context.Context) error {
 func (s *elasticsearchScaler) getQueryResult(ctx context.Context) (float64, error) {
 	// Build the request body.
 	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(buildQuery(s.metadata)); err != nil {
+	if err := json.NewEncoder(&body).Encode(buildQuery(&s.metadata)); err != nil {
 		s.logger.Error(err, "Error encoding query: %s", err)
 	}
 
 	// Run the templated search
 	res, err := s.esClient.SearchTemplate(
 		&body,
-		s.esClient.SearchTemplate.WithIndex(s.metadata.indexes...),
+		s.esClient.SearchTemplate.WithIndex(s.metadata.Indexes...),
 		s.esClient.SearchTemplate.WithContext(ctx),
 	)
 	if err != nil {
@@ -289,7 +152,7 @@ func (s *elasticsearchScaler) getQueryResult(ctx context.Context) (float64, erro
 	if err != nil {
 		return 0, err
 	}
-	v, err := getValueFromSearch(b, s.metadata.valueLocation)
+	v, err := getValueFromSearch(b, s.metadata.ValueLocation)
 	if err != nil {
 		return 0, err
 	}
@@ -298,14 +161,14 @@ func (s *elasticsearchScaler) getQueryResult(ctx context.Context) (float64, erro
 
 func buildQuery(metadata *elasticsearchMetadata) map[string]interface{} {
 	parameters := map[string]interface{}{}
-	for _, p := range metadata.parameters {
-		if p != "" {
-			kv := splitAndTrimBySep(p, ":")
-			parameters[kv[0]] = kv[1]
+	for _, p := range metadata.Parameters {
+		kv := strings.SplitN(p, ":", 2)
+		if len(kv) == 2 {
+			parameters[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
 		}
 	}
 	query := map[string]interface{}{
-		"id": metadata.searchTemplateName,
+		"id": metadata.SearchTemplateName,
 	}
 	if len(parameters) > 0 {
 		query["params"] = parameters
@@ -333,9 +196,9 @@ func getValueFromSearch(body []byte, valueLocation string) (float64, error) {
 func (s *elasticsearchScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	externalMetric := &v2.ExternalMetricSource{
 		Metric: v2.MetricIdentifier{
-			Name: s.metadata.metricName,
+			Name: s.metadata.MetricName,
 		},
-		Target: GetMetricTargetMili(s.metricType, s.metadata.targetValue),
+		Target: GetMetricTargetMili(s.metricType, s.metadata.TargetValue),
 	}
 	metricSpec := v2.MetricSpec{
 		External: externalMetric, Type: externalMetricType,
@@ -352,14 +215,5 @@ func (s *elasticsearchScaler) GetMetricsAndActivity(ctx context.Context, metricN
 
 	metric := GenerateMetricInMili(metricName, num)
 
-	return []external_metrics.ExternalMetricValue{metric}, num > s.metadata.activationTargetValue, nil
-}
-
-// Splits a string separated by a specified separator and trims space from all the elements.
-func splitAndTrimBySep(s string, sep string) []string {
-	x := strings.Split(s, sep)
-	for i := range x {
-		x[i] = strings.Trim(x[i], " ")
-	}
-	return x
+	return []external_metrics.ExternalMetricValue{metric}, num > s.metadata.ActivationTargetValue, nil
 }

--- a/pkg/scalers/elasticsearch_scaler.go
+++ b/pkg/scalers/elasticsearch_scaler.go
@@ -142,7 +142,7 @@ func (s *elasticsearchScaler) getQueryResult(ctx context.Context) (float64, erro
 	// Run the templated search
 	res, err := s.esClient.SearchTemplate(
 		&body,
-		s.esClient.SearchTemplate.WithIndex(s.metadata.Indexes...),
+		s.esClient.SearchTemplate.WithIndex(s.metadata.Index...),
 		s.esClient.SearchTemplate.WithContext(ctx),
 	)
 	if err != nil {
@@ -167,7 +167,9 @@ func buildQuery(metadata *elasticsearchMetadata) map[string]interface{} {
 	for _, p := range metadata.Parameters {
 		kv := strings.SplitN(p, ":", 2)
 		if len(kv) == 2 {
-			parameters[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+			key := strings.TrimSpace(kv[0])
+			value := strings.TrimSpace(kv[1])
+			parameters[key] = value
 		}
 	}
 	query := map[string]interface{}{

--- a/pkg/scalers/elasticsearch_scaler_test.go
+++ b/pkg/scalers/elasticsearch_scaler_test.go
@@ -3,7 +3,6 @@ package scalers
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,25 +37,25 @@ var testCases = []parseElasticsearchMetadataTestData{
 		name:          "must provide either endpoint addresses or cloud config",
 		metadata:      map[string]string{},
 		authParams:    map[string]string{},
-		expectedError: ErrElasticsearchMissingAddressesOrCloudConfig,
+		expectedError: fmt.Errorf("must provide either endpoint addresses or cloud config"),
 	},
 	{
 		name:          "no apiKey given",
 		metadata:      map[string]string{"cloudID": "my-cluster:xxxxxxxxxxx"},
 		authParams:    map[string]string{},
-		expectedError: ErrScalerConfigMissingField,
+		expectedError: fmt.Errorf("no apiKey specified"),
 	},
 	{
 		name:          "can't provide endpoint addresses and cloud config at the same time",
 		metadata:      map[string]string{"addresses": "http://localhost:9200", "cloudID": "my-cluster:xxxxxxxxxxx"},
 		authParams:    map[string]string{"username": "admin", "apiKey": "xxxxxxxxx"},
-		expectedError: ErrElasticsearchConfigConflict,
+		expectedError: fmt.Errorf("can't provide endpoint addresses and cloud config at the same time"),
 	},
 	{
 		name:          "no index given",
 		metadata:      map[string]string{"addresses": "http://localhost:9200"},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: ErrScalerConfigMissingField,
+		expectedError: fmt.Errorf("no index specified"),
 	},
 	{
 		name: "no searchTemplateName given",
@@ -65,7 +64,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"index":     "index1",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: ErrScalerConfigMissingField,
+		expectedError: fmt.Errorf("no searchTemplateName specified"),
 	},
 	{
 		name: "no valueLocation given",
@@ -75,7 +74,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"searchTemplateName": "searchTemplateName",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: ErrScalerConfigMissingField,
+		expectedError: fmt.Errorf("no valueLocation specified"),
 	},
 	{
 		name: "no targetValue given",
@@ -86,7 +85,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"valueLocation":      "toto",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: ErrScalerConfigMissingField,
+		expectedError: fmt.Errorf("no targetValue given"),
 	},
 	{
 		name: "invalid targetValue",
@@ -98,7 +97,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"targetValue":        "AA",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: strconv.ErrSyntax,
+		expectedError: fmt.Errorf("targetValue parsing error"),
 	},
 	{
 		name: "invalid activationTargetValue",
@@ -111,7 +110,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"activationTargetValue": "AA",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: strconv.ErrSyntax,
+		expectedError: fmt.Errorf("activationTargetValue parsing error"),
 	},
 	{
 		name: "all fields ok",
@@ -130,17 +129,17 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"password": "password",
 		},
 		expectedMetadata: &elasticsearchMetadata{
-			addresses:             []string{"http://localhost:9200"},
-			unsafeSsl:             true,
-			indexes:               []string{"index1"},
-			username:              "admin",
-			password:              "password",
-			searchTemplateName:    "myAwesomeSearch",
-			parameters:            []string{"param1:value1"},
-			valueLocation:         "hits.hits[0]._source.value",
-			targetValue:           12.2,
-			activationTargetValue: 3.33,
-			metricName:            "s0-elasticsearch-myAwesomeSearch",
+			Addresses:             []string{"http://localhost:9200"},
+			UnsafeSsl:             true,
+			Indexes:               []string{"index1"},
+			Username:              "admin",
+			Password:              "password",
+			SearchTemplateName:    "myAwesomeSearch",
+			Parameters:            []string{"param1:value1"},
+			ValueLocation:         "hits.hits[0]._source.value",
+			TargetValue:           12.2,
+			ActivationTargetValue: 3.33,
+			MetricName:            "s0-elasticsearch-myAwesomeSearch",
 		},
 		expectedError: nil,
 	},
@@ -160,16 +159,16 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"password": "password",
 		},
 		expectedMetadata: &elasticsearchMetadata{
-			addresses:          []string{"http://localhost:9200"},
-			unsafeSsl:          false,
-			indexes:            []string{"index1", "index2"},
-			username:           "admin",
-			password:           "password",
-			searchTemplateName: "myAwesomeSearch",
-			parameters:         []string{"param1:value1"},
-			valueLocation:      "hits.hits[0]._source.value",
-			targetValue:        12,
-			metricName:         "s0-elasticsearch-myAwesomeSearch",
+			Addresses:          []string{"http://localhost:9200"},
+			UnsafeSsl:          false,
+			Indexes:            []string{"index1", "index2"},
+			Username:           "admin",
+			Password:           "password",
+			SearchTemplateName: "myAwesomeSearch",
+			Parameters:         []string{"param1:value1"},
+			ValueLocation:      "hits.hits[0]._source.value",
+			TargetValue:        12,
+			MetricName:         "s0-elasticsearch-myAwesomeSearch",
 		},
 		expectedError: nil,
 	},
@@ -189,16 +188,16 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"password": "password",
 		},
 		expectedMetadata: &elasticsearchMetadata{
-			addresses:          []string{"http://localhost:9200"},
-			unsafeSsl:          false,
-			indexes:            []string{"index1", "index2"},
-			username:           "admin",
-			password:           "password",
-			searchTemplateName: "myAwesomeSearch",
-			parameters:         []string{"param1:value1"},
-			valueLocation:      "hits.hits[0]._source.value",
-			targetValue:        12,
-			metricName:         "s0-elasticsearch-myAwesomeSearch",
+			Addresses:          []string{"http://localhost:9200"},
+			UnsafeSsl:          false,
+			Indexes:            []string{"index1", "index2"},
+			Username:           "admin",
+			Password:           "password",
+			SearchTemplateName: "myAwesomeSearch",
+			Parameters:         []string{"param1:value1"},
+			ValueLocation:      "hits.hits[0]._source.value",
+			TargetValue:        12,
+			MetricName:         "s0-elasticsearch-myAwesomeSearch",
 		},
 		expectedError: nil,
 	},
@@ -218,16 +217,16 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"password": "password",
 		},
 		expectedMetadata: &elasticsearchMetadata{
-			addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
-			unsafeSsl:          false,
-			indexes:            []string{"index1"},
-			username:           "admin",
-			password:           "password",
-			searchTemplateName: "myAwesomeSearch",
-			parameters:         []string{"param1:value1"},
-			valueLocation:      "hits.hits[0]._source.value",
-			targetValue:        12,
-			metricName:         "s0-elasticsearch-myAwesomeSearch",
+			Addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
+			UnsafeSsl:          false,
+			Indexes:            []string{"index1"},
+			Username:           "admin",
+			Password:           "password",
+			SearchTemplateName: "myAwesomeSearch",
+			Parameters:         []string{"param1:value1"},
+			ValueLocation:      "hits.hits[0]._source.value",
+			TargetValue:        12,
+			MetricName:         "s0-elasticsearch-myAwesomeSearch",
 		},
 		expectedError: nil,
 	},
@@ -247,16 +246,16 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"password": "password",
 		},
 		expectedMetadata: &elasticsearchMetadata{
-			addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
-			unsafeSsl:          false,
-			indexes:            []string{"index1"},
-			username:           "admin",
-			password:           "password",
-			searchTemplateName: "myAwesomeSearch",
-			parameters:         []string{"param1:value1"},
-			valueLocation:      "hits.hits[0]._source.value",
-			targetValue:        12,
-			metricName:         "s0-elasticsearch-myAwesomeSearch",
+			Addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
+			UnsafeSsl:          false,
+			Indexes:            []string{"index1"},
+			Username:           "admin",
+			Password:           "password",
+			SearchTemplateName: "myAwesomeSearch",
+			Parameters:         []string{"param1:value1"},
+			ValueLocation:      "hits.hits[0]._source.value",
+			TargetValue:        12,
+			MetricName:         "s0-elasticsearch-myAwesomeSearch",
 		},
 		expectedError: nil,
 	},
@@ -279,16 +278,16 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"ELASTICSEARCH_PASSWORD": "password",
 		},
 		expectedMetadata: &elasticsearchMetadata{
-			addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
-			unsafeSsl:          false,
-			indexes:            []string{"index1"},
-			username:           "admin",
-			password:           "password",
-			searchTemplateName: "myAwesomeSearch",
-			parameters:         []string{"param1:value1"},
-			valueLocation:      "hits.hits[0]._source.value",
-			targetValue:        12,
-			metricName:         "s0-elasticsearch-myAwesomeSearch",
+			Addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
+			UnsafeSsl:          false,
+			Indexes:            []string{"index1"},
+			Username:           "admin",
+			Password:           "password",
+			SearchTemplateName: "myAwesomeSearch",
+			Parameters:         []string{"param1:value1"},
+			ValueLocation:      "hits.hits[0]._source.value",
+			TargetValue:        12,
+			MetricName:         "s0-elasticsearch-myAwesomeSearch",
 		},
 		expectedError: nil,
 	},
@@ -307,7 +306,7 @@ func TestParseElasticsearchMetadata(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				fmt.Println(tc.name)
-				assert.Equal(t, tc.expectedMetadata, metadata)
+				assert.Equal(t, tc.expectedMetadata, &metadata)
 			}
 		})
 	}
@@ -329,16 +328,16 @@ func TestUnsafeSslDefaultValue(t *testing.T) {
 			"password": "password",
 		},
 		expectedMetadata: &elasticsearchMetadata{
-			addresses:          []string{"http://localhost:9200"},
-			unsafeSsl:          false,
-			indexes:            []string{"index1"},
-			username:           "admin",
-			password:           "password",
-			searchTemplateName: "myAwesomeSearch",
-			parameters:         []string{"param1:value1"},
-			valueLocation:      "hits.hits[0]._source.value",
-			targetValue:        12,
-			metricName:         "s0-elasticsearch-myAwesomeSearch",
+			Addresses:          []string{"http://localhost:9200"},
+			UnsafeSsl:          false,
+			Indexes:            []string{"index1"},
+			Username:           "admin",
+			Password:           "password",
+			SearchTemplateName: "myAwesomeSearch",
+			Parameters:         []string{"param1:value1"},
+			ValueLocation:      "hits.hits[0]._source.value",
+			TargetValue:        12,
+			MetricName:         "s0-elasticsearch-myAwesomeSearch",
 		},
 		expectedError: nil,
 	}
@@ -347,7 +346,7 @@ func TestUnsafeSslDefaultValue(t *testing.T) {
 		AuthParams:      tc.authParams,
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, tc.expectedMetadata, metadata)
+	assert.Equal(t, tc.expectedMetadata, &metadata)
 }
 
 func TestBuildQuery(t *testing.T) {
@@ -443,7 +442,8 @@ func TestBuildQuery(t *testing.T) {
 				AuthParams:      tc.authParams,
 			})
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedQuery, buildQuery(metadata))
+			scaler := elasticsearchScaler{metadata: metadata}
+			assert.Equal(t, tc.expectedQuery, buildQuery(&scaler.metadata))
 		})
 	}
 }
@@ -462,7 +462,8 @@ func TestElasticsearchGetMetricSpecForScaling(t *testing.T) {
 			TriggerIndex:    testData.triggerIndex,
 		})
 		if testData.metadataTestData.expectedError != nil {
-			assert.ErrorIs(t, err, testData.metadataTestData.expectedError)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), testData.metadataTestData.expectedError.Error())
 			continue
 		}
 		if err != nil {

--- a/pkg/scalers/elasticsearch_scaler_test.go
+++ b/pkg/scalers/elasticsearch_scaler_test.go
@@ -131,7 +131,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 		expectedMetadata: &elasticsearchMetadata{
 			Addresses:             []string{"http://localhost:9200"},
 			UnsafeSsl:             true,
-			Indexes:               []string{"index1"},
+			Index:                 []string{"index1"},
 			Username:              "admin",
 			Password:              "password",
 			SearchTemplateName:    "myAwesomeSearch",
@@ -161,7 +161,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 		expectedMetadata: &elasticsearchMetadata{
 			Addresses:          []string{"http://localhost:9200"},
 			UnsafeSsl:          false,
-			Indexes:            []string{"index1", "index2"},
+			Index:              []string{"index1", "index2"},
 			Username:           "admin",
 			Password:           "password",
 			SearchTemplateName: "myAwesomeSearch",
@@ -190,7 +190,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 		expectedMetadata: &elasticsearchMetadata{
 			Addresses:          []string{"http://localhost:9200"},
 			UnsafeSsl:          false,
-			Indexes:            []string{"index1", "index2"},
+			Index:              []string{"index1", "index2"},
 			Username:           "admin",
 			Password:           "password",
 			SearchTemplateName: "myAwesomeSearch",
@@ -219,7 +219,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 		expectedMetadata: &elasticsearchMetadata{
 			Addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
 			UnsafeSsl:          false,
-			Indexes:            []string{"index1"},
+			Index:              []string{"index1"},
 			Username:           "admin",
 			Password:           "password",
 			SearchTemplateName: "myAwesomeSearch",
@@ -248,7 +248,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 		expectedMetadata: &elasticsearchMetadata{
 			Addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
 			UnsafeSsl:          false,
-			Indexes:            []string{"index1"},
+			Index:              []string{"index1"},
 			Username:           "admin",
 			Password:           "password",
 			SearchTemplateName: "myAwesomeSearch",
@@ -280,7 +280,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 		expectedMetadata: &elasticsearchMetadata{
 			Addresses:          []string{"http://localhost:9200", "http://localhost:9201"},
 			UnsafeSsl:          false,
-			Indexes:            []string{"index1"},
+			Index:              []string{"index1"},
 			Username:           "admin",
 			Password:           "password",
 			SearchTemplateName: "myAwesomeSearch",
@@ -331,7 +331,7 @@ func TestUnsafeSslDefaultValue(t *testing.T) {
 		expectedMetadata: &elasticsearchMetadata{
 			Addresses:          []string{"http://localhost:9200"},
 			UnsafeSsl:          false,
-			Indexes:            []string{"index1"},
+			Index:              []string{"index1"},
 			Username:           "admin",
 			Password:           "password",
 			SearchTemplateName: "myAwesomeSearch",

--- a/pkg/scalers/elasticsearch_scaler_test.go
+++ b/pkg/scalers/elasticsearch_scaler_test.go
@@ -37,25 +37,25 @@ var testCases = []parseElasticsearchMetadataTestData{
 		name:          "must provide either endpoint addresses or cloud config",
 		metadata:      map[string]string{},
 		authParams:    map[string]string{},
-		expectedError: fmt.Errorf("must provide either endpoint addresses or cloud config"),
+		expectedError: fmt.Errorf("must provide either cloud config or endpoint addresses"),
 	},
 	{
 		name:          "no apiKey given",
 		metadata:      map[string]string{"cloudID": "my-cluster:xxxxxxxxxxx"},
 		authParams:    map[string]string{},
-		expectedError: fmt.Errorf("no apiKey specified"),
+		expectedError: fmt.Errorf("both cloudID and apiKey must be provided when cloudID or apiKey is used"),
 	},
 	{
 		name:          "can't provide endpoint addresses and cloud config at the same time",
 		metadata:      map[string]string{"addresses": "http://localhost:9200", "cloudID": "my-cluster:xxxxxxxxxxx"},
 		authParams:    map[string]string{"username": "admin", "apiKey": "xxxxxxxxx"},
-		expectedError: fmt.Errorf("can't provide endpoint addresses and cloud config at the same time"),
+		expectedError: fmt.Errorf("can't provide both cloud config and endpoint addresses"),
 	},
 	{
 		name:          "no index given",
 		metadata:      map[string]string{"addresses": "http://localhost:9200"},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: fmt.Errorf("no index specified"),
+		expectedError: fmt.Errorf("missing required parameter"),
 	},
 	{
 		name: "no searchTemplateName given",
@@ -64,7 +64,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"index":     "index1",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: fmt.Errorf("no searchTemplateName specified"),
+		expectedError: fmt.Errorf("missing required parameter"),
 	},
 	{
 		name: "no valueLocation given",
@@ -74,7 +74,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"searchTemplateName": "searchTemplateName",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: fmt.Errorf("no valueLocation specified"),
+		expectedError: fmt.Errorf("missing required parameter"),
 	},
 	{
 		name: "no targetValue given",
@@ -85,7 +85,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"valueLocation":      "toto",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: fmt.Errorf("no targetValue given"),
+		expectedError: fmt.Errorf("missing required parameter"),
 	},
 	{
 		name: "invalid targetValue",
@@ -97,7 +97,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"targetValue":        "AA",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: fmt.Errorf("targetValue parsing error"),
+		expectedError: fmt.Errorf("unable to set param"),
 	},
 	{
 		name: "invalid activationTargetValue",
@@ -110,7 +110,7 @@ var testCases = []parseElasticsearchMetadataTestData{
 			"activationTargetValue": "AA",
 		},
 		authParams:    map[string]string{"username": "admin"},
-		expectedError: fmt.Errorf("activationTargetValue parsing error"),
+		expectedError: fmt.Errorf("unable to set param"),
 	},
 	{
 		name: "all fields ok",
@@ -302,7 +302,8 @@ func TestParseElasticsearchMetadata(t *testing.T) {
 				ResolvedEnv:     tc.resolvedEnv,
 			})
 			if tc.expectedError != nil {
-				assert.ErrorIs(t, err, tc.expectedError)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError.Error())
 			} else {
 				assert.NoError(t, err)
 				fmt.Println(tc.name)

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -49,8 +49,9 @@ type kafkaScaler struct {
 }
 
 const (
-	stringEnable  = "enable"
-	stringDisable = "disable"
+	stringEnable     = "enable"
+	stringDisable    = "disable"
+	defaultUnsafeSsl = false
 )
 
 type kafkaMetadata struct {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Because i deleted `const defaultUnsafeSsl = false` in the `elasticseach_scaler.go`, `kafka_scaler.go` is giving error `pkg/scalers/kafka_scaler.go:354:19: undefined: defaultUnsafeSsl`. That's why I added the `const` in `kafka_scaler.go`.
### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!-- 
Related: [5797](https://github.com/kedacore/keda/pull/5797)
-->