### PR TITLE
fix: fix failing webhook check when targetRef doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Fix failing webhook check when the targetRef object doesn't exist ([#6842](https://github.com/kedacore/keda/pull/6842))
 - **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **General**: Remove klogr dependency and replace with zap ([#5732](https://github.com/kedacore/keda/issues/5732))
 - **General**: Sets hpaName in Status when ScaledObject adopts/finds an existing HPA ([#6336](https://github.com/kedacore/keda/issues/6336))


### PR DESCRIPTION
The PR's intent is to fix a behavior whereby the SO creation fails when the targetRef object does not exist, which seems to be a byproduct of verifying that container resources are set, not an intentional check. The following are my reasons:

* To be similar to HPA's behavior, which doesn't fail when the targetRef object doesn't exist.
* This also makes sense through an eventual consistency lense: we shouldn't expect the SO to be always created before the `Deployment`/`StatefulSet`/etc.
* Also, currently if the target is not `Deployment` or `StatefulSet`, the container resouce check doesn't handle it, it just returns and doesn't error out even if the target doesn't exist, which corroborates the view that the target's existence is not what is intentionally checked. 

Other few side changes:
* I've added logic to fail the case where the deployment **does** exist, and a cpu/memory trigger references a non-existent `containerName`, which seems to be a reasonable check. A corresponding unit test is also added.
* Some reordering of the unit tests in the file (the diff is a bit confusing :smile:)
* A redundant unit test have been removed, the one of the two that were added for the `LimitRange` case. The first of which (where no `LimitRange` exist) is already covered in the above tests.
* An inner if condition on the trigger type within the `verifyCPUMemoryScalers` function is removed since it is duplicated.

The autogenerated code changes are not part of my changes, it just seems that they weren't generated for the latest change on main. 

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
