### PR TITLE
e2e test checker - use keda-tools container for dependencies (gh)

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -10,6 +10,7 @@ jobs:
   triage:
     runs-on: equinix-2cpu-8gb
     name: Comment evaluate
+    container: ghcr.io/kedacore/keda-tools:1.22.5
     outputs:
       run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember == 'true' }}
       pr_num: ${{ steps.parser.outputs.pr_num }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

CNCF runners are missing gh:

```
/home/runner/_work/_temp/3f017fe0-a33c-4dc3-bc3e-aae743e5300e.sh: line 8: gh: command not found
```
