### PR TITLE
fix: increase timeout for HPA name status update test in the scaledobject controller test

### DIFF
--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -402,7 +402,7 @@ var _ = Describe("ScaledObjectController", func() {
 				err = k8sClient.Get(context.Background(), types.NamespacedName{Name: soName, Namespace: "default"}, so)
 				Expect(err).ToNot(HaveOccurred())
 				return so.Status.HpaName
-			}).Should(Equal(fmt.Sprintf("keda-hpa-%s", soName)))
+			}).WithTimeout(60 * time.Second).WithPolling(2 * time.Second).Should(Equal(fmt.Sprintf("keda-hpa-%s", soName)))
 		})
 
 		//https://github.com/kedacore/keda/issues/2407


### PR DESCRIPTION
The `sets the hpaName in status if not set and HPA already exists` test is failing in some PR's due to insufficient timeout (1s default) for the controller to reconcile and update the HpaName status after it was manually cleared.

Increased timeout to 60s to allow proper reconciliation.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))