### PR TITLE
Fix: Prefixes in envFrom within deployment specs are being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,10 +73,10 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Admission Webhook blocks ScaledObject without metricType with fallback ([#6696](https://github.com/kedacore/keda/issues/6696))
+- **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **AWS SQS Queue Scaler**: Fix AWS SQS Queue queueURLFromEnv not working ([#6712](https://github.com/kedacore/keda/issues/6712))
 - **Azure Service Bus scaler**: Fix Azure Service Bus scaler add default Operation ([#6730](https://github.com/kedacore/keda/issues/6730))
 - **Temporal Scaler**: Fix Temporal Scaler does not work properly with API Key authentication against Temporal Cloud as TLS is not enabled on the client ([#6703](https://github.com/kedacore/keda/issues/6703))
-- **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **AWS SQS Queue Scaler**: Fix AWS SQS Queue queueURLFromEnv not working ([#6712](https://github.com/kedacore/keda/issues/6712))
 - **Azure Service Bus scaler**: Fix Azure Service Bus scaler add default Operation ([#6730](https://github.com/kedacore/keda/issues/6730))
 - **Temporal Scaler**: Fix Temporal Scaler does not work properly with API Key authentication against Temporal Cloud as TLS is not enabled on the client ([#6703](https://github.com/kedacore/keda/issues/6703))
+- **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 
 ### Deprecations
 

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -392,7 +392,7 @@ func resolveEnv(ctx context.Context, client client.Client, logger logr.Logger, c
 	accessSecrets := readSecrets(secretAccessRestricted, namespace)
 	if container.EnvFrom != nil {
 		for _, source := range container.EnvFrom {
-			// prefix is used to prefix the environment variable, prefix is empty string if not set
+			// prefix is used to prefix environment variables, prefix is empty string if not set
 			// if prefix is set, all environment variables will be prefixed with the prefix
 			envPrefix := source.Prefix
 			if source.ConfigMapRef != nil {

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -392,12 +392,15 @@ func resolveEnv(ctx context.Context, client client.Client, logger logr.Logger, c
 	accessSecrets := readSecrets(secretAccessRestricted, namespace)
 	if container.EnvFrom != nil {
 		for _, source := range container.EnvFrom {
+			// prefix is used to prefix the environment variable, prefix is empty string if not set
+			// if prefix is set, all environment variables will be prefixed with the prefix
+			envPrefix := source.Prefix
 			if source.ConfigMapRef != nil {
 				configMap, err := resolveConfigMap(ctx, client, source.ConfigMapRef, namespace)
 				switch {
 				case err == nil:
 					for k, v := range configMap {
-						resolved[k] = v
+						resolved[envPrefix+k] = v
 					}
 				case source.ConfigMapRef.Optional != nil && *source.ConfigMapRef.Optional:
 					// ignore error when ConfigMap is marked as optional
@@ -410,7 +413,7 @@ func resolveEnv(ctx context.Context, client client.Client, logger logr.Logger, c
 				switch {
 				case err == nil:
 					for k, v := range secretsMap {
-						resolved[k] = v
+						resolved[envPrefix+k] = v
 					}
 				case source.SecretRef.Optional != nil && *source.SecretRef.Optional:
 					// ignore error when Secret is marked as optional

--- a/pkg/scaling/resolver/scale_resolvers_test.go
+++ b/pkg/scaling/resolver/scale_resolvers_test.go
@@ -917,6 +917,7 @@ func TestEnvWithRestrictSecretAccess(t *testing.T) {
 }
 
 func TestEnvWithRestrictedNamespace(t *testing.T) {
+	envPrefix := "PREFIX_"
 	tests := []struct {
 		name      string
 		expected  map[string]string
@@ -952,6 +953,20 @@ func TestEnvWithRestrictedNamespace(t *testing.T) {
 			},
 			expected: map[string]string{secretKey: secretData},
 		},
+		{
+			name: "env reference secret key with prefix",
+			container: &corev1.Container{
+				EnvFrom: []corev1.EnvFromSource{{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretName,
+						},
+					},
+					Prefix: envPrefix,
+				}},
+			},
+			expected: map[string]string{envPrefix + secretKey: secretData},
+		},
 	}
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -965,69 +980,6 @@ func TestEnvWithRestrictedNamespace(t *testing.T) {
 	mockSecretNamespaceLister.EXPECT().Get(secretName).Return(secret, nil).AnyTimes()
 	mockSecretLister := mock_v1.NewMockSecretLister(ctrl)
 	mockSecretLister.EXPECT().Secrets(clusterNamespace).Return(mockSecretNamespaceLister).AnyTimes()
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			restrictSecretAccess = "true"
-			kedaNamespace = "keda"
-			ctx := context.Background()
-			envMap, _ := resolveEnv(ctx, fake.NewClientBuilder().Build(), logf.Log.WithName("test"), test.container, clusterNamespace, mockSecretLister)
-			if diff := cmp.Diff(envMap, test.expected); diff != "" {
-				t.Errorf("Returned env map is different: %s", diff)
-			}
-		})
-	}
-}
-
-func TestResolveEnvWithPrefix(t *testing.T) {
-	envPrefix := "PREFIX_"
-	tests := []struct {
-		name      string
-		expected  map[string]string
-		container *corev1.Container
-	}{
-		{
-			name: "env reference secret key without prefix",
-			container: &corev1.Container{
-				EnvFrom: []corev1.EnvFromSource{{
-					SecretRef: &corev1.SecretEnvSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: secretName,
-						},
-					},
-				}},
-			},
-			expected: map[string]string{envKey: secretData},
-		},
-		{
-			name: "env reference secret key with prefix",
-			container: &corev1.Container{
-				EnvFrom: []corev1.EnvFromSource{{
-					SecretRef: &corev1.SecretEnvSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: secretName,
-						},
-					},
-					Prefix: envPrefix,
-				}},
-			},
-			expected: map[string]string{envPrefix + envKey: secretData},
-		},
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: clusterNamespace,
-			Name:      secretName,
-		},
-		Data: map[string][]byte{envKey: []byte(secretData)},
-	}
-
-	ctrl := gomock.NewController(t)
-	mockSecretNamespaceLister := mock_v1.NewMockSecretNamespaceLister(ctrl)
-	mockSecretNamespaceLister.EXPECT().Get(secretName).Return(secret, nil).AnyTimes()
-	mockSecretLister := mock_v1.NewMockSecretLister(ctrl)
-	mockSecretLister.EXPECT().Secrets(clusterNamespace).Return(mockSecretNamespaceLister).AnyTimes()
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			restrictSecretAccess = "true"


### PR DESCRIPTION
## Issue

When envFrom includes a prefix setting, the scale resolver ignores this prefix and adds environment variable keys to the ScalerConfig without the prefix.



```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kafka-config
data:
  BOOTSTRAP_SERVERS: "kafka.example.com"
  PORT: "9092"
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-app
  labels:
    app: dummy-app
spec:
  selector:
    matchLabels:
      app: dummy-app
  template:
    metadata:
      labels:
        app: dummy-app
    spec:
      containers:
      - name: app-container
        image: nginx:latest
        envFrom:
        - configMapRef:
            name: kafka-config
          prefix: "KAFKA_" # Having PREFIX
```

`resolveEnv` is ignoring the `prefix` setting and loading envs without `prefix`:
Actual:
```
BOOTSTRAP_SERVERS
PORT
```
Desired:
```
KAFKA_BOOTSTRAP_SERVERS
KAFKA_PORT
```

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed._

## FIX

`resolveEnv` correctly applies prefixes to keys when a prefix is specified. 
1. Get `prefix`, prefix is an empty string if not set
2. Prefix `Env Key` : `prefix + k`


### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes https://github.com/kedacore/keda/issues/6728