### PR TITLE
Update Remote Container references to Dev Containers

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,7 +5,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Building](#building)
-  - [Quick start with Visual Studio Code Remote - Containers](#quick-start-with-visual-studio-code-remote---containers)
+  - [Quick start with Visual Studio Code Dev Containers](#quick-start-with-visual-studio-code-dev-containers)
   - [Locally directly](#locally-directly)
 - [Deploying](#deploying)
   - [Custom KEDA locally outside cluster](#custom-keda-locally-outside-cluster)
@@ -25,14 +25,14 @@
 
 ## Building
 
-### Quick start with [Visual Studio Code Remote - Containers](https://code.visualstudio.com/docs/remote/containers)
+### Quick start with [Visual Studio Code Dev Containers](https://code.visualstudio.com/docs/remote/containers)
 
 This helps you pull and build quickly - dev containers launch the project inside a container with all the tooling
 required for a consistent and seamless developer experience.
 
 This means you don't have to install and configure your dev environment as the container handles this for you.
 
-To get started install [VSCode](https://code.visualstudio.com/) and the [Remote Containers extensions](
+To get started install [VSCode](https://code.visualstudio.com/) and the [Dev Containers extensions](
 https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 
 Clone the repo and launch code:
@@ -43,7 +43,7 @@ cd keda
 code .
 ```
 
-Once VSCode launches run `CTRL+SHIFT+P -> Remote-Containers: Reopen in container` and then use the integrated
+Once VSCode launches run `CTRL+SHIFT+P -> Dev Containers: Reopen in container` and then use the integrated
 terminal to run:
 
 ```bash


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Remote Containers in VS code are called `Dev Containers`. Updated the BUILD.md to reflect that nuance. Particularly helpful for the command palate walkthrough of setting up Dev Container during local dev work.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
