### PR TITLE
fix: add missing omitempty tags in the AuthPodIdentity struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **AWS SQS Queue Scaler**: Fix AWS SQS Queue queueURLFromEnv not working ([#6712](https://github.com/kedacore/keda/issues/6712))
 - **Azure Service Bus scaler**: Fix Azure Service Bus scaler add default Operation ([#6730](https://github.com/kedacore/keda/issues/6730))
 - **Temporal Scaler**: Fix Temporal Scaler does not work properly with API Key authentication against Temporal Cloud as TLS is not enabled on the client ([#6703](https://github.com/kedacore/keda/issues/6703))
+- **AuthPodIdentity**: add missing omitempty json tags in the AuthPodIdentity struct ([#6799](https://github.com/kedacore/keda/issues/6779))
 
 ### Deprecations
 

--- a/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -142,24 +142,24 @@ type AuthPodIdentity struct {
 	Provider PodIdentityProvider `json:"provider"`
 
 	// +optional
-	IdentityID *string `json:"identityId"`
+	IdentityID *string `json:"identityId,omitempty"`
 
 	// +optional
 	// Set identityTenantId to override the default Azure tenant id. If this is set, then the IdentityID must also be set
-	IdentityTenantID *string `json:"identityTenantId"`
+	IdentityTenantID *string `json:"identityTenantId,omitempty"`
 
 	// +optional
 	// Set identityAuthorityHost to override the default Azure authority host. If this is set, then the IdentityTenantID must also be set
-	IdentityAuthorityHost *string `json:"identityAuthorityHost"`
+	IdentityAuthorityHost *string `json:"identityAuthorityHost,omitempty"`
 
 	// +kubebuilder:validation:Optional
 	// RoleArn sets the AWS RoleArn to be used. Mutually exclusive with IdentityOwner
-	RoleArn *string `json:"roleArn"`
+	RoleArn *string `json:"roleArn,omitempty"`
 
 	// +kubebuilder:validation:Enum=keda;workload
 	// +optional
 	// IdentityOwner configures which identity has to be used during auto discovery, keda or the scaled workload. Mutually exclusive with roleArn
-	IdentityOwner *string `json:"identityOwner"`
+	IdentityOwner *string `json:"identityOwner,omitempty"`
 }
 
 func (a *AuthPodIdentity) GetIdentityID() string {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Added missing omitempty json tags in the AuthPodIdentity struct

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Fixes #6779

