### PR TITLE
fix: AWS SQS Queue queueURLFromEnv not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+**AWS SQS Queue Scaler**: Fix AWS SQS Queue queueURLFromEnv not working ([#6712](https://github.com/kedacore/keda/issues/6712))
 
 ### Deprecations
 

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -29,7 +29,7 @@ type awsSqsQueueScaler struct {
 type awsSqsQueueMetadata struct {
 	TargetQueueLength           int64  `keda:"name=queueLength, order=triggerMetadata, default=5"`
 	ActivationTargetQueueLength int64  `keda:"name=activationQueueLength, order=triggerMetadata, default=0"`
-	QueueURL                    string `keda:"name=queueURL;queueURLFromEnv, order=triggerMetadata;resolvedEnv"`
+	QueueURL                    string `keda:"name=queueURL, order=triggerMetadata;resolvedEnv"`
 	queueName                   string
 	AwsRegion                   string `keda:"name=awsRegion, order=triggerMetadata;authParams"`
 	AwsEndpoint                 string `keda:"name=awsEndpoint, order=triggerMetadata, optional"`


### PR DESCRIPTION
Modified the tag configuration for the `QueueURL` field in `awsSqsQueueMetadata` struct to correctly handle environment variable resolution:

The issue was that the previous tag definition caused double application of the "FromEnv" suffix when resolving environment variables.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6712 