### PR TITLE
Refactor Loki scaler

### DIFF
--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -25,18 +25,6 @@ import (
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
-const (
-	promServerAddress       = "serverAddress"
-	promQuery               = "query"
-	promQueryParameters     = "queryParameters"
-	promThreshold           = "threshold"
-	promActivationThreshold = "activationThreshold"
-	promNamespace           = "namespace"
-	promCustomHeaders       = "customHeaders"
-	ignoreNullValues        = "ignoreNullValues"
-	unsafeSsl               = "unsafeSsl"
-)
-
 type prometheusScaler struct {
 	metricType v2.MetricTargetType
 	metadata   *prometheusMetadata


### PR DESCRIPTION
- Refactor the scaler to match the new metadata guidelines.
- Removed some prometheus const because of error in `Static Checks`:

`
pkg/scalers/prometheus_scaler.go:29:2: const promServerAddress is unused (unused)
pkg/scalers/prometheus_scaler.go:30:2: const promQuery is unused (unused)
pkg/scalers/prometheus_scaler.go:31:2: const promQueryParameters is unused (unused)
pkg/scalers/prometheus_scaler.go:32:2: const promThreshold is unused (unused)
pkg/scalers/prometheus_scaler.go:33:2: const promActivationThreshold is unused (unused)
pkg/scalers/prometheus_scaler.go:34:2: const promNamespace is unused (unused)
pkg/scalers/prometheus_scaler.go:35:2: const promCustomHeaders is unused (unused)
pkg/scalers/prometheus_scaler.go:36:2: const ignoreNullValues is unused (unused)
pkg/scalers/prometheus_scaler.go:37:2: const unsafeSsl is unused (unused)
`
### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Related: [5797](https://github.com/kedacore/keda/pull/5797)