### PR TITLE
fix: Use AMD64 machine to generate docker images

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: oracle-aarch64-4cpu-16gb
+    runs-on: equinix-4cpu-16gb
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Push Release
-    runs-on: oracle-aarch64-4cpu-16gb
+    runs-on: equinix-4cpu-16gb
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
ARM64 machines are failing with multi-platform docker build. I thope that AMD64 machines do it better 🤞 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

