### PR TITLE
Fix race conditions in tests external scaler and predictkube scaler

### DIFF
--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -133,14 +133,16 @@ func TestExternalPushScaler_Run(t *testing.T) {
 	defer cancel()
 	for {
 		<-time.After(time.Second * 1)
-		if resultCount == serverCount*iterationCount {
-			t.Logf("resultCount == %d", resultCount)
+		currentCount := atomic.LoadInt64(&resultCount)
+		if currentCount == serverCount*iterationCount {
+			t.Logf("resultCount == %d", currentCount)
 			return
 		}
 
 		retries++
 		if retries > 10 {
-			t.Fatalf("Expected resultCount to be %d after %d retries, but got %d", serverCount*iterationCount, retries, resultCount)
+			currentCount = atomic.LoadInt64(&resultCount)
+			t.Fatalf("Expected resultCount to be %d after %d retries, but got %d", serverCount*iterationCount, retries, currentCount)
 			return
 		}
 	}


### PR DESCRIPTION
Fix race conditions in tests external scaler and predictkube scaler

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #6760 #6761 
