### PR TITLE
fix call log.Error with nil value error

### DIFF
--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -267,7 +267,7 @@ func (p *PromMetrics) RecordScaledJobError(namespace string, scaledJob string, e
 	// initialize metric with 0 if not already set
 	_, errscaledjob := scaledJobErrors.GetMetricWith(labels)
 	if errscaledjob != nil {
-		log.Error(err, "Unable to write to metrics to Prometheus Server: %v")
+		log.Error(errscaledjob, "Unable to write to metrics to Prometheus Server: %v")
 		return
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

use correct err for log.Error

and the code should be 

```
		log.Error(errscaledjob, "Unable to write to metrics to Prometheus Server", "labels", labels)
```

but I'm not sure.



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
