### PR TITLE
fix: ScalerCache gets the lock before operate the scalers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Admission Webhook blocks ScaledObject without metricType with fallback ([#6696](https://github.com/kedacore/keda/issues/6696))
+- **General**: ScalerCache gets the lock before operate the scalers to prevent panics ([#6739](https://github.com/kedacore/keda/pull/6739))
 - **AWS SQS Queue Scaler**: Fix AWS SQS Queue queueURLFromEnv not working ([#6712](https://github.com/kedacore/keda/issues/6712))
 - **Temporal Scaler**: Fix Temporal Scaler does not work properly with API Key authentication against Temporal Cloud as TLS is not enabled on the client ([#6703](https://github.com/kedacore/keda/issues/6703))
 

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -79,6 +79,8 @@ func (c *ScalersCache) getScalerBuilder(index int) (ScalerBuilder, error) {
 
 // GetPushScalers returns array of push scalers stored in the cache
 func (c *ScalersCache) GetPushScalers() []scalers.PushScaler {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	var result []scalers.PushScaler
 	for _, s := range c.Scalers {
 		if ps, ok := s.Scaler.(scalers.PushScaler); ok {

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -67,12 +67,13 @@ func (c *ScalersCache) GetScalers() ([]scalers.Scaler, []scalersconfig.ScalerCon
 
 // getScalerBuilder returns a ScalerBuilder stored in the cache
 func (c *ScalersCache) getScalerBuilder(index int) (ScalerBuilder, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
 	if index < 0 || index >= len(c.Scalers) {
 		return ScalerBuilder{}, fmt.Errorf("scaler with id %d not found. Len = %d", index, len(c.Scalers))
 	}
 
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
 	return c.Scalers[index], nil
 }
 

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -166,21 +166,18 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 }
 
 func (c *ScalersCache) refreshScaler(ctx context.Context, index int) (scalers.Scaler, error) {
-	oldSb, err := c.getScalerBuilder(index)
-	if err != nil {
-		return nil, err
-	}
-
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+
+	if index < 0 || index >= len(c.Scalers) {
+		return nil, fmt.Errorf("scaler with id %d not found. Len = %d", index, len(c.Scalers))
+	}
+
+	oldSb := c.Scalers[index]
 
 	newScaler, sConfig, err := oldSb.Factory()
 	if err != nil {
 		return nil, err
-	}
-
-	if index < 0 || index >= len(c.Scalers) {
-		return nil, fmt.Errorf("scaler with id %d not found. Len = %d", index, len(c.Scalers))
 	}
 
 	c.Scalers[index] = ScalerBuilder{


### PR DESCRIPTION
With the current implementation, a race condition can happen because we check the scalers size before signaling the lock, so hypothetically, the value of `c.Scalers` can change between the line when it's checked and the line when is accessed, allowing the case where `c.Scalers` is cleaned and then the index is accessed, generating a panic because of accessing out of the array length.

Checking the code and considering the original problem of [the issue](https://github.com/kedacore/keda/issues/6725), my hypothesis is that the scaler fails during the HPA metric request. It calls to [GetScaledObjectMetrics](https://github.com/kedacore/keda/blob/8e6a985a730ec5b171d2d55309d6a14ad475e764/pkg/scaling/scale_handler.go#L423) and there, after the scaler failure, [the whole ScaledObject is refreshed](https://github.com/kedacore/keda/blob/8e6a985a730ec5b171d2d55309d6a14ad475e764/pkg/scaling/scale_handler.go#L571), triggering [the only code that changes the value of `c.Scalers` from a valid slice to `nil`. (cache Close())](https://github.com/kedacore/keda/blob/8e6a985a730ec5b171d2d55309d6a14ad475e764/pkg/scaling/cache/scalers_cache.go#L91)

If an operator loop starts just after the metric requests, it could happen that the refresh action has been triggered over the current cache item that is in process of being revoked, generating the race condition because the length of `s.Scalers` has been verified without any lock (so in theory the index exists), and then the execution pointer has waited until the write lock is released (when `c.Scalers` is already `nil`). As soon as the Close() code ends, the lock is released and the code within the refresh function continues, trying to access an index that existed during the check but not during the access because of not locking the read lock before checking `c.Scalers`



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/6725
