### PR TITLE
fix: Revert changes to not use CNCF runners

### DIFF
--- a/.github/workflows/auto-add-issues-to-project.yml
+++ b/.github/workflows/auto-add-issues-to-project.yml
@@ -5,7 +5,7 @@ on:
       - opened
 jobs:
   track_issue:
-    runs-on: equinix-2cpu-8gb
+    runs-on: ubuntu-latest
     steps:
       - name: Get project data
         env:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: equinix-4cpu-16gb
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: build
-    runs-on: equinix-4cpu-16gb
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -91,7 +91,7 @@ jobs:
     needs: build
     uses: kedacore/keda/.github/workflows/template-trivy-scan.yml@main
     with:
-      runs-on: equinix-4cpu-16gb
+      runs-on: ubuntu-latest
       scan-type: "fs"
       format: "sarif"
       exit-code: 0
@@ -101,7 +101,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        runner: [oracle-aarch64-4cpu-16gb, equinix-4cpu-16gb]
+        runner: [ARM64, ubuntu-latest]
     uses: kedacore/keda/.github/workflows/template-trivy-scan.yml@main
     with:
       runs-on: ${{ matrix.runner }}
@@ -115,7 +115,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        runner: [oracle-aarch64-4cpu-16gb, equinix-4cpu-16gb]
+        runner: [ARM64, ubuntu-latest]
     uses: kedacore/keda/.github/workflows/template-trivy-scan.yml@main
     with:
       runs-on: ${{ matrix.runner }}

--- a/.github/workflows/pr-e2e-checker.yml
+++ b/.github/workflows/pr-e2e-checker.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   e2e-checker:
     name: label checker
-    runs-on: equinix-2cpu-8gb
+    runs-on: ubuntu-latest
     steps:
       - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2
         name: Enqueue e2e

--- a/.github/workflows/pr-e2e-creator.yml
+++ b/.github/workflows/pr-e2e-creator.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   check-creator:
     name: check-creator
-    runs-on: equinix-2cpu-8gb
+    runs-on: ubuntu-latest
     steps:
       - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2
         name: Enqueue e2e

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   triage:
-    runs-on: equinix-2cpu-8gb
+    runs-on: ubuntu-latest
     name: Comment evaluate
     container: ghcr.io/kedacore/keda-tools:1.22.5
     outputs:
@@ -67,7 +67,7 @@ jobs:
 
   build-test-images:
     needs: triage
-    runs-on: equinix-4cpu-16gb
+    runs-on: ubuntu-latest
     name: Build images
     container: ghcr.io/kedacore/keda-tools:1.22.5
     if: needs.triage.outputs.run-e2e == 'true'
@@ -147,7 +147,7 @@ jobs:
 
   run-test:
     needs: [triage, build-test-images]
-    runs-on: equinix-keda-runner
+    runs-on: e2e
     name: Execute e2e tests
     container: ghcr.io/kedacore/keda-tools:1.22.5
     if: needs.triage.outputs.run-e2e == 'true'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: oracle-aarch64-4cpu-16gb
+          - runner: ARM64
             name: arm64
-          - runner: equinix-4cpu-16gb
+          - runner: ubuntu-latest
             name: amd64
     steps:
       - name: Check out code
@@ -81,9 +81,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: oracle-aarch64-4cpu-16gb
+          - runner: ARM64
             name: arm64
-          - runner: equinix-4cpu-16gb
+          - runner: ubuntu-latest
             name: amd64
     steps:
       - name: Check out code
@@ -112,9 +112,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: oracle-aarch64-4cpu-16gb
+          - runner: ARM64
             name: arm64
-          - runner: equinix-4cpu-16gb
+          - runner: ubuntu-latest
             name: amd64
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -151,7 +151,7 @@ jobs:
   trivy-scan:
     uses: kedacore/keda/.github/workflows/template-trivy-scan.yml@main
     with:
-      runs-on: equinix-4cpu-16gb
+      runs-on: ubuntu-latest
       scan-type: "fs"
       format: "table"
       output: ""

--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   pr_bot:
     name: PR Bot
-    runs-on: equinix-2cpu-8gb
+    runs-on: ubuntu-latest
     steps:
       - name: "Add welcome comment on PR #${{ github.event.number }} (draft)"
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Push Release
-    runs-on: equinix-4cpu-16gb
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   codeQl:
     name: Analyze CodeQL Go
-    runs-on: equinix-4cpu-16gb
+    runs-on: ubuntu-latest
     container: ghcr.io/kedacore/keda-tools:1.22.5
     if: (github.actor != 'dependabot[bot]')
     steps:

--- a/.github/workflows/static-analysis-semgrep.yml
+++ b/.github/workflows/static-analysis-semgrep.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   semgrep:
     name: Analyze Semgrep
-    runs-on: equinix-4cpu-16gb
+    runs-on: ubuntu-latest
     container: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:

--- a/.github/workflows/template-arm64-smoke-tests.yml
+++ b/.github/workflows/template-arm64-smoke-tests.yml
@@ -9,6 +9,6 @@ jobs:
     concurrency: arm-smoke-tests
     uses: kedacore/keda/.github/workflows/template-smoke-tests.yml@main
     with:
-      runs-on: oracle-aarch64-4cpu-16gb
+      runs-on: ARM64
       kubernetesVersion: v1.30
       kindImage: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   e2e-tests:
     name: Run e2e test
-    runs-on: oracle-aarch64-4cpu-16gb
+    runs-on: ARM64
     # keda-tools is built from github.com/test-tools/tools/Dockerfile
     container: ghcr.io/kedacore/keda-tools:1.22.5
     concurrency: e2e-tests

--- a/.github/workflows/template-versions-smoke-tests.yml
+++ b/.github/workflows/template-versions-smoke-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   smoke-tests:
-    name: equinix-4cpu-16gb
+    name: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +19,6 @@ jobs:
             kindImage: kindest/node:v1.28.9@sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0
     uses: kedacore/keda/.github/workflows/template-smoke-tests.yml@main
     with:
-      runs-on: equinix-4cpu-16gb
+      runs-on: ubuntu-latest
       kubernetesVersion: ${{ matrix.kubernetesVersion }}
       kindImage: ${{ matrix.kindImage }}

--- a/.github/workflows/v1-build.yml
+++ b/.github/workflows/v1-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   validate:
     name: Validate
-    runs-on: equinix-2cpu-8gb
+    runs-on: ubuntu-latest
     container: kedacore/build-tools:v1
     steps:
       - name: Check out code


### PR DESCRIPTION
CNCF Runners aren't ready, so this PR Removes all the usages of them

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
