### PR TITLE
Remove external API calls in datadog scaler initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Allow excluding labels from being propagated from ScaledObject and ScaledJob to generated HPA and Job objects ([#6849](https://github.com/kedacore/keda/issues/6849))
 - **General**: Improve Events emitted from ScaledObject controller ([#6802](https://github.com/kedacore/keda/issues/6802))
 - **Datadog Scaler**: Fix bug with datadogNamespace config ([#6828](https://github.com/kedacore/keda/pull/6828))
+- **Datadog Scaler**: Remove external API calls in datadog scaler initialization ([#6828](https://github.com/kedacore/keda/pull/6828))
 - **Metrics API**: Support multiple auth methods simultaneously in Metrics API scaler ([#6642](https://github.com/kedacore/keda/issues/6642))
 - **Temporal Scaler**: Support custom tlsServerName ([#6820](https://github.com/kedacore/keda/pull/6820))
 

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -166,7 +166,7 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 	case "cron":
 		return scalers.NewCronScaler(config)
 	case "datadog":
-		return scalers.NewDatadogScaler(ctx, config)
+		return scalers.NewDatadogScaler(config)
 	case "dynatrace":
 		return scalers.NewDynatraceScaler(config)
 	case "elasticsearch":


### PR DESCRIPTION
Updating the datadog scaler such that failed API calls to Datadog still result in fallbacks executing. 

The root of the issue is that the datadog scaler can make external requests on creation. Currently in calls to `NewDatadogScaler()`, a validation endpoint is called to verify a connection can be made. If the endpoint is down, it can result in a failed call to `buildScalers()` [here](https://github.com/kedacore/keda/blob/1d5f3c56a6812cbf387eb24b1bcabae9dee122a8/pkg/scaling/scale_handler.go#L355-L358). Subsequently, calls to `GetScaledObjectMetrics()`, (which can call `buildScalers()` under the hood) then hit [this code block](https://github.com/kedacore/keda/blob/1d5f3c56a6812cbf387eb24b1bcabae9dee122a8/pkg/scaling/scale_handler.go#L428-L433) preventing [the fallback code later in the function](https://github.com/kedacore/keda/blob/1d5f3c56a6812cbf387eb24b1bcabae9dee122a8/pkg/scaling/scale_handler.go#L551) from executing.

This change moves that validation API call into the `GetMetricsAndActivity()` code path which is configured to lead to the fallback path.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
