### PR TITLE
Fix incorrect URL encoding in RabbitMQ vhosts containing %2f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **General**: Remove klogr dependency and replace with zap ([#5732](https://github.com/kedacore/keda/issues/5732))
 - **General**: Sets hpaName in Status when ScaledObject adopts/finds an existing HPA ([#6336](https://github.com/kedacore/keda/issues/6336))
+- **RabbitMQ**: Fix incorrect URL encoding in RabbitMQ vhosts containing %2f ([#6963](https://github.com/kedacore/keda/issues/6963))
 
 ### Deprecations
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -455,7 +455,7 @@ func getVhostAndPathFromURL(rawPath, vhostName string) (resolvedVhostPath, resol
 	if vhostName != "" {
 		resolvedVhostPath = "/" + url.QueryEscape(vhostName)
 	}
-	if resolvedVhostPath == "" || resolvedVhostPath == "/" || resolvedVhostPath == "//" {
+	if resolvedVhostPath == "" || resolvedVhostPath == "/" {
 		resolvedVhostPath = rabbitRootVhostPath
 	}
 
@@ -469,7 +469,12 @@ func (s *rabbitMQScaler) getQueueInfoViaHTTP(ctx context.Context) (*queueInfo, e
 		return nil, err
 	}
 
-	vhost, subpaths := getVhostAndPathFromURL(parsedURL.Path, s.metadata.VhostName)
+	path := parsedURL.RawPath
+	if path == "" {
+		path = parsedURL.Path
+	}
+
+	vhost, subpaths := getVhostAndPathFromURL(path, s.metadata.VhostName)
 	parsedURL.Path = subpaths
 
 	if s.metadata.Username != "" && s.metadata.Password != "" {

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -318,33 +318,39 @@ type resolvedVhostAndPathTestData struct {
 var getVhostAndPathFromURLTestData = []resolvedVhostAndPathTestData{
 	// level 0 + vhost
 	{"myVhost", "", "/myVhost", ""},
+	{"%2FmyVhost", "", "/%2FmyVhost", ""},
 
 	// level 0 + vhost as /, // and empty
 	{"/", "", rabbitRootVhostPath, ""},
 	{"//", "", rabbitRootVhostPath, ""},
+	{"/%2F", "", rabbitRootVhostPath, ""},
 	{"", "", rabbitRootVhostPath, ""},
 
 	// level 1 + vhost
 	{"sub1/myVhost", "", "/myVhost", "/sub1"},
 	{"sub1/", "overridenVhost", "/overridenVhost", "/sub1"},
 	{"myVhost", "overridenVhost", "/overridenVhost", ""},
+	{"sub1/%2FmyVhost", "", "/%2FmyVhost", "/sub1"},
 
 	// level 1 + vhost as / and //
 	{"sub1/", "", rabbitRootVhostPath, "/sub1"},
 	{"sub1/", "myVhost", "/myVhost", "/sub1"},
 	{"myVhost", "overridenVhost", "/overridenVhost", ""},
 	{"sub1//", "", rabbitRootVhostPath, "/sub1"},
+	{"sub1/%2F", "", rabbitRootVhostPath, "/sub1"},
 
 	// level 2 + vhost
 	{"sub1/sub2/myVhost", "", "/myVhost", "/sub1/sub2"},
 	{"sub1/sub2/myVhost", "overridenVhost", "/overridenVhost", "/sub1/sub2"},
 	{"myVhost", "overridenVhost", "/overridenVhost", ""},
+	{"sub1/sub2/%2FmyVhost", "", "/%2FmyVhost", "/sub1/sub2"},
 
 	// level 2 + vhost as / and //
 	{"sub1/sub2/", "", rabbitRootVhostPath, "/sub1/sub2"},
 	{"sub1/sub2/", "myVhost", "/myVhost", "/sub1/sub2"},
 	{"sub1/myVhost", "overridenVhost", "/overridenVhost", "/sub1"},
 	{"sub1/sub2//", "", rabbitRootVhostPath, "/sub1/sub2"},
+	{"sub1/sub2/%2F", "", rabbitRootVhostPath, "/sub1/sub2"},
 }
 
 func Test_getVhostAndPathFromURL(t *testing.T) {


### PR DESCRIPTION
This fixes the incorrect URL encoding in RabbitMQ vhosts by passing the `RawPath` to `getVhostAndPathFromURL` (which is sometimes empty, e.g. when there would be no difference with `Path`).

I've added testcases for vhosts containing `%2F`.
I've removed the check for `//` in `getVhostAndPathFromURL` because it is no longer necessary.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6963 
