### PR TITLE
Allow using secretRef for hashicorpVault auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Here is an overview of all new **experimental** features:
 
 ### Improvements
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **Hashicorp Vault**:  Allow using secretRef for hashicorpVault auth ([#6026](https://github.com/kedacore/keda/issues/6026))
 
 ### Fixes
 

--- a/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -235,7 +235,12 @@ type Credential struct {
 	Token string `json:"token,omitempty"`
 
 	// +optional
-	ServiceAccount string `json:"serviceAccount,omitempty"`
+	ServiceAccount string                     `json:"serviceAccount,omitempty"`
+	TokenSecret    *HashicorpVaultTokenSecret `json:"tokenSecret,omitempty"`
+}
+
+type HashicorpVaultTokenSecret struct {
+	ValueFrom ValueFromSecret `json:"valueFrom"`
 }
 
 // VaultAuthentication contains the list of Hashicorp Vault authentication methods

--- a/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
@@ -439,6 +439,26 @@ spec:
                         type: string
                       token:
                         type: string
+                      tokenSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
                     type: object
                   mount:
                     type: string

--- a/config/crd/bases/keda.sh_triggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_triggerauthentications.yaml
@@ -438,6 +438,26 @@ spec:
                         type: string
                       token:
                         type: string
+                      tokenSecret:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
                     type: object
                   mount:
                     type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,6 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: keda-operator
 rules:
 - apiGroups:
@@ -136,6 +137,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  creationTimestamp: null
   name: keda-operator
   namespace: keda
 rules:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: keda-operator
 rules:
 - apiGroups:
@@ -137,7 +136,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: keda-operator
   namespace: keda
 rules:

--- a/pkg/scaling/resolver/hashicorpvault_handler_test.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resolver
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -182,7 +183,7 @@ func TestHashicorpVaultHandler_getSecretValue_specify_secret_type(t *testing.T) 
 		},
 	}
 	vaultHandler := NewHashicorpVaultHandler(&vault)
-	err := vaultHandler.Initialize(logf.Log.WithName("test"))
+	err := vaultHandler.Initialize(context.TODO(), nil, logf.Log.WithName("test"), "", nil)
 	defer vaultHandler.Stop()
 	assert.Nil(t, err)
 	secrets := []kedav1alpha1.VaultSecret{{
@@ -322,7 +323,7 @@ func TestHashicorpVaultHandler_ResolveSecret(t *testing.T) {
 		},
 	}
 	vaultHandler := NewHashicorpVaultHandler(&vault)
-	err := vaultHandler.Initialize(logf.Log.WithName("test"))
+	err := vaultHandler.Initialize(context.TODO(), nil, logf.Log.WithName("test"), "", nil)
 	defer vaultHandler.Stop()
 	assert.Nil(t, err)
 
@@ -358,7 +359,7 @@ func TestHashicorpVaultHandler_ResolveSecret_UsingRootToken(t *testing.T) {
 		},
 	}
 	vaultHandler := NewHashicorpVaultHandler(&vault)
-	err := vaultHandler.Initialize(logf.Log.WithName("test"))
+	err := vaultHandler.Initialize(context.TODO(), nil, logf.Log.WithName("test"), "", nil)
 	defer vaultHandler.Stop()
 	assert.Nil(t, err)
 
@@ -395,7 +396,7 @@ func TestHashicorpVaultHandler_DefaultKubernetesVaultRole(t *testing.T) {
 	}
 
 	vaultHandler := NewHashicorpVaultHandler(&vault)
-	err := vaultHandler.Initialize(logf.Log.WithName("test"))
+	err := vaultHandler.Initialize(context.TODO(), nil, logf.Log.WithName("test"), "", nil)
 	defer vaultHandler.Stop()
 	assert.Errorf(t, err, "open %s : no such file or directory", defaultServiceAccountPath)
 	assert.Equal(t, vaultHandler.vault.Credential.ServiceAccount, defaultServiceAccountPath)
@@ -413,7 +414,7 @@ func TestHashicorpVaultHandler_ResolveSecrets_SameCertAndKey(t *testing.T) {
 		},
 	}
 	vaultHandler := NewHashicorpVaultHandler(&vault)
-	err := vaultHandler.Initialize(logf.Log.WithName("test"))
+	err := vaultHandler.Initialize(context.TODO(), nil, logf.Log.WithName("test"), "", nil)
 	defer vaultHandler.Stop()
 	assert.Nil(t, err)
 	secrets := []kedav1alpha1.VaultSecret{{
@@ -481,7 +482,7 @@ func TestHashicorpVaultHandler_fetchSecret(t *testing.T) {
 		},
 	}
 	vaultHandler := NewHashicorpVaultHandler(&vault)
-	err := vaultHandler.Initialize(logf.Log.WithName("test"))
+	err := vaultHandler.Initialize(context.TODO(), nil, logf.Log.WithName("test"), "", nil)
 	defer vaultHandler.Stop()
 	assert.Nil(t, err)
 
@@ -537,7 +538,7 @@ func TestHashicorpVaultHandler_Initialize(t *testing.T) {
 				Namespace: testData.namespace,
 			}
 			vaultHandler := NewHashicorpVaultHandler(&vault)
-			err := vaultHandler.Initialize(logf.Log.WithName("test"))
+			err := vaultHandler.Initialize(context.TODO(), nil, logf.Log.WithName("test"), "", nil)
 			defer vaultHandler.Stop()
 			assert.Nil(t, err)
 
@@ -616,7 +617,7 @@ func TestHashicorpVaultHandler_Token_VaultTokenAuth(t *testing.T) {
 			config := vaultapi.DefaultConfig()
 			client, err := vaultapi.NewClient(config)
 			assert.Nil(t, err)
-			token, err := vaultHandler.token(client)
+			token, err := vaultHandler.token(context.TODO(), nil, client, logf.Log.WithName("test"), "", nil)
 			if testData.isError {
 				assert.Equalf(t, vaultHandler.vault.Credential.ServiceAccount, testData.credential.ServiceAccount, "test %s: expected %s but found %s", testData.name, "random/path", vaultHandler.vault.Credential.ServiceAccount)
 				assert.NotNilf(t, err, "test %s: expected error but got success, testData - %+v", testData.name, testData)

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -266,7 +266,7 @@ func resolveAuthRef(ctx context.Context, client client.Client, logger logr.Logge
 			}
 			if triggerAuthSpec.HashiCorpVault != nil && len(triggerAuthSpec.HashiCorpVault.Secrets) > 0 {
 				vault := NewHashicorpVaultHandler(triggerAuthSpec.HashiCorpVault)
-				err := vault.Initialize(logger)
+				err := vault.Initialize(ctx, client, logger, triggerNamespace, secretsLister)
 				defer vault.Stop()
 				if err != nil {
 					logger.Error(err, "error authenticating to Vault", "triggerAuthRef.Name", triggerAuthRef.Name)


### PR DESCRIPTION
Allow referring to a k8s secret that contain hashicorp Vault token. Similar to AzureKeyVault and AWSSecretManager https://keda.sh/docs/2.15/concepts/authentication/#re-use-credentials-and-delegate-auth-with-triggerauthentication

```diff
apiVersion: keda.sh/v1alpha1
kind: TriggerAuthentication
metadata:
  name: {trigger-authentication-name}
  namespace: default # must be same namespace as the ScaledObject
spec:
  podIdentity:
      provider: none | azure-workload | aws | aws-eks | gcp  # Optional. Default: none
      identityId: <identity-id>                                           # Optional. Only used by azure & azure-workload providers.
      roleArn: <role-arn>                                                 # Optional. Only used by aws provider.
      identityOwner: keda|workload                                        # Optional. Only used by aws provider.
  secretTargetRef:                                                        # Optional.
  - parameter: {scaledObject-parameter-name}                              # Required.
    name: {secret-name}                                                   # Required.
    key: {secret-key-name}                                                # Required.
  env:                                                                    # Optional.
  - parameter: {scaledObject-parameter-name}                              # Required.
    name: {env-name}                                                      # Required.
    containerName: {container-name}                                       # Optional. Default: scaleTargetRef.envSourceContainerName of ScaledObject
  hashiCorpVault:                                                         # Optional.
    address: {hashicorp-vault-address}                                    # Required.
    namespace: {hashicorp-vault-namespace}                                # Optional. Default is root namespace. Useful for Vault Enterprise
    authentication: token | kubernetes                                    # Required.
    role: {hashicorp-vault-role}                                          # Optional.
    mount: {hashicorp-vault-mount}                                        # Optional.
    credential:                                                           # Optional.
      token: {hashicorp-vault-token}                                      # Optional.
      serviceAccount: {path-to-service-account-file}                      # Optional.
+     tokenSecret:                                                        # Optional.
+       valueFrom:                                                        # Required.
+         secretKeyRef:                                                   # Required.
+           name: {my-secret}                                             # Required.
+           key: {my-key}                                                 # Required.
    secrets:                                                              # Required.
    - parameter: {scaledObject-parameter-name}                            # Required.
      key: {hashicorp-vault-secret-key-name}                               # Required.
      path: {hashicorp-vault-secret-path}
```
###  TODO
- [ ] Create new test
- [x] Add Changelog
- [ ] Add PR to doc
### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/6026
