### PR TITLE
add activation feature for cpu & memory scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,11 @@ Here is an overview of all new **experimental** features:
 ### Improvements
 
 - **AWS CloudWatch Scaler**: Add support for ignoreNullValues ([#5352](https://github.com/kedacore/keda/issues/5352))
+- **CPU/Memory Scaler**: Add activation feature ([#6057](https://github.com/kedacore/keda/issues/6057))
 - **GCP Scalers**: Added custom time horizon in GCP scalers ([#5778](https://github.com/kedacore/keda/issues/5778))
 - **GitHub Scaler**: Fixed pagination, fetching repository list ([#5738](https://github.com/kedacore/keda/issues/5738))
 - **Kafka**: Fix logic to scale to zero on invalid offset even with earliest offsetResetPolicy ([#5689](https://github.com/kedacore/keda/issues/5689))
 - **RabbitMQ Scaler**: Add connection name for AMQP ([#5958](https://github.com/kedacore/keda/issues/5958))
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
 ### Fixes
 

--- a/pkg/scalers/cpu_memory_scaler.go
+++ b/pkg/scalers/cpu_memory_scaler.go
@@ -3,6 +3,8 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -11,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
 
@@ -18,17 +21,23 @@ type cpuMemoryScaler struct {
 	metadata     *cpuMemoryMetadata
 	resourceName v1.ResourceName
 	logger       logr.Logger
+	client       client.Client
 }
 
 type cpuMemoryMetadata struct {
-	Type               v2.MetricTargetType
-	AverageValue       *resource.Quantity
-	AverageUtilization *int32
-	ContainerName      string
+	Type                         v2.MetricTargetType
+	AverageValue                 *resource.Quantity
+	AverageUtilization           *int32
+	ContainerName                string
+	ActivationAverageValue       *resource.Quantity
+	ActivationAverageUtilization *int32
+	ScalableObjectName           string
+	ScalableObjectType           string
+	ScalableObjectNamespace      string
 }
 
 // NewCPUMemoryScaler creates a new cpuMemoryScaler
-func NewCPUMemoryScaler(resourceName v1.ResourceName, config *scalersconfig.ScalerConfig) (Scaler, error) {
+func NewCPUMemoryScaler(resourceName v1.ResourceName, config *scalersconfig.ScalerConfig, client client.Client) (Scaler, error) {
 	logger := InitializeLogger(config, "cpu_memory_scaler")
 
 	meta, parseErr := parseResourceMetadata(config, logger)
@@ -40,12 +49,13 @@ func NewCPUMemoryScaler(resourceName v1.ResourceName, config *scalersconfig.Scal
 		metadata:     meta,
 		resourceName: resourceName,
 		logger:       logger,
+		client:       client,
 	}, nil
 }
 
 func parseResourceMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) (*cpuMemoryMetadata, error) {
 	meta := &cpuMemoryMetadata{}
-	var value string
+	var value, activationValue string
 	var ok bool
 	value, ok = config.TriggerMetadata["type"]
 	switch {
@@ -63,10 +73,17 @@ func parseResourceMetadata(config *scalersconfig.ScalerConfig, logger logr.Logge
 	if value, ok = config.TriggerMetadata["value"]; !ok || value == "" {
 		return nil, fmt.Errorf("no value given")
 	}
+	if activationValue, ok = config.TriggerMetadata["activationValue"]; !ok || activationValue == "" {
+		activationValue = "0"
+	}
+
 	switch meta.Type {
 	case v2.AverageValueMetricType:
 		averageValueQuantity := resource.MustParse(value)
 		meta.AverageValue = &averageValueQuantity
+
+		activationValueQuantity := resource.MustParse(activationValue)
+		meta.ActivationAverageValue = &activationValueQuantity
 	case v2.UtilizationMetricType:
 		valueNum, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
@@ -74,6 +91,13 @@ func parseResourceMetadata(config *scalersconfig.ScalerConfig, logger logr.Logge
 		}
 		utilizationNum := int32(valueNum)
 		meta.AverageUtilization = &utilizationNum
+
+		valueNum, err = strconv.ParseInt(activationValue, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		activationAverageUtilization := int32(valueNum)
+		meta.ActivationAverageUtilization = &activationAverageUtilization
 	default:
 		return nil, fmt.Errorf("unsupported metric type, allowed values are 'Utilization' or 'AverageValue'")
 	}
@@ -82,12 +106,52 @@ func parseResourceMetadata(config *scalersconfig.ScalerConfig, logger logr.Logge
 		meta.ContainerName = value
 	}
 
+	meta.ScalableObjectName = config.ScalableObjectName
+	meta.ScalableObjectNamespace = config.ScalableObjectNamespace
+	meta.ScalableObjectType = config.ScalableObjectType
+
 	return meta, nil
 }
 
 // Close no need for cpuMemory scaler
 func (s *cpuMemoryScaler) Close(context.Context) error {
 	return nil
+}
+
+func (s *cpuMemoryScaler) getHPA(ctx context.Context) (*v2.HorizontalPodAutoscaler, error) {
+	if s.metadata.ScalableObjectType == "ScaledObject" {
+		scaledObject := &kedav1alpha1.ScaledObject{}
+		err := s.client.Get(ctx, types.NamespacedName{
+			Name:      s.metadata.ScalableObjectName,
+			Namespace: s.metadata.ScalableObjectNamespace,
+		}, scaledObject)
+
+		if err != nil {
+			return nil, err
+		}
+
+		hpa := &v2.HorizontalPodAutoscaler{}
+		err = s.client.Get(ctx, types.NamespacedName{
+			Name:      scaledObject.Status.HpaName,
+			Namespace: s.metadata.ScalableObjectNamespace,
+		}, hpa)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return hpa, nil
+	} else if s.metadata.ScalableObjectType == "ScaledJob" {
+		scaledJob := &kedav1alpha1.ScaledJob{}
+		err := s.client.Get(ctx, types.NamespacedName{
+			Name:      s.metadata.ScalableObjectName,
+			Namespace: s.metadata.ScalableObjectNamespace,
+		}, scaledJob)
+
+		return nil, err
+	}
+
+	return nil, fmt.Errorf("invalid scalable object type: %s", s.metadata.ScalableObjectType)
 }
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
@@ -120,7 +184,42 @@ func (s *cpuMemoryScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSp
 	return []v2.MetricSpec{metricSpec}
 }
 
-// GetMetricsAndActivity no need for cpu/memory scaler and always active for cpu/memory scaler
-func (s *cpuMemoryScaler) GetMetricsAndActivity(_ context.Context, _ string) ([]external_metrics.ExternalMetricValue, bool, error) {
-	return nil, true, nil
+// GetMetricsAndActivity only returns the activity of the cpu/memory scaler
+func (s *cpuMemoryScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
+	hpa, err := s.getHPA(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if hpa == nil {
+		return nil, false, fmt.Errorf("HPA not found")
+	}
+
+	for _, metric := range hpa.Status.CurrentMetrics {
+		if metric.Resource == nil {
+			continue
+		}
+
+		if string(metric.Resource.Name) != metricName {
+			continue
+		}
+
+		if s.metadata.Type == v2.AverageValueMetricType {
+			averageValue := metric.Resource.Current.AverageValue
+			if averageValue == nil {
+				return nil, false, fmt.Errorf("HPA has no average value")
+			}
+
+			return nil, averageValue.Cmp(*s.metadata.ActivationAverageValue) == 1, nil
+		} else if s.metadata.Type == v2.UtilizationMetricType {
+			averageUtilization := metric.Resource.Current.AverageUtilization
+			if averageUtilization == nil {
+				return nil, false, fmt.Errorf("HPA has no average utilization")
+			}
+
+			return nil, *averageUtilization > *s.metadata.ActivationAverageUtilization, nil
+		}
+	}
+
+	return nil, false, fmt.Errorf("no matching resource metric found for %s", s.resourceName)
 }

--- a/pkg/scalers/cpu_memory_scaler_test.go
+++ b/pkg/scalers/cpu_memory_scaler_test.go
@@ -2,6 +2,11 @@ package scalers
 
 import (
 	"context"
+	"fmt"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -20,8 +25,9 @@ type parseCPUMemoryMetadataTestData struct {
 
 // A complete valid metadata example for reference
 var validCPUMemoryMetadata = map[string]string{
-	"type":  "Utilization",
-	"value": "50",
+	"type":            "Utilization",
+	"value":           "50",
+	"activationValue": "40",
 }
 var validContainerCPUMemoryMetadata = map[string]string{
 	"type":          "Utilization",
@@ -37,6 +43,7 @@ var testCPUMemoryMetadata = []parseCPUMemoryMetadataTestData{
 	{v2.UtilizationMetricType, map[string]string{"value": "50"}, false},
 	{"", map[string]string{"type": "AverageValue", "value": "50"}, false},
 	{v2.AverageValueMetricType, map[string]string{"value": "50"}, false},
+	{"", map[string]string{"type": "AverageValue", "value": "50", "activationValue": "40"}, false},
 	{"", map[string]string{"type": "Value", "value": "50"}, true},
 	{v2.ValueMetricType, map[string]string{"value": "50"}, true},
 	{"", map[string]string{"type": "AverageValue"}, true},
@@ -64,7 +71,8 @@ func TestGetMetricSpecForScaling(t *testing.T) {
 	config := &scalersconfig.ScalerConfig{
 		TriggerMetadata: validCPUMemoryMetadata,
 	}
-	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config)
+	kubeClient := fake.NewFakeClient()
+	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config, kubeClient)
 	metricSpec := scaler.GetMetricSpecForScaling(context.Background())
 
 	assert.Equal(t, metricSpec[0].Type, v2.ResourceMetricSourceType)
@@ -76,7 +84,7 @@ func TestGetMetricSpecForScaling(t *testing.T) {
 		TriggerMetadata: map[string]string{"value": "50"},
 		MetricType:      v2.UtilizationMetricType,
 	}
-	scaler, _ = NewCPUMemoryScaler(v1.ResourceCPU, config)
+	scaler, _ = NewCPUMemoryScaler(v1.ResourceCPU, config, kubeClient)
 	metricSpec = scaler.GetMetricSpecForScaling(context.Background())
 
 	assert.Equal(t, metricSpec[0].Type, v2.ResourceMetricSourceType)
@@ -89,7 +97,8 @@ func TestGetContainerMetricSpecForScaling(t *testing.T) {
 	config := &scalersconfig.ScalerConfig{
 		TriggerMetadata: validContainerCPUMemoryMetadata,
 	}
-	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config)
+	kubeClient := fake.NewFakeClient()
+	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config, kubeClient)
 	metricSpec := scaler.GetMetricSpecForScaling(context.Background())
 
 	assert.Equal(t, metricSpec[0].Type, v2.ContainerResourceMetricSourceType)
@@ -102,11 +111,137 @@ func TestGetContainerMetricSpecForScaling(t *testing.T) {
 		TriggerMetadata: map[string]string{"value": "50", "containerName": "bar"},
 		MetricType:      v2.UtilizationMetricType,
 	}
-	scaler, _ = NewCPUMemoryScaler(v1.ResourceCPU, config)
+	scaler, _ = NewCPUMemoryScaler(v1.ResourceCPU, config, kubeClient)
 	metricSpec = scaler.GetMetricSpecForScaling(context.Background())
 
 	assert.Equal(t, metricSpec[0].Type, v2.ContainerResourceMetricSourceType)
 	assert.Equal(t, metricSpec[0].ContainerResource.Name, v1.ResourceCPU)
 	assert.Equal(t, metricSpec[0].ContainerResource.Target.Type, v2.UtilizationMetricType)
 	assert.Equal(t, metricSpec[0].ContainerResource.Container, "bar")
+}
+
+func createScaledObject() *kedav1alpha1.ScaledObject {
+	maxReplicas := int32(3)
+	minReplicas := int32(0)
+	pollingInterval := int32(10)
+	return &kedav1alpha1.ScaledObject{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "keda.sh/v1alpha1",
+			Kind:       "ScaledObject",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "test-namespace",
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			MaxReplicaCount: &maxReplicas,
+			MinReplicaCount: &minReplicas,
+			PollingInterval: &pollingInterval,
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "test-deployment",
+			},
+			Triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "cpu",
+					Metadata: map[string]string{
+						"activationValue": "500",
+						"value":           "800",
+					},
+					MetricType: v2.UtilizationMetricType,
+				},
+			},
+		},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			HpaName: "keda-hpa-test-name",
+		},
+	}
+}
+
+func createHPAWithAverageUtilization(averageUtilization int32) (*v2.HorizontalPodAutoscaler, error) {
+	minReplicas := int32(1)
+	averageValue, err := resource.ParseQuantity("800m")
+	if err != nil {
+		fmt.Errorf("Error parsing quantity: %s", err)
+		return nil, err
+	}
+
+	return &v2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keda-hpa-test-name",
+			Namespace: "test-namespace",
+		},
+		Spec: v2.HorizontalPodAutoscalerSpec{
+			MaxReplicas: 3,
+			MinReplicas: &minReplicas,
+			Metrics: []v2.MetricSpec{
+
+				{
+					Type: v2.ResourceMetricSourceType,
+					Resource: &v2.ResourceMetricSource{
+						Name: v1.ResourceCPU,
+						Target: v2.MetricTarget{
+							AverageUtilization: &averageUtilization,
+							Type:               v2.UtilizationMetricType,
+						},
+					},
+				},
+			},
+		},
+		Status: v2.HorizontalPodAutoscalerStatus{
+			CurrentMetrics: []v2.MetricStatus{
+				{
+					Type: v2.ResourceMetricSourceType,
+					Resource: &v2.ResourceMetricStatus{
+						Name: v1.ResourceCPU,
+						Current: v2.MetricValueStatus{
+							AverageUtilization: &averageUtilization,
+							AverageValue:       &averageValue,
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func TestGetMetricsAndActivity_IsActive(t *testing.T) {
+	config := &scalersconfig.ScalerConfig{
+		TriggerMetadata:         validCPUMemoryMetadata,
+		ScalableObjectType:      "ScaledObject",
+		ScalableObjectName:      "test-name",
+		ScalableObjectNamespace: "test-namespace",
+	}
+
+	hpa, err := createHPAWithAverageUtilization(50)
+	if err != nil {
+		t.Errorf("Error creating HPA: %s", err)
+	}
+
+	kubeClient := fake.NewClientBuilder().WithObjects(hpa, createScaledObject()).Build()
+	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config, kubeClient)
+
+	_, isActive, _ := scaler.GetMetricsAndActivity(context.Background(), "cpu")
+	assert.Equal(t, isActive, true)
+}
+
+func TestGetMetricsAndActivity_IsNotActive(t *testing.T) {
+	config := &scalersconfig.ScalerConfig{
+		TriggerMetadata:         validCPUMemoryMetadata,
+		ScalableObjectType:      "ScaledObject",
+		ScalableObjectName:      "test-name",
+		ScalableObjectNamespace: "test-namespace",
+	}
+
+	hpa, err := createHPAWithAverageUtilization(30)
+	if err != nil {
+		t.Errorf("Error creating HPA: %s", err)
+	}
+
+	kubeClient := fake.NewClientBuilder().WithRuntimeObjects(hpa, createScaledObject()).Build()
+	scaler, _ := NewCPUMemoryScaler(v1.ResourceCPU, config, kubeClient)
+
+	_, isActive, _ := scaler.GetMetricsAndActivity(context.Background(), "cpu")
+	assert.Equal(t, isActive, false)
 }

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -157,7 +157,7 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 	case "couchdb":
 		return scalers.NewCouchDBScaler(ctx, config)
 	case "cpu":
-		return scalers.NewCPUMemoryScaler(corev1.ResourceCPU, config)
+		return scalers.NewCPUMemoryScaler(corev1.ResourceCPU, config, client)
 	case "cron":
 		return scalers.NewCronScaler(config)
 	case "datadog":
@@ -202,7 +202,7 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 	case "loki":
 		return scalers.NewLokiScaler(config)
 	case "memory":
-		return scalers.NewCPUMemoryScaler(corev1.ResourceMemory, config)
+		return scalers.NewCPUMemoryScaler(corev1.ResourceMemory, config, client)
 	case "metrics-api":
 		return scalers.NewMetricsAPIScaler(config)
 	case "mongodb":

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
-
-	. "github.com/kedacore/keda/v2/tests/helper"
 )
 
 // Load environment variables from .env file
@@ -135,7 +133,8 @@ spec:
   - type: cpu
     metadata:
       type: Utilization
-      value: "50"
+      value: "10"
+			activationValue: "5"
   - type: kubernetes-workload
     metadata:
       podSelector: 'pod={{.WorkloadDeploymentName}}'
@@ -245,9 +244,18 @@ func scaleToZero(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicas, 60, 1),
 		"Replica count should be %v", maxReplicas)
 
-	// scale external trigger in (expect replicas back to 0 -- external trigger not active)
-	KubernetesScaleDeployment(t, kc, workloadDeploymentName, int64(minReplicas), testNamespace)
+	// activate cpu trigger
+	KubectlReplaceWithTemplate(t, data, "triggerJobTemplate", triggerJob)
 
+	// replica count should not change from maxReplicas
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, maxReplicas, 60)
+
+	// scale external trigger in (expect replicas to stay at maxReplicas -- external trigger not active)
+	KubernetesScaleDeployment(t, kc, workloadDeploymentName, int64(minReplicas), testNamespace)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, maxReplicas, 60)
+
+	// remove trigger job to deactivate cpu trigger
+	KubectlDeleteWithTemplate(t, data, "triggerJobTemplate", triggerJob)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicas, 60, 1),
 		"Replica count should be %v", minReplicas)
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Currently, the cpu & memory scalers lack the activation feature because they delegate the scaling responsibilities to the built-in Kubernetes HPA controller. As a result, even if the scale target is currently scaled-out by the cpu/memory metric being above the threshold value, if some other Keda scalers which use External Metrics are used in conjunction with the cpu/memory scaler, it will be deactivated (and thus scaled to zero) when all other scalers using External Metrics are deactivated.

Hence, my proposal is to introduce a way to check the activation of the cpu/memory scaler. Since the scaling behavior will be handled by the HPA controller, cpu/memory scaler only needs to feed in the activation value to the scaled object controller in its `GetMetricsAndActivity()` method. Moreover to enable such feature, I introduce `activationValue` field in cpu/memory trigger's metadata.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6057

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
