### PR TITLE
require race condition check for PRs to pass

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -70,7 +70,6 @@ jobs:
 
       - name: Test with race detector enabled
         run: make test-race
-        continue-on-error: true   # there are good number of race conditions currently in KEDA, don't block the development for this
 
       - name: Create test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4


### PR DESCRIPTION
https://github.com/kedacore/keda/pull/6760 enabled the race condition detector for unit tests but not required to pass for PRs to merge. Since it currently reports no failures, I would like to propose this to be a binding requirement for PR to merge.


closes: https://github.com/kedacore/keda/issues/6761