### PR TITLE
Fix Vault PKI param using camel case param when making API call to Vault PKI endpoint

### DIFF
--- a/pkg/scaling/resolver/hashicorpvault_handler.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resolver
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -29,7 +28,7 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 )
 
-// HashicorpVaultHandler is specification of Hashi Corp Vault
+// HashicorpVaultHandler is a specification of HashiCorp Vault
 type HashicorpVaultHandler struct {
 	vault  *kedav1alpha1.HashiCorpVault
 	client *vaultapi.Client
@@ -176,12 +175,12 @@ RenewWatcherLoop:
 	}
 }
 
-// Read is used to get a secret from vault Read api. (e.g. secret)
+// Read is used to get a secret from vault Read api. (e.g., secret)
 func (vh *HashicorpVaultHandler) Read(path string) (*vaultapi.Secret, error) {
 	return vh.client.Logical().Read(path)
 }
 
-// Write is used to get a secret from vault that needs to pass along data and uses the vault Write api. (e.g. pki)
+// Write is used to get a secret from vault that needs to pass along data and uses the vault Write api. (e.g., pki)
 func (vh *HashicorpVaultHandler) Write(path string, data map[string]interface{}) (*vaultapi.Secret, error) {
 	return vh.client.Logical().Write(path, data)
 }
@@ -195,15 +194,29 @@ func (vh *HashicorpVaultHandler) Stop() {
 
 // getPkiRequest format the pkiData in a format that the vault sdk understands.
 func (vh *HashicorpVaultHandler) getPkiRequest(pkiData *kedav1alpha1.VaultPkiData) (map[string]interface{}, error) {
-	var data map[string]interface{}
-	a, err := json.Marshal(pkiData)
-	if err != nil {
-		return nil, err
+	data := make(map[string]interface{})
+	if pkiData.CommonName != "" {
+		data["common_name"] = pkiData.CommonName
 	}
-	err = json.Unmarshal(a, &data)
-	if err != nil {
-		return nil, err
+	if pkiData.AltNames != "" {
+		data["alt_names"] = pkiData.AltNames
 	}
+	if pkiData.IPSans != "" {
+		data["ip_sans"] = pkiData.IPSans
+	}
+	if pkiData.URISans != "" {
+		data["uri_sans"] = pkiData.URISans
+	}
+	if pkiData.OtherSans != "" {
+		data["other_sans"] = pkiData.OtherSans
+	}
+	if pkiData.TTL != "" {
+		data["ttl"] = pkiData.TTL
+	}
+	if pkiData.Format != "" {
+		data["format"] = pkiData.Format
+	}
+
 	return data, nil
 }
 

--- a/pkg/scaling/resolver/hashicorpvault_handler_test.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler_test.go
@@ -87,7 +87,30 @@ var pkiRequestTestDataset = []pkiRequestTestData{
 		raw:    `{ "commonName": "test" }`,
 		secret: kedav1alpha1.VaultSecret{},
 		expected: map[string]interface{}{
-			"commonName": "test",
+			"common_name": "test",
+		},
+	},
+	{
+		name: "full pki request with all fields",
+		secret: kedav1alpha1.VaultSecret{
+			PkiData: kedav1alpha1.VaultPkiData{
+				CommonName: "test",
+				AltNames:   "test2",
+				IPSans:     "192.168.1.1",
+				URISans:    "test.com",
+				OtherSans:  "othersans.com",
+				TTL:        "24h",
+				Format:     "pem",
+			},
+		},
+		expected: map[string]interface{}{
+			"common_name": "test",
+			"alt_names":   "test2",
+			"ip_sans":     "192.168.1.1",
+			"uri_sans":    "test.com",
+			"other_sans":  "othersans.com",
+			"ttl":         "24h",
+			"format":      "pem",
 		},
 	},
 }
@@ -123,7 +146,7 @@ func mockVault(t *testing.T, useRootToken bool) *httptest.Server {
 		case "/v1/auth/token/lookup-self":
 			data = vaultTokenSelf
 			if useRootToken {
-				// remove renewable field
+				// remove the renewable field
 				delete(data, "renewable")
 			}
 		case "/v1/kv_v2/data/keda": //todo: more generic


### PR DESCRIPTION
### Summary
Currently, the vaultPkiData struct uses camel case to marshal and unmarshal JSON object https://github.com/kedacore/keda/blob/37a0f2c5a715e7fdbdb43e77c00f524a2b15f34e/apis/keda/v1alpha1/triggerauthentication_types.go#L264-L272

However, under the official doc of the hashicorp vault pki api, it uses camel case https://developer.hashicorp.com/vault/api-docs/secret/pki#generate-certificate-and-key
![image](https://github.com/user-attachments/assets/0fcb4223-c816-44da-b868-5087f3041302)

### TODO
Add e2e tests and figure out why existing test cases pass previously 

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/6852

