### PR TITLE
fix: fix incorrect nil return value

### DIFF
--- a/controllers/eventing/reconciler.go
+++ b/controllers/eventing/reconciler.go
@@ -79,7 +79,7 @@ func Reconcile(ctx context.Context, reqLogger logr.Logger, r cloudEventSourceRec
 	}
 
 	if eventSourceChanged {
-		if RequestEventLoop(ctx, reqLogger, r, cloudEventSource) != nil {
+		if err = RequestEventLoop(ctx, reqLogger, r, cloudEventSource); err != nil {
 			return ctrl.Result{}, err
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Since we have already checked err before and returned != nil, err must be nil here. In fact, it should return  `RequestEventLoop(ctx, reqLogger, r, cloudEventSource)`.



### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

