### PR TITLE
Replace deprecated webhook.Validator with webhook.CustomValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ New deprecation(s):
 
 ### Other
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **General**: Replace deprecated webhook.Validator with webhook.CustomValidator ([#6660](https://github.com/kedacore/keda/issues/6660))
 
 ## v2.17.0
 

--- a/apis/eventing/v1alpha1/cloudeventsource_webhook.go
+++ b/apis/eventing/v1alpha1/cloudeventsource_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -45,16 +46,47 @@ func (cces *ClusterCloudEventSource) SetupWebhookWithManager(mgr ctrl.Manager) e
 
 // +kubebuilder:webhook:path=/validate-eventing-keda-sh-v1alpha1-cloudeventsource,mutating=false,failurePolicy=ignore,sideEffects=None,groups=eventing.keda.sh,resources=cloudeventsources,verbs=create;update,versions=v1alpha1,name=vcloudeventsource.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &CloudEventSource{}
+// CloudEventSourceCustomValidator is a custom validator for CloudEventSource objects
+type CloudEventSourceCustomValidator struct{}
+
+func (cescv CloudEventSourceCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ces := obj.(*CloudEventSource)
+	return ces.ValidateCreate(request.DryRun)
+}
+
+func (cescv CloudEventSourceCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ces := newObj.(*CloudEventSource)
+	old := oldObj.(*CloudEventSource)
+	return ces.ValidateUpdate(old, request.DryRun)
+}
+
+func (cescv CloudEventSourceCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ces := obj.(*CloudEventSource)
+	return ces.ValidateDelete(request.DryRun)
+}
+
+var _ webhook.CustomValidator = &CloudEventSourceCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (ces *CloudEventSource) ValidateCreate() (admission.Warnings, error) {
+func (ces *CloudEventSource) ValidateCreate(_ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(ces, "", "  ")
 	cloudeventsourcelog.Info(fmt.Sprintf("validating cloudeventsource creation for %s", string(val)))
 	return validateSpec(&ces.Spec)
 }
 
-func (ces *CloudEventSource) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (ces *CloudEventSource) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(ces, "", "  ")
 	cloudeventsourcelog.V(1).Info(fmt.Sprintf("validating cloudeventsource update for %s", string(val)))
 
@@ -66,22 +98,53 @@ func (ces *CloudEventSource) ValidateUpdate(old runtime.Object) (admission.Warni
 	return validateSpec(&ces.Spec)
 }
 
-func (ces *CloudEventSource) ValidateDelete() (admission.Warnings, error) {
+func (ces *CloudEventSource) ValidateDelete(_ *bool) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // +kubebuilder:webhook:path=/validate-eventing-keda-sh-v1alpha1-clustercloudeventsource,mutating=false,failurePolicy=ignore,sideEffects=None,groups=eventing.keda.sh,resources=clustercloudeventsources,verbs=create;update,versions=v1alpha1,name=vclustercloudeventsource.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &ClusterCloudEventSource{}
+// ClusterCloudEventSourceCustomValidator is a custom validator for ClusterCloudEventSource objects
+type ClusterCloudEventSourceCustomValidator struct{}
+
+func (ccescv ClusterCloudEventSourceCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cces := obj.(*ClusterCloudEventSource)
+	return cces.ValidateCreate(request.DryRun)
+}
+
+func (ccescv ClusterCloudEventSourceCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cces := newObj.(*ClusterCloudEventSource)
+	old := oldObj.(*ClusterCloudEventSource)
+	return cces.ValidateUpdate(old, request.DryRun)
+}
+
+func (ccescv ClusterCloudEventSourceCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cces := obj.(*ClusterCloudEventSource)
+	return cces.ValidateDelete(request.DryRun)
+}
+
+var _ webhook.CustomValidator = &ClusterCloudEventSourceCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (cces *ClusterCloudEventSource) ValidateCreate() (admission.Warnings, error) {
+func (cces *ClusterCloudEventSource) ValidateCreate(_ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(cces, "", "  ")
 	cloudeventsourcelog.Info(fmt.Sprintf("validating clustercloudeventsource creation for %s", string(val)))
 	return validateSpec(&cces.Spec)
 }
 
-func (cces *ClusterCloudEventSource) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (cces *ClusterCloudEventSource) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(cces, "", "  ")
 	cloudeventsourcelog.V(1).Info(fmt.Sprintf("validating clustercloudeventsource update for %s", string(val)))
 
@@ -93,7 +156,7 @@ func (cces *ClusterCloudEventSource) ValidateUpdate(old runtime.Object) (admissi
 	return validateSpec(&cces.Spec)
 }
 
-func (cces *ClusterCloudEventSource) ValidateDelete() (admission.Warnings, error) {
+func (cces *ClusterCloudEventSource) ValidateDelete(_ *bool) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/apis/eventing/v1alpha1/cloudeventsource_webhook.go
+++ b/apis/eventing/v1alpha1/cloudeventsource_webhook.go
@@ -34,12 +34,14 @@ var cloudeventsourcelog = logf.Log.WithName("cloudeventsource-validation-webhook
 
 func (ces *CloudEventSource) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
+		WithValidator(&CloudEventSourceCustomValidator{}).
 		For(ces).
 		Complete()
 }
 
 func (cces *ClusterCloudEventSource) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
+		WithValidator(&ClusterCloudEventSourceCustomValidator{}).
 		For(cces).
 		Complete()
 }

--- a/apis/keda/v1alpha1/scaledjob_webhook.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook.go
@@ -33,6 +33,7 @@ var scaledjoblog = logf.Log.WithName("scaledjob-validation-webhook")
 
 func (s *ScaledJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
+		WithValidator(&ScaledJobCustomValidator{}).
 		For(s).
 		Complete()
 }

--- a/apis/keda/v1alpha1/scaledjob_webhook.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -38,16 +39,47 @@ func (s *ScaledJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/validate-keda-sh-v1alpha1-scaledjob,mutating=false,failurePolicy=ignore,sideEffects=None,groups=keda.sh,resources=scaledjobs,verbs=create;update,versions=v1alpha1,name=vscaledjob.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &ScaledJob{}
+// ScaledJobCustomValidator is a custom validator for ScaledJob objects
+type ScaledJobCustomValidator struct{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (s *ScaledJob) ValidateCreate() (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(s, "", "  ")
-	scaledjoblog.Info(fmt.Sprintf("validating scaledjob creation for %s", string(val)))
-	return nil, verifyTriggers(s, "create", false)
+func (sjcv ScaledJobCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sj := obj.(*ScaledJob)
+	return sj.ValidateCreate(request.DryRun)
 }
 
-func (s *ScaledJob) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (sjcv ScaledJobCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sj := newObj.(*ScaledJob)
+	old := oldObj.(*ScaledJob)
+	return sj.ValidateUpdate(old, request.DryRun)
+}
+
+func (sjcv ScaledJobCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sj := obj.(*ScaledJob)
+	return sj.ValidateDelete(request.DryRun)
+}
+
+var _ webhook.CustomValidator = &ScaledJobCustomValidator{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (s *ScaledJob) ValidateCreate(dryRun *bool) (admission.Warnings, error) {
+	val, _ := json.MarshalIndent(s, "", "  ")
+	scaledjoblog.Info(fmt.Sprintf("validating scaledjob creation for %s", string(val)))
+	return nil, verifyTriggers(s, "create", *dryRun)
+}
+
+func (s *ScaledJob) ValidateUpdate(old runtime.Object, dryRun *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(s, "", "  ")
 	scaledobjectlog.V(1).Info(fmt.Sprintf("validating scaledjob update for %s", string(val)))
 
@@ -56,10 +88,10 @@ func (s *ScaledJob) ValidateUpdate(old runtime.Object) (admission.Warnings, erro
 		scaledjoblog.V(1).Info("finalizer removal, skipping validation")
 		return nil, nil
 	}
-	return nil, verifyTriggers(s, "update", false)
+	return nil, verifyTriggers(s, "update", *dryRun)
 }
 
-func (s *ScaledJob) ValidateDelete() (admission.Warnings, error) {
+func (s *ScaledJob) ValidateDelete(_ *bool) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/apis/keda/v1alpha1/triggerauthentication_webhook.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -49,16 +50,47 @@ func (cta *ClusterTriggerAuthentication) SetupWebhookWithManager(mgr ctrl.Manage
 
 // +kubebuilder:webhook:path=/validate-keda-sh-v1alpha1-triggerauthentication,mutating=false,failurePolicy=ignore,sideEffects=None,groups=keda.sh,resources=triggerauthentications,verbs=create;update,versions=v1alpha1,name=vstriggerauthentication.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &TriggerAuthentication{}
+// TriggerAuthenticationCustomValidator is a custom validator for TriggerAuthentication objects
+type TriggerAuthenticationCustomValidator struct{}
+
+func (tacv TriggerAuthenticationCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ta := obj.(*TriggerAuthentication)
+	return ta.ValidateCreate(request.DryRun)
+}
+
+func (tacv TriggerAuthenticationCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ta := newObj.(*TriggerAuthentication)
+	old := oldObj.(*TriggerAuthentication)
+	return ta.ValidateUpdate(old, request.DryRun)
+}
+
+func (tacv TriggerAuthenticationCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ta := obj.(*TriggerAuthentication)
+	return ta.ValidateDelete(request.DryRun)
+}
+
+var _ webhook.CustomValidator = &TriggerAuthenticationCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (ta *TriggerAuthentication) ValidateCreate() (admission.Warnings, error) {
+func (ta *TriggerAuthentication) ValidateCreate(_ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(ta, "", "  ")
 	triggerauthenticationlog.Info(fmt.Sprintf("validating triggerauthentication creation for %s", string(val)))
 	return validateSpec(&ta.Spec)
 }
 
-func (ta *TriggerAuthentication) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (ta *TriggerAuthentication) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(ta, "", "  ")
 	scaledobjectlog.V(1).Info(fmt.Sprintf("validating triggerauthentication update for %s", string(val)))
 
@@ -70,22 +102,53 @@ func (ta *TriggerAuthentication) ValidateUpdate(old runtime.Object) (admission.W
 	return validateSpec(&ta.Spec)
 }
 
-func (ta *TriggerAuthentication) ValidateDelete() (admission.Warnings, error) {
+func (ta *TriggerAuthentication) ValidateDelete(_ *bool) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // +kubebuilder:webhook:path=/validate-keda-sh-v1alpha1-clustertriggerauthentication,mutating=false,failurePolicy=ignore,sideEffects=None,groups=keda.sh,resources=clustertriggerauthentications,verbs=create;update,versions=v1alpha1,name=vsclustertriggerauthentication.kb.io,admissionReviewVersions=v1
 
-var _ webhook.Validator = &ClusterTriggerAuthentication{}
+// ClusterTriggerAuthenticationCustomValidator is a custom validator for ClusterTriggerAuthentication objects
+type ClusterTriggerAuthenticationCustomValidator struct{}
+
+func (ctacv ClusterTriggerAuthenticationCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cta := obj.(*ClusterTriggerAuthentication)
+	return cta.ValidateCreate(request.DryRun)
+}
+
+func (ctacv ClusterTriggerAuthenticationCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cta := newObj.(*ClusterTriggerAuthentication)
+	old := oldObj.(*ClusterTriggerAuthentication)
+	return cta.ValidateUpdate(old, request.DryRun)
+}
+
+func (ctacv ClusterTriggerAuthenticationCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	request, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cta := obj.(*ClusterTriggerAuthentication)
+	return cta.ValidateDelete(request.DryRun)
+}
+
+var _ webhook.CustomValidator = &ClusterTriggerAuthenticationCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (cta *ClusterTriggerAuthentication) ValidateCreate() (admission.Warnings, error) {
+func (cta *ClusterTriggerAuthentication) ValidateCreate(_ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(cta, "", "  ")
 	triggerauthenticationlog.Info(fmt.Sprintf("validating clustertriggerauthentication creation for %s", string(val)))
 	return validateSpec(&cta.Spec)
 }
 
-func (cta *ClusterTriggerAuthentication) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
+func (cta *ClusterTriggerAuthentication) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
 	val, _ := json.MarshalIndent(cta, "", "  ")
 	scaledobjectlog.V(1).Info(fmt.Sprintf("validating clustertriggerauthentication update for %s", string(val)))
 
@@ -98,7 +161,7 @@ func (cta *ClusterTriggerAuthentication) ValidateUpdate(old runtime.Object) (adm
 	return validateSpec(&cta.Spec)
 }
 
-func (cta *ClusterTriggerAuthentication) ValidateDelete() (admission.Warnings, error) {
+func (cta *ClusterTriggerAuthentication) ValidateDelete(_ *bool) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/apis/keda/v1alpha1/triggerauthentication_webhook.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook.go
@@ -38,12 +38,14 @@ var triggerauthenticationlog = logf.Log.WithName("triggerauthentication-validati
 
 func (ta *TriggerAuthentication) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
+		WithValidator(&TriggerAuthenticationCustomValidator{}).
 		For(ta).
 		Complete()
 }
 
 func (cta *ClusterTriggerAuthentication) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
+		WithValidator(&ClusterTriggerAuthenticationCustomValidator{}).
 		For(cta).
 		Complete()
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

As suggested in #6660, this PR replaces the deprecated `webhook.Validator` with `webhook.CustomValidator`.

The controller-runtime has not been updated yet, as the current version already supports `webhook.CustomValidator`.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6660
