### PR TITLE
Update hpaName in ScaledObject status when HPA already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **General**: Remove klogr dependency and replace with zap ([#5732](https://github.com/kedacore/keda/issues/5732))
+- **General**: Sets hpaName in Status when ScaledObject adopts/finds an existing HPA ([#6336](https://github.com/kedacore/keda/issues/6336))
 - **Temporal Scaler**: Fix Temporal Scaler TLS version ([#6707](https://github.com/kedacore/keda/pull/6707))
 
 ### Deprecations

--- a/controllers/keda/hpa.go
+++ b/controllers/keda/hpa.go
@@ -38,6 +38,19 @@ import (
 	version "github.com/kedacore/keda/v2/version"
 )
 
+// storeHpaNameInStatus updates the ScaledObject status subresource with the hpaName.
+func (r *ScaledObjectReconciler) storeHpaNameInStatus(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, hpaName string) error {
+	status := scaledObject.Status.DeepCopy()
+	status.HpaName = hpaName
+
+	err := kedastatus.UpdateScaledObjectStatus(ctx, r.Client, logger, scaledObject, status)
+	if err != nil {
+		logger.Error(err, "Failed to update scaledObject status with used hpaName")
+		return err
+	}
+	return nil
+}
+
 // createAndDeployNewHPA creates and deploy HPA in the cluster for specified ScaledObject
 func (r *ScaledObjectReconciler) createAndDeployNewHPA(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, gvkr *kedav1alpha1.GroupVersionKindResource) error {
 	hpaName := getHPAName(scaledObject)
@@ -54,17 +67,7 @@ func (r *ScaledObjectReconciler) createAndDeployNewHPA(ctx context.Context, logg
 		return err
 	}
 
-	// store hpaName in the ScaledObject
-	status := scaledObject.Status.DeepCopy()
-	status.HpaName = hpaName
-
-	err = kedastatus.UpdateScaledObjectStatus(ctx, r.Client, logger, scaledObject, status)
-	if err != nil {
-		logger.Error(err, "Failed to update scaledObject status with used hpaName")
-		return err
-	}
-
-	return nil
+	return r.storeHpaNameInStatus(ctx, logger, scaledObject, hpaName)
 }
 
 // newHPAForScaledObject returns HPA as it is specified in ScaledObject

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -479,6 +479,14 @@ func (r *ScaledObjectReconciler) ensureHPAForScaledObjectExists(ctx context.Cont
 		return false, err
 	}
 
+	// If the HPA name does not match the one in ScaledObject status, we need to update the status
+	if scaledObject.Status.HpaName != hpaName {
+		err = r.storeHpaNameInStatus(ctx, logger, scaledObject, hpaName)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	return false, nil
 }
 

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -349,6 +349,62 @@ var _ = Describe("ScaledObjectController", func() {
 			Expect(errors.IsNotFound(err)).To(Equal(true))
 		})
 
+		It("sets the hpaName in status if not set and HPA already exists", func() {
+			// Create the scaling target.
+			deploymentName := "hpa-name-update"
+			soName := "so-" + deploymentName
+			err := k8sClient.Create(context.Background(), generateDeployment(deploymentName))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the ScaledObject without specifying name.
+			so := &kedav1alpha1.ScaledObject{
+				ObjectMeta: metav1.ObjectMeta{Name: soName, Namespace: "default"},
+				Spec: kedav1alpha1.ScaledObjectSpec{
+					ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+						Name: deploymentName,
+					},
+					Advanced: &kedav1alpha1.AdvancedConfig{
+						HorizontalPodAutoscalerConfig: &kedav1alpha1.HorizontalPodAutoscalerConfig{},
+					},
+					Triggers: []kedav1alpha1.ScaleTriggers{
+						{
+							Type: "cron",
+							Metadata: map[string]string{
+								"timezone":        "UTC",
+								"start":           "0 * * * *",
+								"end":             "1 * * * *",
+								"desiredReplicas": "1",
+							},
+						},
+					},
+				},
+			}
+			err = k8sClient.Create(context.Background(), so)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Get and confirm the HPA.
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{Name: fmt.Sprintf("keda-hpa-%s", soName), Namespace: "default"}, hpa)
+			}).ShouldNot(HaveOccurred())
+			Expect(hpa.Name).To(Equal(fmt.Sprintf("keda-hpa-%s", soName)))
+
+			// Remove the HPA name from the ScaledObject.
+			Eventually(func() error {
+				err = k8sClient.Get(context.Background(), types.NamespacedName{Name: soName, Namespace: "default"}, so)
+				Expect(err).ToNot(HaveOccurred())
+				so.Status.HpaName = ""
+				return k8sClient.Status().Update(context.Background(), so)
+			}).ShouldNot(HaveOccurred())
+
+			// Wait until the hpaName is updated in the scaled object.
+			Eventually(func() string {
+				err = k8sClient.Get(context.Background(), types.NamespacedName{Name: soName, Namespace: "default"}, so)
+				Expect(err).ToNot(HaveOccurred())
+				return so.Status.HpaName
+			}).Should(Equal(fmt.Sprintf("keda-hpa-%s", soName)))
+		})
+
 		//https://github.com/kedacore/keda/issues/2407
 		It("cache is correctly recreated if SO is deleted and created", func() {
 			// Create the scaling target.


### PR DESCRIPTION
When the ScaledObject adopts an HPA or if the hpaName in the ScaledObject status is removed for any reason, the hpaName status will no longer get set. It is only set when the HPA is created by the ScaledObject.

We add setting the HPA name in the ScaledObject status to the regular reconciliation loop for the ScaledObject.

See https://github.com/kedacore/keda/issues/6336

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6336 
