### PR TITLE
fix: ensure consistent JSON log format for automaxprocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ New deprecation(s):
 
 ### Improvements
 
+- **General**: Centralize and improve automaxprocs configuration with proper structured logging ([#5970](https://github.com/kedacore/keda/issues/5970))
 - **General**: Prevent multiple ScaledObjects managing one HPA ([#6130](https://github.com/kedacore/keda/issues/6130))
 - **General**: Show full triggers'types and authentications'types in status ([#6187](https://github.com/kedacore/keda/issues/6187))
 - **AWS CloudWatch Scaler**: Add support for ignoreNullValues ([#5352](https://github.com/kedacore/keda/issues/5352))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Here is an overview of all new **experimental** features:
 
 ### Fixes
 
+- **General**: Centralize and improve automaxprocs configuration with proper structured logging ([#5970](https://github.com/kedacore/keda/issues/5970))
 - **General**: Paused ScaledObject count is reported correctly after operator restart ([#6321](https://github.com/kedacore/keda/issues/6321))
 
 ### Deprecations
@@ -108,7 +109,6 @@ New deprecation(s):
 
 ### Improvements
 
-- **General**: Centralize and improve automaxprocs configuration with proper structured logging ([#5970](https://github.com/kedacore/keda/issues/5970))
 - **General**: Prevent multiple ScaledObjects managing one HPA ([#6130](https://github.com/kedacore/keda/issues/6130))
 - **General**: Show full triggers'types and authentications'types in status ([#6187](https://github.com/kedacore/keda/issues/6187))
 - **AWS CloudWatch Scaler**: Add support for ignoreNullValues ([#5352](https://github.com/kedacore/keda/issues/5352))

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -26,7 +26,6 @@ import (
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
-	_ "go.uber.org/automaxprocs"
 	appsv1 "k8s.io/api/apps/v1"
 	apimetrics "k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -254,6 +253,12 @@ func main() {
 
 	err = printWelcomeMsg(cmd)
 	if err != nil {
+		return
+	}
+
+	err = kedautil.ConfigureMaxProcs(logger)
+	if err != nil {
+		logger.Error(err, "failed to set max procs")
 		return
 	}
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	_ "go.uber.org/automaxprocs"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
@@ -115,6 +114,13 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	ctx := ctrl.SetupSignalHandler()
+
+	err := kedautil.ConfigureMaxProcs(setupLog)
+	if err != nil {
+		setupLog.Error(err, "failed to set max procs")
+		os.Exit(1)
+	}
+
 	namespaces, err := kedautil.GetWatchNamespaces()
 	if err != nil {
 		setupLog.Error(err, "failed to get watch namespace")

--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-	_ "go.uber.org/automaxprocs"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -79,6 +78,12 @@ func main() {
 	pflag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	err := kedautil.ConfigureMaxProcs(setupLog)
+	if err != nil {
+		setupLog.Error(err, "failed to set max procs")
+		os.Exit(1)
+	}
 
 	ctx := ctrl.SetupSignalHandler()
 

--- a/pkg/util/maxprocs.go
+++ b/pkg/util/maxprocs.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"go.uber.org/automaxprocs/maxprocs"
+	"k8s.io/klog/v2"
+)
+
+// ConfigureMaxProcs sets up automaxprocs with proper logging configuration.
+// It wraps the automaxprocs logger to handle structured logging with string keys
+// to prevent panics when automaxprocs tries to pass numeric keys.
+func ConfigureMaxProcs(logger klog.Logger) error {
+	_, err := maxprocs.Set(maxprocs.Logger(func(format string, args ...interface{}) {
+		logger.Info(fmt.Sprintf(format, args...))
+	}))
+	return err
+}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
Configures automaxprocs to use the application logger instead of default console logging to maintain consistent JSON format across all log output.
output:
```
keda-admission-webhooks:
 ~/ k logs deployments.apps/keda-admission-webhooks -n keda
2024-11-15T18:39:05Z	INFO	setup	maxprocs: Updating GOMAXPROCS=1: determined from CPU quota	{"system": "automaxprocs"}
2024-11-15T18:39:05Z	INFO	setup	Starting admission webhooks
2024-11-15T18:39:05Z	INFO	setup	KEDA Version: main
2024-11-15T18:39:05Z	INFO	setup	Git Commit: c2a6df04230e1f62d335127e0a02694015c79fa6
2024-11-15T18:39:05Z	INFO	setup	Go Version: go1.23.3
2024-11-15T18:39:05Z	INFO	setup	Go OS/Arch: linux/arm64
2024-11-15T18:39:05Z	INFO	setup	Running on Kubernetes 1.30	{"version": "v1.30.0"}
2024-11-15T18:39:05Z	INFO	controller-runtime.builder	skip registering a mutating webhook, object does not implement admission.Defaulter or WithDefaulter wasn't called	{"GVK": "keda.sh/v1alpha1, Kind=ScaledObject"}
```

keda-operator:
```
 ~/ k logs deployment/keda-operator -n keda
2024-11-15T18:39:00Z	INFO	setup	maxprocs: Updating GOMAXPROCS=1: determined from CPU quota	{"system": "automaxprocs"}
2024-11-15T18:39:00Z	INFO	setup	Starting manager
2024-11-15T18:39:00Z	INFO	setup	KEDA Version: main
2024-11-15T18:39:00Z	INFO	setup	Git Commit: c2a6df04230e1f62d335127e0a02694015c79fa6
2024-11-15T18:39:00Z	INFO	setup	Go Version: go1.23.3
2024-11-15T18:39:00Z	INFO	setup	Go OS/Arch: linux/arm64
2024-11-15T18:39:00Z	INFO	setup	Running on Kubernetes 1.30	{"version": "v1.30.0"}
2024-11-15T18:39:01Z	INFO	starting server	{"name": "health probe", "addr": "[::]:8081"}
I1115 18:39:01.071646       1 leaderelection.go:254] attempting to acquire leader lease keda/operator.keda.sh...
I1115 18:39:39.767722       1 leaderelection.go:268] successfully acquired lease keda/operator.keda.sh
```

keda-operator-metrics-apiserver:
```
 ~/ k logs deployments.apps/keda-operator-metrics-apiserver -n keda                       
I1115 18:38:55.350590       1 welcome.go:34] "msg"="Starting metrics server" "logger"="keda_metrics_adapter"
I1115 18:38:55.350752       1 welcome.go:35] "msg"="KEDA Version: main" "logger"="keda_metrics_adapter"
I1115 18:38:55.350756       1 welcome.go:36] "msg"="Git Commit: c2a6df04230e1f62d335127e0a02694015c79fa6" "logger"="keda_metrics_adapter"
I1115 18:38:55.350759       1 welcome.go:37] "msg"="Go Version: go1.23.3" "logger"="keda_metrics_adapter"
I1115 18:38:55.350761       1 welcome.go:38] "msg"="Go OS/Arch: linux/arm64" "logger"="keda_metrics_adapter"
I1115 18:38:55.350775       1 welcome.go:39] "msg"="Running on Kubernetes 1.30" "logger"="keda_metrics_adapter" "version"={"major":"1","minor":"30","gitVersion":"v1.30.0","gitCommit":"7c48c2bd72b9bf5c44d21d7338cc7bea77d0ad2a","gitTreeState":"clean","buildDate":"2024-05-13T22:02:25Z","goVersion":"go1.22.2","compiler":"gc","platform":"linux/arm64"}
I1115 18:38:55.350913       1 main.go:263] "msg"="maxprocs: Updating GOMAXPROCS=1: determined from CPU quota" "logger"="keda_metrics_adapter"
I1115 18:38:55.351645       1 main.go:112] "msg"="Connecting Metrics Service gRPC client to the server" "address"="keda-operator.keda.svc.cluster.local:9666" "logger"="keda_metrics_adapter"
```

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #5970 

