### PR TITLE
Implement backoff when receive rate limit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Here is an overview of all new **experimental** features:
 - **Elasticsearch Scaler**: Support IgnoreNullValues at Elasticsearch scaler ([#6599](https://github.com/kedacore/keda/pull/6599))
 - **GitHub Scaler**: Add support to use ETag for conditional requests against the Github API ([#6503](https://github.com/kedacore/keda/issues/6503))
 - **GitHub Scaler**: Filter workflows via query parameter for improved queue count accuracy ([#6519](https://github.com/kedacore/keda/pull/6519))
+- **Github Scaler**: Implement backoff when receive rate limit errors ([#6643](https://github.com/kedacore/keda/issues/6643))
 - **IBMMQ Scaler**: Handling StatusNotFound in IBMMQ scaler ([#6472](https://github.com/kedacore/keda/pull/6472))
 - **RabbitMQ Scaler**: Support use of the ‘vhostName’ parameter in the ‘TriggerAuthentication’ resource ([#6369](https://github.com/kedacore/keda/issues/6369))
 - **Selenium Grid**: Add trigger param to set custom capabilities for matching specific Nodes ([#6536](https://github.com/kedacore/keda/issues/6536))

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -820,6 +820,9 @@ func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64,
 	return queueCount, nil
 }
 
+// func (s *githubRunnerScaler) shouldWaitForRateLimit(ctx context.Context) (bool, time.Duration)
+// Function should return boolean and how long to wait in time
+
 // waitForRateLimitReset waits until the rate limit reset time or retry-after time is reached.
 func (s *githubRunnerScaler) waitForRateLimitReset(ctx context.Context) error {
 	if s.rateLimits.Remaining == 0 && !s.rateLimits.ResetTime.IsZero() && time.Now().Before(s.rateLimits.ResetTime) {

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -194,6 +194,7 @@ func apiStubHandlerCustomJob(hasRateLeft bool, exceeds30Repos bool, jobResponse 
 		} else {
 			w.Header().Set("X-RateLimit-Remaining", "0")
 			w.WriteHeader(http.StatusForbidden)
+			return
 		}
 		if strings.HasSuffix(r.URL.String(), "jobs?per_page=100") {
 			// nosemgrep: no-direct-write-to-responsewriter

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -501,6 +501,48 @@ func TestNewGitHubRunnerScaler_QueueLength_SingleRepo_WithNotModified(t *testing
 	}
 }
 
+func TestNewGitHubRunnerScaler_ShouldWait_ResetTime(t *testing.T) {
+	mockGitHubRunnerScaler := githubRunnerScaler{
+		rateLimit: RateLimit{
+			Remaining:      0,
+			ResetTime:      time.Now().Add(15 * time.Second),
+			RetryAfterTime: time.Now(),
+		},
+	}
+
+	wait, waitDuration := mockGitHubRunnerScaler.shouldWaitForRateLimit()
+
+	if !wait {
+		t.Fail()
+	}
+
+	expectedWait := 15 * time.Second
+	if waitDuration < expectedWait-1*time.Second || waitDuration > expectedWait+1*time.Second {
+		t.Fail()
+	}
+}
+
+func TestNewGitHubRunnerScaler_ShouldWait_RetryAfterTime(t *testing.T) {
+	mockGitHubRunnerScaler := githubRunnerScaler{
+		rateLimit: RateLimit{
+			Remaining:      0,
+			ResetTime:      time.Now(),
+			RetryAfterTime: time.Now().Add(15 * time.Second),
+		},
+	}
+
+	wait, waitDuration := mockGitHubRunnerScaler.shouldWaitForRateLimit()
+
+	if !wait {
+		t.Fail()
+	}
+
+	expectedWait := 15 * time.Second
+	if waitDuration < expectedWait-1*time.Second || waitDuration > expectedWait+1*time.Second {
+		t.Fail()
+	}
+}
+
 func TestNewGitHubRunnerScaler_404(t *testing.T) {
 	var apiStub = apiStubHandler404()
 

--- a/tests/scalers/github_runner/github_runner_test.go
+++ b/tests/scalers/github_runner/github_runner_test.go
@@ -219,6 +219,7 @@ spec:
       labels: {{.Labels}}
       runnerScopeFromEnv: "RUNNER_SCOPE"
       enableEtags: "true"
+      enableBackoff: "true"
     authenticationRef:
      name: github-trigger-auth
 `


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Adds support to backoff when a rate limit error occurs as per  [handle rate limit errors appropriately](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#handle-rate-limit-errors-appropriately):
* If the retry-after response header is present, you should not retry your request until after that many seconds has elapsed.
* If the x-ratelimit-remaining header is 0, you should not make another request until after the time specified by the x-ratelimit-reset header. The x-ratelimit-reset header is in UTC epoch seconds.

- [N/A]When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6643 

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
