### PR TITLE
fix: AWS Secret manager respect pod identity overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **AWS Secret Manager**: Pod identity overrides are honored ([#6195](https://github.com/kedacore/keda/issues/6195))
 - **Metrics API**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
 
 ### Deprecations

--- a/pkg/scaling/resolver/aws_secretmanager_handler.go
+++ b/pkg/scaling/resolver/aws_secretmanager_handler.go
@@ -86,6 +86,7 @@ func (ash *AwsSecretManagerHandler) Initialize(ctx context.Context, client clien
 			return fmt.Errorf("AccessKeyID and AccessSecretKey are expected when not using a pod identity provider")
 		}
 	case kedav1alpha1.PodIdentityProviderAws:
+		ash.awsMetadata.UsingPodIdentity = true
 		if ash.secretManager.PodIdentity.IsWorkloadIdentityOwner() {
 			awsRoleArn, err := resolveServiceAccountAnnotation(ctx, client, podSpec.ServiceAccountName, triggerNamespace, kedav1alpha1.PodIdentityAnnotationEKS, true)
 			if err != nil {


### PR DESCRIPTION
Basically, we weren't setting pod identity flag when pod identity is set for AWS secret manager, as there isn't any ID & key, default value is used, doing a fallback to the global pod identity configuration (if configured) or using node identity

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/6195


