### PR TITLE
Aligns command structure across all deployments

### DIFF
--- a/config/metrics-server/deployment.yaml
+++ b/config/metrics-server/deployment.yaml
@@ -54,8 +54,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: ""
+          command:
+            - /keda-adapter
           args:
-          - /usr/local/bin/keda-adapter
           - --secure-port=6443
           - --zap-log-level=error
           - --client-ca-file=/certs/ca.crt


### PR DESCRIPTION
Currently the way the config is for the  written metrics-apiserver is both out of sync with how the other two deployments are structured but it also produces a somewhat spurious start command.  If you inspect the running process you see that the start command is the following:
```
/keda-adapter --secure-port=6443 --logtostderr=true --v=0 /usr/local/bin/keda-adapter --secure-port=6443 --logtostderr=true --stderrthreshold=ERROR --v=0 --client-ca-file=/certs/ca.crt --tls-cert-file=/certs/tls.crt --tls-private-key-file=/certs/tls.key --cert-dir=/certs
```

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

