### PR TITLE
Refactor huawei cloudeye scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ You can find all deprecations in [this overview](https://github.com/kedacore/ked
 New deprecation(s):
 
 - **GCP Pub/Sub Scaler**: The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead" ([#6866](https://github.com/kedacore/keda/pull/6866))
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **Huawei Cloudeye Scaler**: The 'minMetricValue' setting is DEPRECATED and will be removed in v2.20 - Use 'activationTargetMetricValue' instead" ([#6978](https://github.com/kedacore/keda/pull/6978))
 
 ### Breaking Changes
 

--- a/pkg/scalers/huawei_cloudeye_scaler_test.go
+++ b/pkg/scalers/huawei_cloudeye_scaler_test.go
@@ -135,15 +135,6 @@ var testHuaweiCloudeyeMetadata = []parseHuaweiCloudeyeMetadataTestData{
 		true,
 		"metadata miss targetMetricValue"},
 	{map[string]string{
-		"namespace":         "SYS.ELB",
-		"dimensionName":     "lbaas_instance_id",
-		"dimensionValue":    "5e052238-0346-xxb0-86ea-92d9f33e29d2",
-		"metricName":        "mb_l7_qps",
-		"targetMetricValue": "100"},
-		testHuaweiAuthenticationWithCloud,
-		true,
-		"metadata miss minMetricValue"},
-	{map[string]string{
 		"namespace":                   "SYS.ELB",
 		"dimensionName":               "lbaas_instance_id",
 		"dimensionValue":              "5e052238-0346-xxb0-86ea-92d9f33e29d2",
@@ -153,6 +144,16 @@ var testHuaweiCloudeyeMetadata = []parseHuaweiCloudeyeMetadataTestData{
 		testHuaweiAuthenticationWithCloud,
 		true,
 		"invalid activationTargetMetricValue"},
+	{map[string]string{
+		"namespace":                   "SYS.ELB",
+		"dimensionName":               "lbaas_instance_id",
+		"dimensionValue":              "5e052238-0346-xxb0-86ea-92d9f33e29d2",
+		"metricName":                  "mb_l7_qps",
+		"targetMetricValue":           "100",
+		"activationTargetMetricValue": "5"},
+		testHuaweiAuthenticationWithCloud,
+		false,
+		"using activationTargetMetricValue"},
 }
 
 var huaweiCloudeyeMetricIdentifiers = []huaweiCloudeyeMetricIdentifier{
@@ -162,7 +163,7 @@ var huaweiCloudeyeMetricIdentifiers = []huaweiCloudeyeMetricIdentifier{
 
 func TestHuaweiCloudeyeParseMetadata(t *testing.T) {
 	for _, testData := range testHuaweiCloudeyeMetadata {
-		_, err := parseHuaweiCloudeyeMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams}, logr.Discard())
+		_, err := parseHuaweiCloudeyeMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata, AuthParams: testData.authParams})
 		if err != nil && !testData.isError {
 			t.Errorf("%s: Expected success but got error %s", testData.comment, err)
 		}
@@ -174,11 +175,11 @@ func TestHuaweiCloudeyeParseMetadata(t *testing.T) {
 
 func TestHuaweiCloudeyeGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range huaweiCloudeyeMetricIdentifiers {
-		meta, err := parseHuaweiCloudeyeMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, TriggerIndex: testData.triggerIndex}, logr.Discard())
+		meta, err := parseHuaweiCloudeyeMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: testData.metadataTestData.authParams, TriggerIndex: testData.triggerIndex})
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockHuaweiCloudeyeScaler := huaweiCloudeyeScaler{"", meta, logr.Discard()}
+		mockHuaweiCloudeyeScaler := huaweiCloudeyeScaler{metricType: "", metadata: meta, logger: logr.Discard()}
 
 		metricSpec := mockHuaweiCloudeyeScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name


### PR DESCRIPTION
Refactor the scaler to match the new metadata guidelines.

Good review required, because there is no e2e test for the Huawei Cloudeye scaler.

Because there is a deprecate announcement in it I will create a changelog item and the items according the [deprecation policy.](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Changelog has been updated and is aligned with our [changelog requirements]
- [X] Tests have been added
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #5797
Docs: https://github.com/kedacore/keda-docs/pull/1610