### PR TITLE
Fix nats-jetstream scaler to use account ID instead of name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,7 @@ New deprecation(s):
 - **AWS Secret Manager**: Pod identity overrides are honored ([#6195](https://github.com/kedacore/keda/issues/6195))
 - **AWS SQS Scaler**: Improve error handling for SQS queue metrics ([#6178](https://github.com/kedacore/keda/issues/6178))
 - **Azure Event Hub Scaler**: Checkpointer errors are correctly handled ([#6084](https://github.com/kedacore/keda/issues/6084))
-- **JetStream**: NATS API uses account ID and not account name to filter by account ([#6415] (https://github.com/kedacore/keda/pull/6415))
+- **JetStream**: NATS API uses account ID and not account name to filter by account ([#6415](https://github.com/kedacore/keda/pull/6415))
 - **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ New deprecation(s):
 - **AWS SQS Scaler**: Improve error handling for SQS queue metrics ([#6178](https://github.com/kedacore/keda/issues/6178))
 - **Azure Event Hub Scaler**: Checkpointer errors are correctly handled ([#6084](https://github.com/kedacore/keda/issues/6084))
 - **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
+- **JetStream**: NATS API uses account ID and not account name to filter by account
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ New deprecation(s):
 - **AWS SQS Scaler**: Improve error handling for SQS queue metrics ([#6178](https://github.com/kedacore/keda/issues/6178))
 - **Azure Event Hub Scaler**: Checkpointer errors are correctly handled ([#6084](https://github.com/kedacore/keda/issues/6084))
 - **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
-- **JetStream**: NATS API uses account ID and not account name to filter by account
+- **JetStream**: NATS API uses account ID and not account name to filter by account ([#6415] (https://github.com/kedacore/keda/pull/6415))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,8 +138,8 @@ New deprecation(s):
 - **AWS Secret Manager**: Pod identity overrides are honored ([#6195](https://github.com/kedacore/keda/issues/6195))
 - **AWS SQS Scaler**: Improve error handling for SQS queue metrics ([#6178](https://github.com/kedacore/keda/issues/6178))
 - **Azure Event Hub Scaler**: Checkpointer errors are correctly handled ([#6084](https://github.com/kedacore/keda/issues/6084))
-- **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
 - **JetStream**: NATS API uses account ID and not account name to filter by account ([#6415] (https://github.com/kedacore/keda/pull/6415))
+- **Metrics API Scaler**: Prometheus metrics can have multiple labels ([#6077](https://github.com/kedacore/keda/issues/6077))
 
 ### Deprecations
 

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -64,6 +64,7 @@ type jetStreamCluster struct {
 }
 
 type accountDetail struct {
+	Id      string          `json:id`
 	Name    string          `json:"name"`
 	Streams []*streamDetail `json:"stream_detail"`
 }
@@ -278,7 +279,7 @@ func (s *natsJetStreamScaler) getNATSJetstreamMonitoringData(ctx context.Context
 			}
 
 			for _, jetStreamAccount := range jetStreamAccountResp.Accounts {
-				if jetStreamAccount.Name == s.metadata.account {
+				if jetStreamAccount.Id == s.metadata.account {
 					for _, stream := range jetStreamAccount.Streams {
 						if stream.Name == s.metadata.stream {
 							for _, consumer := range stream.Consumers {
@@ -305,7 +306,7 @@ func (s *natsJetStreamScaler) setNATSJetStreamMonitoringData(jetStreamAccountRes
 
 	// find and assign the stream that we are looking for.
 	for _, jsAccount := range jetStreamAccountResp.Accounts {
-		if jsAccount.Name == s.metadata.account {
+		if jsAccount.Id == s.metadata.account {
 			for _, stream := range jsAccount.Streams {
 				if stream.Name == s.metadata.stream {
 					s.stream = stream

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -64,7 +64,7 @@ type jetStreamCluster struct {
 }
 
 type accountDetail struct {
-	Id      string          `json:id`
+	Id      string          `json:"id"`
 	Name    string          `json:"name"`
 	Streams []*streamDetail `json:"stream_detail"`
 }

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -64,7 +64,7 @@ type jetStreamCluster struct {
 }
 
 type accountDetail struct {
-	Id      string          `json:"id"`
+	ID      string          `json:"id"`
 	Name    string          `json:"name"`
 	Streams []*streamDetail `json:"stream_detail"`
 }
@@ -279,7 +279,7 @@ func (s *natsJetStreamScaler) getNATSJetstreamMonitoringData(ctx context.Context
 			}
 
 			for _, jetStreamAccount := range jetStreamAccountResp.Accounts {
-				if jetStreamAccount.Id == s.metadata.account {
+				if jetStreamAccount.ID == s.metadata.account {
 					for _, stream := range jetStreamAccount.Streams {
 						if stream.Name == s.metadata.stream {
 							for _, consumer := range stream.Consumers {
@@ -306,7 +306,7 @@ func (s *natsJetStreamScaler) setNATSJetStreamMonitoringData(jetStreamAccountRes
 
 	// find and assign the stream that we are looking for.
 	for _, jsAccount := range jetStreamAccountResp.Accounts {
-		if jsAccount.Id == s.metadata.account {
+		if jsAccount.ID == s.metadata.account {
 			for _, stream := range jsAccount.Streams {
 				if stream.Name == s.metadata.stream {
 					s.stream = stream

--- a/pkg/scalers/nats_jetstream_scaler_test.go
+++ b/pkg/scalers/nats_jetstream_scaler_test.go
@@ -131,7 +131,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G",
+			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer"}},
 				}},
@@ -145,7 +145,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G",
+			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -159,7 +159,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G",
+			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
 				Streams: []*streamDetail{{Name: "mystream", State: streamState{LastSequence: 1},
 					Consumers: []consumerDetail{{Name: "pull_consumer_bad", NumPending: 100}},
 				}},
@@ -173,7 +173,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G",
+			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
 				Streams: []*streamDetail{{Name: "mystreamBad", State: streamState{LastSequence: 1},
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -187,7 +187,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G",
+			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -202,7 +202,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 		},
 		&jetStreamEndpointResponse{
 			MetaCluster: metaCluster{ClusterSize: 3},
-			Accounts: []accountDetail{{Name: "$G",
+			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100, Cluster: consumerCluster{Leader: "leader"}}},
 				}},
@@ -217,7 +217,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 		},
 		&jetStreamEndpointResponse{
 			MetaCluster: metaCluster{ClusterSize: 3},
-			Accounts: []accountDetail{{Name: "$G",
+			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
 				Streams: []*streamDetail{{Name: "mystream"}},
 			}},
 		}, false, true},

--- a/pkg/scalers/nats_jetstream_scaler_test.go
+++ b/pkg/scalers/nats_jetstream_scaler_test.go
@@ -131,7 +131,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G",
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer"}},
 				}},
@@ -145,7 +145,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G",
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -159,7 +159,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G",
 				Streams: []*streamDetail{{Name: "mystream", State: streamState{LastSequence: 1},
 					Consumers: []consumerDetail{{Name: "pull_consumer_bad", NumPending: 100}},
 				}},
@@ -173,7 +173,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G",
 				Streams: []*streamDetail{{Name: "mystreamBad", State: streamState{LastSequence: 1},
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -187,7 +187,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G",
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -202,7 +202,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 		},
 		&jetStreamEndpointResponse{
 			MetaCluster: metaCluster{ClusterSize: 3},
-			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G",
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100, Cluster: consumerCluster{Leader: "leader"}}},
 				}},
@@ -217,7 +217,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 		},
 		&jetStreamEndpointResponse{
 			MetaCluster: metaCluster{ClusterSize: 3},
-			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G",
 				Streams: []*streamDetail{{Name: "mystream"}},
 			}},
 		}, false, true},

--- a/pkg/scalers/nats_jetstream_scaler_test.go
+++ b/pkg/scalers/nats_jetstream_scaler_test.go
@@ -131,7 +131,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer"}},
 				}},
@@ -145,7 +145,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -159,7 +159,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
 				Streams: []*streamDetail{{Name: "mystream", State: streamState{LastSequence: 1},
 					Consumers: []consumerDetail{{Name: "pull_consumer_bad", NumPending: 100}},
 				}},
@@ -173,7 +173,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
 				Streams: []*streamDetail{{Name: "mystreamBad", State: streamState{LastSequence: 1},
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -187,7 +187,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			0, "s0-nats-jetstream-mystream",
 		},
 		&jetStreamEndpointResponse{
-			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100}},
 				}},
@@ -202,7 +202,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 		},
 		&jetStreamEndpointResponse{
 			MetaCluster: metaCluster{ClusterSize: 3},
-			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
 				Streams: []*streamDetail{{Name: "mystream",
 					Consumers: []consumerDetail{{Name: "pull_consumer", NumPending: 100, Cluster: consumerCluster{Leader: "leader"}}},
 				}},
@@ -217,7 +217,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 		},
 		&jetStreamEndpointResponse{
 			MetaCluster: metaCluster{ClusterSize: 3},
-			Accounts: []accountDetail{{Name: "$G", Id: "$G", 
+			Accounts: []accountDetail{{Name: "$G", ID: "$G", 
 				Streams: []*streamDetail{{Name: "mystream"}},
 			}},
 		}, false, true},


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

NATS API uses account ID to filter by account (as confirmed by NATS team).  
<img width="985" alt="image" src="https://github.com/user-attachments/assets/ead69354-a5eb-453d-a13c-5433a5b9ff00">

Current checks causes an issue when account ID and name are different. Updating the checks to use account ID instead.

To replicate issue, create a NATS account with name different from ID like below
```
  "account_details": [
    {
      "name": "platform",
      "id": "AABMFGXW62SSPMCCGFFOP7HFDFFBJWFAM3MC66OM2EHJDZS5CWTSHCWA",
      "memory": 0,
      "storage": 285,
      "reserved_memory": 0,
      "reserved_storage": 18446744073709551615,
      "accounts": 0,
      "ha_assets": 0,
      "api": {
        "total": 7088,
        "errors": 0
      },
```
Create nats-jetstream ScaledObject, check logs and find error `“scaler”: “natsJetStreamScaler”, “error”: “leader node not found for consumer”`

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been updated
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
