### PR TITLE
fix: truncate label values longer than 63 characters

### DIFF
--- a/controllers/keda/util/string.go
+++ b/controllers/keda/util/string.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/controllers/keda/util/string.go
+++ b/controllers/keda/util/string.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"strings"
+	"unicode"
+)
+
+func Truncate(s string, threshold int) string {
+	if len(s) > threshold {
+		s = s[:threshold]
+		s = strings.TrimRightFunc(s, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+		})
+	}
+	return s
+}

--- a/controllers/keda/util/string_test.go
+++ b/controllers/keda/util/string_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/controllers/keda/util/string_test.go
+++ b/controllers/keda/util/string_test.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		threshold int
+		want      string
+	}{
+		{
+			name:      "string shorter than threshold",
+			input:     "hello",
+			threshold: 10,
+			want:      "hello",
+		},
+		{
+			name:      "string longer than threshold ending with special chars",
+			input:     "abc---def---ghi---",
+			threshold: 5,
+			want:      "abc",
+		},
+		{
+			name:      "63 character limit case",
+			input:     "this-is-64-characters-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			threshold: 63,
+			want:      "this-is-64-characters-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"[:63],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Truncate(tt.input, tt.threshold)
+			if got != tt.want {
+				t.Errorf("Truncuate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/scalers/aws/aws_dynamodb/aws_dynamodb_test.go
+++ b/tests/scalers/aws/aws_dynamodb/aws_dynamodb_test.go
@@ -128,7 +128,7 @@ spec:
 var (
 	testNamespace             = fmt.Sprintf("%s-ns", testName)
 	deploymentName            = fmt.Sprintf("%s-deployment", testName)
-	scaledObjectName          = fmt.Sprintf("%s-so", testName)
+	scaledObjectName          = "this-is-a-very-long-name-that-exceeds-kubernetes-label-length-limit-xxxxx"
 	secretName                = fmt.Sprintf("%s-secret", testName)
 	dynamoDBTableName         = fmt.Sprintf("table-%d", GetRandomNumber())
 	awsAccessKeyID            = os.Getenv("TF_AWS_ACCESS_KEY")

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -28,7 +28,7 @@ var (
 	workloadDeploymentName = fmt.Sprintf("%s-workload-deployment", testName)
 	testNamespace          = fmt.Sprintf("%s-ns", testName)
 	deploymentName         = fmt.Sprintf("%s-deployment", testName)
-	scaledObjectName := "this-is-a-very-long-name-that-exceeds-kubernetes-label-length-limit-xxxxx"
+	scaledObjectName       = fmt.Sprintf("%s-so", testName)
 	hpaName                = fmt.Sprintf("keda-hpa-%s-so", testName)
 )
 

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -28,7 +28,7 @@ var (
 	workloadDeploymentName = fmt.Sprintf("%s-workload-deployment", testName)
 	testNamespace          = fmt.Sprintf("%s-ns", testName)
 	deploymentName         = fmt.Sprintf("%s-deployment", testName)
-	scaledObjectName       = fmt.Sprintf("%s-so", testName)
+	scaledObjectName := "this-is-a-very-long-name-that-exceeds-kubernetes-label-length-limit-xxxxx"
 	hpaName                = fmt.Sprintf("keda-hpa-%s-so", testName)
 )
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
When creating a `ScaledObject` with a name exceeding 63 characters, an error occurs due to Kubernetes' label length limitations. This PR addresses the issue by truncating the `ScaledObject` name to ensure it adheres to the label length requirements.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6370 

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #

Made local testing:
deployment.yaml:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
        resources:
          requests:
            cpu: "100m"
            memory: "128Mi"
          limits:
            cpu: "200m"
            memory: "256Mi"
```

scaledobject.yaml:
```
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: this-is-64-characters-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
spec:
  minReplicaCount: 1
  maxReplicaCount: 10
  scaleTargetRef:
    name: nginx
  triggers:
  - type: cpu
    metricType: Utilization
    metadata:
      type: Utilization
      value: "60"
```

and get:
```
 ~/ k get scaledobjects.keda.sh
NAME                                                               SCALETARGETKIND      SCALETARGETNAME   MIN   MAX   READY   ACTIVE   FALLBACK   PAUSED    TRIGGERS   AUTHENTICATIONS   AGE
this-is-64-characters-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx   apps/v1.Deployment   nginx             1     10    True    True     False      Unknown                                6m28s
```
and:
```
Name:         this-is-64-characters-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Namespace:    default
Labels:       scaledobject.keda.sh/name=this-is-64-characters-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Annotations:  <none>
API Version:  keda.sh/v1alpha1
Kind:         ScaledObject
Metadata:
  Creation Timestamp:  2024-11-30T15:54:10Z
  Finalizers:
    finalizer.keda.sh
  Generation:        1
  Resource Version:  4932
  UID:               e6447cc3-14ec-45bf-a3dd-0fd8e4267743
Spec:
  Max Replica Count:  10
  Min Replica Count:  1
  Scale Target Ref:
    Name:  nginx
  Triggers:
    Metadata:
      Type:       Utilization
      Value:      60
    Metric Type:  Utilization
    Type:         cpu
Status:
  Conditions:
    Message:               ScaledObject is defined correctly and is ready for scaling
    Reason:                ScaledObjectReady
    Status:                True
    Type:                  Ready
    Message:               Scaling is performed because triggers are active
    Reason:                ScalerActive
    Status:                True
    Type:                  Active
    Message:               No fallbacks are active on this scaled object
    Reason:                NoFallbackFound
    Status:                False
    Type:                  Fallback
    Status:                Unknown
    Type:                  Paused
  Hpa Name:                keda-hpa-this-is-64-characters-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
  Last Active Time:        2024-11-30T16:00:22Z
  Original Replica Count:  3
  Resource Metric Names:
    cpu
  Scale Target GVKR:
    Group:            apps
    Kind:             Deployment
    Resource:         deployments
    Version:          v1
  Scale Target Kind:  apps/v1.Deployment
Events:
  Type    Reason              Age    From           Message
  ----    ------              ----   ----           -------
  Normal  KEDAScalersStarted  6m29s  keda-operator  Scaler cpu is built.
  Normal  KEDAScalersStarted  6m29s  keda-operator  Started scalers watch
  Normal  ScaledObjectReady   6m29s  keda-operator  ScaledObject is ready for scaling
```