### PR TITLE
feat(scaler): Add TLS support for Artemis scaler

### DIFF
--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -37,6 +37,12 @@ type artemisMetadata struct {
 	QueueLength           int64  `keda:"name=queueLength, order=triggerMetadata, optional, default=10"`
 	ActivationQueueLength int64  `keda:"name=activationQueueLength, order=triggerMetadata, optional, default=10"`
 	CorsHeader            string `keda:"name=corsHeader, order=triggerMetadata, optional"`
+	UnsafeSsl             bool   `keda:"name=unsafeSsl, order=triggerMetadata, optional, default=false"`
+	TLS                   bool   `keda:"name=tls, order=triggerMetadata, optional, default=false"`
+	CA                    string `keda:"name=ca, order=triggerMetadata, optional"`
+	Cert                  string `keda:"name=cert, order=triggerMetadata, optional"`
+	Key                   string `keda:"name=key, order=triggerMetadata, optional"`
+	KeyPassword           string `keda:"name=keyPassword, order=triggerMetadata, optional"`
 }
 
 //revive:enable:var-naming
@@ -77,15 +83,24 @@ func (a *artemisMetadata) Validate() error {
 	if a.CorsHeader == "" {
 		a.CorsHeader = fmt.Sprintf(defaultCorsHeader, a.ManagementEndpoint)
 	}
+
+	if (a.Cert == "") != (a.Key == "") {
+		return fmt.Errorf("both cert and key must be provided when using TLS")
+	}
+
+	if a.TLS && a.CA == "" {
+		return fmt.Errorf("CA certificate must be provided when using TLS")
+	}
+
+	if a.TLS && a.UnsafeSsl {
+		return fmt.Errorf("'tls' and 'unsafeSsl' cannot both be specified")
+	}
+
 	return nil
 }
 
 // NewArtemisQueueScaler creates a new artemis queue Scaler
 func NewArtemisQueueScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
-	// do we need to guarantee this timeout for a specific
-	// reason? if not, we can have buildScaler pass in
-	// the global client
-	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
 
 	metricType, err := GetMetricTargetType(config)
 	if err != nil {
@@ -95,6 +110,24 @@ func NewArtemisQueueScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	artemisMetadata, err := parseArtemisMetadata(config)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing artemis metadata: %w", err)
+	}
+	// do we need to guarantee this timeout for a specific
+	// reason? if not, we can have buildScaler pass in
+	// the global client
+	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, artemisMetadata.UnsafeSsl)
+
+	if artemisMetadata.TLS {
+		tlsConfig, err := kedautil.NewTLSConfigWithPassword(
+			artemisMetadata.Cert,
+			artemisMetadata.Key,
+			artemisMetadata.KeyPassword,
+			artemisMetadata.CA,
+			artemisMetadata.UnsafeSsl,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure TLS: %w", err)
+		}
+		httpClient.Transport = kedautil.CreateHTTPTransportWithTLSConfig(tlsConfig)
 	}
 
 	return &artemisScaler{
@@ -149,7 +182,13 @@ func getAPIParameters(meta artemisMetadata) (artemisMetadata, error) {
 }
 
 func (s *artemisScaler) getMonitoringEndpoint() string {
-	replacer := strings.NewReplacer("<<managementEndpoint>>", s.metadata.ManagementEndpoint,
+	scheme := "http"
+
+	if s.metadata.TLS {
+		scheme = "https"
+	}
+	replacer := strings.NewReplacer(
+		"<<managementEndpoint>>", fmt.Sprintf("%s://%s", scheme, s.metadata.ManagementEndpoint),
 		"<<queueName>>", s.metadata.QueueName,
 		"<<brokerName>>", s.metadata.BrokerName,
 		"<<brokerAddress>>", s.metadata.BrokerAddress)

--- a/pkg/scalers/artemis_scaler_test.go
+++ b/pkg/scalers/artemis_scaler_test.go
@@ -163,3 +163,30 @@ func TestArtemisGetMetricSpecForScaling(t *testing.T) {
 		}
 	}
 }
+
+func TestArtemisTLSConfiguration(t *testing.T) {
+	metadata := map[string]string{
+		"managementEndpoint": "localhost:8161",
+		"queueName":          "queue1",
+		"brokerName":         "broker-activemq",
+		"brokerAddress":      "test",
+		"ca":                 "/path/to/ca.pem",
+		"cert":               "/path/to/cert.pem",
+		"key":                "/path/to/key.pem",
+	}
+
+	resolvedEnv := map[string]string{
+		"username": "admin",
+		"password": "admin",
+	}
+
+	_, err := parseArtemisMetadata(&scalersconfig.ScalerConfig{
+		ResolvedEnv:     resolvedEnv,
+		TriggerMetadata: metadata,
+		AuthParams:      artemisAuthParams, // Ensure valid AuthParams are provided
+	})
+
+	if err != nil {
+		t.Errorf("Expected success but got error: %v", err)
+	}
+}


### PR DESCRIPTION
### Description

This PR introduces TLS support for the Artemis scaler, allowing secure communication with Artemis brokers.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] Changelog has not been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*

### Related Issues and PRs

Fixes #6448

---

### Notes

This PR includes:
- TLS configuration support (CA, Cert, Key) for Artemis scaler.
- Updated unit tests and metadata validation.

Testing TLS functionality directly in an e2e environment might require additional configuration.