### PR TITLE
Refactor azure queue scaler

### DIFF
--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	defaultTargetQueueLength           = 5
 	targetQueueLengthDefault           = 5
 	activationTargetQueueLengthDefault = 0
 	defaultScaleOnInFlight             = true

--- a/pkg/scalers/azure_queue_scaler.go
+++ b/pkg/scalers/azure_queue_scaler.go
@@ -57,10 +57,6 @@ type azureQueueMetadata struct {
 	TriggerIndex          int
 }
 
-func (m *azureQueueMetadata) Validate() error {
-	return nil
-}
-
 func NewAzureQueueScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	metricType, err := GetMetricTargetType(config)
 	if err != nil {
@@ -92,11 +88,6 @@ func parseAzureQueueMetadata(config *scalersconfig.ScalerConfig) (azureQueueMeta
 	err := config.TypedConfig(&meta)
 	if err != nil {
 		return meta, kedav1alpha1.AuthPodIdentity{}, fmt.Errorf("error parsing azure queue metadata: %w", err)
-	}
-
-	err = meta.Validate()
-	if err != nil {
-		return meta, kedav1alpha1.AuthPodIdentity{}, err
 	}
 
 	endpointSuffix, err := azure.ParseAzureStorageEndpointSuffix(config.TriggerMetadata, azure.QueueEndpoint)

--- a/pkg/scalers/azure_queue_scaler_test.go
+++ b/pkg/scalers/azure_queue_scaler_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	v2 "k8s.io/api/autoscaling/v2"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -31,6 +33,7 @@ var testAzQueueResolvedEnv = map[string]string{
 }
 
 type parseAzQueueMetadataTestData struct {
+	name        string
 	metadata    map[string]string
 	isError     bool
 	resolvedEnv map[string]string
@@ -39,82 +42,281 @@ type parseAzQueueMetadataTestData struct {
 }
 
 type azQueueMetricIdentifier struct {
+	name             string
 	metadataTestData *parseAzQueueMetadataTestData
 	triggerIndex     int
-	name             string
+	metricName       string
 }
 
 var testAzQueueMetadata = []parseAzQueueMetadataTestData{
-	// nothing passed
-	{map[string]string{}, true, testAzQueueResolvedEnv, map[string]string{}, ""},
-	// properly formed
-	{map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "5"}, false, testAzQueueResolvedEnv, map[string]string{}, ""},
-	// Empty queueName
-	{map[string]string{"connectionFromEnv": "CONNECTION", "queueName": ""}, true, testAzQueueResolvedEnv, map[string]string{}, ""},
-	// improperly formed queueLength
-	{map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "AA"}, true, testAzQueueResolvedEnv, map[string]string{}, ""},
-	// improperly formed activationQueueLength
-	{map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "1", "activationQueueLength": "AA"}, true, testAzQueueResolvedEnv, map[string]string{}, ""},
-	// podIdentity = azure-workload with account name
-	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue"}, false, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// podIdentity = azure-workload without account name
-	{map[string]string{"accountName": "", "queueName": "sample_queue"}, true, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// podIdentity = azure-workload without queue name
-	{map[string]string{"accountName": "sample_acc", "queueName": ""}, true, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// podIdentity = azure-workload with cloud
-	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "AzurePublicCloud"}, false, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// podIdentity = azure-workload with invalid cloud
-	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "InvalidCloud"}, true, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// podIdentity = azure-workload with private cloud and endpoint suffix
-	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "Private", "endpointSuffix": "queue.core.private.cloud"}, false, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// podIdentity = azure-workload with private cloud and no endpoint suffix
-	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "Private", "endpointSuffix": ""}, true, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// podIdentity = azure-workload with endpoint suffix and no cloud
-	{map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "", "endpointSuffix": "ignored"}, false, testAzQueueResolvedEnv, map[string]string{}, kedav1alpha1.PodIdentityProviderAzureWorkload},
-	// connection from authParams
-	{map[string]string{"queueName": "sample", "queueLength": "5"}, false, testAzQueueResolvedEnv, map[string]string{"connection": "value"}, kedav1alpha1.PodIdentityProviderNone},
+	{
+		name:        "nothing passed",
+		metadata:    map[string]string{},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
+	{
+		name:        "properly formed",
+		metadata:    map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "5"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
+	{
+		name:        "empty queueName",
+		metadata:    map[string]string{"connectionFromEnv": "CONNECTION", "queueName": ""},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
+	{
+		name:        "improperly formed queueLength",
+		metadata:    map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "AA"},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
+	{
+		name:        "improperly formed activationQueueLength",
+		metadata:    map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "1", "activationQueueLength": "AA"},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
+	{
+		name:        "podIdentity azure-workload with account name",
+		metadata:    map[string]string{"accountName": "sample_acc", "queueName": "sample_queue"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "podIdentity azure-workload without account name",
+		metadata:    map[string]string{"accountName": "", "queueName": "sample_queue"},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "podIdentity azure-workload without queue name",
+		metadata:    map[string]string{"accountName": "sample_acc", "queueName": ""},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "podIdentity azure-workload with cloud",
+		metadata:    map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "AzurePublicCloud"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "podIdentity azure-workload with invalid cloud",
+		metadata:    map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "InvalidCloud"},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "podIdentity azure-workload with private cloud and endpoint suffix",
+		metadata:    map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "Private", "endpointSuffix": "queue.core.private.cloud"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "podIdentity azure-workload with private cloud and no endpoint suffix",
+		metadata:    map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "Private", "endpointSuffix": ""},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "podIdentity azure-workload with endpoint suffix and no cloud",
+		metadata:    map[string]string{"accountName": "sample_acc", "queueName": "sample_queue", "cloud": "", "endpointSuffix": "ignored"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: kedav1alpha1.PodIdentityProviderAzureWorkload,
+	},
+	{
+		name:        "connection from authParams",
+		metadata:    map[string]string{"queueName": "sample", "queueLength": "5"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{"connection": "value"},
+		podIdentity: kedav1alpha1.PodIdentityProviderNone,
+	},
+	{
+		name:        "valid queueLengthStrategy all",
+		metadata:    map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "5", "queueLengthStrategy": "all"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
+	{
+		name:        "valid queueLengthStrategy visibleonly",
+		metadata:    map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "5", "queueLengthStrategy": "visibleonly"},
+		isError:     false,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
+	{
+		name:        "invalid queueLengthStrategy",
+		metadata:    map[string]string{"connectionFromEnv": "CONNECTION", "queueName": "sample", "queueLength": "5", "queueLengthStrategy": "invalid"},
+		isError:     true,
+		resolvedEnv: testAzQueueResolvedEnv,
+		authParams:  map[string]string{},
+		podIdentity: "",
+	},
 }
 
 var azQueueMetricIdentifiers = []azQueueMetricIdentifier{
-	{&testAzQueueMetadata[1], 0, "s0-azure-queue-sample"},
-	{&testAzQueueMetadata[5], 1, "s1-azure-queue-sample_queue"},
+	{
+		name:             "properly formed queue metric",
+		metadataTestData: &testAzQueueMetadata[1],
+		triggerIndex:     0,
+		metricName:       "s0-azure-queue-sample",
+	},
+	{
+		name:             "azure-workload queue metric",
+		metadataTestData: &testAzQueueMetadata[5],
+		triggerIndex:     1,
+		metricName:       "s1-azure-queue-sample_queue",
+	},
+}
+
+type mockAzureQueueClient struct {
+	peekMessageCount int
+	totalMessages    int32
+}
+
+func (m *mockAzureQueueClient) getMessageCount(visibleOnly bool) int64 {
+	if visibleOnly {
+		if m.peekMessageCount >= 32 {
+			return int64(m.totalMessages)
+		}
+		return int64(m.peekMessageCount)
+	}
+	return int64(m.totalMessages)
 }
 
 func TestAzQueueParseMetadata(t *testing.T) {
 	for _, testData := range testAzQueueMetadata {
-		_, podIdentity, err := parseAzureQueueMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata,
-			ResolvedEnv: testData.resolvedEnv, AuthParams: testData.authParams,
-			PodIdentity: kedav1alpha1.AuthPodIdentity{Provider: testData.podIdentity}},
-			logr.Discard())
-		if err != nil && !testData.isError {
-			t.Error("Expected success but got error", err)
-		}
-		if testData.isError && err == nil {
-			t.Errorf("Expected error but got success. testData: %v", testData)
-		}
-		if testData.podIdentity != "" && testData.podIdentity != podIdentity.Provider && err == nil {
-			t.Error("Expected success but got error: podIdentity value is not returned as expected")
-		}
+		t.Run(testData.name, func(t *testing.T) {
+			config := &scalersconfig.ScalerConfig{
+				TriggerMetadata: testData.metadata,
+				ResolvedEnv:     testData.resolvedEnv,
+				AuthParams:      testData.authParams,
+				PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: testData.podIdentity},
+			}
+
+			_, podIdentity, err := parseAzureQueueMetadata(config)
+			if err != nil && !testData.isError {
+				t.Error("Expected success but got error", err)
+			}
+			if testData.isError && err == nil {
+				t.Errorf("Expected error but got success. testData: %v", testData)
+			}
+			if testData.podIdentity != "" && testData.podIdentity != podIdentity.Provider && err == nil {
+				t.Error("Expected success but got error: podIdentity value is not returned as expected")
+			}
+		})
 	}
 }
 
 func TestAzQueueGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azQueueMetricIdentifiers {
-		meta, _, err := parseAzureQueueMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata,
-			ResolvedEnv: testData.metadataTestData.resolvedEnv, AuthParams: testData.metadataTestData.authParams,
-			PodIdentity: kedav1alpha1.AuthPodIdentity{Provider: testData.metadataTestData.podIdentity}, TriggerIndex: testData.triggerIndex},
-			logr.Discard())
-		if err != nil {
-			t.Fatal("Could not parse metadata:", err)
-		}
-		mockAzQueueScaler := azureQueueScaler{
-			metadata: meta,
-		}
+		t.Run(testData.name, func(t *testing.T) {
+			config := &scalersconfig.ScalerConfig{
+				TriggerMetadata: testData.metadataTestData.metadata,
+				ResolvedEnv:     testData.metadataTestData.resolvedEnv,
+				AuthParams:      testData.metadataTestData.authParams,
+				PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: testData.metadataTestData.podIdentity},
+				TriggerIndex:    testData.triggerIndex,
+			}
 
-		metricSpec := mockAzQueueScaler.GetMetricSpecForScaling(context.Background())
-		metricName := metricSpec[0].External.Metric.Name
-		if metricName != testData.name {
-			t.Error("Wrong External metric source name:", metricName)
-		}
+			meta, _, err := parseAzureQueueMetadata(config)
+			if err != nil {
+				t.Fatal("Could not parse metadata:", err)
+			}
+
+			mockAzQueueScaler := azureQueueScaler{
+				metadata:   meta,
+				logger:     logr.Discard(),
+				metricType: v2.AverageValueMetricType,
+			}
+
+			metricSpec := mockAzQueueScaler.GetMetricSpecForScaling(context.Background())
+			metricName := metricSpec[0].External.Metric.Name
+			assert.Equal(t, testData.metricName, metricName)
+		})
+	}
+}
+
+func TestAzQueueGetMessageCount(t *testing.T) {
+	testCases := []struct {
+		name          string
+		strategy      string
+		peekMessages  int
+		totalMessages int32
+		expectedCount int64
+	}{
+		{
+			name:          "default strategy (all)",
+			strategy:      "",
+			peekMessages:  10,
+			totalMessages: 100,
+			expectedCount: 100,
+		},
+		{
+			name:          "explicit all strategy",
+			strategy:      "all",
+			peekMessages:  10,
+			totalMessages: 100,
+			expectedCount: 100,
+		},
+		{
+			name:          "visibleonly strategy with less than 32 messages",
+			strategy:      "visibleonly",
+			peekMessages:  10,
+			totalMessages: 100,
+			expectedCount: 10,
+		},
+		{
+			name:          "visibleonly strategy with 32 or more messages",
+			strategy:      "visibleonly",
+			peekMessages:  35,
+			totalMessages: 100,
+			expectedCount: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &mockAzureQueueClient{
+				peekMessageCount: tc.peekMessages,
+				totalMessages:    tc.totalMessages,
+			}
+
+			count := mockClient.getMessageCount(tc.strategy == "visibleonly")
+			assert.Equal(t, tc.expectedCount, count)
+		})
 	}
 }


### PR DESCRIPTION
- Refactor the scaler to match the new metadata guidelines.
- In #5875 the contributor indicated that he needed help with making the tests. These were not there yet, so I added them during the refactoring

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Related: [5797](https://github.com/kedacore/keda/pull/5797)