### PR TITLE
fix: Use pinned version for all the pending tasks

### DIFF
--- a/.github/workflows/auto-add-issues-to-project.yml
+++ b/.github/workflows/auto-add-issues-to-project.yml
@@ -3,6 +3,10 @@ on:
   issues:
     types:
       - opened
+
+permissions:
+  contents: read
+
 jobs:
   track_issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   fossa-key: 9e722f2c8904586d61f97f0bf05a99e4 # This is a public key only for pushing, it's safe here
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -24,13 +24,13 @@ jobs:
       - run: go version
       - name: Get branch name
         id: branch-name
-        uses: tj-actions/branch-names@v8
-      - uses: fossas/fossa-action@main
+        uses: tj-actions/branch-names@6871f53176ad61624f978536bbf089c574dc19a2 # v8.0.1
+      - uses: fossas/fossa-action@09bcf127dc0ccb4b5a023f6f906728878e8610ba # v1.4.0
         name: Scanning with FOSSA
         with:
           api-key: ${{ env.fossa-key }}
           branch: ${{ steps.branch-name.outputs.current_branch }}
-      - uses: fossas/fossa-action@main
+      - uses: fossas/fossa-action@09bcf127dc0ccb4b5a023f6f906728878e8610ba # v1.4.0
         name: Executing tests with FOSSA
         with:
           api-key: ${{ env.fossa-key }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -47,7 +47,7 @@ jobs:
         run: make test
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           # Username used to log in to a Docker registry. If not set then no login will occur
           username: ${{ github.repository_owner }}
@@ -57,14 +57,14 @@ jobs:
           registry: ghcr.io
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Publish on GitHub Container Registry
         run: make publish-multiarch
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Check Cosign install!
         run: cosign version

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     uses: kedacore/keda/.github/workflows/template-main-e2e-test.yml@main

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: tspascoal/get-user-teams-membership@v2
+      - uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
         id: checkUserMember
         with:
           username: ${{ github.actor }}
@@ -109,7 +109,7 @@ jobs:
           make e2e-regex-check
 
       - name: React to comment with failure
-        uses: dkershner6/reaction-action@v2
+        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
         if: steps.regex-validation.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
         run: exit 1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           # Username used to log in to a Docker registry. If not set then no login will occur
           username: ${{ github.repository_owner }}
@@ -174,7 +174,7 @@ jobs:
           gh pr checkout ${{ needs.triage.outputs.pr_num }}
           git checkout ${{ needs.triage.outputs.commit_sha }}
 
-      - uses: oNaiPs/secrets-to-env-action@v1
+      - uses: oNaiPs/secrets-to-env-action@ec46a22bfc9b37e014b627b3208b07eb8909ea0f # v1.5
         with:
           secrets: ${{ toJSON(secrets) }}
 
@@ -219,7 +219,7 @@ jobs:
           TEST_CLUSTER_NAME: keda-e2e-cluster-pr
 
       - name: React to comment with success
-        uses: dkershner6/reaction-action@v2
+        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
         if: steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -237,7 +237,7 @@ jobs:
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
 
       - name: React to comment with failure
-        uses: dkershner6/reaction-action@v2
+        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
         if: steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -69,7 +69,7 @@ jobs:
         run: make test
 
       - name: Create test Summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:
           paths: "report.xml"
         if: always()
@@ -146,7 +146,7 @@ jobs:
           go-version: "1.23"
       - name: Get golangci
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   trivy-scan:
     uses: kedacore/keda/.github/workflows/template-trivy-scan.yml@main

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -75,6 +75,9 @@ jobs:
         if: always()
 
   validate-dockerfiles:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: validate-dockerfiles - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     container: ghcr.io/kedacore/keda-tools:1.23.3
@@ -106,6 +109,9 @@ jobs:
         run: make docker-build
 
   validate-dev-container:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     name: Validate dev-container - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     container: ghcr.io/kedacore/keda-tools:1.23.3

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - "v*"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Push Release

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -44,7 +44,7 @@ jobs:
         run: go mod tidy -compat=1.23
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           # Username used to log in to a Docker registry. If not set then no login will occur
           username: ${{ github.repository_owner }}
@@ -63,7 +63,7 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Publish KEDA images on GitHub Container Registry
         run: make publish-multiarch
@@ -72,7 +72,7 @@ jobs:
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Check Cosign install!
         run: cosign version
@@ -87,7 +87,7 @@ jobs:
         # Get release information to determine id of the current release
       - name: Get Release
         id: get-release-info
-        uses: bruceadams/get-release@v1.3.2
+        uses: bruceadams/get-release@74c3d60f5a28f358ccf241a00c9021ea16f0569f # v1.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request: {}
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Register workspace path
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - uses: oNaiPs/secrets-to-env-action@v1
+      - uses: oNaiPs/secrets-to-env-action@ec46a22bfc9b37e014b627b3208b07eb8909ea0f # v1.5
         with:
           secrets: ${{ toJSON(secrets) }}
 

--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Create k8s ${{ inputs.kubernetesVersion }} Kind Cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
           node_image: ${{ inputs.kindImage }}
           cluster_name: smoke-tests-cluster-${{ inputs.kubernetesVersion }}

--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -12,6 +12,10 @@ on:
       kindImage:
         required: true
         type: string
+
+permissions:
+  contents: read
+
 jobs:
   smoke-tests:
     name: Validate k8s-${{ inputs.kubernetesVersion }}

--- a/.github/workflows/template-trivy-scan.yml
+++ b/.github/workflows/template-trivy-scan.yml
@@ -31,6 +31,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   trivy-scan:
     name: Trivy - ${{ inputs.runs-on }} - ${{ inputs.scan-type }} ${{ inputs.image-ref }}

--- a/.github/workflows/v1-build.yml
+++ b/.github/workflows/v1-build.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - v1
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate


### PR DESCRIPTION
I'm fixing semgrep detections and this is one of them as not using versions pinned by commit sha is vulnerable to tampering

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
