### PR TITLE
enable race condition check for unit tests

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -68,10 +68,16 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Test with race detector enabled
+        run: make test-race
+        continue-on-error: true   # there are good number of race conditions currently in KEDA, don't block the development for this
+
       - name: Create test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:
-          paths: "report.xml"
+          paths: |
+            report.xml
+            report-race.xml
         if: always()
 
   validate-dockerfiles:

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ all: build
 test: manifests generate fmt vet envtest gotestsum ## Run tests and export the result to junit format.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GOTESTSUM) --format standard-quiet --rerun-fails --junitfile report.xml
 
+.PHONY: test-race
+test-race: manifests generate fmt vet envtest gotestsum ## Run tests and export the result to junit format.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GOTESTSUM) --format standard-quiet --rerun-fails --junitfile report-race.xml --packages=./... -- -race
+
 .PHONY:
 az-login:
 	@az login --service-principal -u $(TF_AZURE_SP_APP_ID) -p "$(AZURE_SP_KEY)" --tenant $(TF_AZURE_SP_TENANT)

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestEmptyScalersCache(t *testing.T) {
+	RegisterTestingT(t)
+
+	cache := &ScalersCache{
+		Scalers: make([]ScalerBuilder, 0),
+	}
+	go func() {
+		scalers, configs := cache.GetScalers()
+		Expect(scalers).To(BeEmpty())
+		Expect(configs).To(BeEmpty())
+	}()
+
+	go func() {
+		pushScalers := cache.GetPushScalers()
+		Expect(pushScalers).To(BeEmpty())
+	}()
+
+	go func() {
+		metrics := cache.GetMetricSpecForScaling(context.Background())
+		Expect(metrics).To(BeEmpty())
+	}()
+
+	go func() {
+		metrics, err := cache.GetMetricSpecForScalingForScaler(context.Background(), 0)
+		Expect(err).To(Not(BeNil()))
+		Expect(metrics).To(BeNil())
+	}()
+
+	go func() {
+		cache.Close(context.Background())
+	}()
+}


### PR DESCRIPTION
This PR adds an option to run unit tests with race detection enabled. Also adding a trivial test for the scalers cache which discovers existing race condition.
```
WARNING: DATA RACE
Write at 0x00c000b25ec8 by goroutine 73:
  github.com/kedacore/keda/v2/pkg/scaling/cache.(*ScalersCache).Close()
      /home/projects/go/src/github.com/kedacore/keda/pkg/scaling/cache/scalers_cache.go:94 +0xa4
  github.com/kedacore/keda/v2/pkg/scaling/cache.TestEmptyScalersCache.func5()
      /home/projects/go/src/github.com/kedacore/keda/pkg/scaling/cache/scalers_cache_test.go:55 +0x3c

Previous read at 0x00c000b25ec8 by goroutine 70:
  github.com/kedacore/keda/v2/pkg/scaling/cache.(*ScalersCache).GetPushScalers()
      /home/projects/go/src/github.com/kedacore/keda/pkg/scaling/cache/scalers_cache.go:82 +0x49
  github.com/kedacore/keda/v2/pkg/scaling/cache.TestEmptyScalersCache.func2()
      /home/projects/go/src/github.com/kedacore/keda/pkg/scaling/cache/scalers_cache_test.go:39 +0x44

Goroutine 73 (running) created at:
  github.com/kedacore/keda/v2/pkg/scaling/cache.TestEmptyScalersCache()
      /home/projects/go/src/github.com/kedacore/keda/pkg/scaling/cache/scalers_cache_test.go:54 +0x2e4
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /usr/lib/go/src/testing/testing.go:1851 +0x44

Goroutine 70 (finished) created at:
  github.com/kedacore/keda/v2/pkg/scaling/cache.TestEmptyScalersCache()
      /home/projects/go/src/github.com/kedacore/keda/pkg/scaling/cache/scalers_cache_test.go:38 +0x1a4
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /usr/lib/go/src/testing/testing.go:1851 +0x44
```

Intentionally not enabling this by default and not requiring PRs to pass because there is a number of already existing race conditions that are outside of the scope of this PR to address, one getting fixed already in https://github.com/kedacore/keda/pull/6739.

### Checklist

- [x] Tests have been added
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

List of currently reported race conditions - [all_races.txt](https://github.com/user-attachments/files/20064705/all_races.txt)

relates to: https://github.com/kedacore/keda/pull/6739
see also: https://github.com/kedacore/keda/issues/6761