### PR TITLE
fix: Events e2e tests pass again

### DIFF
--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -6,6 +6,7 @@ package trigger_update_so_test
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -408,7 +409,7 @@ func testErrEventSourceEmitValue(t *testing.T, _ *kubernetes.Clientset, data tem
 
 			assert.NoError(t, err)
 			assert.Condition(t, func() bool {
-				if data["message"] == "ScaledObject doesn't have correct scaleTargetRef specification" || data["message"] == "Target resource doesn't exist" {
+				if strings.Contains(data["message"], "ScaledObject doesn't have correct scaleTargetRef specification") || strings.Contains(data["message"], "Target resource doesn't exist") {
 					return true
 				}
 				return false

--- a/tests/internals/events/events_test.go
+++ b/tests/internals/events/events_test.go
@@ -329,7 +329,7 @@ func checkingEvent(t *testing.T, namespace string, scaledObject string, index in
 
 	assert.NoError(t, err)
 	lastEventMessage := strings.Trim(string(result), "\"")
-	assert.Equal(t, eventReason+":"+message, lastEventMessage)
+	assert.Contains(t, lastEventMessage, eventReason+":"+message)
 }
 
 func testNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
