### PR TITLE
refactor gcp pubsub scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ You can find all deprecations in [this overview](https://github.com/kedacore/ked
 
 New deprecation(s):
 
+- **GCP Pub/Sub Scaler**: The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead" ([#6866](https://github.com/kedacore/keda/pull/6866))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
 ### Breaking Changes

--- a/pkg/scalers/gcp/gcp_stackdriver_client.go
+++ b/pkg/scalers/gcp/gcp_stackdriver_client.go
@@ -26,17 +26,17 @@ const (
 	// keep that value to not break the behaviour
 	// We need to revisit this in KEDA v3
 	// https://github.com/kedacore/keda/issues/5429
-	defaultTimeHorizon = "2m"
+	defaultTimeHorizon = 2 * time.Minute
 
 	// Visualization of aggregation window:
 	// aggregationTimeHorizon: [- - - - -]
 	// alignmentPeriod:         [- - -][- - -] (may shift slightly left or right arbitrarily)
 
 	// For aggregations, a shorter time horizon may not return any data
-	aggregationTimeHorizon = "5m"
+	aggregationTimeHorizon = 5 * time.Minute
 	// To prevent the aggregation window from being too big,
 	// which may result in the data being stale for too long
-	alignmentPeriod = "3m"
+	alignmentPeriod = 3 * time.Minute
 
 	// Not all aggregations are meaningful for distribution metrics,
 	// so we only support a subset of them
@@ -347,9 +347,9 @@ func getActualProjectID(s *StackDriverClient, projectID string) string {
 // | align delta(3m)
 // | every 3m
 // | group_by [], count(value)
-func (s StackDriverClient) BuildMQLQuery(projectID, resourceType, metric, resourceName, aggregation, timeHorizon string) (string, error) {
+func (s StackDriverClient) BuildMQLQuery(projectID, resourceType, metric, resourceName, aggregation string, timeHorizon time.Duration) (string, error) {
 	th := timeHorizon
-	if th == "" {
+	if time.Duration(0) >= timeHorizon {
 		th = defaultTimeHorizon
 		if aggregation != "" {
 			th = aggregationTimeHorizon

--- a/pkg/scalers/gcp/gcp_stackdriver_client_test.go
+++ b/pkg/scalers/gcp/gcp_stackdriver_client_test.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,48 +14,48 @@ func TestBuildMQLQuery(t *testing.T) {
 		metric       string
 		resourceName string
 		aggregation  string
-		timeHorizon  string
+		timeHorizon  time.Duration
 
 		expected string
 		isError  bool
 	}{
 		{
 			"topic with aggregation",
-			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "count", "1m",
+			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "count", time.Minute,
 			"fetch pubsub_topic | metric 'pubsub.googleapis.com/topic/x' | filter (resource.project_id == 'myproject' && resource.topic_id == 'mytopic')" +
-				" | within 1m | align delta(3m) | every 3m | group_by [], count(value)",
+				" | within 1m0s | align delta(3m0s) | every 3m0s | group_by [], count(value)",
 			false,
 		},
 		{
 			"topic without aggregation",
-			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "", "",
+			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "", time.Duration(0),
 			"fetch pubsub_topic | metric 'pubsub.googleapis.com/topic/x' | filter (resource.project_id == 'myproject' && resource.topic_id == 'mytopic')" +
-				" | within 2m",
+				" | within 2m0s",
 			false,
 		},
 		{
 			"subscription with aggregation",
-			"subscription", "pubsub.googleapis.com/subscription/x", "mysubscription", "percentile99", "",
+			"subscription", "pubsub.googleapis.com/subscription/x", "mysubscription", "percentile99", time.Duration(0),
 			"fetch pubsub_subscription | metric 'pubsub.googleapis.com/subscription/x' | filter (resource.project_id == 'myproject' && resource.subscription_id == 'mysubscription')" +
-				" | within 5m | align delta(3m) | every 3m | group_by [], percentile(value, 99)",
+				" | within 5m0s | align delta(3m0s) | every 3m0s | group_by [], percentile(value, 99)",
 			false,
 		},
 		{
 			"subscription without aggregation",
-			"subscription", "pubsub.googleapis.com/subscription/x", "mysubscription", "", "4m",
+			"subscription", "pubsub.googleapis.com/subscription/x", "mysubscription", "", time.Minute * 4,
 			"fetch pubsub_subscription | metric 'pubsub.googleapis.com/subscription/x' | filter (resource.project_id == 'myproject' && resource.subscription_id == 'mysubscription')" +
-				" | within 4m",
+				" | within 4m0s",
 			false,
 		},
 		{
 			"invalid percentile",
-			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "percentile101", "1m",
+			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "percentile101", time.Minute,
 			"invalid percentile value: 101",
 			true,
 		},
 		{
 			"unsupported aggregation function",
-			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "max", "",
+			"topic", "pubsub.googleapis.com/topic/x", "mytopic", "max", time.Duration(0),
 			"unsupported aggregation function: max",
 			true,
 		},

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -78,6 +78,7 @@ func parsePubSubMetadata(config *scalersconfig.ScalerConfig) (*pubsubMetadata, e
 	}
 
 	if meta.SubscriptionSize != 0 {
+		meta.Mode = pubSubDefaultModeSubscriptionSize
 		meta.Value = float64(meta.SubscriptionSize)
 	}
 

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	v2 "k8s.io/api/autoscaling/v2"
@@ -36,15 +37,15 @@ type pubsubScaler struct {
 }
 
 type pubsubMetadata struct {
-	SubscriptionSize int      `keda:"name=subscriptionSize, order=triggerMetadata, optional, deprecatedAnnounce=The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead"`
-	Mode             string   `keda:"name=mode, order=triggerMetadata, default=SubscriptionSize"`
-	Value            float64  `keda:"name=value, order=triggerMetadata, default=10"`
-	ActivationValue  float64  `keda:"name=activationValue, order=triggerMetadata, optional"`
-	Aggregation      string   `keda:"name=aggregation, order=triggerMetadata, optional"`
-	TimeHorizon      string   `keda:"name=timeHorizon, order=triggerMetadata, optional"`
-	ValueIfNull      *float64 `keda:"name=valueIfNull, order=triggerMetadata, optional"`
-	SubscriptionName string   `keda:"name=subscriptionName, order=triggerMetadata;resolvedEnv, optional"`
-	TopicName        string   `keda:"name=topicName, order=triggerMetadata;resolvedEnv, optional"`
+	SubscriptionSize int           `keda:"name=subscriptionSize, order=triggerMetadata, optional, deprecatedAnnounce=The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead"`
+	Mode             string        `keda:"name=mode, order=triggerMetadata, default=SubscriptionSize"`
+	Value            float64       `keda:"name=value, order=triggerMetadata, default=10"`
+	ActivationValue  float64       `keda:"name=activationValue, order=triggerMetadata, default=0"`
+	Aggregation      string        `keda:"name=aggregation, order=triggerMetadata, optional"`
+	TimeHorizon      time.Duration `keda:"name=timeHorizon, order=triggerMetadata, optional"`
+	ValueIfNull      *float64      `keda:"name=valueIfNull, order=triggerMetadata, optional"`
+	SubscriptionName string        `keda:"name=subscriptionName, order=triggerMetadata;resolvedEnv, optional"`
+	TopicName        string        `keda:"name=topicName, order=triggerMetadata;resolvedEnv, optional"`
 	// a resource is one of subscription or topic
 	resourceType     string
 	resourceName     string

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -36,8 +36,8 @@ type pubsubScaler struct {
 }
 
 type pubsubMetadata struct {
-	SubscriptionSize int      `keda:"name=subscriptionSize, order=triggerMetadata, optional, deprecatedAnnounce=This subscriptionSize field is deprecated. Use mode and value fields instead"`
-	Mode             string   `keda:"name=mode, order=triggerMetadata, optional"`
+	SubscriptionSize int      `keda:"name=subscriptionSize, order=triggerMetadata, optional, deprecatedAnnounce=The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead"`
+	Mode             string   `keda:"name=mode, order=triggerMetadata, default=SubscriptionSize"`
 	Value            float64  `keda:"name=value, order=triggerMetadata, default=10"`
 	ActivationValue  float64  `keda:"name=activationValue, order=triggerMetadata, optional"`
 	Aggregation      string   `keda:"name=aggregation, order=triggerMetadata, optional"`
@@ -77,10 +77,6 @@ func parsePubSubMetadata(config *scalersconfig.ScalerConfig) (*pubsubMetadata, e
 		return nil, fmt.Errorf("error parsing gcp pubsub metadata: %w", err)
 	}
 
-	if meta.Mode == "" {
-		meta.Mode = pubSubDefaultModeSubscriptionSize
-	}
-
 	if meta.SubscriptionSize != 0 {
 		meta.Value = float64(meta.SubscriptionSize)
 	}
@@ -116,9 +112,6 @@ func (s *pubsubScaler) Close(context.Context) error {
 
 func (meta *pubsubMetadata) Validate() error {
 	if meta.SubscriptionSize != 0 {
-		if meta.Mode != "" {
-			return fmt.Errorf("you can use either mode and value fields or subscriptionSize field")
-		}
 		if meta.TopicName != "" {
 			return fmt.Errorf("you cannot use subscriptionSize field together with topicName field. Use subscriptionName field instead")
 		}

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -2,10 +2,8 @@ package scalers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -24,8 +22,8 @@ const (
 	resourceTypePubSubSubscription = "subscription"
 	resourceTypePubSubTopic        = "topic"
 
-	pubSubModeSubscriptionSize = "SubscriptionSize"
-	pubSubDefaultValue         = 10
+	pubSubDefaultModeSubscriptionSize = "SubscriptionSize"
+	pubSubDefaultValue                = 10
 )
 
 var regexpCompositeSubscriptionIDPrefix = regexp.MustCompile(compositeSubscriptionIDPrefix)
@@ -38,18 +36,20 @@ type pubsubScaler struct {
 }
 
 type pubsubMetadata struct {
-	mode            string
-	value           float64
-	activationValue float64
-
+	SubscriptionSize int      `keda:"name=subscriptionSize, order=triggerMetadata, optional, deprecatedAnnounce=This subscriptionSize field is deprecated. Use mode and value fields instead"`
+	Mode             string   `keda:"name=mode, order=triggerMetadata, optional"`
+	Value            float64  `keda:"name=value, order=triggerMetadata, default=10"`
+	ActivationValue  float64  `keda:"name=activationValue, order=triggerMetadata, optional"`
+	Aggregation      string   `keda:"name=aggregation, order=triggerMetadata, optional"`
+	TimeHorizon      string   `keda:"name=timeHorizon, order=triggerMetadata, optional"`
+	ValueIfNull      *float64 `keda:"name=valueIfNull, order=triggerMetadata, optional"`
+	SubscriptionName string   `keda:"name=subscriptionName, order=triggerMetadata;resolvedEnv, optional"`
+	TopicName        string   `keda:"name=topicName, order=triggerMetadata;resolvedEnv, optional"`
 	// a resource is one of subscription or topic
 	resourceType     string
 	resourceName     string
 	gcpAuthorization *gcp.AuthorizationMetadata
 	triggerIndex     int
-	aggregation      string
-	timeHorizon      string
-	valueIfNull      *float64
 }
 
 // NewPubSubScaler creates a new pubsubScaler
@@ -73,137 +73,25 @@ func NewPubSubScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	}, nil
 }
 
-func parsePubSubResourceConfig(config *scalersconfig.ScalerConfig, meta *pubsubMetadata) error {
-	sub, subPresent := config.TriggerMetadata["subscriptionName"]
-	subFromEnv, subFromEnvPresent := config.TriggerMetadata["subscriptionNameFromEnv"]
-	if subPresent && subFromEnvPresent {
-		return fmt.Errorf("exactly one of subscriptionName or subscriptionNameFromEnv is allowed")
-	}
-	hasSub := subPresent || subFromEnvPresent
+func parsePubSubMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) (*pubsubMetadata, error) {
+	meta := &pubsubMetadata{}
 
-	topic, topicPresent := config.TriggerMetadata["topicName"]
-	topicFromEnv, topicFromEnvPresent := config.TriggerMetadata["topicNameFromEnv"]
-	if topicPresent && topicFromEnvPresent {
-		return fmt.Errorf("exactly one of topicName or topicNameFromEnv is allowed")
-	}
-	hasTopic := topicPresent || topicFromEnvPresent
-
-	if (!hasSub && !hasTopic) || (hasSub && hasTopic) {
-		return fmt.Errorf("exactly one of subscription or topic name must be given")
+	if err := config.TypedConfig(meta); err != nil {
+		return nil, fmt.Errorf("error parsing gcp pubsub metadata: %w", err)
 	}
 
-	if hasSub {
-		if subPresent {
-			if sub == "" {
-				return fmt.Errorf("no subscription name given")
-			}
+	if meta.SubscriptionSize != 0 {
+		meta.Value = float64(meta.SubscriptionSize)
+	} else if meta.Mode == "" {
+		meta.Mode = pubSubDefaultModeSubscriptionSize
+	}
 
-			meta.resourceName = sub
-		} else {
-			if subFromEnv == "" {
-				return fmt.Errorf("no environment variable name given for resolving subscription name")
-			}
-
-			resolvedSub, ok := config.ResolvedEnv[subFromEnv]
-			if !ok {
-				return fmt.Errorf("resolved environment doesn't contain name '%s'", subFromEnv)
-			}
-
-			if resolvedSub == "" {
-				return fmt.Errorf("resolved environment subscription name is empty")
-			}
-
-			meta.resourceName = config.ResolvedEnv[subFromEnv]
-		}
-
+	if meta.SubscriptionName != "" {
+		meta.resourceName = meta.SubscriptionName
 		meta.resourceType = resourceTypePubSubSubscription
 	} else {
-		if topicPresent {
-			if topic == "" {
-				return fmt.Errorf("no topic name given")
-			}
-
-			meta.resourceName = topic
-		} else {
-			if topicFromEnv == "" {
-				return fmt.Errorf("no environment variable name given for resolving topic name")
-			}
-
-			resolvedTopic, ok := config.ResolvedEnv[topicFromEnv]
-			if !ok {
-				return fmt.Errorf("resolved environment doesn't contain name '%s'", topicFromEnv)
-			}
-
-			if resolvedTopic == "" {
-				return fmt.Errorf("resolved environment topic name is empty")
-			}
-
-			meta.resourceName = config.ResolvedEnv[topicFromEnv]
-		}
-
+		meta.resourceName = meta.TopicName
 		meta.resourceType = resourceTypePubSubTopic
-	}
-
-	return nil
-}
-
-func parsePubSubMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) (*pubsubMetadata, error) {
-	meta := pubsubMetadata{mode: pubSubModeSubscriptionSize, value: pubSubDefaultValue}
-
-	mode, modePresent := config.TriggerMetadata["mode"]
-	value, valuePresent := config.TriggerMetadata["value"]
-
-	if subSize, subSizePresent := config.TriggerMetadata["subscriptionSize"]; subSizePresent {
-		if modePresent || valuePresent {
-			return nil, errors.New("you can use either mode and value fields or subscriptionSize field")
-		}
-		if _, topicPresent := config.TriggerMetadata["topicName"]; topicPresent {
-			return nil, errors.New("you cannot use subscriptionSize field together with topicName field. Use subscriptionName field instead")
-		}
-		logger.Info("subscriptionSize field is deprecated. Use mode and value fields instead")
-		subSizeValue, err := strconv.ParseFloat(subSize, 64)
-		if err != nil {
-			return nil, fmt.Errorf("value parsing error %w", err)
-		}
-		meta.value = subSizeValue
-	} else {
-		if modePresent {
-			meta.mode = mode
-		}
-
-		if valuePresent {
-			triggerValue, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				return nil, fmt.Errorf("value parsing error %w", err)
-			}
-			meta.value = triggerValue
-		}
-	}
-
-	if val, ok := config.TriggerMetadata["valueIfNull"]; ok && val != "" {
-		valueIfNull, err := strconv.ParseFloat(val, 64)
-		if err != nil {
-			return nil, fmt.Errorf("valueIfNull parsing error %w", err)
-		}
-		meta.valueIfNull = &valueIfNull
-	}
-
-	meta.aggregation = config.TriggerMetadata["aggregation"]
-
-	meta.timeHorizon = config.TriggerMetadata["timeHorizon"]
-
-	err := parsePubSubResourceConfig(config, &meta)
-	if err != nil {
-		return nil, err
-	}
-
-	meta.activationValue = 0
-	if val, ok := config.TriggerMetadata["activationValue"]; ok {
-		activationValue, err := strconv.ParseFloat(val, 64)
-		if err != nil {
-			return nil, fmt.Errorf("activationValue parsing error %w", err)
-		}
-		meta.activationValue = activationValue
 	}
 
 	auth, err := gcp.GetGCPAuthorization(config)
@@ -212,7 +100,8 @@ func parsePubSubMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger)
 	}
 	meta.gcpAuthorization = auth
 	meta.triggerIndex = config.TriggerIndex
-	return &meta, nil
+
+	return meta, nil
 }
 
 func (s *pubsubScaler) Close(context.Context) error {
@@ -226,13 +115,32 @@ func (s *pubsubScaler) Close(context.Context) error {
 	return nil
 }
 
+func (meta *pubsubMetadata) Validate() error {
+	if meta.SubscriptionSize != 0 {
+		if meta.Mode != "" {
+			return fmt.Errorf("you can use either mode and value fields or subscriptionSize field")
+		}
+		if meta.TopicName != "" {
+			return fmt.Errorf("you cannot use subscriptionSize field together with topicName field. Use subscriptionName field instead")
+		}
+	}
+
+	hasSub := meta.SubscriptionName != ""
+	hasTopic := meta.TopicName != ""
+	if (!hasSub && !hasTopic) || (hasSub && hasTopic) {
+		return fmt.Errorf("exactly one of subscription or topic name must be given")
+	}
+
+	return nil
+}
+
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *pubsubScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
 	externalMetric := &v2.ExternalMetricSource{
 		Metric: v2.MetricIdentifier{
 			Name: GenerateMetricNameWithIndex(s.metadata.triggerIndex, kedautil.NormalizeString(fmt.Sprintf("gcp-ps-%s", s.metadata.resourceName))),
 		},
-		Target: GetMetricTargetMili(s.metricType, s.metadata.value),
+		Target: GetMetricTargetMili(s.metricType, s.metadata.Value),
 	}
 
 	// Create the metric spec for the HPA
@@ -246,11 +154,11 @@ func (s *pubsubScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec 
 
 // GetMetricsAndActivity connects to Stack Driver and finds the size of the pub sub subscription
 func (s *pubsubScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
-	mode := s.metadata.mode
+	mode := s.metadata.Mode
 
 	// SubscriptionSize is actually NumUndeliveredMessages in GCP PubSub.
 	// Considering backward compatibility, fallback "SubscriptionSize" to "NumUndeliveredMessages"
-	if mode == pubSubModeSubscriptionSize {
+	if mode == pubSubDefaultModeSubscriptionSize {
 		mode = "NumUndeliveredMessages"
 	}
 
@@ -264,7 +172,7 @@ func (s *pubsubScaler) GetMetricsAndActivity(ctx context.Context, metricName str
 
 	metric := GenerateMetricInMili(metricName, value)
 
-	return []external_metrics.ExternalMetricValue{metric}, value > s.metadata.activationValue, nil
+	return []external_metrics.ExternalMetricValue{metric}, value > s.metadata.ActivationValue, nil
 }
 
 func (s *pubsubScaler) setStackdriverClient(ctx context.Context) error {
@@ -292,7 +200,7 @@ func (s *pubsubScaler) getMetrics(ctx context.Context, metricType string) (float
 	}
 	resourceID, projectID := getResourceData(s)
 	query, err := s.client.BuildMQLQuery(
-		projectID, s.metadata.resourceType, metricType, resourceID, s.metadata.aggregation, s.metadata.timeHorizon,
+		projectID, s.metadata.resourceType, metricType, resourceID, s.metadata.Aggregation, s.metadata.TimeHorizon,
 	)
 	if err != nil {
 		return -1, err
@@ -300,7 +208,7 @@ func (s *pubsubScaler) getMetrics(ctx context.Context, metricType string) (float
 
 	// Pubsub metrics are collected every 60 seconds so no need to aggregate them.
 	// See: https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub
-	return s.client.QueryMetrics(ctx, projectID, query, s.metadata.valueIfNull)
+	return s.client.QueryMetrics(ctx, projectID, query, s.metadata.ValueIfNull)
 }
 
 func getResourceData(s *pubsubScaler) (string, string) {

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -113,7 +113,7 @@ var gcpSubscriptionDefaults = []gcpPubSubSubscription{
 func TestPubSubParseMetadata(t *testing.T) {
 	for _, testData := range testPubSubMetadata {
 		t.Run(testData.testName, func(t *testing.T) {
-			_, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testPubSubResolvedEnv}, logr.Discard())
+			_, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testPubSubResolvedEnv})
 			if err != nil && !testData.isError {
 				t.Error("Expected success but got error", err)
 			}
@@ -127,7 +127,7 @@ func TestPubSubParseMetadata(t *testing.T) {
 func TestPubSubMetadataDefaultValues(t *testing.T) {
 	for _, testData := range gcpSubscriptionDefaults {
 		t.Run(testData.metadataTestData.testName, func(t *testing.T) {
-			metaData, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.metadataTestData.authParams, TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv}, logr.Discard())
+			metaData, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.metadataTestData.authParams, TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv})
 			if err != nil {
 				t.Error("Expected success but got error", err)
 			}
@@ -144,7 +144,7 @@ func TestPubSubMetadataDefaultValues(t *testing.T) {
 func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range gcpPubSubMetricIdentifiers {
 		t.Run(testData.metadataTestData.testName, func(t *testing.T) {
-			meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex}, logr.Discard())
+			meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex})
 			if err != nil {
 				t.Fatal("Could not parse metadata:", err)
 			}
@@ -162,7 +162,7 @@ func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
 func TestGcpPubSubResourceName(t *testing.T) {
 	for _, testData := range gcpResourceNameTests {
 		t.Run(testData.metadataTestData.testName, func(t *testing.T) {
-			meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex}, logr.Discard())
+			meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex})
 			if err != nil {
 				t.Fatal("Could not parse metadata:", err)
 			}

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -126,47 +126,53 @@ func TestPubSubParseMetadata(t *testing.T) {
 
 func TestPubSubMetadataDefaultValues(t *testing.T) {
 	for _, testData := range gcpSubscriptionDefaults {
-		metaData, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.metadataTestData.authParams, TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv}, logr.Discard())
-		if err != nil {
-			t.Error("Expected success but got error", err)
-		}
-		if pubSubDefaultModeSubscriptionSize != metaData.Mode {
-			t.Errorf(`Expected mode "%s" but got "%s"`, pubSubDefaultModeSubscriptionSize, metaData.Mode)
-		}
-		if pubSubDefaultValue != metaData.Value {
-			t.Errorf(`Expected value "%d" but got "%f"`, pubSubDefaultValue, metaData.Value)
-		}
+		t.Run(testData.metadataTestData.testName, func(t *testing.T) {
+			metaData, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.metadataTestData.authParams, TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv}, logr.Discard())
+			if err != nil {
+				t.Error("Expected success but got error", err)
+			}
+			if pubSubDefaultModeSubscriptionSize != metaData.Mode {
+				t.Errorf(`Expected mode "%s" but got "%s"`, pubSubDefaultModeSubscriptionSize, metaData.Mode)
+			}
+			if pubSubDefaultValue != metaData.Value {
+				t.Errorf(`Expected value "%d" but got "%f"`, pubSubDefaultValue, metaData.Value)
+			}
+		})
 	}
 }
 
 func TestGcpPubSubGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range gcpPubSubMetricIdentifiers {
-		meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex}, logr.Discard())
-		if err != nil {
-			t.Fatal("Could not parse metadata:", err)
-		}
-		mockGcpPubSubScaler := pubsubScaler{nil, "", meta, logr.Discard()}
+		t.Run(testData.metadataTestData.testName, func(t *testing.T) {
+			meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex}, logr.Discard())
+			if err != nil {
+				t.Fatal("Could not parse metadata:", err)
+			}
+			mockGcpPubSubScaler := pubsubScaler{nil, "", meta, logr.Discard()}
 
-		metricSpec := mockGcpPubSubScaler.GetMetricSpecForScaling(context.Background())
-		metricName := metricSpec[0].External.Metric.Name
-		if metricName != testData.name {
-			t.Error("Wrong External metric source name:", metricName)
-		}
+			metricSpec := mockGcpPubSubScaler.GetMetricSpecForScaling(context.Background())
+			metricName := metricSpec[0].External.Metric.Name
+			if metricName != testData.name {
+				t.Error("Wrong External metric source name:", metricName)
+			}
+		})
 	}
 }
 
 func TestGcpPubSubResourceName(t *testing.T) {
 	for _, testData := range gcpResourceNameTests {
-		meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex}, logr.Discard())
-		if err != nil {
-			t.Fatal("Could not parse metadata:", err)
-		}
-		mockGcpPubSubScaler := pubsubScaler{nil, "", meta, logr.Discard()}
-		resourceID, projectID := getResourceData(&mockGcpPubSubScaler)
+		t.Run(testData.metadataTestData.testName, func(t *testing.T) {
+			meta, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, ResolvedEnv: testPubSubResolvedEnv, TriggerIndex: testData.triggerIndex}, logr.Discard())
+			if err != nil {
+				t.Fatal("Could not parse metadata:", err)
+			}
+			mockGcpPubSubScaler := pubsubScaler{nil, "", meta, logr.Discard()}
+			resourceID, projectID := getResourceData(&mockGcpPubSubScaler)
 
-		if resourceID != testData.name || projectID != testData.projectID {
-			t.Error("Wrong Resource parsing:", resourceID, projectID)
-		}
+			if resourceID != testData.name || projectID != testData.projectID {
+				t.Error("Wrong Resource parsing:", resourceID, projectID)
+			}
+		})
 	}
 }
 

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -16,6 +16,7 @@ var testPubSubResolvedEnv = map[string]string{
 }
 
 type parsePubSubMetadataTestData struct {
+	testName   string
 	authParams map[string]string
 	metadata   map[string]string
 	isError    bool
@@ -35,57 +36,57 @@ type gcpPubSubSubscription struct {
 }
 
 var testPubSubMetadata = []parsePubSubMetadataTestData{
-	{map[string]string{}, map[string]string{}, true},
+	{"empty", map[string]string{}, map[string]string{}, true},
 	// all properly formed with deprecated field
-	{nil, map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"all properly formed with deprecated field", nil, map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// all properly formed with subscriptionName
-	{nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "5"}, false},
+	{"all properly formed with subscriptionName", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "5"}, false},
 	// all properly formed with oldest unacked message age mode
-	{nil, map[string]string{"subscriptionName": "mysubscription", "mode": "OldestUnackedMessageAge", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"all properly formed with oldest unacked message age mode", nil, map[string]string{"subscriptionName": "mysubscription", "mode": "OldestUnackedMessageAge", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// missing subscriptionName
-	{nil, map[string]string{"subscriptionName": "", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"missing subscriptionName", nil, map[string]string{"subscriptionName": "", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// missing credentials
-	{nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": ""}, true},
+	{"missing credentials", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": ""}, true},
 	// malformed subscriptionSize
-	{nil, map[string]string{"subscriptionName": "mysubscription", "value": "AA", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"malformed subscriptionSize", nil, map[string]string{"subscriptionName": "mysubscription", "value": "AA", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// malformed mode
-	{nil, map[string]string{"subscriptionName": "", "mode": "AA", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"malformed mode", nil, map[string]string{"subscriptionName": "", "mode": "AA", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// malformed activationTargetValue
-	{nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "AA"}, true},
+	{"malformed activationTargetValue", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "AA"}, true},
 	// Credentials from AuthParams
-	{map[string]string{"GoogleApplicationCredentials": "Creds"}, map[string]string{"subscriptionName": "mysubscription", "value": "7"}, false},
+	{"Credentials from AuthParams", map[string]string{"GoogleApplicationCredentials": "Creds"}, map[string]string{"subscriptionName": "mysubscription", "value": "7"}, false},
 	// Credentials from AuthParams with empty creds
-	{map[string]string{"GoogleApplicationCredentials": ""}, map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7"}, true},
+	{"Credentials from AuthParams with empty creds", map[string]string{"GoogleApplicationCredentials": ""}, map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7"}, true},
 	// with full link to subscription
-	{nil, map[string]string{"subscriptionName": "projects/myproject/subscriptions/mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"with full link to subscription", nil, map[string]string{"subscriptionName": "projects/myproject/subscriptions/mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// with full (bad) link to subscription
-	{nil, map[string]string{"subscriptionName": "projects/myproject/mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"with full (bad) link to subscription", nil, map[string]string{"subscriptionName": "projects/myproject/mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// properly formed float value and activationTargetValue
-	{nil, map[string]string{"subscriptionName": "mysubscription", "value": "7.1", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "2.1"}, false},
+	{"properly formed float value and activationTargetValue", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7.1", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "2.1"}, false},
 	// All optional omitted
-	{nil, map[string]string{"subscriptionName": "mysubscription", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"All optional omitted", nil, map[string]string{"subscriptionName": "mysubscription", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// value omitted when mode present
-	{nil, map[string]string{"subscriptionName": "mysubscription", "mode": "SubscriptionSize", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"value omitted when mode present", nil, map[string]string{"subscriptionName": "mysubscription", "mode": "SubscriptionSize", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// all properly formed with topicName
-	{nil, map[string]string{"topicName": "mytopic", "mode": "MessageSizes", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"all properly formed with topicName", nil, map[string]string{"topicName": "mytopic", "mode": "MessageSizes", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// with full link to topic
-	{nil, map[string]string{"topicName": "projects/myproject/topics/mytopic", "mode": "MessageSizes", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"with full link to topic", nil, map[string]string{"topicName": "projects/myproject/topics/mytopic", "mode": "MessageSizes", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// with full (bad) link to topic
-	{nil, map[string]string{"topicName": "projects/myproject/mytopic", "mode": "MessageSizes", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"with full (bad) link to topic", nil, map[string]string{"topicName": "projects/myproject/mytopic", "mode": "MessageSizes", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// both subscriptionName and topicName present
-	{nil, map[string]string{"subscriptionName": "mysubscription", "topicName": "mytopic", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"both subscriptionName and topicName present", nil, map[string]string{"subscriptionName": "mysubscription", "topicName": "mytopic", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// both subscriptionName and topicName missing
-	{nil, map[string]string{"value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"both subscriptionName and topicName missing", nil, map[string]string{"value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// both subscriptionSize and topicName present
-	{nil, map[string]string{"subscriptionSize": "7", "topicName": "mytopic", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"both subscriptionSize and topicName present", nil, map[string]string{"subscriptionSize": "7", "topicName": "mytopic", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// both subscriptionName and subscriptionNameFromEnv present
-	{nil, map[string]string{"subscriptionName": "mysubscription", "subscriptionNameFromEnv": "MY_ENV_SUBSCRIPTION", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"both subscriptionName and subscriptionNameFromEnv present", nil, map[string]string{"subscriptionName": "mysubscription", "subscriptionNameFromEnv": "MY_ENV_SUBSCRIPTION", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// both topicName and topicNameFromEnv present
-	{nil, map[string]string{"topicName": "mytopic", "topicNameFromEnv": "MY_ENV_TOPIC", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	{"both topicName and topicNameFromEnv present", nil, map[string]string{"topicName": "mytopic", "topicNameFromEnv": "MY_ENV_TOPIC", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// subscriptionNameFromEnv present
-	{nil, map[string]string{"subscriptionNameFromEnv": "MY_ENV_SUBSCRIPTION", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"subscriptionNameFromEnv present", nil, map[string]string{"subscriptionNameFromEnv": "MY_ENV_SUBSCRIPTION", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// topicNameFromEnv present
-	{nil, map[string]string{"topicNameFromEnv": "MY_ENV_TOPIC", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"topicNameFromEnv present", nil, map[string]string{"topicNameFromEnv": "MY_ENV_TOPIC", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 }
 
 var gcpPubSubMetricIdentifiers = []gcpPubSubMetricIdentifier{
@@ -111,13 +112,15 @@ var gcpSubscriptionDefaults = []gcpPubSubSubscription{
 
 func TestPubSubParseMetadata(t *testing.T) {
 	for _, testData := range testPubSubMetadata {
-		_, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testPubSubResolvedEnv}, logr.Discard())
-		if err != nil && !testData.isError {
-			t.Error("Expected success but got error", err)
-		}
-		if testData.isError && err == nil {
-			t.Error("Expected error but got success")
-		}
+		t.Run(testData.testName, func(t *testing.T) {
+			_, err := parsePubSubMetadata(&scalersconfig.ScalerConfig{AuthParams: testData.authParams, TriggerMetadata: testData.metadata, ResolvedEnv: testPubSubResolvedEnv}, logr.Discard())
+			if err != nil && !testData.isError {
+				t.Error("Expected success but got error", err)
+			}
+			if testData.isError && err == nil {
+				t.Error("Expected error but got success")
+			}
+		})
 	}
 }
 
@@ -127,11 +130,11 @@ func TestPubSubMetadataDefaultValues(t *testing.T) {
 		if err != nil {
 			t.Error("Expected success but got error", err)
 		}
-		if pubSubModeSubscriptionSize != metaData.mode {
-			t.Errorf(`Expected mode "%s" but got "%s"`, pubSubModeSubscriptionSize, metaData.mode)
+		if pubSubDefaultModeSubscriptionSize != metaData.Mode {
+			t.Errorf(`Expected mode "%s" but got "%s"`, pubSubDefaultModeSubscriptionSize, metaData.Mode)
 		}
-		if pubSubDefaultValue != metaData.value {
-			t.Errorf(`Expected value "%d" but got "%f"`, pubSubDefaultValue, metaData.value)
+		if pubSubDefaultValue != metaData.Value {
+			t.Errorf(`Expected value "%d" but got "%f"`, pubSubDefaultValue, metaData.Value)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

refactor gcp pubsub scaler to use typed config

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/5797
