### PR TITLE
fix: Enable TLS when using API Key for Temporal scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ## History
 
 - [Unreleased](#unreleased)
-- [v2.17.0](#v2161)
+- [v2.17.0](#v2170)
 - [v2.16.1](#v2161)
 - [v2.16.0](#v2160)
 - [v2.15.1](#v2151)
@@ -72,7 +72,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+**Temporal Scaler**: Fix Temporal Scaler does not work properly with API Key authentication against Temporal Cloud as TLS is not enabled on the client ([#6703](https://github.com/kedacore/keda/issues/6703))
 
 ### Deprecations
 

--- a/pkg/scalers/temporal.go
+++ b/pkg/scalers/temporal.go
@@ -2,6 +2,7 @@ package scalers
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"time"
@@ -223,6 +224,9 @@ func getTemporalClient(ctx context.Context, meta *temporalMetadata, log logr.Log
 			},
 		))
 		options.Credentials = sdk.NewAPIKeyStaticCredentials(meta.APIKey)
+		options.ConnectionOptions.TLS = &tls.Config{
+			MinVersion: tls.VersionTLS13,
+		}
 	}
 
 	options.ConnectionOptions = sdk.ConnectionOptions{

--- a/pkg/scalers/temporal_test.go
+++ b/pkg/scalers/temporal_test.go
@@ -224,6 +224,30 @@ func TestParseTemporalMetadata(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "apiKey provided",
+			metadata: map[string]string{
+				"endpoint":  "test:7233",
+				"namespace": "default",
+				"taskQueue": "testxx",
+				"apiKey":    "test-api-key",
+			},
+			wantMeta: &temporalMetadata{
+				Endpoint:                  "test:7233",
+				Namespace:                 "default",
+				TaskQueue:                 "testxx",
+				TargetQueueSize:           5,
+				ActivationTargetQueueSize: 0,
+				AllActive:                 false,
+				Unversioned:               false,
+				APIKey:                    "test-api-key",
+				MinConnectTimeout:         5,
+			},
+			authParams: map[string]string{
+				"apiKey": "test-api-key",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, testCase := range cases {


### PR DESCRIPTION
The Temporal scaler was failing with a "connection reset by peer" error when an API key was provided for authentication without explicitly configuring TLS.
This change modifies the getTemporalClient function to enforce a default TLS configuration when an API key is present in the trigger metadata. This aligns with the Temporal client's requirement for TLS when using API key authentication.

Also, a new test case has been added to TestParseTemporalMetadata to ensure the apiKey is correctly parsed.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6703