### PR TITLE
e2e test issues solved

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Scale cluster
         run: make scale-node-pool
         env:
-          NODE_POOL_SIZE: 2
+          NODE_POOL_SIZE: 3
           TEST_CLUSTER_NAME: keda-e2e-cluster-pr
 
       - name: Run end to end tests

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Scale cluster
         run: make scale-node-pool
         env:
-          NODE_POOL_SIZE: 2
+          NODE_POOL_SIZE: 3
 
       - name: Run end to end tests
         env:

--- a/pkg/scalers/kubernetes_workload_scaler.go
+++ b/pkg/scalers/kubernetes_workload_scaler.go
@@ -33,7 +33,7 @@ var phasesCountedAsTerminated = []corev1.PodPhase{
 
 type kubernetesWorkloadMetadata struct {
 	PodSelector     string  `keda:"name=podSelector,     order=triggerMetadata"`
-	Value           float64 `keda:"name=value,           order=triggerMetadata"`
+	Value           float64 `keda:"name=value,           order=triggerMetadata, default=0"`
 	ActivationValue float64 `keda:"name=activationValue, order=triggerMetadata, default=0"`
 
 	namespace      string
@@ -72,17 +72,13 @@ func NewKubernetesWorkloadScaler(kubeClient client.Client, config *scalersconfig
 
 func parseKubernetesWorkloadMetadata(config *scalersconfig.ScalerConfig) (kubernetesWorkloadMetadata, error) {
 	meta := kubernetesWorkloadMetadata{}
-	err := config.TypedConfig(&meta)
-	if err != nil {
-		return meta, fmt.Errorf("error parsing kubernetes workload metadata: %w", err)
-	}
-
 	meta.namespace = config.ScalableObjectNamespace
 	meta.triggerIndex = config.TriggerIndex
 	meta.asMetricSource = config.AsMetricSource
 
-	if meta.asMetricSource {
-		meta.Value = 0
+	err := config.TypedConfig(&meta)
+	if err != nil {
+		return meta, fmt.Errorf("error parsing kubernetes workload metadata: %w", err)
 	}
 
 	selector, err := labels.Parse(meta.PodSelector)

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -253,6 +253,7 @@ func DeleteNamespace(t *testing.T, nsName string) {
 		err = nil
 	}
 	assert.NoErrorf(t, err, "cannot delete kubernetes namespace - %s", err)
+	DeletePodsInNamespace(t, nsName)
 }
 
 func WaitForJobSuccess(t *testing.T, kc *kubernetes.Clientset, jobName, namespace string, iterations, interval int) bool {
@@ -741,6 +742,17 @@ func DeletePodsInNamespaceBySelector(t *testing.T, kc *kubernetes.Clientset, sel
 	}, metav1.ListOptions{
 		LabelSelector: selector,
 	})
+	assert.NoErrorf(t, err, "cannot delete pods - %s", err)
+}
+
+// Delete all pods in namespace
+func DeletePodsInNamespace(t *testing.T, namespace string) {
+	err := GetKubernetesClient(t).CoreV1().Pods(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{
+		GracePeriodSeconds: ptr.To(int64(0)),
+	}, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		err = nil
+	}
 	assert.NoErrorf(t, err, "cannot delete pods - %s", err)
 }
 

--- a/tests/internals/cache_metrics/cache_metrics_test.go
+++ b/tests/internals/cache_metrics/cache_metrics_test.go
@@ -160,8 +160,8 @@ func testCacheMetricsOnPollingInterval(t *testing.T, kc *kubernetes.Clientset, d
 
 	// Metric Value = 8, DesiredAverageMetricValue = 2
 	// should scale in to 8/2 = 4 replicas, irrespective of current replicas
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	// Changing Metric Value to 4, but because we have a long polling interval, the replicas number should remain the same
 	data.MonitoredDeploymentReplicas = 4
@@ -196,8 +196,8 @@ func testDirectQuery(t *testing.T, kc *kubernetes.Clientset, data templateData) 
 
 	// Metric Value = 8, DesiredAverageMetricValue = 2
 	// should scale in to 8/2 = 4 replicas, irrespective of current replicas
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	// Changing Metric Value to 4, deployment should scale to 2
 	data.MonitoredDeploymentReplicas = 4

--- a/tests/internals/idle_replicas/idle_replicas_test.go
+++ b/tests/internals/idle_replicas/idle_replicas_test.go
@@ -147,8 +147,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- scale to max replicas ---")
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 4, testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/internals/restore_original/restore_original_test.go
+++ b/tests/internals/restore_original/restore_original_test.go
@@ -138,8 +138,8 @@ func testScale(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scaling ---")
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 }
 
 func testRestore(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/internals/scaled_job_validation/scaled_job_validation_test.go
+++ b/tests/internals/scaled_job_validation/scaled_job_validation_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	testName = "scaled-object-validation-test"
+	testName = "scaled-job-validation-test"
 )
 
 var (

--- a/tests/internals/value_metric_type/value_metric_type_test.go
+++ b/tests/internals/value_metric_type/value_metric_type_test.go
@@ -149,8 +149,8 @@ func testScaleByAverageValue(t *testing.T, kc *kubernetes.Clientset, data templa
 
 	// Metric Value = 8, DesiredAverageMetricValue = 2
 	// should scale in to 8/2 = 4 replicas, irrespective of current replicas
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }

--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -25,11 +25,11 @@ import (
 )
 
 var (
-	concurrentTests        = 15
+	concurrentTests        = 25
 	regularTestsTimeout    = "20m"
 	regularTestsRetries    = 3
 	sequentialTestsTimeout = "20m"
-	sequentialTestsRetries = 1
+	sequentialTestsRetries = 2
 )
 
 type TestResult struct {

--- a/tests/scalers/azure/azure_event_hub_dapr_wi/azure_event_hub_dapr_wi_test.go
+++ b/tests/scalers/azure/azure_event_hub_dapr_wi/azure_event_hub_dapr_wi_test.go
@@ -26,7 +26,7 @@ import (
 var _ = godotenv.Load("../../../.env")
 
 const (
-	testName              = "azure-event-hub-dapr"
+	testName              = "azure-event-hub-dapr-wi"
 	eventhubConsumerGroup = "$Default"
 )
 

--- a/tests/scalers/azure/azure_service_bus_queue_regex/azure_service_bus_queue_regex_test.go
+++ b/tests/scalers/azure/azure_service_bus_queue_regex/azure_service_bus_queue_regex_test.go
@@ -202,8 +202,8 @@ func testScale(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Clie
 	// check different aggregation operations
 	data.Operation = "max"
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	data.Operation = "avg"
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)

--- a/tests/scalers/azure/azure_service_bus_topic_regex/azure_service_bus_topic_regex_test.go
+++ b/tests/scalers/azure/azure_service_bus_topic_regex/azure_service_bus_topic_regex_test.go
@@ -225,8 +225,8 @@ func testScale(t *testing.T, kc *kubernetes.Clientset, client *azservicebus.Clie
 	// check different aggregation operations
 	data.Operation = "max"
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	data.Operation = "avg"
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)

--- a/tests/scalers/elasticsearch/elasticsearch_test.go
+++ b/tests/scalers/elasticsearch/elasticsearch_test.go
@@ -81,7 +81,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{.DeploymentName}}
@@ -397,7 +397,7 @@ func testElasticsearchScaler(t *testing.T, kc *kubernetes.Clientset) {
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
 
 	t.Log("--- testing scale out ---")
-	addElements(t, 5)
+	addElements(t, 10)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", maxReplicaCount)

--- a/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
+++ b/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
@@ -139,6 +140,9 @@ func TestScaler(t *testing.T) {
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, scalerName, testNamespace, 1, 60, 1),
+		"replica count should be 1 after 1 minute")
+
 	assert.True(t, WaitForJobCount(t, kc, testNamespace, 0, 60, 1),
 		"job count should be 0 after 1 minute")
 
@@ -184,7 +188,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	data.MetricValue = 0
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
-	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 0, 60, 1),
-		"job count should be 0 after 1 minute")
+	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 0, 120, 1),
+		"job count should be 0 after 2 minute")
 	KubectlDeleteWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 }

--- a/tests/scalers/github_runner/github_runner_test.go
+++ b/tests/scalers/github_runner/github_runner_test.go
@@ -313,13 +313,11 @@ func TestScaler(t *testing.T) {
 
 	// test scaling Scaled Job with App
 	KubectlApplyWithTemplate(t, data, "scaledGhaJobTemplate", scaledGhaJobTemplate)
-	// testActivation(t, kc, client)
 	testJobScaleOut(t, kc, client, ghaWorkflowID)
 	testJobScaleIn(t, kc)
 
 	// test scaling Scaled Job
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
-	// testActivation(t, kc, client)
 	testJobScaleOut(t, kc, client, workflowID)
 	testJobScaleIn(t, kc)
 

--- a/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_amqp/rabbitmq_queue_amqp_test.go
@@ -111,8 +111,8 @@ func getTemplateData() (templateData, []Template) {
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),

--- a/tests/scalers/rabbitmq/rabbitmq_queue_amqp_auth/rabbitmq_queue_amqp_auth_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_amqp_auth/rabbitmq_queue_amqp_auth_test.go
@@ -20,7 +20,7 @@ import (
 var _ = godotenv.Load("../../../.env")
 
 const (
-	testName = "rmq-queue-amqp-test"
+	testName = "rmq-queue-amqp-auth-test"
 )
 
 var (

--- a/tests/scalers/rabbitmq/rabbitmq_queue_amqp_vhost/rabbitmq_queue_amqp_vhost_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_amqp_vhost/rabbitmq_queue_amqp_vhost_test.go
@@ -111,8 +111,8 @@ func getTemplateData() (templateData, []Template) {
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http/rabbitmq_queue_http_test.go
@@ -110,8 +110,8 @@ func getTemplateData() (templateData, []Template) {
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_aad_wi/rabbitmq_queue_http_aad_wi_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_aad_wi/rabbitmq_queue_http_aad_wi_test.go
@@ -162,8 +162,8 @@ func getTemplateData() (templateData, []Template) {
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_auth/rabbitmq_queue_http_auth_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_auth/rabbitmq_queue_http_auth_test.go
@@ -20,7 +20,7 @@ import (
 var _ = godotenv.Load("../../../.env")
 
 const (
-	testName = "rmq-queue-http-test"
+	testName = "rmq-queue-http-test-auth"
 )
 
 var (

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_vhost/rabbitmq_queue_http_vhost_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_vhost/rabbitmq_queue_http_vhost_test.go
@@ -110,8 +110,8 @@ func getTemplateData() (templateData, []Template) {
 func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale out ---")
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, messageCount)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 1),
-		"replica count should be 4 after 1 minute")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 3),
+		"replica count should be 4 after 3 minute")
 
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),

--- a/tests/sequential/datadog_dca/datadog_dca_test.go
+++ b/tests/sequential/datadog_dca/datadog_dca_test.go
@@ -1,6 +1,10 @@
 //go:build e2e
 // +build e2e
 
+// Temporally moved to standalone e2e as I found that the DD Agent autogenerates DatadogMetric from other
+// unrelated HPAs. Until we get a response about how to disable this, the best solution is moving this test
+// to run standalone. We should move back it again once we solve this problem
+
 package datadog_dca_test
 
 import (

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -51,8 +51,7 @@ image:
   repository: "otel/opentelemetry-collector-contrib"
 config:
   exporters:
-    logging:
-      loglevel: debug
+    debug: {}
     prometheus:
       endpoint: 0.0.0.0:8889
   receivers:
@@ -72,7 +71,7 @@ config:
         receivers:
           - otlp
         exporters:
-          - logging
+          - debug
           - prometheus
       logs: null
 `


### PR DESCRIPTION
This PR solves:
- Small bug introduced during Kubernetes workload refactor related with using scaler as source
- Deprecation of the logging exporter in opentelemetry collector 
- Reorder the solace test to not cleanup resources not deployed yet
- Solace test use helm wait instead of sleep
- Add internal retries checking event hub message during event emiter tests
- Azure Event Hub dapr test use different namespace for regular auth and pod identity
- RabbitMQ AMQP Auth test use different namespace for regular auth and pod identity
- Increased scaling out timeouts in some test cases
- Datadog Cluster Agent e2e moved to standalone as the agent generates (datadog) metrics from other e2e tests in progress (@arapulido is checking this on their side)
- Eager scaling strategy test checks the status of the publishing job before checking the amount of workload's job
- ArtemisMQ uses our own image and the activation limits are lower
- increase the nodes from 2 to 3
- Added more concurrency
- External job checks the scaler and increases the timeout
- Namespace deletion also kills all the pods to remove stuck pods
- Elastic search enqueues more items
- scaled-job-validation-test uses its own namespace
- rmq-queue-http-test-auth uses its own namespace

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
