### PR TITLE
fix: e2e test checks label value by name and not by index

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/joho/godotenv"
+	prommodel "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -1144,4 +1145,13 @@ func WatchForEventAfterTrigger(
 	case <-time.After(watchTimeout + 5*time.Second):
 		assert.Fail(t, "Timed out waiting for result from Kubernetes event watch channel")
 	}
+}
+
+func ExtractPrometheusLabelValue(key string, labels []*prommodel.LabelPair) string {
+	for _, label := range labels {
+		if label.Name != nil && *label.Name == key {
+			return *label.Value
+		}
+	}
+	return ""
 }

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -1213,10 +1213,10 @@ func testCloudEventEmitted(t *testing.T, data templateData) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			if len(labels) >= 5 &&
-				*labels[0].Value == "opentelemetry-metrics-test-ce" &&
-				*labels[1].Value == "http" &&
-				*labels[3].Value == "opentelemetry-metrics-test-ns" &&
-				*labels[4].Value == "emitted" {
+				ExtractPrometheusLabelValue("cloudEventSource", labels) == "opentelemetry-metrics-test-ce" &&
+				ExtractPrometheusLabelValue("eventsink", labels) == "http" &&
+				ExtractPrometheusLabelValue("namespace", labels) == "opentelemetry-metrics-test-ns" &&
+				ExtractPrometheusLabelValue("state", labels) == "emitted" {
 				assert.GreaterOrEqual(t, *metric.Counter.Value, float64(1))
 				found = true
 			}
@@ -1245,10 +1245,10 @@ func testCloudEventEmittedError(t *testing.T, data templateData) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			if len(labels) >= 5 &&
-				*labels[0].Value == "opentelemetry-metrics-test-ce-w" &&
-				*labels[1].Value == "http" &&
-				*labels[3].Value == "opentelemetry-metrics-test-ns" &&
-				*labels[4].Value == "failed" {
+				ExtractPrometheusLabelValue("cloudEventSource", labels) == "opentelemetry-metrics-test-ce-w" &&
+				ExtractPrometheusLabelValue("eventsink", labels) == "http" &&
+				ExtractPrometheusLabelValue("namespace", labels) == "opentelemetry-metrics-test-ns" &&
+				ExtractPrometheusLabelValue("state", labels) == "failed" {
 				assert.GreaterOrEqual(t, *metric.Counter.Value, float64(5))
 				found = true
 			}

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -1361,7 +1361,7 @@ func testCloudEventEmitted(t *testing.T, data templateData) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			if len(labels) >= 4 &&
-				ExtractPrometheusLabelValue("cloudEventSource", labels) == "prometheus-metrics-test-ce" &&
+				ExtractPrometheusLabelValue("cloudeventsource", labels) == "prometheus-metrics-test-ce" &&
 				ExtractPrometheusLabelValue("eventsink", labels) == "http" &&
 				ExtractPrometheusLabelValue("namespace", labels) == "prometheus-metrics-test-ns" &&
 				ExtractPrometheusLabelValue("state", labels) == "emitted" {

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -1361,10 +1361,10 @@ func testCloudEventEmitted(t *testing.T, data templateData) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			if len(labels) >= 4 &&
-				*labels[0].Value == "prometheus-metrics-test-ce" &&
-				*labels[1].Value == "http" &&
-				*labels[2].Value == "prometheus-metrics-test-ns" &&
-				*labels[3].Value == "emitted" {
+				ExtractPrometheusLabelValue("cloudEventSource", labels) == "prometheus-metrics-test-ce" &&
+				ExtractPrometheusLabelValue("eventsink", labels) == "http" &&
+				ExtractPrometheusLabelValue("namespace", labels) == "prometheus-metrics-test-ns" &&
+				ExtractPrometheusLabelValue("state", labels) == "emitted" {
 				assert.GreaterOrEqual(t, *metric.Counter.Value, float64(1))
 				found = true
 			}
@@ -1393,10 +1393,10 @@ func testCloudEventEmittedError(t *testing.T, data templateData) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			if len(labels) >= 4 &&
-				*labels[0].Value == "prometheus-metrics-test-ce-w" &&
-				*labels[1].Value == "http" &&
-				*labels[2].Value == "prometheus-metrics-test-ns" &&
-				*labels[3].Value == "failed" {
+				ExtractPrometheusLabelValue("cloudEventSource", labels) == "prometheus-metrics-test-ce-w" &&
+				ExtractPrometheusLabelValue("eventsink", labels) == "http" &&
+				ExtractPrometheusLabelValue("namespace", labels) == "prometheus-metrics-test-ns" &&
+				ExtractPrometheusLabelValue("state", labels) == "failed" {
 				assert.GreaterOrEqual(t, *metric.Counter.Value, float64(5))
 				found = true
 			}

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -1393,7 +1393,7 @@ func testCloudEventEmittedError(t *testing.T, data templateData) {
 		for _, metric := range metrics {
 			labels := metric.GetLabel()
 			if len(labels) >= 4 &&
-				ExtractPrometheusLabelValue("cloudEventSource", labels) == "prometheus-metrics-test-ce-w" &&
+				ExtractPrometheusLabelValue("cloudeventsource", labels) == "prometheus-metrics-test-ce-w" &&
 				ExtractPrometheusLabelValue("eventsink", labels) == "http" &&
 				ExtractPrometheusLabelValue("namespace", labels) == "prometheus-metrics-test-ns" &&
 				ExtractPrometheusLabelValue("state", labels) == "failed" {


### PR DESCRIPTION
As we don't check otel metrics directly but exported via Prometheus in collector, we are affected by posible changes in how the labels are generated, for example, with the collector v1.128.0, the metrics is:

```bash
keda_cloudeventsource_events_emitted_count_total{
cloudEventSource="opentelemetry-metrics-test-ce",
eventsink="http",
job="unknown_service:keda",
namespace="opentelemetry-metrics-test-ns",
otel_scope_name="keda-open-telemetry-metrics",
otel_scope_schema_url="",
otel_scope_version="",
state="emitted"
} 1
```

And the same metric from the collector v1.127.0 is:

```bash
keda_cloudeventsource_events_emitted_count_total{
cloudEventSource="opentelemetry-metrics-test-ce",
eventsink="http",
job="unknown_service:keda",
namespace="opentelemetry-metrics-test-ns",
state="emitted"
} 1
```

This PR changes the search to get the value by key and not by position to be resilient to changes in the labels because of metric tranformations under the scope of the test

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

