### PR TITLE
Introducing KEDA Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 <a href="https://bestpractices.coreinfrastructure.org/projects/3791"><img src="https://bestpractices.coreinfrastructure.org/projects/3791/badge"></a>
 <a href="https://artifacthub.io/packages/helm/kedacore/keda"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kedacore"></a>
 <a href="https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fkedacore%2Fkeda?ref=badge_shield" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fkedacore%2Fkeda.svg?type=shield"/></a>
-<a href="https://twitter.com/kedaorg"><img src="https://img.shields.io/twitter/follow/kedaorg?style=social" alt="Twitter"></a></p>
+<a href="https://twitter.com/kedaorg"><img src="https://img.shields.io/twitter/follow/kedaorg?style=social" alt="Twitter"></a>
+<a href="https://gurubase.io/g/keda"><img src="https://img.shields.io/badge/Gurubase-Ask%20KEDA%20Guru-006BFF" alt="Gurubase"></a></p>
 
 KEDA allows for fine-grained autoscaling (including to/from zero) for event driven Kubernetes workloads. KEDA serves
 as a Kubernetes Metrics Server and allows users to define autoscaling rules using a dedicated Kubernetes custom


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [KEDA Guru](https://gurubase.io/g/keda) to Gurubase. KEDA Guru uses the data from this repo and data from the [docs](https://keda.sh/docs/2.15/) to answer questions by leveraging the LLM.

In this PR, I showcased the "KEDA Guru", which highlights that KEDA now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable KEDA Guru in Gurubase, just let me know that's totally fine.
