### PR TITLE
Refactor CPU/Memory scaler config

### DIFF
--- a/pkg/scalers/cpu_memory_scaler.go
+++ b/pkg/scalers/cpu_memory_scaler.go
@@ -63,6 +63,10 @@ func parseResourceMetadata(config *scalersconfig.ScalerConfig, logger logr.Logge
 		return meta, err
 	}
 
+	if config.MetricType != "" {
+		meta.MetricType = config.MetricType
+	}
+
 	// This is deprecated and can be removed later
 	if meta.Type != "" {
 		logger.Info("The 'type' setting is DEPRECATED and will be removed in v2.18 - Use 'metricType' instead.")

--- a/pkg/scalers/cpu_memory_scaler_test.go
+++ b/pkg/scalers/cpu_memory_scaler_test.go
@@ -18,7 +18,6 @@ type parseCPUMemoryMetadataTestData struct {
 	isError    bool
 }
 
-// A complete valid metadata example for reference
 var validCPUMemoryMetadata = map[string]string{
 	"type":  "Utilization",
 	"value": "50",
@@ -44,17 +43,18 @@ var testCPUMemoryMetadata = []parseCPUMemoryMetadataTestData{
 }
 
 func TestCPUMemoryParseMetadata(t *testing.T) {
-	for _, testData := range testCPUMemoryMetadata {
+	logger := logr.Discard()
+	for i, testData := range testCPUMemoryMetadata {
 		config := &scalersconfig.ScalerConfig{
 			TriggerMetadata: testData.metadata,
 			MetricType:      testData.metricType,
 		}
-		_, err := parseResourceMetadata(config, logr.Discard())
+		_, err := parseResourceMetadata(config, logger)
 		if err != nil && !testData.isError {
-			t.Error("Expected success but got error", err)
+			t.Errorf("Test case %d: Expected success but got error: %v", i, err)
 		}
 		if testData.isError && err == nil {
-			t.Error("Expected error but got success")
+			t.Errorf("Test case %d: Expected error but got success", i)
 		}
 	}
 }


### PR DESCRIPTION
- Refactor the scaler to match the new metadata guidelines.
- The parameter `type` is already from release 2.7 deprecated. I think it's time to announce the removal  and remove the deprecated code in version 2.18.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Related: [5797](https://github.com/kedacore/keda/pull/5797)
Docs: https://github.com/kedacore/keda-docs/pull/1484