### PR TITLE
add: enable webhook patching with flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Enable OpenSSF Scorecard to enhance security practices across the project ([#5913](https://github.com/kedacore/keda/issues/5913))
 - **General**: Introduce new NSQ scaler ([#3281](https://github.com/kedacore/keda/issues/3281))
+- **General**: Operator flag to control patching of webhook resources certificates ([#6184](https://github.com/kedacore/keda/issues/6184))
 
 #### Experimental
 
@@ -136,7 +137,6 @@ New deprecation(s):
 - **AWS SQS Scaler**: Improve error handling for SQS queue metrics ([#6178](https://github.com/kedacore/keda/issues/6178))
 - **Azure Event Hub Scaler**: Checkpointer errors are correctly handled ([#6084](https://github.com/kedacore/keda/issues/6084))
 - **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
-- **Operator Webhook Flag**: Enable patching of webhook resources. ([#6184](https://github.com/kedacore/keda/issues/6184))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ New deprecation(s):
 - **AWS SQS Scaler**: Improve error handling for SQS queue metrics ([#6178](https://github.com/kedacore/keda/issues/6178))
 - **Azure Event Hub Scaler**: Checkpointer errors are correctly handled ([#6084](https://github.com/kedacore/keda/issues/6084))
 - **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
+- **Operator Webhook Flag**: Enable patching of webhook resources. ([#6184](https://github.com/kedacore/keda/issues/6184))
 
 ### Deprecations
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -85,6 +85,7 @@ func main() {
 	var enableCertRotation bool
 	var validatingWebhookName string
 	var caDirs []string
+	var enableWebhookPatching bool
 	pflag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", true, "Enable the prometheus metric of keda-operator.")
 	pflag.BoolVar(&enableOpenTelemetryMetrics, "enable-opentelemetry-metrics", false, "Enable the opentelemetry metric of keda-operator.")
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the prometheus metric endpoint binds to.")
@@ -107,6 +108,7 @@ func main() {
 	pflag.BoolVar(&enableCertRotation, "enable-cert-rotation", false, "enable automatic generation and rotation of TLS certificates/keys")
 	pflag.StringVar(&validatingWebhookName, "validating-webhook-name", "keda-admission", "ValidatingWebhookConfiguration name. Defaults to keda-admission")
 	pflag.StringArrayVar(&caDirs, "ca-dir", []string{"/custom/ca"}, "Directory with CA certificates for scalers to authenticate TLS connections. Can be specified multiple times. Defaults to /custom/ca")
+	pflag.BoolVar(&enableWebhookPatching, "enable-webhook-patching", true, "Enable patching of webhook resources. Defaults to true.")
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -305,6 +307,7 @@ func main() {
 			APIServiceName:        "v1beta1.external.metrics.k8s.io",
 			Logger:                setupLog,
 			Ready:                 certReady,
+			EnableWebhookPatching: enableWebhookPatching,
 		}
 		if err := certManager.AddCertificateRotation(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to set up cert rotation")

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -55,19 +55,20 @@ type CertManager struct {
 
 // AddCertificateRotation registers all needed services to generate the certificates and patches needed resources with the caBundle
 func (cm CertManager) AddCertificateRotation(ctx context.Context, mgr manager.Manager) error {
-	var rotatorHooks []rotator.WebhookInfo
+	rotatorHooks := []rotator.WebhookInfo{
+		{
+			Name: cm.APIServiceName,
+			Type: rotator.APIService,
+		},
+	}
 
 	if cm.EnableWebhookPatching {
-		rotatorHooks = []rotator.WebhookInfo{
-			{
+		rotatorHooks = append(rotatorHooks,
+			rotator.WebhookInfo{
 				Name: cm.ValidatingWebhookName,
 				Type: rotator.Validating,
 			},
-			{
-				Name: cm.APIServiceName,
-				Type: rotator.APIService,
-			},
-		}
+		)
 	} else {
 		cm.Logger.V(1).Info("Webhook patching is disabled, skipping webhook certificates")
 	}


### PR DESCRIPTION
Includes a flag in the operator to the webhook patching 

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs/pull/1509)) - 
- [x] A PR is opened to update our Helm chart on ([repo](https://github.com/kedacore/charts/pull/715)) - 
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6184 
