### PR TITLE
chore: use kedacore cached trivy image

### DIFF
--- a/.github/workflows/template-trivy-scan.yml
+++ b/.github/workflows/template-trivy-scan.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Run Trivy
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/kedacore/trivy-db
         with:
           scan-type: ${{ inputs.scan-type }}
           image-ref: ${{ inputs.image-ref }}


### PR DESCRIPTION
https://github.com/orgs/kedacore/packages/container/package/trivy-db

for now, synced manually by:
```
$ oras pull ghcr.io/aquasecurity/trivy-db:2
$ oras push ghcr.io/kedacore/trivy-db:2
```
I will followup with some automation later