### PR TITLE
fix: Initial delay e2e test use a scaler without failures

### DIFF
--- a/tests/internals/initial_delay_cooldownperiod/initial_delay_cooldownperiod_test.go
+++ b/tests/internals/initial_delay_cooldownperiod/initial_delay_cooldownperiod_test.go
@@ -78,13 +78,10 @@ spec:
         scaleDown:
           stabilizationWindowSeconds: 15
   triggers:
-  - type: cron
+  - type: kubernetes-workload
     metadata:
-      timezone: Etc/UTC
-      start: {{.StartMin}} * * * *
-      end: {{.EndMin}} * * * *
-      desiredReplicas: '0'
-`
+      podSelector: 'pod=no-matches'
+      value: '1'`
 )
 
 func TestScaler(t *testing.T) {


### PR DESCRIPTION
I think that after moving the cron scaler to the declarative parsing, 0 is treated as error and this test failed because during errors, the scaling to 0 doesn't apply. This PR changes the scaler to other that returns 0 without errors

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


