### PR TITLE
fix(Redis Streams): Allow default value of 0 for activationLagCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Here is an overview of all new **experimental** features:
 ### Fixes
 
 - **AWS Scalers**: Add AWS region to the AWS Config Cache key ([#6128](https://github.com/kedacore/keda/issues/6128))
+- **Redis Streams**: Allow default value of 0 for activationLagCount ([#6478](https://github.com/kedacore/keda/issues/6478))
 
 ### Deprecations
 

--- a/pkg/scalers/redis_streams_scaler.go
+++ b/pkg/scalers/redis_streams_scaler.go
@@ -56,7 +56,7 @@ type redisStreamsMetadata struct {
 	ConsumerGroupName         string              `keda:"name=consumerGroup,       order=triggerMetadata, optional"`
 	DatabaseIndex             int                 `keda:"name=databaseIndex,       order=triggerMetadata, optional"`
 	ConnectionInfo            redisConnectionInfo `keda:"optional"`
-	ActivationLagCount        int64               `keda:"name=activationLagCount,  order=triggerMetadata, optional"`
+	ActivationLagCount        int64               `keda:"name=activationLagCount,  order=triggerMetadata, default=0"`
 	MetadataEnableTLS         string              `keda:"name=enableTLS,           order=triggerMetadata, optional"`
 	AuthParamEnableTLS        string              `keda:"name=tls,                 order=authParams, optional"`
 }
@@ -82,11 +82,6 @@ func (r *redisStreamsMetadata) Validate() error {
 		if r.TargetLag != 0 {
 			r.scaleFactor = lagFactor
 			r.TargetPendingEntriesCount = 0
-
-			if r.ActivationLagCount == 0 {
-				err := errors.New("activationLagCount required for Redis lag")
-				return err
-			}
 		} else {
 			r.scaleFactor = xPendingFactor
 		}

--- a/pkg/scalers/redis_streams_scaler_test.go
+++ b/pkg/scalers/redis_streams_scaler_test.go
@@ -290,6 +290,30 @@ func TestParseRedisClusterStreamsMetadata(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "zero activation lag count with lag count is allowed",
+			metadata: map[string]string{
+				"stream":             "my-stream",
+				"lagCount":           "7",
+				"activationLagCount": "0",
+				"consumerGroup":      "consumer1",
+			},
+			authParams: map[string]string{
+				"addresses": ":7001, :7002",
+			},
+			wantMeta: &redisStreamsMetadata{
+				StreamName:                "my-stream",
+				TargetPendingEntriesCount: 0,
+				TargetLag:                 7,
+				ActivationLagCount:        0,
+				ConsumerGroupName:         "consumer1",
+				ConnectionInfo: redisConnectionInfo{
+					Addresses: []string{":7001", ":7002"},
+				},
+				scaleFactor: lagFactor,
+			},
+			wantErr: nil,
+		},
+		{
 			name: "address is defined in auth params",
 			metadata: map[string]string{
 				"stream":              "my-stream",


### PR DESCRIPTION
This PR was created due to a bug found and reported as an issue #6478.

The documentation Redis Streams states that a default of 0 is allowed. In version `v2.15.1` seems that be possible.
In `v2.16` a check is applied with a refactoring where the value 0 is not allowed:

```
if r.ActivationLagCount == 0 {
	err := errors.New("activationLagCount required for Redis lag")
	return err
}
```

The code contains the following line:
```
return []external_metrics.ExternalMetricValue{metric}, metricCount > s.metadata.ActivationLagCount, nil
```

The second return value (the boolean) determines whether the scaler is active. This becomes `true` if `metricCount > ActivationLagCount`.
Because `ActivationLagCount` cannot be 0, this means that there must be at least 2 messages before scaling is activated. This means that scaling can never be activated on 1 message.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6478