### PR TITLE
ScaledJob: Support metadata annotations for ephemeral volume claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Here is an overview of all new **experimental** features:
 - **AWS Secret Manager**: Pod identity overrides are honored ([#6195](https://github.com/kedacore/keda/issues/6195))
 - **Azure Event Hub Scaler**: Checkpointer errors are correctly handled ([#6084](https://github.com/kedacore/keda/issues/6084))
 - **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
+- **ScaledJob CRD**: Support metadata annotations for ephemeral volume claims ([#6254](https://github.com/kedacore/keda/issues/6254))
 
 ### Deprecations
 

--- a/config/crd/patches/scaledjob_patch.yaml
+++ b/config/crd/patches/scaledjob_patch.yaml
@@ -19,6 +19,10 @@
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/jobTargetRef/properties/template/properties/metadata/x-kubernetes-preserve-unknown-fields
   value: true
 
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/jobTargetRef/properties/template/properties/spec/properties/volumes/items/properties/ephemeral/properties/volumeClaimTemplate/properties/metadata/x-kubernetes-preserve-unknown-fields
+  value: true
+
 ## triggers are shared by ScaledObjects and ScaledJobs and therefore generated for both, including all properties.
 ## since the metricType property is only supported for ScaledObject, removing it from the generated ScaledJob CRD
 - op: remove


### PR DESCRIPTION
Add `x-kubernetes-preserve-unknown-fields` to ScaledJob CRD in order to support metadata in ephemeral volume claims

Based on https://github.com/kedacore/keda/issues/1311

Previously, ArgoCD used to see a diff, bypassed the error but kept the application "OutOfSync":
![image](https://github.com/user-attachments/assets/2bd97cdd-f151-42c8-82f0-57ec97ed5d7b)
Yet a warning was triggered: `unknown field "spec.jobTargetRef.template.spec.volumes[5].ephemeral.volumeClaimTemplate.metadata.annotations"`  

Now the change is applied, the desired block is part of the "live manifest" and the application is "Synced":
![image](https://github.com/user-attachments/assets/97425e10-5630-46b7-a448-6a5ae198a0cd)

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6254
