### PR TITLE
fix: Selenium Grid scaler logic on platformName is set empty or `any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Here is an overview of all new **experimental** features:
 ### Fixes
 
 - **AWS Scalers**: Add AWS region to the AWS Config Cache key ([#6128](https://github.com/kedacore/keda/issues/6128))
+- **Selenium Grid**: Scaler logic on platformName is set empty or `any` ([#6477](https://github.com/kedacore/keda/issues/6477))
 
 ### Deprecations
 

--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -251,17 +251,16 @@ func countMatchingSessions(sessions Sessions, browserName string, browserVersion
 // This function checks if the request capabilities match the scaler metadata
 func checkRequestCapabilitiesMatch(request Capability, browserName string, browserVersion string, _ string, platformName string) bool {
 	// Check if browserName matches
-	browserNameMatch := request.BrowserName == "" && browserName == "" ||
+	browserNameMatch := (request.BrowserName == "" && browserName == "") ||
 		strings.EqualFold(browserName, request.BrowserName)
 
 	// Check if browserVersion matches
 	browserVersionMatch := (request.BrowserVersion == "" && browserVersion == "") ||
-		(request.BrowserVersion == "stable" && browserVersion == "") ||
-		(strings.HasPrefix(browserVersion, request.BrowserVersion) && request.BrowserVersion != "" && browserVersion != "")
+		(request.BrowserVersion != "" && strings.HasPrefix(browserVersion, request.BrowserVersion))
 
 	// Check if platformName matches
-	platformNameMatch := request.PlatformName == "" && platformName == "" ||
-		strings.EqualFold(platformName, request.PlatformName)
+	platformNameMatch := (request.PlatformName == "" || strings.EqualFold("any", request.PlatformName) || strings.EqualFold(platformName, request.PlatformName)) &&
+		(platformName == "" || platformName == "any" || strings.EqualFold(platformName, request.PlatformName))
 
 	return browserNameMatch && browserVersionMatch && platformNameMatch
 }
@@ -269,17 +268,17 @@ func checkRequestCapabilitiesMatch(request Capability, browserName string, brows
 // This function checks if Node stereotypes or ongoing sessions match the scaler metadata
 func checkStereotypeCapabilitiesMatch(capability Capability, browserName string, browserVersion string, sessionBrowserName string, platformName string) bool {
 	// Check if browserName matches
-	browserNameMatch := capability.BrowserName == "" && browserName == "" ||
+	browserNameMatch := (capability.BrowserName == "" && browserName == "") ||
 		strings.EqualFold(browserName, capability.BrowserName) ||
 		strings.EqualFold(sessionBrowserName, capability.BrowserName)
 
 	// Check if browserVersion matches
-	browserVersionMatch := capability.BrowserVersion == "" && browserVersion == "" ||
-		(strings.HasPrefix(browserVersion, capability.BrowserVersion) && capability.BrowserVersion != "" && browserVersion != "")
+	browserVersionMatch := (capability.BrowserVersion == "" && browserVersion == "") ||
+		(capability.BrowserVersion != "" && strings.HasPrefix(browserVersion, capability.BrowserVersion))
 
 	// Check if platformName matches
-	platformNameMatch := capability.PlatformName == "" && platformName == "" ||
-		strings.EqualFold(platformName, capability.PlatformName)
+	platformNameMatch := (capability.PlatformName == "" || strings.EqualFold("any", capability.PlatformName) || strings.EqualFold(platformName, capability.PlatformName)) &&
+		(platformName == "" || platformName == "any" || strings.EqualFold(platformName, capability.PlatformName))
 
 	return browserNameMatch && browserVersionMatch && platformNameMatch
 }

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -1043,6 +1043,74 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			wantErr:             false,
 		},
 		{
+			name: "1 queue request without platformName and scaler metadata without platfromName should return 1 new node and 1 ongoing session",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"grid": {
+							"sessionCount": 2,
+							"maxSession": 2,
+							"totalSlots": 2
+						},
+						"nodesInfo": {
+							"nodes": [
+								{
+									"id": "node-1",
+									"status": "UP",
+									"sessionCount": 1,
+									"maxSession": 1,
+									"slotCount": 1,
+									"stereotypes": "[{\"slots\": 1, \"stereotype\": {\"browserName\": \"chrome\", \"platformName\": \"any\"}}]",
+									"sessions": [
+										{
+											"id": "session-1",
+											"capabilities": "{\"browserName\": \"chrome\", \"platformName\": \"any\"}",
+											"slot": {
+												"id": "9ce1edba-72fb-465e-b311-ee473d8d7b64",
+												"stereotype": "{\"browserName\": \"chrome\", \"platformName\": \"any\"}"
+											}
+										}
+									]
+								},
+								{
+									"id": "node-2",
+									"status": "UP",
+									"sessionCount": 1,
+									"maxSession": 1,
+									"slotCount": 1,
+									"stereotypes": "[{\"slots\": 1, \"stereotype\": {\"browserName\": \"chrome\", \"platformName\": \"linux\"}}]",
+									"sessions": [
+										{
+											"id": "session-2",
+											"capabilities": "{\"browserName\": \"chrome\", \"browserVersion\": \"91.0\", \"platformName\": \"linux\"}",
+											"slot": {
+												"id": "9ce1edba-72fb-465e-b311-ee473d8d7b64",
+												"stereotype": "{\"browserName\": \"chrome\", \"platformName\": \"linux\"}"
+											}
+										}
+									]
+								}
+							]
+						},
+						"sessionsInfo": {
+							"sessionQueueRequests": [
+								"{\"browserName\": \"chrome\", \"platformName\": \"linux\"}",
+								"{\"browserName\": \"chrome\"}",
+								"{\"browserName\": \"chrome\", \"platformName\": \"any\"}"
+							]
+						}
+					}
+				}`),
+				browserName:        "chrome",
+				sessionBrowserName: "chrome",
+				browserVersion:     "",
+				platformName:       "",
+			},
+			wantNewRequestNodes: 2,
+			wantOnGoingSessions: 1,
+			wantErr:             false,
+		},
+		{
 			name: "1 active session with matching browsername and version should return count as 2",
 			args: args{
 				b: []byte(`{


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

When Node stereotype set `"platformName": ""` (empty), node started up and registered to Hub with converting to `"platformName": "windows"`. Similarly, the same behavior in session capabilities. This unexpected behavior impacts the scaler in counting the pending and ongoing sessions.
This issue is fixed in Grid core https://github.com/SeleniumHQ/selenium/pull/15036 (`platformName` is empty should be considered as enum ANY instead of WINDOWS). Available from 4.28.0 onwards.

The incoming request with setting capability `"platformName": "any"` or not set. It will be assigned to any Node with the stereotype `platformName: any` or not set.
So, updating the scaler condition to be aligned with the same behavior.

### Checklist

<!-- - [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md) -->
<!-- - [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md) -->
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
<!-- - [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)* -->
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
