### PR TITLE
fix: correct Update logic for PausedReplicasPredicate to handle empty annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ None.
 - **New Relic Scaler** Store forgotten logger ([#3945](https://github.com/kedacore/keda/issues/3945))
 - **Prometheus Scaler:** Treat Inf the same as Null result ([#3644](https://github.com/kedacore/keda/issues/3644))
 - **NATS Jetstream:** Correctly count messages that should be redelivered (waiting for ack) towards keda value ([#3787](https://github.com/kedacore/keda/issues/3787))
+- **General:** Fix: update the logic for PausedReplicasPredicate to handle empty annotations ([#6062](https://github.com/kedacore/keda/issues/6062))
 
 ### Deprecations
 

--- a/controllers/keda/util/predicate.go
+++ b/controllers/keda/util/predicate.go
@@ -20,15 +20,19 @@ func (PausedReplicasPredicate) Update(e event.UpdateEvent) bool {
 
 	newAnnotations := e.ObjectNew.GetAnnotations()
 	oldAnnotations := e.ObjectOld.GetAnnotations()
-	if newAnnotations != nil && oldAnnotations != nil {
-		if newVal, ok1 := newAnnotations[PausedReplicasAnnotation]; ok1 {
-			if oldVal, ok2 := oldAnnotations[PausedReplicasAnnotation]; ok2 {
-				return newVal != oldVal
-			}
-			return true
-		}
+
+	newPausedValue := ""
+	oldPausedValue := ""
+
+	if newAnnotations != nil {
+		newPausedValue = newAnnotations[PausedReplicasAnnotation]
 	}
-	return false
+
+	if oldAnnotations != nil {
+		oldPausedValue = oldAnnotations[PausedReplicasAnnotation]
+	}
+
+	return newPausedValue != oldPausedValue
 }
 
 type ScaleObjectReadyConditionPredicate struct {

--- a/controllers/keda/util/predicate_test.go
+++ b/controllers/keda/util/predicate_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func createObjectWithAnnotations(annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAnnotations(annotations)
+	return obj
+}
+
+func TestPausedReplicasPredicate_Update(t *testing.T) {
+	predicate := PausedReplicasPredicate{}
+
+	tests := []struct {
+		name      string
+		oldObject *unstructured.Unstructured
+		newObject *unstructured.Unstructured
+		expected  bool
+	}{
+		{
+			name:      "Both objects have the same annotation value",
+			oldObject: createObjectWithAnnotations(map[string]string{PausedReplicasAnnotation: "8"}),
+			newObject: createObjectWithAnnotations(map[string]string{PausedReplicasAnnotation: "8"}),
+			expected:  false,
+		},
+		{
+			name:      "Annotation value changed from 8 to 10",
+			oldObject: createObjectWithAnnotations(map[string]string{PausedReplicasAnnotation: "8"}),
+			newObject: createObjectWithAnnotations(map[string]string{PausedReplicasAnnotation: "10"}),
+			expected:  true,
+		},
+		{
+			name:      "Old annotation is nil, new annotation has value",
+			oldObject: createObjectWithAnnotations(nil),
+			newObject: createObjectWithAnnotations(map[string]string{PausedReplicasAnnotation: "10"}),
+			expected:  true,
+		},
+		{
+			name:      "Old annotation has value, new annotation is nil",
+			oldObject: createObjectWithAnnotations(map[string]string{PausedReplicasAnnotation: "8"}),
+			newObject: createObjectWithAnnotations(nil),
+			expected:  true,
+		},
+		{
+			name:      "Both annotations are nil",
+			oldObject: createObjectWithAnnotations(nil),
+			newObject: createObjectWithAnnotations(nil),
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := event.UpdateEvent{
+				ObjectOld: tt.oldObject,
+				ObjectNew: tt.newObject,
+			}
+			result := predicate.Update(event)
+			if result != tt.expected {
+				t.Errorf("expected %v, but got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
annotations

In the original code, when `newAnnotations` is nil and `oldAnnotations` isn't nil, the function incorrectly returned `false`, which should return `true` when transitioning from nil to a non-nil state or vice versa. The new logic ensures that any change in the paused replicas annotation is correctly detected, even if one of the annotations is nil.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

This PR refactors the Update function in the PausedReplicasPredicate to handle more conditions related to the PausedReplicasAnnotation. The new implementation ensures that changes between nil and non-nil annotations are detected properly. Additionally, tests have been added to cover various cases, including when the annotations are nil, unchanged, or have different values.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6062

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
