### PR TITLE
fix: temporal scaler was not setting up tls for apikey auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **AWS SQS Queue Scaler**: Fix AWS SQS Queue queueURLFromEnv not working ([#6712](https://github.com/kedacore/keda/issues/6712))
 - **Azure Service Bus scaler**: Fix Azure Service Bus scaler add default Operation ([#6730](https://github.com/kedacore/keda/issues/6730))
 - **Temporal Scaler**: Fix Temporal Scaler does not work properly with API Key authentication against Temporal Cloud as TLS is not enabled on the client ([#6703](https://github.com/kedacore/keda/issues/6703))
-- **Temporal Scaler**: Fix Temporal Scaler was still not working after attempted fix ([#6707](https://github.com/kedacore/keda/pull/6707))
+- **Temporal Scaler**: Fix Temporal Scaler TLS version ([#6707](https://github.com/kedacore/keda/pull/6707))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **AWS SQS Queue Scaler**: Fix AWS SQS Queue queueURLFromEnv not working ([#6712](https://github.com/kedacore/keda/issues/6712))
 - **Azure Service Bus scaler**: Fix Azure Service Bus scaler add default Operation ([#6730](https://github.com/kedacore/keda/issues/6730))
 - **Temporal Scaler**: Fix Temporal Scaler does not work properly with API Key authentication against Temporal Cloud as TLS is not enabled on the client ([#6703](https://github.com/kedacore/keda/issues/6703))
+- **Temporal Scaler**: Fix Temporal Scaler was still not working after attempted fix ([#6707](https://github.com/kedacore/keda/pull/6707))
 
 ### Deprecations
 

--- a/pkg/scalers/temporal.go
+++ b/pkg/scalers/temporal.go
@@ -209,10 +209,13 @@ func getTemporalClient(ctx context.Context, meta *temporalMetadata, log logr.Log
 		}),
 	}
 
+	var tlsConfig *tls.Config
+
 	if meta.APIKey != "" {
 		dialOptions = append(dialOptions, grpc.WithUnaryInterceptor(
 			func(ctx context.Context, method string, req any, reply any,
-				cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+				cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+			) error {
 				return invoker(
 					metadata.AppendToOutgoingContext(ctx, "temporal-namespace", meta.Namespace),
 					method,
@@ -224,21 +227,22 @@ func getTemporalClient(ctx context.Context, meta *temporalMetadata, log logr.Log
 			},
 		))
 		options.Credentials = sdk.NewAPIKeyStaticCredentials(meta.APIKey)
-		options.ConnectionOptions.TLS = &tls.Config{
-			MinVersion: tls.VersionTLS13,
+		tlsConfig = &tls.Config{
+			MinVersion: kedautil.GetMinTLSVersion(),
+		}
+	}
+
+	if meta.Cert != "" && meta.Key != "" {
+		var err error
+		tlsConfig, err = kedautil.NewTLSConfigWithPassword(meta.Cert, meta.Key, meta.KeyPassword, meta.CA, meta.UnsafeSsl)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	options.ConnectionOptions = sdk.ConnectionOptions{
 		DialOptions: dialOptions,
-	}
-
-	if meta.Cert != "" && meta.Key != "" {
-		tlsConfig, err := kedautil.NewTLSConfigWithPassword(meta.Cert, meta.Key, meta.KeyPassword, meta.CA, meta.UnsafeSsl)
-		if err != nil {
-			return nil, err
-		}
-		options.ConnectionOptions.TLS = tlsConfig
+		TLS:         tlsConfig,
 	}
 
 	return sdk.DialContext(ctx, options)


### PR DESCRIPTION
After seeing `connection reset by peer` errors in my Temporal KEDA scaler, I started digging and found out about #6724, which was released earlier today. I deployed the new v2.17.1 Helm chart to my K8S cluster and still kept seeing the same errors, then decided to dig into the scaler code to see what I could find. 

@rickbrouwer and I connected to explore options, and we realized that the TLS settings from #6707 were being overwritten, thus causing the error previously mentioned. This change fixed the main issue for good by rearranging the *tls.config variable, and it is already validated against a production K8S cluster.


### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #

Relates to #
