### PR TITLE
Require the same version we replace for prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/prometheus/client_golang v1.21.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.63.0
-	github.com/prometheus/prometheus v0.0.0-00010101000000-000000000000
+	github.com/prometheus/prometheus v0.54.0
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9
 	github.com/redis/go-redis/v9 v9.7.3

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1342,7 +1342,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v0.0.0-00010101000000-000000000000 => github.com/prometheus/prometheus v0.54.0
+# github.com/prometheus/prometheus v0.54.0 => github.com/prometheus/prometheus v0.54.0
 ## explicit; go 1.21.0
 github.com/prometheus/prometheus/model/exemplar
 github.com/prometheus/prometheus/model/histogram


### PR DESCRIPTION
hey yall!  We recently took a dependency on `github.com/kedacore/keda/v2`

But that's now causing all our IDEs to break with
```
go list -modfile=go.mod -m -json -mod=mod all
go: [github.com/prometheus/prometheus@v0.0.0-00010101000000-000000000000](http://github.com/prometheus/prometheus@v0.0.0-00010101000000-000000000000): invalid version: unknown revision 000000000000
```

seems like it's due to this line here https://github.com/kedacore/keda/blob/e23ef462abb5948802d303a56aebe53adbabbcde/go.mod#L80

I asked that ^ question in Slack and @JorTurFer asked that I open this PR

_Provide a description of what has been changed_

So this just changes the require line to match what we're replacing so that when downstream projects take a dependency on keda, they don't import a bad version.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #
https://kubernetes.slack.com/archives/CKZJ36A5D/p1747927855084599
