### PR TITLE
Selenium Grid: Add trigger param to set custom capabilities for matching specific Nodes

### DIFF
--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -17,6 +17,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 		browserVersion     string
 		platformName       string
 		nodeMaxSessions    int64
+		capabilities       string
 	}
 	tests := []struct {
 		name                string
@@ -1907,6 +1908,112 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			wantErr:             false,
 		},
 		{
+			name: "4_sessions_requests_with_matching_browserName_and_platformName_when_set_nodeMaxSessions_2_and_3_requests_match_should_return_count_as_1_and_1_ongoing_session",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"grid": {
+							"sessionCount": 1,
+							"maxSession": 2,
+							"totalSlots": 2
+						},
+						"nodesInfo": {
+							"nodes": [
+								{
+									"id": "node-1",
+									"status": "UP",
+									"sessionCount": 1,
+									"maxSession": 2,
+									"slotCount": 2,
+									"stereotypes": "[{\"slots\": 2, \"stereotype\": {\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"linux\", \"se:downloadsEnabled\": true}}]",
+									"sessions": [
+										{
+											"id": "session-1",
+											"capabilities": "{\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"linux\", \"se:downloadsEnabled\": true}",
+											"slot": {
+												"id": "9ce1edba-72fb-465e-b311-ee473d8d7b64",
+												"stereotype": "{\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"linux\", \"se:downloadsEnabled\": true}"
+											}
+										}
+									]
+								}
+							]
+						},
+						"sessionsInfo": {
+							"sessionQueueRequests": [
+								"{\n  \"browserName\": \"chrome\",\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"se:downloadsEnabled\": true,\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"se:downloadsEnabled\": true,\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"se:downloadsEnabled\": true,\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"platformName\": \"Windows 11\"\n}"]
+						}
+					}
+				}`),
+				browserName:        "chrome",
+				sessionBrowserName: "chrome",
+				browserVersion:     "",
+				platformName:       "linux",
+				nodeMaxSessions:    2,
+				capabilities:       "{\"se:downloadsEnabled\": true}",
+			},
+			wantNewRequestNodes: 1,
+			wantOnGoingSessions: 1,
+			wantErr:             false,
+		},
+		{
+			name: "4_sessions_requests_with_matching_browserName_and_platformName_when_set_extra_capabilities_and_2_requests_match_should_return_count_as_2_and_ongoing_1",
+			args: args{
+				b: []byte(`{
+					"data": {
+						"grid": {
+							"sessionCount": 1,
+							"maxSession": 1,
+							"totalSlots": 1
+						},
+						"nodesInfo": {
+							"nodes": [
+								{
+									"id": "node-1",
+									"status": "UP",
+									"sessionCount": 1,
+									"maxSession": 1,
+									"slotCount": 1,
+									"stereotypes": "[{\"slots\": 1, \"stereotype\": {\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"linux\", \"myApp:version\": \"beta\", \"myApp:scope\": \"internal\"}}]",
+									"sessions": [
+										{
+											"id": "session-1",
+											"capabilities": "{\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"linux\", \"myApp:version\": \"beta\", \"myApp:scope\": \"internal\"}",
+											"slot": {
+												"id": "9ce1edba-72fb-465e-b311-ee473d8d7b64",
+												"stereotype": "{\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"linux\", \"myApp:version\": \"beta\", \"myApp:scope\": \"internal\"}"
+											}
+										}
+									]
+								}
+							]
+						},
+						"sessionsInfo": {
+							"sessionQueueRequests": [
+								"{\n  \"browserName\": \"chrome\",\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"myApp:version\": \"beta\",\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"myApp:version\": \"beta\",\n \"myApp:scope\": \"internal\",\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"myApp:version\": \"beta\",\n \"myApp:scope\": \"internal\",\n \"platformName\": \"linux\"\n}",
+								"{\n  \"browserName\": \"chrome\",\n \"platformName\": \"Windows 11\"\n}"]
+						}
+					}
+				}`),
+				browserName:        "chrome",
+				sessionBrowserName: "chrome",
+				browserVersion:     "",
+				platformName:       "linux",
+				nodeMaxSessions:    1,
+				capabilities:       "{\"myApp:version\": \"beta\", \"myApp:scope\": \"internal\"}",
+			},
+			wantNewRequestNodes: 2,
+			wantOnGoingSessions: 1,
+			wantErr:             false,
+		},
+		{
 			name: "Given_2_requests_include_1_without_browserVersion_When_scaler_metadata_explicit_name_version_platform_Then_scaler_should_scale_up_for_1_request_has_browserVersion_and_return_0_ongoing_sessions",
 			args: args{
 				b: []byte(`{
@@ -2865,7 +2972,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			newRequestNodes, onGoingSessions, err := getCountFromSeleniumResponse(tt.args.b, tt.args.browserName, tt.args.browserVersion, tt.args.sessionBrowserName, tt.args.platformName, tt.args.nodeMaxSessions, logr.Discard())
+			newRequestNodes, onGoingSessions, err := getCountFromSeleniumResponse(tt.args.b, tt.args.browserName, tt.args.browserVersion, tt.args.sessionBrowserName, tt.args.platformName, tt.args.nodeMaxSessions, tt.args.capabilities, logr.Discard())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getCountFromSeleniumResponse() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -2926,6 +3033,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				BrowserVersion:     "",
 				PlatformName:       "",
 				NodeMaxSessions:    1,
+				Capabilities:       "",
 			},
 		},
 		{
@@ -2948,6 +3056,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				BrowserVersion:     "",
 				PlatformName:       "",
 				NodeMaxSessions:    1,
+				Capabilities:       "",
 			},
 		},
 		{
@@ -2969,6 +3078,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				BrowserVersion:     "",
 				PlatformName:       "",
 				NodeMaxSessions:    1,
+				Capabilities:       "",
 			},
 		},
 		{
@@ -2997,6 +3107,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				BrowserVersion:     "",
 				PlatformName:       "",
 				NodeMaxSessions:    1,
+				Capabilities:       "",
 			},
 		},
 		{
@@ -3025,6 +3136,37 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				Username:           "username",
 				Password:           "password",
 				NodeMaxSessions:    1,
+				Capabilities:       "",
+			},
+		},
+		{
+			name: "valid capabilities should return metadata",
+			args: args{
+				config: &scalersconfig.ScalerConfig{
+					AuthParams: map[string]string{
+						"username": "username",
+						"password": "password",
+					},
+					TriggerMetadata: map[string]string{
+						"url":                "http://selenium-hub:4444/graphql",
+						"browserName":        "MicrosoftEdge",
+						"sessionBrowserName": "msedge",
+						"capabilities":       "{\"se:downloadsEnabled\": true}",
+					},
+				},
+			},
+			wantErr: false,
+			want: &seleniumGridScalerMetadata{
+				URL:                "http://selenium-hub:4444/graphql",
+				BrowserName:        "MicrosoftEdge",
+				SessionBrowserName: "msedge",
+				TargetValue:        1,
+				BrowserVersion:     "",
+				PlatformName:       "",
+				Username:           "username",
+				Password:           "password",
+				NodeMaxSessions:    1,
+				Capabilities:       "{\"se:downloadsEnabled\": true}",
 			},
 		},
 		{
@@ -3049,6 +3191,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:          false,
 				PlatformName:       "",
 				NodeMaxSessions:    1,
+				Capabilities:       "",
 			},
 		},
 		{
@@ -3075,6 +3218,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:           true,
 				PlatformName:        "",
 				NodeMaxSessions:     1,
+				Capabilities:        "",
 			},
 		},
 		{
@@ -3116,6 +3260,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:           true,
 				PlatformName:        "",
 				NodeMaxSessions:     1,
+				Capabilities:        "",
 			},
 		},
 		{
@@ -3143,6 +3288,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:           true,
 				PlatformName:        "Windows 11",
 				NodeMaxSessions:     1,
+				Capabilities:        "",
 			},
 		},
 		{
@@ -3177,6 +3323,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:           true,
 				PlatformName:        "Windows 11",
 				NodeMaxSessions:     3,
+				Capabilities:        "",
 			},
 		},
 		{
@@ -3212,6 +3359,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:           true,
 				PlatformName:        "Windows 11",
 				NodeMaxSessions:     3,
+				Capabilities:        "",
 			},
 		},
 		{
@@ -3247,6 +3395,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:           true,
 				PlatformName:        "Windows 11",
 				NodeMaxSessions:     3,
+				Capabilities:        "",
 			},
 		},
 		{
@@ -3281,6 +3430,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				UnsafeSsl:           true,
 				PlatformName:        "Windows 11",
 				NodeMaxSessions:     3,
+				Capabilities:        "",
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

Besides current main capabilities `browserName`, `browserVersion`, `platformName` are used for matching Node. Selenium Grid supports setting more custom capabilities for matching specific Nodes https://www.selenium.dev/documentation/grid/configuration/toml_options/#setting-custom-capabilities-for-matching-specific-nodes
Via this PR, one more trigger parameter is added with the name `capabilities` to define a JSON string with custom capabilities for matching specific Nodes. This helps users create more scalers to scale their Nodes with custom capabilities

For example:
```
  triggers:
    - type: selenium-grid
      metadata:
        url: 'http://selenium-hub:4444/graphql'
        browserName: 'chrome'
        platformName: 'Linux'
        unsafeSsl : 'true'
        capabilities: '{"myApp:version": "beta", "myApp:scope": "internal"}'
```

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
