### PR TITLE
Update k8s support to 1.32

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -76,10 +76,10 @@ body:
     label: Kubernetes Version
     description: What version of Kubernetes that are you running?
     options:
+    - "1.32"
+    - "1.31"
     - "1.30"
-    - "1.29"
-    - "1.28"
-    - "< 1.28"
+    - "< 1.29"
     - "Other"
   validations:
     required: false

--- a/.github/workflows/template-arm64-smoke-tests.yml
+++ b/.github/workflows/template-arm64-smoke-tests.yml
@@ -10,5 +10,5 @@ jobs:
     uses: kedacore/keda/.github/workflows/template-smoke-tests.yml@main
     with:
       runs-on: ARM64
-      kubernetesVersion: v1.30
-      kindImage: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
+      kubernetesVersion: v1.32
+      kindImage: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027

--- a/.github/workflows/template-versions-smoke-tests.yml
+++ b/.github/workflows/template-versions-smoke-tests.yml
@@ -9,14 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetesVersion: [v1.30, v1.29, v1.28]
+        kubernetesVersion: [v1.32 v1.31, v1.30]
         include:
+          - kubernetesVersion: v1.32
+            kindImage: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+          - kubernetesVersion: v1.31
+            kindImage: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
           - kubernetesVersion: v1.30
-            kindImage: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
-          - kubernetesVersion: v1.29
-            kindImage: kindest/node:v1.29.4@sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8
-          - kubernetesVersion: v1.28
-            kindImage: kindest/node:v1.28.9@sha256:dca54bc6a6079dd34699d53d7d4ffa2e853e46a20cd12d619a09207e35300bd0
+            kindImage: kindest/node:v1.30.8@sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf
     uses: kedacore/keda/.github/workflows/template-smoke-tests.yml@main
     with:
       runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ GO_LDFLAGS="-X=github.com/kedacore/keda/v2/version.GitCommit=$(GIT_COMMIT) -X=gi
 COSIGN_FLAGS ?= -y -a GIT_HASH=${GIT_COMMIT} -a GIT_VERSION=${VERSION} -a BUILD_DATE=${DATE}
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31
+ENVTEST_K8S_VERSION = 1.32
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.

--- a/pkg/util/welcome.go
+++ b/pkg/util/welcome.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	minSupportedVersion = 29
-	maxSupportedVersion = 31
+	minSupportedVersion = 30
+	maxSupportedVersion = 32
 )
 
 func PrintWelcome(logger logr.Logger, kubeVersion K8sVersion, component string) {


### PR DESCRIPTION
### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


