### PR TITLE
fix: Use the the GH TOKEN to pull trivy's DB

### DIFF
--- a/.github/workflows/template-trivy-scan.yml
+++ b/.github/workflows/template-trivy-scan.yml
@@ -49,6 +49,8 @@ jobs:
           exit-code: ${{ inputs.exit-code }}
           severity: ${{ inputs.severity }}
           trivy-config: trivy.yml
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Temporal fix -> https://github.com/aquasecurity/trivy-action/issues/389#issuecomment-2370823704
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

