### PR TITLE
fix!: fix CheckFallbackValid logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,10 @@ Here is an overview of all new **experimental** features:
 - **General**: Fix CVE-2025-29786 ([#6637](https://github.com/kedacore/keda/issues/6637))
 - **General**: Fix CVE-2025-30204 ([#6641](https://github.com/kedacore/keda/pull/6641))
 - **General**: Fix event text when deactivation fails ([#6469](https://github.com/kedacore/keda/issues/6469))
+- **General**: Fix fallback validation check bug ([#6407](https://github.com/kedacore/keda/pull/6407))
 - **General**: Make sure the exposed metrics (from KEDA operator) are updated when there is a change to triggers ([#6618](https://github.com/kedacore/keda/pull/6618))
 - **General**: Paused ScaledObject count is reported correctly after operator restart ([#6321](https://github.com/kedacore/keda/issues/6321))
+- **General**: Reiterate fix (after [#6407](https://github.com/kedacore/keda/pull/6407)) for fallback validation in admission webhook. ([#6538](https://github.com/kedacore/keda/pull/6538))
 - **General**: ScaledJobs ready status set to true when recoverred problem ([#6329](https://github.com/kedacore/keda/pull/6329))
 - **AWS Scalers**: Add AWS region to the AWS Config Cache key ([#6128](https://github.com/kedacore/keda/issues/6128))
 - **External Scaler**: Support server TLS without custom CA ([#6606](https://github.com/kedacore/keda/pull/6606))
@@ -122,7 +124,6 @@ New deprecation(s):
 ### Other
 
 - **General**: Add debug logs tracking validation of ScaledObjects on webhook ([#6498](https://github.com/kedacore/keda/pull/6498))
-- **General**: Fix fallback validation check bug ([#6407](https://github.com/kedacore/keda/pull/6407))
 - **General**: New eventreason KEDAScalersInfo to display important information ([#6328](https://github.com/kedacore/keda/issues/6328))
 - **Apache Kafka Scaler**: Remove unused awsEndpoint in Apache Kafka scaler ([#6627](https://github.com/kedacore/keda/pull/6627))
 - **External Scalers**: Allow `float64` values in externalmetrics' `MetricValue` & `TargetSize`. The old fields are still there because of backward compatibility. ([#5159](https://github.com/kedacore/keda/issues/5159))

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -23,10 +23,7 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var scaledobjecttypeslog = logf.Log.WithName("scaledobject-types")
 
 // +genclient
 // +kubebuilder:object:root=true
@@ -297,12 +294,25 @@ func CheckFallbackValid(scaledObject *ScaledObject) error {
 			scaledObject.Spec.Fallback.FailureThreshold, scaledObject.Spec.Fallback.Replicas)
 	}
 
-	for _, trigger := range scaledObject.Spec.Triggers {
-		if trigger.Type == cpuString || trigger.Type == memoryString {
-			scaledobjecttypeslog.Error(nil, fmt.Sprintf("type is %s , but fallback it is not supported by the CPU & memory scalers", trigger.Type))
+	if scaledObject.IsUsingModifiers() {
+		if scaledObject.Spec.Advanced.ScalingModifiers.MetricType != autoscalingv2.AverageValueMetricType {
+			return fmt.Errorf("when using ScalingModifiers, ScaledObject.Spec.Advanced.ScalingModifiers.MetricType must be AverageValue to have fallback enabled")
 		}
-		if trigger.MetricType != autoscalingv2.AverageValueMetricType {
-			return fmt.Errorf("MetricType=%s, but fallback can only be enabled for triggers with metric of type AverageValue", trigger.MetricType)
+	} else {
+		fallbackValid := false
+		for _, trigger := range scaledObject.Spec.Triggers {
+			if trigger.Type == cpuString || trigger.Type == memoryString {
+				continue
+			}
+			// If at least one trigger is of the type `AverageValue`, then having fallback is valid.
+			if trigger.MetricType == autoscalingv2.AverageValueMetricType {
+				fallbackValid = true
+				break
+			}
+		}
+
+		if !fallbackValid {
+			return fmt.Errorf("at least one trigger (that is not cpu or memory) has to have the `AverageValue` type for the fallback to be enabled")
 		}
 	}
 	return nil


### PR DESCRIPTION
This fixes the `CheckFallbackValid` logic used in the admission webhook. The way it should go is:

- If we are using `ScalingModifiers` and `ScaledObject.Spec.Advanced.ScalingModifiers.MetricType` is not `AverageValue`, then this is invalid. So, this becomes inline with the change in #6521 

- If we are not using `ScalingModifiers`

   1. If only cpu and memory are used, then fallback is invalid.
   2. If some other triggers are used (solely or in addition to cpu/memory), and not one of them has `AverageValue` type, then fallback is invalid.
   3. If some other triggers are used (solely or in addition to cpu/memory), and **_at least_** one of them has `AverageValue` type, then fallback **is** valid. This is actually inline with the code logic with the function `doFallback`, where it is called for _every_ `metricSpec` that has the type `AverageValue`.
   
The PR #6407 seems related to this. I am not sure what it is trying to do per se with regards to the cpu and memory. Because it seems to be _logging_ instead of returning the error when encountering cpu/memory, then falling to the next [if condition ](https://github.com/kedacore/keda/blob/914163cb33f7f04550e7434a19b039f5b893af4a/apis/keda/v1alpha1/scaledobject_types.go#L296)which will return the error _either way_

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
