### PR TITLE
fix: prevent e2e test reset when adding non-skip labels

### DIFF
--- a/.github/workflows/pr-e2e-checker.yml
+++ b/.github/workflows/pr-e2e-checker.yml
@@ -20,7 +20,7 @@ jobs:
   e2e-checker:
     name: label checker
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'skip-e2e' || (github.event.action == 'unlabeled' && github.event.label.name == 'skip-e2e')
+    if: github.event.label.name == 'skip-e2e'
     steps:
       - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2
         name: Enqueue e2e

--- a/.github/workflows/pr-e2e-checker.yml
+++ b/.github/workflows/pr-e2e-checker.yml
@@ -20,6 +20,7 @@ jobs:
   e2e-checker:
     name: label checker
     runs-on: ubuntu-latest
+    if: github.event.label.name == 'skip-e2e' || (github.event.action == 'unlabeled' && github.event.label.name == 'skip-e2e')
     steps:
       - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2
         name: Enqueue e2e


### PR DESCRIPTION
Adding any label (like `ok-to-merge`) to a PR triggers the e2e-checker workflow, which resets successful e2e test status from green to queued. This PR ensures that the e2e-checker only trigger the workflow when the `skip-e2e` label is added or removed, ignoring all other label changes.

I think this is very useful so we can use labels like `ok-to-merge` so we have an overview of which PRs have two approvals for example and the tests have passed to know which ones can continue.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
