### PR TITLE
chore: Use the same secret for the PAT

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -52,7 +52,7 @@ jobs:
           # Username used to log in to a Docker registry. If not set then no login will occur
           username: ${{ github.repository_owner }}
           # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
-          password: ${{ secrets.GHCR_AUTH_PAT }}
+          password: ${{ secrets.GH_AUTOMATION_PAT }}
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
 

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -135,7 +135,7 @@ jobs:
           # Username used to log in to a Docker registry. If not set then no login will occur
           username: ${{ github.repository_owner }}
           # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
-          password: ${{ secrets.GHCR_AUTH_PAT }}
+          password: ${{ secrets.GH_AUTOMATION_PAT }}
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -49,7 +49,7 @@ jobs:
           # Username used to log in to a Docker registry. If not set then no login will occur
           username: ${{ github.repository_owner }}
           # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
-          password: ${{ secrets.GHCR_AUTH_PAT }}
+          password: ${{ secrets.GH_AUTOMATION_PAT }}
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
 


### PR DESCRIPTION
Currently, `GH_AUTOMATION_PAT ` has the same values as `GHCR_AUTH_PAT`, this PR unifies both envs

EDIT: I'm @JorTurFer and I didn't notice that I was logged in with the wrong account

### Checklist


- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

