### PR TITLE
Provide ClusterCloudEventSource around the management of TriggerAuthentication/ClusterTriggerAuthentication resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### New
 
 - **CloudEventSource**: Introduce ClusterCloudEventSource ([#3533](https://github.com/kedacore/keda/issues/3533))
-- **CloudEventSource**: Provide CloudEvents around the management of ScaledJobs resources ([#3523](https://github.com/kedacore/keda/issues/3523))
+- **CloudEventSource**: Provide ClusterCloudEventSource around the management of ScaledJobs resources ([#3523](https://github.com/kedacore/keda/issues/3523))
+- **CloudEventSource**: Provide ClusterCloudEventSource around the management of TriggerAuthentication/ClusterTriggerAuthentication resources ([#3524](https://github.com/kedacore/keda/issues/3524))
 
 #### Experimental
 

--- a/apis/eventing/v1alpha1/cloudevent_types.go
+++ b/apis/eventing/v1alpha1/cloudevent_types.go
@@ -17,7 +17,8 @@ limitations under the License.
 package v1alpha1
 
 // CloudEventType contains the list of cloudevent types
-// +kubebuilder:validation:Enum=keda.scaledobject.ready.v1;keda.scaledobject.failed.v1;keda.scaledobject.removed.v1;keda.scaledjob.ready.v1;keda.scaledjob.failed.v1;keda.scaledjob.removed.v1
+// +kubebuilder:validation:Enum=keda.scaledobject.ready.v1;keda.scaledobject.failed.v1;keda.scaledobject.removed.v1;keda.scaledjob.ready.v1;keda.scaledjob.failed.v1;keda.scaledjob.removed.v1;keda.authentication.triggerauthentication.created.v1;keda.authentication.triggerauthentication.updated.v1;keda.authentication.triggerauthentication.removed.v1;keda.authentication.clustertriggerauthentication.created.v1;keda.authentication.clustertriggerauthentication.updated.v1;keda.authentication.clustertriggerauthentication.removed.v1
+
 type CloudEventType string
 
 const (
@@ -38,6 +39,24 @@ const (
 
 	// ScaledJobRemovedType is for event when removed ScaledJob
 	ScaledJobRemovedType CloudEventType = "keda.scaledjob.removed.v1"
+
+	// TriggerAuthenticationCreatedType is for event when a new TriggerAuthentication is created
+	TriggerAuthenticationCreatedType CloudEventType = "keda.authentication.triggerauthentication.created.v1"
+
+	// TriggerAuthenticationUpdatedType is for event when a TriggerAuthentication is updated
+	TriggerAuthenticationUpdatedType CloudEventType = "keda.authentication.triggerauthentication.updated.v1"
+
+	// TriggerAuthenticationRemovedType is for event when a TriggerAuthentication is deleted
+	TriggerAuthenticationRemovedType CloudEventType = "keda.authentication.triggerauthentication.removed.v1"
+
+	// ClusterTriggerAuthenticationCreatedType is for event when a new ClusterTriggerAuthentication is created
+	ClusterTriggerAuthenticationCreatedType CloudEventType = "keda.authentication.clustertriggerauthentication.created.v1"
+
+	// ClusterTriggerAuthenticationCreatedType is for event when a ClusterTriggerAuthentication is updated
+	ClusterTriggerAuthenticationUpdatedType CloudEventType = "keda.authentication.clustertriggerauthentication.updated.v1"
+
+	// ClusterTriggerAuthenticationRemovedType is for event when a ClusterTriggerAuthentication is deleted
+	ClusterTriggerAuthenticationRemovedType CloudEventType = "keda.authentication.clustertriggerauthentication.removed.v1"
 )
 
 var AllEventTypes = []CloudEventType{

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -246,15 +246,15 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&kedacontrollers.TriggerAuthenticationReconciler{
-		Client:        mgr.GetClient(),
-		EventRecorder: eventRecorder,
+		Client:       mgr.GetClient(),
+		EventHandler: eventEmitter,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TriggerAuthentication")
 		os.Exit(1)
 	}
 	if err = (&kedacontrollers.ClusterTriggerAuthenticationReconciler{
-		Client:        mgr.GetClient(),
-		EventRecorder: eventRecorder,
+		Client:       mgr.GetClient(),
+		EventHandler: eventEmitter,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterTriggerAuthentication")
 		os.Exit(1)

--- a/config/crd/bases/eventing.keda.sh_cloudeventsources.yaml
+++ b/config/crd/bases/eventing.keda.sh_cloudeventsources.yaml
@@ -83,8 +83,6 @@ spec:
                 properties:
                   excludedEventTypes:
                     items:
-                      description: CloudEventType contains the list of cloudevent
-                        types
                       enum:
                       - keda.scaledobject.ready.v1
                       - keda.scaledobject.failed.v1
@@ -92,12 +90,16 @@ spec:
                       - keda.scaledjob.ready.v1
                       - keda.scaledjob.failed.v1
                       - keda.scaledjob.removed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
                       type: string
                     type: array
                   includedEventTypes:
                     items:
-                      description: CloudEventType contains the list of cloudevent
-                        types
                       enum:
                       - keda.scaledobject.ready.v1
                       - keda.scaledobject.failed.v1
@@ -105,6 +107,12 @@ spec:
                       - keda.scaledjob.ready.v1
                       - keda.scaledjob.failed.v1
                       - keda.scaledjob.removed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
                       type: string
                     type: array
                 type: object

--- a/config/crd/bases/eventing.keda.sh_clustercloudeventsources.yaml
+++ b/config/crd/bases/eventing.keda.sh_clustercloudeventsources.yaml
@@ -81,8 +81,6 @@ spec:
                 properties:
                   excludedEventTypes:
                     items:
-                      description: CloudEventType contains the list of cloudevent
-                        types
                       enum:
                       - keda.scaledobject.ready.v1
                       - keda.scaledobject.failed.v1
@@ -90,12 +88,16 @@ spec:
                       - keda.scaledjob.ready.v1
                       - keda.scaledjob.failed.v1
                       - keda.scaledjob.removed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
                       type: string
                     type: array
                   includedEventTypes:
                     items:
-                      description: CloudEventType contains the list of cloudevent
-                        types
                       enum:
                       - keda.scaledobject.ready.v1
                       - keda.scaledobject.failed.v1
@@ -103,6 +105,12 @@ spec:
                       - keda.scaledjob.ready.v1
                       - keda.scaledjob.failed.v1
                       - keda.scaledjob.removed.v1
+                      - keda.authentication.triggerauthentication.created.v1
+                      - keda.authentication.triggerauthentication.updated.v1
+                      - keda.authentication.triggerauthentication.removed.v1
+                      - keda.authentication.clustertriggerauthentication.created.v1
+                      - keda.authentication.clustertriggerauthentication.updated.v1
+                      - keda.authentication.clustertriggerauthentication.removed.v1
                       type: string
                     type: array
                 type: object

--- a/controllers/keda/clustertriggerauthentication_controller.go
+++ b/controllers/keda/clustertriggerauthentication_controller.go
@@ -18,18 +18,21 @@ package keda
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	eventingv1alpha1 "github.com/kedacore/keda/v2/apis/eventing/v1alpha1"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/common/message"
+	"github.com/kedacore/keda/v2/pkg/eventemitter"
 	"github.com/kedacore/keda/v2/pkg/eventreason"
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
 )
@@ -37,7 +40,7 @@ import (
 // ClusterTriggerAuthenticationReconciler reconciles a ClusterTriggerAuthentication object
 type ClusterTriggerAuthenticationReconciler struct {
 	client.Client
-	record.EventRecorder
+	eventemitter.EventHandler
 }
 
 type clusterTriggerAuthMetricsData struct {
@@ -80,8 +83,12 @@ func (r *ClusterTriggerAuthenticationReconciler) Reconcile(ctx context.Context, 
 	r.updatePromMetrics(clusterTriggerAuthentication, req.NamespacedName.String())
 
 	if clusterTriggerAuthentication.ObjectMeta.Generation == 1 {
-		r.EventRecorder.Event(clusterTriggerAuthentication, corev1.EventTypeNormal, eventreason.ClusterTriggerAuthenticationAdded, "New ClusterTriggerAuthentication configured")
+		r.Emit(clusterTriggerAuthentication, req.NamespacedName.Namespace, corev1.EventTypeNormal, eventingv1alpha1.ClusterTriggerAuthenticationCreatedType, eventreason.ClusterTriggerAuthenticationAdded, message.ClusterTriggerAuthenticationCreatedMsg)
+	} else {
+		msg := fmt.Sprintf(message.ClusterTriggerAuthenticationUpdatedMsg, clusterTriggerAuthentication.Name)
+		r.Emit(clusterTriggerAuthentication, req.NamespacedName.Namespace, corev1.EventTypeNormal, eventingv1alpha1.ClusterTriggerAuthenticationUpdatedType, eventreason.ClusterTriggerAuthenticationUpdated, msg)
 	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/keda/triggerauthentication_controller.go
+++ b/controllers/keda/triggerauthentication_controller.go
@@ -18,18 +18,21 @@ package keda
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	eventingv1alpha1 "github.com/kedacore/keda/v2/apis/eventing/v1alpha1"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/common/message"
+	"github.com/kedacore/keda/v2/pkg/eventemitter"
 	"github.com/kedacore/keda/v2/pkg/eventreason"
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/util"
@@ -38,7 +41,7 @@ import (
 // TriggerAuthenticationReconciler reconciles a TriggerAuthentication object
 type TriggerAuthenticationReconciler struct {
 	client.Client
-	record.EventRecorder
+	eventemitter.EventHandler
 }
 
 type triggerAuthMetricsData struct {
@@ -81,7 +84,10 @@ func (r *TriggerAuthenticationReconciler) Reconcile(ctx context.Context, req ctr
 	r.updatePromMetrics(triggerAuthentication, req.NamespacedName.String())
 
 	if triggerAuthentication.ObjectMeta.Generation == 1 {
-		r.EventRecorder.Event(triggerAuthentication, corev1.EventTypeNormal, eventreason.TriggerAuthenticationAdded, "New TriggerAuthentication configured")
+		r.Emit(triggerAuthentication, req.NamespacedName.Namespace, corev1.EventTypeNormal, eventingv1alpha1.TriggerAuthenticationCreatedType, eventreason.TriggerAuthenticationAdded, message.TriggerAuthenticationCreatedMsg)
+	} else {
+		msg := fmt.Sprintf(message.TriggerAuthenticationUpdatedMsg, triggerAuthentication.Name)
+		r.Emit(triggerAuthentication, req.NamespacedName.Namespace, corev1.EventTypeNormal, eventingv1alpha1.TriggerAuthenticationUpdatedType, eventreason.TriggerAuthenticationUpdated, msg)
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/common/message/message.go
+++ b/pkg/common/message/message.go
@@ -34,4 +34,12 @@ const (
 	ScaledJobReadyMsg = "ScaledJob is ready for scaling"
 
 	ScaledJobRemoved = "ScaledJob was deleted"
+
+	TriggerAuthenticationCreatedMsg = "New TriggerAuthentication configured"
+
+	TriggerAuthenticationUpdatedMsg = "ClusterTriggerAuthentication %s is updated"
+
+	ClusterTriggerAuthenticationCreatedMsg = "New ClusterTriggerAuthentication configured"
+
+	ClusterTriggerAuthenticationUpdatedMsg = "ClusterTriggerAuthentication %s is updated"
 )

--- a/pkg/eventreason/eventreason.go
+++ b/pkg/eventreason/eventreason.go
@@ -77,6 +77,9 @@ const (
 	// TriggerAuthenticationFailed is for event when a TriggerAuthentication occurs error
 	TriggerAuthenticationFailed = "TriggerAuthenticationFailed"
 
+	// TriggerAuthenticationUpdated is for event when a TriggerAuthentication is updated
+	TriggerAuthenticationUpdated = "ClusterTriggerAuthenticationUpdated"
+
 	// ClusterTriggerAuthenticationDeleted is for event when a ClusterTriggerAuthentication is deleted
 	ClusterTriggerAuthenticationDeleted = "ClusterTriggerAuthenticationDeleted"
 
@@ -85,4 +88,7 @@ const (
 
 	// ClusterTriggerAuthenticationFailed is for event when a ClusterTriggerAuthentication occurs error
 	ClusterTriggerAuthenticationFailed = "ClusterTriggerAuthenticationFailed"
+
+	// ClusterTriggerAuthenticationUpdated is for event when a ClusterTriggerAuthentication is updated
+	ClusterTriggerAuthenticationUpdated = "ClusterTriggerAuthenticationUpdated"
 )

--- a/tests/internals/events/events_test.go
+++ b/tests/internals/events/events_test.go
@@ -395,7 +395,7 @@ func testScaledJobTargetNotSupportEventErr(t *testing.T, _ *kubernetes.Clientset
 	checkingEvent(t, testNamespace, scaledJobErrName, -1, eventreason.ScaledJobCheckFailed, "Failed to ensure ScaledJob is correctly created")
 }
 
-func testTriggerAuthenticationEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+func testTriggerAuthenticationEvent(t *testing.T, _ *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing ScaledJob normal event ---")
 
 	KubectlApplyWithTemplate(t, data, "secretTemplate", secretTemplate)
@@ -421,5 +421,4 @@ func testTriggerAuthenticationEvent(t *testing.T, kc *kubernetes.Clientset, data
 	KubectlDeleteWithTemplate(t, data, "secret2Template", secret2Template)
 	KubectlDeleteWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
 	KubectlDeleteWithTemplate(t, data, "clusterTriggerAuthenticationTemplate", clusterTriggerAuthenticationTemplate)
-
 }

--- a/tests/internals/events/events_test.go
+++ b/tests/internals/events/events_test.go
@@ -28,6 +28,10 @@ var (
 	scaledObjectName                    = fmt.Sprintf("%s-so", testName)
 	scaledObjectTargetNotFoundName      = fmt.Sprintf("%s-so-target-error", testName)
 	scaledObjectTargetNoSubresourceName = fmt.Sprintf("%s-so-target-no-subresource", testName)
+	secretName                          = fmt.Sprintf("%s-secret", testName)
+	secretName2                         = fmt.Sprintf("%s-secret-2", testName)
+	triggerAuthName                     = fmt.Sprintf("%s-ta", testName)
+	clusterTriggerAuthName              = fmt.Sprintf("%s-cta", testName)
 
 	scaledJobName    = fmt.Sprintf("%s-sj", testName)
 	scaledJobErrName = fmt.Sprintf("%s-sj-target-error", testName)
@@ -43,6 +47,11 @@ type templateData struct {
 	DaemonsetName                       string
 	ScaledJobName                       string
 	ScaledJobErrName                    string
+	SecretName                          string
+	SecretName2                         string
+	SecretTargetName                    string
+	TriggerAuthName                     string
+	ClusterTriggerAuthName              string
 }
 
 const (
@@ -223,6 +232,54 @@ spec:
         typex: Utilization
         value: "50"
 `
+
+	secretTemplate = `apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretName}}
+  namespace: {{.TestNamespace}}
+data:
+  AUTH_PASSWORD: U0VDUkVUCg==
+  AUTH_USERNAME: VVNFUgo=
+`
+	secret2Template = `apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretName2}}
+  namespace: {{.TestNamespace}}
+data:
+  AUTH_PASSWORD: U0VDUkVUCg==
+  AUTH_USERNAME: VVNFUgo=
+`
+
+	triggerAuthenticationTemplate = `apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{.TriggerAuthName}}
+  namespace: {{.TestNamespace}}
+spec:
+  secretTargetRef:
+    - parameter: username
+      name: {{.SecretTargetName}}
+      key: AUTH_USERNAME
+    - parameter: password
+      name: {{.SecretTargetName}}
+      key: AUTH_PASSWORD
+`
+
+	clusterTriggerAuthenticationTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ClusterTriggerAuthentication
+metadata:
+  name: {{.ClusterTriggerAuthName}}
+spec:
+  secretTargetRef:
+    - parameter: username
+      name: {{.SecretTargetName}}
+      key: AUTH_USERNAME
+    - parameter: password
+      name: {{.SecretTargetName}}
+      key: AUTH_PASSWORD
+`
 )
 
 func TestEvents(t *testing.T) {
@@ -242,6 +299,9 @@ func TestEvents(t *testing.T) {
 
 	testScaledJobNormalEvent(t, kc, data)
 	testScaledJobTargetNotSupportEventErr(t, kc, data)
+
+	testTriggerAuthenticationEvent(t, kc, data)
+
 	// cleanup
 	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
@@ -257,11 +317,15 @@ func getTemplateData() (templateData, []Template) {
 		ScaledObjectTargetNoSubresourceName: scaledObjectTargetNoSubresourceName,
 		ScaledJobName:                       scaledJobName,
 		ScaledJobErrName:                    scaledJobErrName,
+		SecretName:                          secretName,
+		SecretName2:                         secretName2,
+		TriggerAuthName:                     triggerAuthName,
+		ClusterTriggerAuthName:              clusterTriggerAuthName,
 	}, []Template{}
 }
 
-func checkingEvent(t *testing.T, scaledObject string, index int, eventreason string, message string) {
-	result, err := ExecuteCommand(fmt.Sprintf("kubectl get events -n %s --field-selector involvedObject.name=%s --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[%d].reason}:{.items[%d].message}\"", testNamespace, scaledObject, index, index))
+func checkingEvent(t *testing.T, namespace string, scaledObject string, index int, eventreason string, message string) {
+	result, err := ExecuteCommand(fmt.Sprintf("kubectl get events -n %s --field-selector involvedObject.name=%s --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[%d].reason}:{.items[%d].message}\"", namespace, scaledObject, index, index))
 
 	assert.NoError(t, err)
 	lastEventMessage := strings.Trim(string(result), "\"")
@@ -279,9 +343,9 @@ func testNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) 
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 2, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 1),
 		"replica count should be 2 after 1 minute")
-	checkingEvent(t, scaledObjectName, 0, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
-	checkingEvent(t, scaledObjectName, 1, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
-	checkingEvent(t, scaledObjectName, 2, eventreason.ScaledObjectReady, message.ScalerReadyMsg)
+	checkingEvent(t, testNamespace, scaledObjectName, 0, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
+	checkingEvent(t, testNamespace, scaledObjectName, 1, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
+	checkingEvent(t, testNamespace, scaledObjectName, 2, eventreason.ScaledObjectReady, message.ScalerReadyMsg)
 
 	KubectlDeleteWithTemplate(t, data, "deploymentTemplate", deploymentTemplate)
 	KubectlDeleteWithTemplate(t, data, "monitoredDeploymentName", monitoredDeploymentTemplate)
@@ -292,8 +356,8 @@ func testTargetNotFoundErr(t *testing.T, _ *kubernetes.Clientset, data templateD
 	t.Log("--- testing target not found error event ---")
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTargetErrTemplate", scaledObjectTargetErrTemplate)
-	checkingEvent(t, scaledObjectTargetNotFoundName, -2, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNotFoundMsg)
-	checkingEvent(t, scaledObjectTargetNotFoundName, -1, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
+	checkingEvent(t, testNamespace, scaledObjectTargetNotFoundName, -2, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNotFoundMsg)
+	checkingEvent(t, testNamespace, scaledObjectTargetNotFoundName, -1, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
 }
 
 func testTargetNotSupportEventErr(t *testing.T, _ *kubernetes.Clientset, data templateData) {
@@ -301,8 +365,8 @@ func testTargetNotSupportEventErr(t *testing.T, _ *kubernetes.Clientset, data te
 
 	KubectlApplyWithTemplate(t, data, "daemonSetTemplate", daemonSetTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTargetNotSupportTemplate", scaledObjectTargetNotSupportTemplate)
-	checkingEvent(t, scaledObjectTargetNoSubresourceName, -2, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNoSubresourceMsg)
-	checkingEvent(t, scaledObjectTargetNoSubresourceName, -1, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
+	checkingEvent(t, testNamespace, scaledObjectTargetNoSubresourceName, -2, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNoSubresourceMsg)
+	checkingEvent(t, testNamespace, scaledObjectTargetNoSubresourceName, -1, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
 }
 
 func testScaledJobNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {
@@ -315,9 +379,9 @@ func testScaledJobNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templ
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 2, testNamespace)
 	assert.True(t, WaitForJobCount(t, kc, testNamespace, 2, 60, 1),
 		"replica count should be 2 after 1 minute")
-	checkingEvent(t, scaledJobName, 0, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
-	checkingEvent(t, scaledJobName, 1, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
-	checkingEvent(t, scaledJobName, 2, eventreason.ScaledJobReady, message.ScaledJobReadyMsg)
+	checkingEvent(t, testNamespace, scaledJobName, 0, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
+	checkingEvent(t, testNamespace, scaledJobName, 1, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
+	checkingEvent(t, testNamespace, scaledJobName, 2, eventreason.ScaledJobReady, message.ScaledJobReadyMsg)
 
 	KubectlDeleteWithTemplate(t, data, "deploymentTemplate", deploymentTemplate)
 	KubectlDeleteWithTemplate(t, data, "monitoredDeploymentName", monitoredDeploymentTemplate)
@@ -328,5 +392,34 @@ func testScaledJobTargetNotSupportEventErr(t *testing.T, _ *kubernetes.Clientset
 	t.Log("--- testing target not support error event ---")
 
 	KubectlApplyWithTemplate(t, data, "scaledJobErrTemplate", scaledJobErrTemplate)
-	checkingEvent(t, scaledJobErrName, -1, eventreason.ScaledJobCheckFailed, "Failed to ensure ScaledJob is correctly created")
+	checkingEvent(t, testNamespace, scaledJobErrName, -1, eventreason.ScaledJobCheckFailed, "Failed to ensure ScaledJob is correctly created")
+}
+
+func testTriggerAuthenticationEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing ScaledJob normal event ---")
+
+	KubectlApplyWithTemplate(t, data, "secretTemplate", secretTemplate)
+	KubectlApplyWithTemplate(t, data, "secret2Template", secret2Template)
+
+	data.SecretTargetName = secretName
+	KubectlApplyWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
+
+	checkingEvent(t, testNamespace, triggerAuthName, 0, eventreason.TriggerAuthenticationAdded, message.TriggerAuthenticationCreatedMsg)
+
+	KubectlApplyWithTemplate(t, data, "clusterTriggerAuthenticationTemplate", clusterTriggerAuthenticationTemplate)
+
+	checkingEvent(t, "default", clusterTriggerAuthName, 0, eventreason.ClusterTriggerAuthenticationAdded, message.ClusterTriggerAuthenticationCreatedMsg)
+
+	data.SecretTargetName = secretName2
+	KubectlApplyWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
+
+	checkingEvent(t, testNamespace, triggerAuthName, -1, eventreason.TriggerAuthenticationUpdated, fmt.Sprintf(message.TriggerAuthenticationUpdatedMsg, triggerAuthName))
+	KubectlApplyWithTemplate(t, data, "clusterTriggerAuthenticationTemplate", clusterTriggerAuthenticationTemplate)
+
+	checkingEvent(t, "default", clusterTriggerAuthName, -1, eventreason.ClusterTriggerAuthenticationUpdated, fmt.Sprintf(message.ClusterTriggerAuthenticationUpdatedMsg, clusterTriggerAuthName))
+	KubectlDeleteWithTemplate(t, data, "secretTemplate", secretTemplate)
+	KubectlDeleteWithTemplate(t, data, "secret2Template", secret2Template)
+	KubectlDeleteWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
+	KubectlDeleteWithTemplate(t, data, "clusterTriggerAuthenticationTemplate", clusterTriggerAuthenticationTemplate)
+
 }


### PR DESCRIPTION
Provide ClusterCloudEventSource around the management of TriggerAuthentication/ClusterTriggerAuthentication resources

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to # **https://github.com/kedacore/keda/issues/3524**
