### PR TITLE
Add azure-workload auth to MSSQL scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Here is an overview of all new **experimental** features:
 - **GCP Scalers**: Added custom time horizon in GCP scalers ([#5778](https://github.com/kedacore/keda/issues/5778))
 - **GitHub Scaler**: Fixed pagination, fetching repository list ([#5738](https://github.com/kedacore/keda/issues/5738))
 - **Kafka**: Fix logic to scale to zero on invalid offset even with earliest offsetResetPolicy ([#5689](https://github.com/kedacore/keda/issues/5689))
+- **MSSQL Scaler**: Add azure-workload auth ([#6104](https://github.com/kedacore/keda/issues/6104))
 - **RabbitMQ Scaler**: Add connection name for AMQP ([#5958](https://github.com/kedacore/keda/issues/5958))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ Here is an overview of all new **experimental** features:
 - **GCP Scalers**: Added custom time horizon in GCP scalers ([#5778](https://github.com/kedacore/keda/issues/5778))
 - **GitHub Scaler**: Fixed pagination, fetching repository list ([#5738](https://github.com/kedacore/keda/issues/5738))
 - **Kafka**: Fix logic to scale to zero on invalid offset even with earliest offsetResetPolicy ([#5689](https://github.com/kedacore/keda/issues/5689))
-- **MSSQL Scaler**: Add azure-workload auth ([#6104](https://github.com/kedacore/keda/issues/6104))
 - **RabbitMQ Scaler**: Add connection name for AMQP ([#5958](https://github.com/kedacore/keda/issues/5958))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -2,183 +2,226 @@ package scalers
 
 import (
 	"context"
-	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
-type mssqlTestData struct {
-	// test inputs
-	metadata    map[string]string
-	resolvedEnv map[string]string
-	authParams  map[string]string
-
-	// expected outputs
-	expectedMetricName       string
+type parseMSSQLMetadataTestData struct {
+	name                     string
+	metadata                 map[string]string
+	resolvedEnv              map[string]string
+	authParams               map[string]string
+	podIdentity              v1alpha1.AuthPodIdentity
+	expectedError            string
 	expectedConnectionString string
-	expectedError            error
+	expectedMetricName       string
 }
 
-type mssqlMetricIdentifier struct {
-	metadataTestData *mssqlTestData
-	triggerIndex     int
-	name             string
-}
-
-var testMssqlMetadata = []mssqlTestData{
-	// direct connection string input
+var testMSSQLMetadata = []parseMSSQLMetadataTestData{
 	{
+		name:                     "Direct connection string input",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"connectionString": "sqlserver://localhost"},
 		expectedConnectionString: "sqlserver://localhost",
 	},
-	// direct connection string input with activationTargetValue
 	{
+		name:                     "Direct connection string input with activationTargetValue",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "activationTargetValue": "20"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"connectionString": "sqlserver://localhost"},
 		expectedConnectionString: "sqlserver://localhost",
 	},
-	// direct connection string input, OLEDB format
 	{
+		name:                     "Direct connection string input, OLEDB format",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"connectionString": "Server=example.database.windows.net;port=1433;Database=AdventureWorks;Persist Security Info=False;User ID=user1;Password=Password#1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"},
 		expectedConnectionString: "Server=example.database.windows.net;port=1433;Database=AdventureWorks;Persist Security Info=False;User ID=user1;Password=Password#1;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
 	},
-	// connection string input via environment variables
 	{
+		name:                     "Connection string input via environment variables",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "connectionStringFromEnv": "test_connection_string"},
 		resolvedEnv:              map[string]string{"test_connection_string": "sqlserver://localhost?database=AdventureWorks"},
 		authParams:               map[string]string{},
 		expectedConnectionString: "sqlserver://localhost?database=AdventureWorks",
 	},
-	// connection string generated from minimal required metadata
 	{
+		name:                     "Connection string generated from minimal required metadata",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "127.0.0.1"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{},
 		expectedMetricName:       "mssql",
 		expectedConnectionString: "sqlserver://127.0.0.1",
 	},
-	// connection string generated from full metadata
 	{
+		name:                     "Connection string generated from full metadata",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user1", "passwordFromEnv": "test_password", "port": "1433", "database": "AdventureWorks"},
 		resolvedEnv:              map[string]string{"test_password": "Password#1"},
 		authParams:               map[string]string{},
 		expectedConnectionString: "sqlserver://user1:Password%231@example.database.windows.net:1433?database=AdventureWorks",
 	},
-	// variation of previous: no port, password from authParams, metricName from database name
 	{
+		name:                     "Variation of previous: no port, password from authParams, metricName from database name",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#2"},
 		expectedMetricName:       "mssql",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net?database=AdventureWorks",
 	},
-	// connection string generated from full authParams
 	{
+		name:                     "Connection string generated from full authParams",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#2", "host": "example.database.windows.net", "username": "user2", "database": "AdventureWorks", "port": "1433"},
 		expectedMetricName:       "mssql",
 		expectedConnectionString: "sqlserver://user2:Password%232@example.database.windows.net:1433?database=AdventureWorks",
 	},
-	// variation of previous: no database name, metricName from host
 	{
+		name:                     "Variation of previous: no database name, metricName from host",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user3"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#3"},
 		expectedMetricName:       "mssql",
 		expectedConnectionString: "sqlserver://user3:Password%233@example.database.windows.net",
 	},
-	// Error: missing query
 	{
+		name:          "Error: missing query",
 		metadata:      map[string]string{"targetValue": "1"},
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{"connectionString": "sqlserver://localhost"},
-		expectedError: ErrMsSQLNoQuery,
+		expectedError: "missing required parameter \"query\" in [triggerMetadata]",
 	},
-	// Error: missing targetValue
 	{
+		name:          "Error: missing targetValue",
 		metadata:      map[string]string{"query": "SELECT 1"},
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{"connectionString": "sqlserver://localhost"},
-		expectedError: ErrMsSQLNoTargetValue,
+		expectedError: "missing required parameter \"targetValue\" in [triggerMetadata]",
 	},
-	// Error: missing host
 	{
+		name:          "Error: missing host",
 		metadata:      map[string]string{"query": "SELECT 1", "targetValue": "1"},
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{},
-		expectedError: ErrScalerConfigMissingField,
+		expectedError: "must provide either connectionstring or host",
+	},
+	{
+		name: "Valid metadata with Azure Workload Identity",
+		metadata: map[string]string{
+			"query":       "SELECT COUNT(*) FROM table",
+			"targetValue": "5",
+			"host":        "mssql-server.database.windows.net",
+			"port":        "1433",
+			"database":    "test-db",
+		},
+		resolvedEnv: map[string]string{},
+		authParams: map[string]string{
+			"workloadIdentityResource": "mssql-resource-id",
+		},
+		podIdentity: v1alpha1.AuthPodIdentity{
+			Provider:              v1alpha1.PodIdentityProviderAzureWorkload,
+			IdentityID:            kedautil.StringPointer("client-id"),
+			IdentityTenantID:      kedautil.StringPointer("tenant-id"),
+			IdentityAuthorityHost: kedautil.StringPointer("https://login.microsoftonline.com/"),
+		},
+		expectedError: "",
+	},
+	{
+		name: "Azure Workload Identity without workloadIdentityResource",
+		metadata: map[string]string{
+			"query":       "SELECT COUNT(*) FROM table",
+			"targetValue": "5",
+			"host":        "mssql-server.database.windows.net",
+			"port":        "1433",
+			"database":    "test-db",
+		},
+		resolvedEnv: map[string]string{},
+		authParams:  map[string]string{},
+		podIdentity: v1alpha1.AuthPodIdentity{
+			Provider:              v1alpha1.PodIdentityProviderAzureWorkload,
+			IdentityID:            kedautil.StringPointer("client-id"),
+			IdentityTenantID:      kedautil.StringPointer("tenant-id"),
+			IdentityAuthorityHost: kedautil.StringPointer("https://login.microsoftonline.com/"),
+		},
+		expectedError: "",
 	},
 }
 
-var mssqlMetricIdentifiers = []mssqlMetricIdentifier{
-	{&testMssqlMetadata[0], 0, "s0-mssql"},
-	{&testMssqlMetadata[1], 1, "s1-mssql"},
-}
-
-func TestMSSQLMetadataParsing(t *testing.T) {
-	for _, testData := range testMssqlMetadata {
-		var config = scalersconfig.ScalerConfig{
-			ResolvedEnv:     testData.resolvedEnv,
-			TriggerMetadata: testData.metadata,
-			AuthParams:      testData.authParams,
-		}
-
-		outputMetadata, err := parseMSSQLMetadata(&config)
-		if err != nil {
-			if testData.expectedError == nil {
-				t.Errorf("Unexpected error parsing input metadata: %v", err)
-			} else if !errors.Is(err, testData.expectedError) {
-				t.Errorf("Expected error '%v' but got '%v'", testData.expectedError, err)
+func TestParseMSSQLMetadata(t *testing.T) {
+	for _, testData := range testMSSQLMetadata {
+		t.Run(testData.name, func(t *testing.T) {
+			config := &scalersconfig.ScalerConfig{
+				TriggerMetadata: testData.metadata,
+				ResolvedEnv:     testData.resolvedEnv,
+				AuthParams:      testData.authParams,
+				PodIdentity:     testData.podIdentity,
 			}
 
-			continue
-		}
+			meta, err := parseMSSQLMetadata(config)
 
-		expectedQuery := "SELECT 1"
-		if outputMetadata.query != expectedQuery {
-			t.Errorf("Wrong query. Expected '%s' but got '%s'", expectedQuery, outputMetadata.query)
-		}
+			if testData.expectedError != "" {
+				assert.EqualError(t, err, testData.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, meta)
 
-		var expectedTargetValue float64 = 1
-		if outputMetadata.targetValue != expectedTargetValue {
-			t.Errorf("Wrong targetValue. Expected %f but got %f", expectedTargetValue, outputMetadata.targetValue)
-		}
-
-		outputConnectionString := getMSSQLConnectionString(outputMetadata)
-		if testData.expectedConnectionString != outputConnectionString {
-			t.Errorf("Wrong connection string. Expected '%s' but got '%s'", testData.expectedConnectionString, outputConnectionString)
-		}
+				if testData.podIdentity.Provider == v1alpha1.PodIdentityProviderAzureWorkload {
+					if workloadIdentityResource, ok := testData.authParams["workloadIdentityResource"]; ok && workloadIdentityResource != "" {
+						// If workloadIdentityResource is provided, all fields should be set
+						assert.Equal(t, workloadIdentityResource, meta.WorkloadIdentityResource)
+						assert.Equal(t, *testData.podIdentity.IdentityID, meta.WorkloadIdentityClientID)
+						assert.Equal(t, *testData.podIdentity.IdentityTenantID, meta.WorkloadIdentityTenantID)
+						assert.Equal(t, *testData.podIdentity.IdentityAuthorityHost, meta.WorkloadIdentityAuthorityHost)
+					} else {
+						// If workloadIdentityResource is not provided, all fields should be empty
+						assert.Empty(t, meta.WorkloadIdentityResource)
+						assert.Empty(t, meta.WorkloadIdentityClientID)
+						assert.Empty(t, meta.WorkloadIdentityTenantID)
+						assert.Empty(t, meta.WorkloadIdentityAuthorityHost)
+					}
+				} else {
+					// If not using Azure Workload Identity, all fields should be empty
+					assert.Empty(t, meta.WorkloadIdentityResource)
+					assert.Empty(t, meta.WorkloadIdentityClientID)
+					assert.Empty(t, meta.WorkloadIdentityTenantID)
+					assert.Empty(t, meta.WorkloadIdentityAuthorityHost)
+				}
+			}
+		})
 	}
 }
 
 func TestMSSQLGetMetricSpecForScaling(t *testing.T) {
-	for _, testData := range mssqlMetricIdentifiers {
-		ctx := context.Background()
-		var config = scalersconfig.ScalerConfig{
-			ResolvedEnv:     testData.metadataTestData.resolvedEnv,
-			TriggerMetadata: testData.metadataTestData.metadata,
-			AuthParams:      testData.metadataTestData.authParams,
-			TriggerIndex:    testData.triggerIndex,
-		}
-		meta, err := parseMSSQLMetadata(&config)
-		if err != nil {
-			t.Fatal("Could not parse metadata:", err)
-		}
+	for _, testData := range testMSSQLMetadata {
+		t.Run(testData.name, func(t *testing.T) {
+			if testData.expectedError != "" {
+				return
+			}
 
-		mockMssqlScaler := mssqlScaler{
-			metadata: meta,
-		}
-		metricSpec := mockMssqlScaler.GetMetricSpecForScaling(ctx)
-		metricName := metricSpec[0].External.Metric.Name
-		if metricName != testData.name {
-			t.Error("Wrong External metric source name:", metricName, testData.name)
-		}
+			meta, err := parseMSSQLMetadata(&scalersconfig.ScalerConfig{
+				TriggerMetadata: testData.metadata,
+				ResolvedEnv:     testData.resolvedEnv,
+				AuthParams:      testData.authParams,
+				PodIdentity:     testData.podIdentity,
+			})
+
+			assert.NoError(t, err)
+
+			mockMSSQLScaler := mssqlScaler{
+				metadata: meta,
+			}
+
+			metricSpec := mockMSSQLScaler.GetMetricSpecForScaling(context.Background())
+
+			assert.NotNil(t, metricSpec)
+			assert.Equal(t, 1, len(metricSpec))
+			assert.Contains(t, metricSpec[0].External.Metric.Name, "mssql")
+		})
 	}
 }

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -208,7 +208,7 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 	case "mongodb":
 		return scalers.NewMongoDBScaler(ctx, config)
 	case "mssql":
-		return scalers.NewMSSQLScaler(config)
+		return scalers.NewMSSQLScaler(ctx, config)
 	case "mysql":
 		return scalers.NewMySQLScaler(config)
 	case "nats-jetstream":

--- a/tests/scalers/mssql/mssql_test.go
+++ b/tests/scalers/mssql/mssql_test.go
@@ -497,7 +497,7 @@ spec:
   containers:
   - name: sqlcmd
     image: mcr.microsoft.com/mssql-tools
-    command: 
+    command:
       - /bin/bash
       - -c
       - "sleep 5 && %s"

--- a/tests/scalers/mssql/mssql_test.go
+++ b/tests/scalers/mssql/mssql_test.go
@@ -494,11 +494,11 @@ spec:
       containers:
       - name: sqlcmd
         image: mcr.microsoft.com/mssql-tools
-        command: 
+        command:
           - /opt/mssql-tools/bin/sqlcmd
           - -S %s -d %s -U %s -P %s -Q "IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[tasks]') AND type in (N'U')) BEGIN CREATE TABLE tasks ([id] int identity primary key, [status] varchar(10)) END ELSE BEGIN TRUNCATE TABLE tasks END"
 
-      restartPolicy: Never`, 
+      restartPolicy: Never`,
 		wiTestNamespace,
 		azureSQLServerFQDN,
 		azureSQLDBName,
@@ -552,6 +552,7 @@ spec:
 	testWIScaleOut(t, kc, wiData)
 	testWIScaleIn(t, kc, wiData)
 }
+
 // Original test helper functions
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

- Refactor the scaler to match the new metadata guidelines.
- Added azure-workload auth

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6104 
Relates to #5797
