### PR TITLE
fix: Improve e2e tests and small fixes

### DIFF
--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -255,13 +255,13 @@ func (s *externalPushScaler) Run(ctx context.Context, active chan<- bool) {
 	runWithLog := func() {
 		grpcClient, err := getClientForConnectionPool(s.metadata)
 		if err != nil {
-			if !errors.Is(err, io.EOF) { //If io.EOF is returned, the stream has terminated with an OK status
+			if !errors.Is(err, io.EOF) { // If io.EOF is returned, the stream has terminated with an OK status
 				s.logger.Error(err, "error running internalRun")
 			}
 			return
 		}
 		if err := handleIsActiveStream(ctx, &s.scaledObjectRef, grpcClient, active); err != nil {
-			if !errors.Is(err, io.EOF) { //If io.EOF is returned, the stream has terminated with an OK status
+			if !errors.Is(err, io.EOF) { // If io.EOF is returned, the stream has terminated with an OK status
 				s.logger.Error(err, "error running internalRun")
 			}
 			return

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -251,31 +251,35 @@ func (s *externalScaler) GetMetricsAndActivity(ctx context.Context, metricName s
 // handleIsActiveStream is the only writer to the active channel and will close it on return.
 func (s *externalPushScaler) Run(ctx context.Context, active chan<- bool) {
 	defer close(active)
+
+	// retry on error from runWithLog() starting by 2 sec backing off * 2 with a max of 2 minute
+	retryDuration := time.Second * 2
+
 	// It's possible for the connection to get terminated anytime, we need to run this in a retry loop
 	runWithLog := func() {
 		grpcClient, err := getClientForConnectionPool(s.metadata)
 		if err != nil {
-			if !errors.Is(err, io.EOF) { // If io.EOF is returned, the stream has terminated with an OK status
-				s.logger.Error(err, "error running internalRun")
-			}
+			s.logger.Error(err, "unable to get connection from the pool")
 			return
 		}
 		if err := handleIsActiveStream(ctx, &s.scaledObjectRef, grpcClient, active); err != nil {
 			if !errors.Is(err, io.EOF) { // If io.EOF is returned, the stream has terminated with an OK status
 				s.logger.Error(err, "error running internalRun")
+				return
 			}
+			// if the connection is properly closed, we reset the timer
+			retryDuration = time.Second * 2
 			return
 		}
 	}
 
-	// retry on error from runWithLog() starting by 2 sec backing off * 2 with a max of 2 minute
-	retryDuration := time.Second * 2
 	// the caller of this function needs to ensure that they call Stop() on the resulting
 	// timer, to release background resources.
 	retryBackoff := func() *time.Timer {
 		tmr := time.NewTimer(retryDuration)
+		s.logger.V(1).Info("external push retry backoff", "duration", retryDuration)
 		retryDuration *= 2
-		if retryDuration > time.Minute*1 {
+		if retryDuration > time.Minute {
 			retryDuration = time.Minute * 1
 		}
 		return tmr

--- a/pkg/scalers/gcp_storage_scaler.go
+++ b/pkg/scalers/gcp_storage_scaler.go
@@ -204,21 +204,21 @@ func (s *gcsScaler) getItemCount(ctx context.Context, maxCount int64) (int64, er
 
 	for count < maxCount {
 		item, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		// The folder is retrieved as an entity, so if size is 0
-		// we can skip it
-		if item.Size == 0 {
-			continue
-		}
 		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				break
+			}
 			if errors.Is(err, storage.ErrBucketNotExist) {
 				s.logger.Info("Bucket " + s.metadata.bucketName + " doesn't exist")
 				return 0, nil
 			}
 			s.logger.Error(err, "failed to enumerate items in bucket "+s.metadata.bucketName)
 			return count, err
+		}
+		// The folder is retrieved as an entity, so if size is 0
+		// we can skip it
+		if item.Size == 0 {
+			continue
 		}
 		count++
 	}

--- a/tests/internals/cache_metrics/cache_metrics_test.go
+++ b/tests/internals/cache_metrics/cache_metrics_test.go
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -239,7 +239,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'
 `
 
 	scaledObjectTemplate = `

--- a/tests/internals/eventemitter/azureeventgridtopic/azureeventgridtopic_test.go
+++ b/tests/internals/eventemitter/azureeventgridtopic/azureeventgridtopic_test.go
@@ -101,7 +101,7 @@ spec:
       spec:
         containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	secretTemplate = `
 apiVersion: v1
@@ -145,7 +145,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: 'nginxinc/nginx-unprivileged'`
+        image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/tests/internals/events/events_test.go
+++ b/tests/internals/events/events_test.go
@@ -89,7 +89,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'
 `
 
 	deploymentTemplate = `
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged:alpine-slim
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTargetErrTemplate = `
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
         - name: {{.DaemonsetName}}
-          image: nginxinc/nginx-unprivileged:alpine-slim
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTargetNotSupportTemplate = `

--- a/tests/internals/fallback/fallback_test.go
+++ b/tests/internals/fallback/fallback_test.go
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/internals/idle_replicas/idle_replicas_test.go
+++ b/tests/internals/idle_replicas/idle_replicas_test.go
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -75,7 +75,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/internals/initial_delay_cooldownperiod/initial_delay_cooldownperiod_test.go
+++ b/tests/internals/initial_delay_cooldownperiod/initial_delay_cooldownperiod_test.go
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'
 `
 
 	scaledObjectTemplate = `

--- a/tests/internals/pause_scaledobject/pause_scaledobject_test.go
+++ b/tests/internals/pause_scaledobject/pause_scaledobject_test.go
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged:alpine-slim
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged:alpine-slim
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
+++ b/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged:alpine-slim
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged:alpine-slim
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
+++ b/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
@@ -100,7 +100,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/internals/replica_update_so/replica_update_so_test.go
+++ b/tests/internals/replica_update_so/replica_update_so_test.go
@@ -109,7 +109,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/internals/restore_original/restore_original_test.go
+++ b/tests/internals/restore_original/restore_original_test.go
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -75,7 +75,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/internals/scaled_object_validation/scaled_object_validation_test.go
+++ b/tests/internals/scaled_object_validation/scaled_object_validation_test.go
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `
@@ -335,7 +335,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
           resources:
             limits:
               cpu: 50m

--- a/tests/internals/scaling_modifiers/scaling_modifiers_test.go
+++ b/tests/internals/scaling_modifiers/scaling_modifiers_test.go
@@ -91,7 +91,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `
@@ -237,7 +237,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	updateMetricsTemplate = `
 apiVersion: batch/v1

--- a/tests/internals/status_update/status_update_test.go
+++ b/tests/internals/status_update/status_update_test.go
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/internals/subresource_scale/subresource_scale_test.go
+++ b/tests/internals/subresource_scale/subresource_scale_test.go
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	argoRolloutTemplate = `apiVersion: argoproj.io/v1alpha1
 kind: Rollout
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1

--- a/tests/internals/trigger_update_so/trigger_update_so_test.go
+++ b/tests/internals/trigger_update_so/trigger_update_so_test.go
@@ -111,7 +111,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `
@@ -135,7 +135,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	metricsServerDeploymentTemplate = `
 apiVersion: apps/v1

--- a/tests/internals/update_ta/update_ta_test.go
+++ b/tests/internals/update_ta/update_ta_test.go
@@ -97,7 +97,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/internals/value_metric_type/value_metric_type_test.go
+++ b/tests/internals/value_metric_type/value_metric_type_test.go
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/scalers/activemq/activemq_test.go
+++ b/tests/scalers/activemq/activemq_test.go
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/arangodb/arangodb_test.go
+++ b/tests/scalers/arangodb/arangodb_test.go
@@ -71,7 +71,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `
@@ -133,7 +133,7 @@ spec:
   template:
     spec:
       containers:
-      - image: nginxinc/nginx-unprivileged
+      - image: ghcr.io/nginx/nginx-unprivileged:1.26
         name: test
         command: ["/bin/sh"]
         args: ["-c", "curl --location --request POST 'https://example-arangodb-cluster-ea.{{.TestNamespace}}.svc.cluster.local:8529/_db/{{.Database}}/_api/document/{{.Collection}}' --header 'Authorization: Basic cm9vdDo=' --data-raw '[{\"Hi\": \"Nathan\"}, {\"Hi\": \"Laura\"}]' -k"]
@@ -158,7 +158,7 @@ spec:
   template:
     spec:
       containers:
-      - image: nginxinc/nginx-unprivileged
+      - image: ghcr.io/nginx/nginx-unprivileged:1.26
         name: test
         command: ["/bin/sh"]
         args: ["-c", "curl --location --request POST 'https://example-arangodb-cluster-ea.{{.TestNamespace}}.svc.cluster.local:8529/_db/{{.Database}}/_api/document/{{.Collection}}' --header 'Authorization: Basic cm9vdDo=' --data-raw '[{\"Hi\": \"Harry\"}, {\"Hi\": \"Neha\"}]' -k"]
@@ -183,7 +183,7 @@ spec:
   template:
     spec:
       containers:
-      - image: nginxinc/nginx-unprivileged
+      - image: ghcr.io/nginx/nginx-unprivileged:1.26
         name: test
         command: ["/bin/sh"]
         args: ["-c", "curl --location --request POST 'https://example-arangodb-cluster-ea.{{.TestNamespace}}.svc.cluster.local:8529/_db/{{.Database}}/_api/cursor' --header 'Authorization: Basic cm9vdDo=' --data-raw '{\"query\": \"FOR doc in {{.Collection}} REMOVE doc in {{.Collection}}\"}' -k"]

--- a/tests/scalers/arangodb/helper.go
+++ b/tests/scalers/arangodb/helper.go
@@ -43,7 +43,7 @@ spec:
   template:
     spec:
       containers:
-        - image: nginxinc/nginx-unprivileged
+        - image: ghcr.io/nginx/nginx-unprivileged:1.26
           name: alpine
           command: ["/bin/sh"]
           args: ["-c", "curl -H 'Authorization: Basic cm9vdDo=' --location --request POST 'https://example-arangodb-cluster-ea.{{.Namespace}}.svc.cluster.local:8529/_api/database' --data-raw '{\"name\": \"{{.Database}}\"}' -k"]
@@ -68,7 +68,7 @@ spec:
   template:
     spec:
       containers:
-        - image: nginxinc/nginx-unprivileged
+        - image: ghcr.io/nginx/nginx-unprivileged:1.26
           name: alpine
           command: ["/bin/sh"]
           args: ["-c", "curl -H 'Authorization: Basic cm9vdDo=' --location --request POST 'https://example-arangodb-cluster-ea.{{.Namespace}}.svc.cluster.local:8529/_db/{{.Database}}/_api/collection' --data-raw '{\"name\": \"{{.Collection}}\"}' -k"]

--- a/tests/scalers/aws/aws_cloudwatch/aws_cloudwatch_test.go
+++ b/tests/scalers/aws/aws_cloudwatch/aws_cloudwatch_test.go
@@ -89,7 +89,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_expression/aws_cloudwatch_expression_test.go
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_cloudwatch_ignore_null_values_false/aws_cloudwatch_ignore_null_values_false_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_ignore_null_values_false/aws_cloudwatch_ignore_null_values_false_test.go
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_cloudwatch_min_metric_value/aws_cloudwatch_min_metric_value_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_min_metric_value/aws_cloudwatch_min_metric_value_test.go
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_cloudwatch_pod_identity/aws_cloudwatch_pod_identity_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_pod_identity/aws_cloudwatch_pod_identity_test.go
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_cloudwatch_pod_identity_eks/aws_cloudwatch_pod_identity_eks_test.go
+++ b/tests/scalers/aws/aws_cloudwatch_pod_identity_eks/aws_cloudwatch_pod_identity_eks_test.go
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_dynamodb/aws_dynamodb_test.go
+++ b/tests/scalers/aws/aws_dynamodb/aws_dynamodb_test.go
@@ -91,7 +91,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_dynamodb_pod_identity/aws_dynamodb_pod_identity_test.go
+++ b/tests/scalers/aws/aws_dynamodb_pod_identity/aws_dynamodb_pod_identity_test.go
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_dynamodb_pod_identity_eks/aws_dynamodb_pod_identity_eks_test.go
+++ b/tests/scalers/aws/aws_dynamodb_pod_identity_eks/aws_dynamodb_pod_identity_eks_test.go
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_dynamodb_streams/aws_dynamodb_streams_test.go
+++ b/tests/scalers/aws/aws_dynamodb_streams/aws_dynamodb_streams_test.go
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/aws/aws_dynamodb_streams_pod_identity/aws_dynamodb_streams_pod_identity_test.go
+++ b/tests/scalers/aws/aws_dynamodb_streams_pod_identity/aws_dynamodb_streams_pod_identity_test.go
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/aws/aws_dynamodb_streams_pod_identity_eks/aws_dynamodb_streams_pod_identity_eks_test.go
+++ b/tests/scalers/aws/aws_dynamodb_streams_pod_identity_eks/aws_dynamodb_streams_pod_identity_eks_test.go
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/aws/aws_kinesis_stream/aws_kinesis_stream_test.go
+++ b/tests/scalers/aws/aws_kinesis_stream/aws_kinesis_stream_test.go
@@ -87,7 +87,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_kinesis_stream_pod_identity/aws_kinesis_stream_pod_identity_test.go
+++ b/tests/scalers/aws/aws_kinesis_stream_pod_identity/aws_kinesis_stream_pod_identity_test.go
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_kinesis_stream_pod_identity_eks/aws_kinesis_stream_pod_identity_eks_test.go
+++ b/tests/scalers/aws/aws_kinesis_stream_pod_identity_eks/aws_kinesis_stream_pod_identity_eks_test.go
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_managed_prometheus/aws_managed_prometheus_test.go
+++ b/tests/scalers/aws/aws_managed_prometheus/aws_managed_prometheus_test.go
@@ -84,7 +84,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_managed_prometheus_pod_identity/aws_managed_prometheus_pod_identity_test.go
+++ b/tests/scalers/aws/aws_managed_prometheus_pod_identity/aws_managed_prometheus_pod_identity_test.go
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_sqs_queue/aws_sqs_queue_test.go
+++ b/tests/scalers/aws/aws_sqs_queue/aws_sqs_queue_test.go
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_sqs_queue_pod_identity/aws_sqs_queue_pod_identity_test.go
+++ b/tests/scalers/aws/aws_sqs_queue_pod_identity/aws_sqs_queue_pod_identity_test.go
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/aws/aws_sqs_queue_pod_identity_eks/aws_sqs_queue_pod_identity_eks_test.go
+++ b/tests/scalers/aws/aws_sqs_queue_pod_identity_eks/aws_sqs_queue_pod_identity_eks_test.go
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/azure/azure_application_insights/azure_application_insights_test.go
+++ b/tests/scalers/azure/azure_application_insights/azure_application_insights_test.go
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
       - name: app-insights-scaler-test
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_application_insights_aad_wi/azure_application_insights_aad_wi_test.go
+++ b/tests/scalers/azure/azure_application_insights_aad_wi/azure_application_insights_aad_wi_test.go
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
       - name: app-insights-scaler-test
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_data_explorer/azure_data_explorer_test.go
+++ b/tests/scalers/azure/azure_data_explorer/azure_data_explorer_test.go
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_data_explorer_aad_wi/azure_data_explorer_aad_wi_test.go
+++ b/tests/scalers/azure/azure_data_explorer_aad_wi/azure_data_explorer_aad_wi_test.go
@@ -69,7 +69,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_log_analytics/azure_log_analytics_test.go
+++ b/tests/scalers/azure/azure_log_analytics/azure_log_analytics_test.go
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_log_analytics_aad_wi/azure_log_analytics_aad_wi_test.go
+++ b/tests/scalers/azure/azure_log_analytics_aad_wi/azure_log_analytics_aad_wi_test.go
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_monitor/azure_monitor_test.go
+++ b/tests/scalers/azure/azure_monitor/azure_monitor_test.go
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
       - name: app-insights-scaler-test
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_monitor_aad_wi/azure_monitor_aad_wi_test.go
+++ b/tests/scalers/azure/azure_monitor_aad_wi/azure_monitor_aad_wi_test.go
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
       - name: app-insights-scaler-test
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_service_bus_queue/azure_service_bus_queue_test.go
+++ b/tests/scalers/azure/azure_service_bus_queue/azure_service_bus_queue_test.go
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_service_bus_queue_aad_wi/azure_service_bus_queue_aad_wi_test.go
+++ b/tests/scalers/azure/azure_service_bus_queue_aad_wi/azure_service_bus_queue_aad_wi_test.go
@@ -63,7 +63,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_service_bus_queue_regex/azure_service_bus_queue_regex_test.go
+++ b/tests/scalers/azure/azure_service_bus_queue_regex/azure_service_bus_queue_regex_test.go
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_service_bus_topic/azure_service_bus_topic_test.go
+++ b/tests/scalers/azure/azure_service_bus_topic/azure_service_bus_topic_test.go
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_service_bus_topic_aad_wi/azure_service_bus_topic_aad_wi_test.go
+++ b/tests/scalers/azure/azure_service_bus_topic_aad_wi/azure_service_bus_topic_aad_wi_test.go
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/azure/azure_service_bus_topic_regex/azure_service_bus_topic_regex_test.go
+++ b/tests/scalers/azure/azure_service_bus_topic_regex/azure_service_bus_topic_regex_test.go
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/scalers/beanstalkd/beanstalkd_test.go
+++ b/tests/scalers/beanstalkd/beanstalkd_test.go
@@ -164,7 +164,7 @@ spec:
     spec:
       containers:
       - name: nginx-deployment
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/cassandra/cassandra_test.go
+++ b/tests/scalers/cassandra/cassandra_test.go
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/couchdb/couchdb_test.go
+++ b/tests/scalers/couchdb/couchdb_test.go
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	secretTemplate = `

--- a/tests/scalers/cpu/cpu_test.go
+++ b/tests/scalers/cpu/cpu_test.go
@@ -161,7 +161,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	triggerJob = `apiVersion: batch/v1
 kind: Job

--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'
 `
 
 	scaledObjectTemplate = `

--- a/tests/scalers/datadog/datadog_api/datadog_api_test.go
+++ b/tests/scalers/datadog/datadog_api/datadog_api_test.go
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/elasticsearch/elasticsearch_test.go
+++ b/tests/scalers/elasticsearch/elasticsearch_test.go
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
+++ b/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: my-app
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/tests/scalers/etcd/etcd_cluster_auth/etcd_cluster_auth_test.go
+++ b/tests/scalers/etcd/etcd_cluster_auth/etcd_cluster_auth_test.go
@@ -91,7 +91,7 @@ spec:
     spec:
       containers:
       - name: my-app
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/tests/scalers/external_push_scaler/external_push_scaler_test.go
+++ b/tests/scalers/external_push_scaler/external_push_scaler_test.go
@@ -86,6 +86,14 @@ spec:
           ports:
           - containerPort: 6000
           - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
 `
 
 	deploymentTemplate = `

--- a/tests/scalers/external_push_scaler/external_push_scaler_test.go
+++ b/tests/scalers/external_push_scaler/external_push_scaler_test.go
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/scalers/external_push_scaler/external_push_scaler_test.go
+++ b/tests/scalers/external_push_scaler/external_push_scaler_test.go
@@ -200,7 +200,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	KubectlDeleteWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	t.Log("scaling to 2 replicas")
-	data.MetricValue = "21"
+	data.MetricValue = "20"
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
@@ -211,7 +211,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("scaling to 3 replicas using floats in the payload")
 	data.MetricValue = "22.222"
 	data.MetricsServerEndpoint = metricsServerEndpointFloat
-	data.MetricThreshold = "7.111"
+	data.MetricThreshold = "6.111"
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 	KubectlReplaceWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 3, 60, 2),

--- a/tests/scalers/external_push_scaler_old_proto/external_push_scaler_old_proto_test.go
+++ b/tests/scalers/external_push_scaler_old_proto/external_push_scaler_old_proto_test.go
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/scalers/external_scaler_so/external_scaler_so_test.go
+++ b/tests/scalers/external_scaler_so/external_scaler_so_test.go
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/scalers/influxdb/influxdb_test.go
+++ b/tests/scalers/influxdb/influxdb_test.go
@@ -178,7 +178,7 @@ spec:
     spec:
       containers:
       - name: nginx-deployment
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
+++ b/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	sutDeploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: 'nginxinc/nginx-unprivileged'`
+        image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/tests/scalers/loki/loki_test.go
+++ b/tests/scalers/loki/loki_test.go
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 ---

--- a/tests/scalers/memory/memory_test.go
+++ b/tests/scalers/memory/memory_test.go
@@ -153,7 +153,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	scaleUpValue   = 1
 	scaleDownValue = 45

--- a/tests/scalers/metrics_api/metrics_api_test.go
+++ b/tests/scalers/metrics_api/metrics_api_test.go
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/openstack_swift/openstack_swift_test.go
+++ b/tests/scalers/openstack_swift/openstack_swift_test.go
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'
 `
 
 	secretTemplate = `

--- a/tests/scalers/solr/solr_test.go
+++ b/tests/scalers/solr/solr_test.go
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/scalers/splunk/splunk_test.go
+++ b/tests/scalers/splunk/splunk_test.go
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/secret-providers/aws_identity_assume_role/aws_identity_assume_role_test.go
+++ b/tests/secret-providers/aws_identity_assume_role/aws_identity_assume_role_test.go
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: workload
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/secret-providers/azure_workload_identity_user_assigned/azure_workload_identity_user_assigned_test.go
+++ b/tests/secret-providers/azure_workload_identity_user_assigned/azure_workload_identity_user_assigned_test.go
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	triggerAuthTemplate = `

--- a/tests/sequential/broken_scaledobject_tolerancy/broken_scaledobject_tolerancy_test.go
+++ b/tests/sequential/broken_scaledobject_tolerancy/broken_scaledobject_tolerancy_test.go
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	deploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: 'nginxinc/nginx-unprivileged'`
+        image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	brokenScaledObjectTemplate = `
 apiVersion: keda.sh/v1alpha1

--- a/tests/sequential/datadog_dca/datadog_dca_test.go
+++ b/tests/sequential/datadog_dca/datadog_dca_test.go
@@ -210,7 +210,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginxinc/nginx-unprivileged
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
         ports:
         - containerPort: 80
 `

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: 'nginxinc/nginx-unprivileged'`
+          image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	sutDeploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: 'nginxinc/nginx-unprivileged'`
+        image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
 
 	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -128,7 +128,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: {{.MonitoredDeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	deploymentTemplate = `
@@ -121,7 +121,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: nginxinc/nginx-unprivileged
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
 `
 
 	scaledObjectTemplate = `

--- a/tests/utils/helper/helper.go
+++ b/tests/utils/helper/helper.go
@@ -48,7 +48,7 @@ data:
 `
 	OtlpConfig = `mode: deployment
 image:
-  repository: "otel/opentelemetry-collector-contrib"
+  repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"
 config:
   exporters:
     debug: {}


### PR DESCRIPTION
There is an issue with latest version of the nginx image that we use for e2e tests -> https://github.com/nginx/docker-nginx-unprivileged/issues/302

As the image isn't relevant for the test, this PR pines the image to a working version and uses the GHCR registry instead of dockerhub.

This PR also fixes some small issues on gcp e2e and also remove some wrong error logging on external_push

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

