### PR TITLE
Adding convenience method to decode AWS RDS secret  https://github.com/…

### DIFF
--- a/pkg/util/aws_rds.go
+++ b/pkg/util/aws_rds.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// RDSSecret represents the structure of an AWS RDS secret
+type RDSSecret struct {
+	Username             string `json:"username"`
+	Password             string `json:"password"`
+	Engine               string `json:"engine"`
+	Host                 string `json:"host"`
+	Port                 int    `json:"port"`
+	DBName               string `json:"dbname"`
+	DBInstanceIdentifier string `json:"dbInstanceIdentifier,omitempty"`
+}
+
+// DecodeRDSSecret takes a JSON string and validates that it matches the AWS RDS secret structure.
+// Returns the decoded secret and any validation errors.
+func DecodeRDSSecret(secretString string) (*RDSSecret, error) {
+	var secret RDSSecret
+	if err := json.Unmarshal([]byte(secretString), &secret); err != nil {
+		return nil, fmt.Errorf("failed to decode RDS secret JSON: %w", err)
+	}
+
+	// Validate required fields
+	if secret.Username == "" {
+		return nil, fmt.Errorf("RDS secret missing required field: username")
+	}
+	if secret.Host == "" {
+		return nil, fmt.Errorf("RDS secret missing required field: host")
+	}
+	if secret.Port == 0 {
+		return nil, fmt.Errorf("RDS secret missing required field: port")
+	}
+	if secret.DBName == "" {
+		return nil, fmt.Errorf("RDS secret missing required field: dbname")
+	}
+
+	return &secret, nil
+}

--- a/pkg/util/aws_rds_test.go
+++ b/pkg/util/aws_rds_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeRDSSecret(t *testing.T) {
+	tests := []struct {
+		name        string
+		secretJSON  string
+		wantErr     bool
+		errContains string
+		validate    func(t *testing.T, secret *RDSSecret)
+	}{
+		{
+			name:       "valid secret with all fields",
+			secretJSON: `{"username":"dbuser","password":"secret123","engine":"mysql","host":"my-db.123456789012.us-east-1.rds.amazonaws.com","port":3306,"dbname":"mydb","dbInstanceIdentifier":"my-db-instance"}`,
+			wantErr:    false,
+			validate: func(t *testing.T, secret *RDSSecret) {
+				assert.Equal(t, "dbuser", secret.Username)
+				assert.Equal(t, "secret123", secret.Password)
+				assert.Equal(t, "mysql", secret.Engine)
+				assert.Equal(t, "my-db.123456789012.us-east-1.rds.amazonaws.com", secret.Host)
+				assert.Equal(t, 3306, secret.Port)
+				assert.Equal(t, "mydb", secret.DBName)
+				assert.Equal(t, "my-db-instance", secret.DBInstanceIdentifier)
+			},
+		},
+		{
+			name:       "valid secret with minimal fields",
+			secretJSON: `{"username":"dbuser","host":"my-db.123456789012.us-east-1.rds.amazonaws.com","port":3306,"dbname":"mydb"}`,
+			wantErr:    false,
+			validate: func(t *testing.T, secret *RDSSecret) {
+				assert.Equal(t, "dbuser", secret.Username)
+				assert.Equal(t, "", secret.Password)
+				assert.Equal(t, "", secret.Engine)
+				assert.Equal(t, "my-db.123456789012.us-east-1.rds.amazonaws.com", secret.Host)
+				assert.Equal(t, 3306, secret.Port)
+				assert.Equal(t, "mydb", secret.DBName)
+				assert.Equal(t, "", secret.DBInstanceIdentifier)
+			},
+		},
+		{
+			name:       "valid secret with empty password",
+			secretJSON: `{"username":"dbuser","password":"","host":"my-db.123456789012.us-east-1.rds.amazonaws.com","port":3306,"dbname":"mydb"}`,
+			wantErr:    false,
+			validate: func(t *testing.T, secret *RDSSecret) {
+				assert.Equal(t, "dbuser", secret.Username)
+				assert.Equal(t, "", secret.Password)
+				assert.Equal(t, "", secret.Engine)
+				assert.Equal(t, "my-db.123456789012.us-east-1.rds.amazonaws.com", secret.Host)
+				assert.Equal(t, 3306, secret.Port)
+				assert.Equal(t, "mydb", secret.DBName)
+			},
+		},
+		{
+			name:        "missing required field - username",
+			secretJSON:  `{"password":"secret123","host":"my-db.123456789012.us-east-1.rds.amazonaws.com","port":3306,"dbname":"mydb"}`,
+			wantErr:     true,
+			errContains: "missing required field: username",
+		},
+		{
+			name:        "missing required field - host",
+			secretJSON:  `{"username":"dbuser","password":"secret123","port":3306,"dbname":"mydb"}`,
+			wantErr:     true,
+			errContains: "missing required field: host",
+		},
+		{
+			name:        "missing required field - port",
+			secretJSON:  `{"username":"dbuser","password":"secret123","host":"my-db.123456789012.us-east-1.rds.amazonaws.com","dbname":"mydb"}`,
+			wantErr:     true,
+			errContains: "missing required field: port",
+		},
+		{
+			name:        "missing required field - dbname",
+			secretJSON:  `{"username":"dbuser","password":"secret123","host":"my-db.123456789012.us-east-1.rds.amazonaws.com","port":3306}`,
+			wantErr:     true,
+			errContains: "missing required field: dbname",
+		},
+		{
+			name:        "invalid JSON",
+			secretJSON:  `{"username":"dbuser","password":"secret123","host":"my-db.123456789012.us-east-1.rds.amazonaws.com","port":3306,"dbname":"mydb"`,
+			wantErr:     true,
+			errContains: "failed to decode RDS secret JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secret, err := DecodeRDSSecret(tt.secretJSON)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Nil(t, secret)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, secret)
+				if tt.validate != nil {
+					tt.validate(t, secret)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
…kedacore/keda/issues/6312

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
