### PR TITLE
Fix waitfordeploymentreplicareadycount duration logs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -192,6 +192,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
     ...
     ...
     // Sleep / poll for replica count using helper method.
+    // Duration should be iterations * intervalSeconds 
     require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 10, 60, 1),
 		"replica count should be 10 after 1 minute")
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -192,7 +192,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
     ...
     ...
     // Sleep / poll for replica count using helper method.
-    // Duration should be iterations * intervalSeconds 
+    // Duration should be iterations * intervalSeconds
     require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 10, 60, 1),
 		"replica count should be 10 after 1 minute")
 }

--- a/tests/internals/fallback/fallback_test.go
+++ b/tests/internals/fallback/fallback_test.go
@@ -420,7 +420,7 @@ func TestFallback(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	testScaleOut(t, kc, data)
 	testFallback(t, kc, data)
@@ -446,7 +446,7 @@ func TestFallbackWithScaledObjectWithoutMetricType(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	// Scale out to 4 replicas (20 / 5 = 4)
 	data.MetricValue = 20
@@ -485,7 +485,7 @@ func TestFallbackWithCurrentReplicasIfHigher(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	// Scale out to 4 replicas (20 / 5 = 4)
 	data.MetricValue = 20
@@ -524,7 +524,7 @@ func TestFallbackWithCurrentReplicasIfLower(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	// Scale out to 4 replicas (20 / 5 = 4)
 	data.MetricValue = 20
@@ -563,7 +563,7 @@ func TestFallbackWithCurrentReplicas(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	// Scale out to 4 replicas (20 / 5 = 4)
 	data.MetricValue = 20
@@ -602,7 +602,7 @@ func TestFallbackWithStatic(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	// Scale out to 4 replicas (20 / 5 = 4)
 	data.MetricValue = 20

--- a/tests/internals/global_custom_ca/global_custom_ca_test.go
+++ b/tests/internals/global_custom_ca/global_custom_ca_test.go
@@ -227,7 +227,7 @@ func TestCustomCa(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+		"replica count should be %d after 9 minutes", minReplicaCount)
 
 	// test scaling
 	testScaleOut(t, kc, data)

--- a/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
+++ b/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
@@ -269,7 +269,7 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, namespace, maxReplicas, 60)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 12, 10),
-		"replica count should be %d after 1 minutes", maxReplicas)
+		"replica count should be %d after 2 minutes", maxReplicas)
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 }

--- a/tests/internals/replica_update_so/replica_update_so_test.go
+++ b/tests/internals/replica_update_so/replica_update_so_test.go
@@ -220,14 +220,14 @@ func scaleMaxReplicasUp(t *testing.T, kc *kubernetes.Clientset, data templateDat
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", maxReplicas)
+		"replica count should be %d after 9 minutes", maxReplicas)
 
 	updatedMaxReplicas := maxReplicas + 10
 	data.MaxReplicas = strconv.Itoa(updatedMaxReplicas)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, updatedMaxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", updatedMaxReplicas)
+		"replica count should be %d after 9 minutes", updatedMaxReplicas)
 }
 
 // expect replicas to decrease because maxReplicas was updated
@@ -241,13 +241,13 @@ func scaleMaxReplicasDown(t *testing.T, kc *kubernetes.Clientset, data templateD
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, updatedMaxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", updatedMaxReplicas)
+		"replica count should be %d after 9 minutes", updatedMaxReplicas)
 
 	data.MaxReplicas = strconv.Itoa(maxReplicas)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", maxReplicas)
+		"replica count should be %d after 9 minutes", maxReplicas)
 }
 
 // starts with minReplicas 0 -> update to higher, expect to scale up
@@ -259,14 +259,14 @@ func scaleMinReplicasUpFromZero(t *testing.T, kc *kubernetes.Clientset, data tem
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	updatedMinReplicas := minReplicas + 5
 	data.MinReplicas = strconv.Itoa(updatedMinReplicas)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, updatedMinReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", updatedMinReplicas)
+		"replica count should be %d after 9 minutes", updatedMinReplicas)
 }
 
 // starts with 5 replicas as minReplicas -> update to 0, expect to scale down
@@ -281,7 +281,7 @@ func scaleMinReplicasDownToZero(t *testing.T, kc *kubernetes.Clientset, data tem
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, updatedMinReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", updatedMinReplicas)
+		"replica count should be %d after 9 minutes", updatedMinReplicas)
 
 	// change minReplicas to default (0)
 	data.MinReplicas = strconv.Itoa(minReplicas)
@@ -289,7 +289,7 @@ func scaleMinReplicasDownToZero(t *testing.T, kc *kubernetes.Clientset, data tem
 
 	// check it scales down to 0
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 }
 
 // help function to load template data

--- a/tests/internals/scaling_modifiers/scaling_modifiers_test.go
+++ b/tests/internals/scaling_modifiers/scaling_modifiers_test.go
@@ -282,7 +282,7 @@ func TestScalingModifiers(t *testing.T) {
 
 	// we ensure that the metrics api server is up and ready
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, metricsServerDeploymentName, namespace, 1, 60, 2),
-		"replica count should be 1 after 2 minute")
+		"replica count should be 1 after 2 minutes")
 
 	testFormula(t, kc, data)
 
@@ -307,7 +307,7 @@ func testFormula(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	assert.NoErrorf(t, err, "cannot scale workload deployment - %s", err)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, "depl-workload-base", namespace, 2, 12, 10),
-		"replica count should be %d after 2 minute", 2)
+		"replica count should be %d after 2 minutes", 2)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 3, 12, 10),
 		"replica count should be %d after 2 minutes", 3)
 
@@ -326,7 +326,7 @@ func testFormula(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	// we ensure that the metrics api server is up and ready
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, metricsServerDeploymentName, namespace, 1, 60, 2),
-		"replica count should be 1 after 2 minute")
+		"replica count should be 1 after 2 minutes")
 
 	data.MetricValue = 2
 	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)

--- a/tests/internals/scaling_modifiers/scaling_modifiers_test.go
+++ b/tests/internals/scaling_modifiers/scaling_modifiers_test.go
@@ -282,7 +282,7 @@ func TestScalingModifiers(t *testing.T) {
 
 	// we ensure that the metrics api server is up and ready
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, metricsServerDeploymentName, namespace, 1, 60, 2),
-		"replica count should be 1 after 1 minute")
+		"replica count should be 1 after 2 minute")
 
 	testFormula(t, kc, data)
 
@@ -307,7 +307,7 @@ func testFormula(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	assert.NoErrorf(t, err, "cannot scale workload deployment - %s", err)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, "depl-workload-base", namespace, 2, 12, 10),
-		"replica count should be %d after 1 minute", 2)
+		"replica count should be %d after 2 minute", 2)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 3, 12, 10),
 		"replica count should be %d after 2 minutes", 3)
 
@@ -326,7 +326,7 @@ func testFormula(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 	// we ensure that the metrics api server is up and ready
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, metricsServerDeploymentName, namespace, 1, 60, 2),
-		"replica count should be 1 after 1 minute")
+		"replica count should be 1 after 2 minute")
 
 	data.MetricValue = 2
 	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)

--- a/tests/internals/trigger_update_so/trigger_update_so_test.go
+++ b/tests/internals/trigger_update_so/trigger_update_so_test.go
@@ -301,7 +301,7 @@ func TestScaledObjectGeneral(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	testTargetValue(t, kc, data)          // one trigger target changes
 	testTwoTriggers(t, kc, data)          // add trigger during active scaling
@@ -320,21 +320,21 @@ func testTargetValue(t *testing.T, kc *kubernetes.Clientset, data templateData) 
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 1, 180, 3),
-		"replica count should be %d after 3 minutes", 1)
+		"replica count should be %d after 9 minutes", 1)
 
 	t.Log("--- test target value 10 ---")
 	data.MetricValue = 10
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", maxReplicas)
+		"replica count should be %d after 9 minutes", maxReplicas)
 
 	t.Log("--- test target value 0 ---")
 	data.MetricValue = 0
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 }
 
 // test adding second trigger during scaling
@@ -346,14 +346,14 @@ func testTwoTriggers(t *testing.T, kc *kubernetes.Clientset, data templateData) 
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, 1, 180, 3),
-		"replica count should be %d after 3 minutes", 1)
+		"replica count should be %d after 9 minutes", 1)
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTwoTriggerTemplate", scaledObjectTwoTriggerTemplate)
 	// scale to max with k8s wl = second trigger
 	KubernetesScaleDeployment(t, kc, workloadDeploymentName, int64(maxReplicas), namespace)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", maxReplicas)
+		"replica count should be %d after 9 minutes", maxReplicas)
 }
 
 // scales to max with kubernetes worload(second trigger), removes it and
@@ -367,13 +367,13 @@ func testRemoveTrigger(t *testing.T, kc *kubernetes.Clientset, data templateData
 	KubernetesScaleDeployment(t, kc, workloadDeploymentName, int64(maxReplicas), namespace)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", maxReplicas)
+		"replica count should be %d after 9 minutes", maxReplicas)
 
 	// update SO -> remove k8s wl == second trigger
 	KubectlApplyWithTemplate(t, data, "scaledObjectTriggerTemplate", scaledObjectTriggerTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, midReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", midReplicas)
+		"replica count should be %d after 9 minutes", midReplicas)
 }
 
 // test 3 triggers scaling works including one cpu metric
@@ -387,7 +387,7 @@ func testThreeTriggersWithCPU(t *testing.T, kc *kubernetes.Clientset, data templ
 	data.MetricValue = 10
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", maxReplicas)
+		"replica count should be %d after 9 minutes", maxReplicas)
 }
 
 // help function to load template data

--- a/tests/internals/update_ta/update_ta_test.go
+++ b/tests/internals/update_ta/update_ta_test.go
@@ -275,7 +275,7 @@ func TestTriggerAuthenticationGeneral(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	testTriggerAuthenticationStatusValue(t, data, triggerAuthKind)
 
@@ -287,7 +287,7 @@ func TestTriggerAuthenticationGeneral(t *testing.T) {
 	CreateKubernetesResources(t, kc, namespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicas)
+		"replica count should be %d after 9 minutes", minReplicas)
 
 	testTriggerAuthenticationStatusValue(t, data, clusterTriggerAuthKind)
 	DeleteKubernetesResources(t, namespace, data, templates)

--- a/tests/scalers/aws/aws_managed_prometheus/aws_managed_prometheus_test.go
+++ b/tests/scalers/aws/aws_managed_prometheus/aws_managed_prometheus_test.go
@@ -150,7 +150,7 @@ func TestScaler(t *testing.T) {
 	t.Log("--- assert ---")
 	expectedReplicaCountNumber := 2 // as mentioned above, as the AMP returns 100 and the threshold set to 50, the expected replica count is 100 / 50 = 2
 	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
-		"replica count should be %d after a minute", expectedReplicaCountNumber)
+		"replica count should be %d after 1 minute", expectedReplicaCountNumber)
 
 	t.Log("--- cleaning up ---")
 	deleteWSInput := amp.DeleteWorkspaceInput{

--- a/tests/scalers/aws/aws_managed_prometheus_pod_identity/aws_managed_prometheus_pod_identity_test.go
+++ b/tests/scalers/aws/aws_managed_prometheus_pod_identity/aws_managed_prometheus_pod_identity_test.go
@@ -135,7 +135,7 @@ func TestScaler(t *testing.T) {
 	t.Log("--- assert ---")
 	expectedReplicaCountNumber := 2 // as mentioned above, as the AMP returns 100 and the threshold set to 50, the expected replica count is 100 / 50 = 2
 	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
-		"replica count should be %d after a minute", expectedReplicaCountNumber)
+		"replica count should be %d after 1 minute", expectedReplicaCountNumber)
 
 	t.Log("--- cleaning up ---")
 	deleteWSInput := amp.DeleteWorkspaceInput{

--- a/tests/scalers/beanstalkd/beanstalkd_test.go
+++ b/tests/scalers/beanstalkd/beanstalkd_test.go
@@ -183,7 +183,7 @@ func TestBeanstalkdScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, beanstalkdDeploymentName, testNamespace, 1, 60, 1),
-		"replica count should be 0 after a minute")
+		"replica count should be 0 after 1 minute")
 
 	// test activation
 	testActivation(t, kc, data)
@@ -245,7 +245,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	addBeanstalkdJobs(t, kc, &data)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 3, 60, 1),
-		"replica count should be 3 after a minute")
+		"replica count should be 3 after 1 minute")
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
@@ -263,5 +263,5 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	removeBeanstalkdJobs(t, kc, &data)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
-		"replica count should be 0 after a minute")
+		"replica count should be 0 after 1 minute")
 }

--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -100,7 +100,7 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
-		"replica count should be 1 after 1 minute")
+		"replica count should be 1 after 2 minute")
 
 	// test scaling
 	testScaleOut(t, kc)
@@ -126,11 +126,11 @@ func getTemplateData() (templateData, []Template) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 2),
-		"replica count should be 4 after 1 minute")
+		"replica count should be 4 after 2 minute")
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
-		"replica count should be 1 after 1 minute")
+		"replica count should be 1 after 2 minute")
 }

--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -126,11 +126,11 @@ func getTemplateData() (templateData, []Template) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 4, 60, 2),
-		"replica count should be 4 after 2 minute")
+		"replica count should be 4 after 2 minutes")
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
-		"replica count should be 1 after 2 minute")
+		"replica count should be 1 after 2 minutes")
 }

--- a/tests/scalers/datadog/datadog_api/datadog_api_test.go
+++ b/tests/scalers/datadog/datadog_api/datadog_api_test.go
@@ -272,7 +272,7 @@ func TestDatadogScalerAPI(t *testing.T) {
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+		"replica count should be %d after 9 minutes", minReplicaCount)
 
 	// test scaling
 	testActivation(t, kc, data)

--- a/tests/scalers/dynatrace/dynatrace_test.go
+++ b/tests/scalers/dynatrace/dynatrace_test.go
@@ -146,7 +146,7 @@ func TestDynatraceScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 1),
-		"replica count should be %s after a minute", minReplicaCount)
+		"replica count should be %s after 1 minute", minReplicaCount)
 
 	// test scaling
 	testActivation(t, kc)
@@ -167,7 +167,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	stopCh := make(chan struct{})
 	go setMetricValue(t, 10, stopCh)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
-		"replica count should be %d after 2 minutes", maxReplicaCount)
+		"replica count should be %d after 3 minutes", maxReplicaCount)
 	close(stopCh)
 }
 
@@ -177,7 +177,7 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	stopCh := make(chan struct{})
 	go setMetricValue(t, 0, stopCh)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
-		"replica count should be %d after 2 minutes", minReplicaCount)
+		"replica count should be %d after 3 minutes", minReplicaCount)
 	close(stopCh)
 }
 

--- a/tests/scalers/gcp/gcp_cloud_tasks/gcp_cloud_tasks_test.go
+++ b/tests/scalers/gcp/gcp_cloud_tasks/gcp_cloud_tasks_test.go
@@ -176,7 +176,7 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
-		"replica count should be 0 after a minute")
+		"replica count should be 0 after 1 minute")
 
 	sdkReady := WaitForDeploymentReplicaReadyCount(t, kc, "gcp-sdk", testNamespace, 1, 60, 1)
 	assert.True(t, sdkReady, "gcp-sdk deployment should be ready after a minute")
@@ -273,7 +273,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 30, 10),
-		fmt.Sprintf("replica count should be %d after five minutes", maxReplicaCount))
+		fmt.Sprintf("replica count should be %d after 5 minutes", maxReplicaCount))
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
@@ -284,5 +284,5 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale in to zero ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
-		"replica count should be 0 after five minute")
+		"replica count should be 0 after 5 minute")
 }

--- a/tests/scalers/gcp/gcp_cloud_tasks_workload_identity/gcp_cloud_tasks_workload_identity_test.go
+++ b/tests/scalers/gcp/gcp_cloud_tasks_workload_identity/gcp_cloud_tasks_workload_identity_test.go
@@ -186,10 +186,10 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
-		"replica count should be 0 after a minute")
+		"replica count should be 0 after 1 minute")
 
 	sdkReady := WaitForDeploymentReplicaReadyCount(t, kc, "gcp-sdk", testNamespace, 1, 60, 1)
-	assert.True(t, sdkReady, "gcp-sdk deployment should be ready after a minute")
+	assert.True(t, sdkReady, "gcp-sdk deployment should be ready after 1 minute")
 
 	if sdkReady {
 		if createGcpCloudTasks(t) == nil {
@@ -284,7 +284,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 30, 10),
-		fmt.Sprintf("replica count should be %d after five minutes", maxReplicaCount))
+		fmt.Sprintf("replica count should be %d after 5 minutes", maxReplicaCount))
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
@@ -295,5 +295,5 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale in to zero ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
-		"replica count should be 0 after five minute")
+		"replica count should be 0 after 5 minute")
 }

--- a/tests/scalers/gcp/gcp_cloud_tasks_workload_identity/gcp_cloud_tasks_workload_identity_test.go
+++ b/tests/scalers/gcp/gcp_cloud_tasks_workload_identity/gcp_cloud_tasks_workload_identity_test.go
@@ -295,5 +295,5 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale in to zero ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
-		"replica count should be 0 after 5 minute")
+		"replica count should be 0 after 5 minutes")
 }

--- a/tests/scalers/gcp/gcp_prometheus_workload_identity/gcp_prometheus_workload_identity_test.go
+++ b/tests/scalers/gcp/gcp_prometheus_workload_identity/gcp_prometheus_workload_identity_test.go
@@ -122,7 +122,7 @@ func TestScaler(t *testing.T) {
 	t.Log("--- assert ---")
 	expectedReplicaCountNumber := 2 // as mentioned above, as the GMP returns 100 and the threshold set to 50, the expected replica count is 100 / 50 = 2
 	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, expectedReplicaCountNumber, 60, 1),
-		"replica count should be %d after a minute", expectedReplicaCountNumber)
+		"replica count should be %d after 1 minute", expectedReplicaCountNumber)
 
 	t.Log("--- cleaning up ---")
 	DeleteKubernetesResources(t, testNamespace, data, templates)

--- a/tests/scalers/gcp/gcp_pubsub/gcp_pubsub_test.go
+++ b/tests/scalers/gcp/gcp_pubsub/gcp_pubsub_test.go
@@ -293,5 +293,5 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale in to zero ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
-		"replica count should be 0 after 5 minute")
+		"replica count should be 0 after 5 minutes")
 }

--- a/tests/scalers/gcp/gcp_pubsub/gcp_pubsub_test.go
+++ b/tests/scalers/gcp/gcp_pubsub/gcp_pubsub_test.go
@@ -178,7 +178,7 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
-		"replica count should be 0 after a minute")
+		"replica count should be 0 after 1 minute")
 
 	sdkReady := WaitForDeploymentReplicaReadyCount(t, kc, "gcp-sdk", testNamespace, 1, 60, 1)
 	assert.True(t, sdkReady, "gcp-sdk deployment should be ready after a minute")
@@ -282,7 +282,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale out ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 30, 10),
-		fmt.Sprintf("replica count should be %d after five minutes", maxReplicaCount))
+		fmt.Sprintf("replica count should be %d after 5 minutes", maxReplicaCount))
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
@@ -293,5 +293,5 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- waiting for replicas to scale in to zero ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 30, 10),
-		"replica count should be 0 after five minute")
+		"replica count should be 0 after 5 minute")
 }

--- a/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
+++ b/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
@@ -131,24 +131,24 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 5, 60, 2),
-		"replica count should be 5 after 2 minute")
+		"replica count should be 5 after 2 minutes")
 
 	// scale monitored deployment to 10 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 10, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 10, 60, 2),
-		"replica count should be 10 after 2 minute")
+		"replica count should be 10 after 2 minutes")
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 5, 60, 2),
-		"replica count should be 5 after 2 minute")
+		"replica count should be 5 after 2 minutes")
 
 	// scale monitored deployment to 0 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 0, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 0, 60, 2),
-		"replica count should be 0 after 2 minute")
+		"replica count should be 0 after 2 minutes")
 }
 
 func getTemplateData() (templateData, []Template) {

--- a/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
+++ b/tests/scalers/kubernetes_workload/kubernetes_workload_test.go
@@ -131,24 +131,24 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 5, 60, 2),
-		"replica count should be 5 after 1 minute")
+		"replica count should be 5 after 2 minute")
 
 	// scale monitored deployment to 10 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 10, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 10, 60, 2),
-		"replica count should be 10 after 1 minute")
+		"replica count should be 10 after 2 minute")
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 5 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 5, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 5, 60, 2),
-		"replica count should be 5 after 1 minute")
+		"replica count should be 5 after 2 minute")
 
 	// scale monitored deployment to 0 replicas
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 0, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, sutDeploymentName, testNamespace, 0, 60, 2),
-		"replica count should be 0 after 1 minute")
+		"replica count should be 0 after 2 minute")
 }
 
 func getTemplateData() (templateData, []Template) {

--- a/tests/scalers/metrics_api/metrics_api_test.go
+++ b/tests/scalers/metrics_api/metrics_api_test.go
@@ -194,7 +194,7 @@ func TestScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+		"replica count should be %d after 9 minutes", minReplicaCount)
 
 	// test scaling
 	testActivation(t, kc, data)

--- a/tests/scalers/mysql/mysql_test.go
+++ b/tests/scalers/mysql/mysql_test.go
@@ -291,9 +291,9 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale in ---")
-	// Check if deployment scale in to 0 after 5 minutes
+	// Check if deployment scale in to 0 after 6 minutes
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 360, 1),
-		"Replica count should be 0 after 5 minutes")
+		"Replica count should be 0 after 6 minutes")
 }
 
 func getTemplateData() (templateData, []Template) {

--- a/tests/scalers/redis/redis_standalone_streams_lag/redis_standalone_streams_lag_test.go
+++ b/tests/scalers/redis/redis_standalone_streams_lag/redis_standalone_streams_lag_test.go
@@ -208,12 +208,12 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData, num
 	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicas, 60, 1),
-		"replica count should be %d after 3 minutes", maxReplicaCount)
+		"replica count should be %d after 1 minutes", maxReplicaCount)
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, minReplicas int) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicas, 60, 1),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+		"replica count should be %d after 1 minutes", minReplicaCount)
 }
 
 func testActivationValue(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int) {

--- a/tests/scalers/redis/redis_standalone_streams_lag/redis_standalone_streams_lag_test.go
+++ b/tests/scalers/redis/redis_standalone_streams_lag/redis_standalone_streams_lag_test.go
@@ -208,12 +208,12 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData, num
 	KubectlReplaceWithTemplate(t, data, "insertJobTemplate", insertJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicas, 60, 1),
-		"replica count should be %d after 1 minutes", maxReplicaCount)
+		"replica count should be %d after 1 minute", maxReplicaCount)
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, minReplicas int) {
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicas, 60, 1),
-		"replica count should be %d after 1 minutes", minReplicaCount)
+		"replica count should be %d after 1 minute", minReplicaCount)
 }
 
 func testActivationValue(t *testing.T, kc *kubernetes.Clientset, data templateData, numMessages int) {

--- a/tests/scalers/splunk/splunk_test.go
+++ b/tests/scalers/splunk/splunk_test.go
@@ -232,11 +232,11 @@ func TestSplunkScaler(t *testing.T) {
 
 	// Wait for splunk to start
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, "splunk", testNamespace, 1, 180, 3),
-		"replica count should be %d after 3 minutes", 1)
+		"replica count should be %d after 9 minutes", 1)
 
 	// Ensure nginx deployment is at min replica count
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+		"replica count should be %d after 9 minutes", minReplicaCount)
 
 	// test scaling
 	testActivation(t, kc)

--- a/tests/scalers/sumologic/sumologic_test.go
+++ b/tests/scalers/sumologic/sumologic_test.go
@@ -172,7 +172,7 @@ func TestSumologicScaler(t *testing.T) {
 
 	// Ensure deployment is at min replica count
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+		"replica count should be %d after 9 minutes", minReplicaCount)
 
 	// Test scaling
 	testActivation(t, kc)

--- a/tests/secret-providers/trigger_auth_bound_service_account_token/trigger_auth_bound_service_account_token_test.go
+++ b/tests/secret-providers/trigger_auth_bound_service_account_token/trigger_auth_bound_service_account_token_test.go
@@ -344,7 +344,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, maxReplicaCount),
-		"replica count should be %d after 3 minutes", maxReplicaCount)
+		"replica count should be %d after 1 minutes", maxReplicaCount)
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/secret-providers/trigger_auth_bound_service_account_token/trigger_auth_bound_service_account_token_test.go
+++ b/tests/secret-providers/trigger_auth_bound_service_account_token/trigger_auth_bound_service_account_token_test.go
@@ -344,7 +344,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, maxReplicaCount),
-		"replica count should be %d after 1 minutes", maxReplicaCount)
+		"replica count should be %d after 1 minute", maxReplicaCount)
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {

--- a/tests/sequential/datadog_dca/datadog_dca_test.go
+++ b/tests/sequential/datadog_dca/datadog_dca_test.go
@@ -356,7 +356,7 @@ func TestDatadogScalerDCA(t *testing.T) {
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 180, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+		"replica count should be %d after 9 minutes", minReplicaCount)
 
 	// test scaling
 	testActivation(t, kc, data)


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Updated test logs to reflect the amount of time the assertion actually takes, only changed the ones using https://github.com/kedacore/keda/blob/main/tests/helper/helper.go#L466

Time for the assertion to fail is `iterations * intervalSeconds`
NOTE: no test changed, only the logging. Because of this Im not sure if most of the checklist bellow make sense for this PR
### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #6972

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
