### PR TITLE
fix: parse timeout config as milliseconds instead of seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Add missing omitempty json tags in the AuthPodIdentity struct ([#6779](https://github.com/kedacore/keda/issues/6779))
+- **General**: Fix parse timeout config as milliseconds instead of seconds ([#6997](https://github.com/kedacore/keda/pull/6997))
 - **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **General**: Remove klogr dependency and replace with zap ([#5732](https://github.com/kedacore/keda/issues/5732))
 - **General**: Sets hpaName in Status when ScaledObject adopts/finds an existing HPA ([#6336](https://github.com/kedacore/keda/issues/6336))

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -82,7 +82,7 @@ func NewPrometheusScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	// handle HTTP client timeout
 	httpClientTimeout := config.GlobalHTTPTimeout
 	if meta.Timeout > 0 {
-		httpClientTimeout = meta.Timeout * time.Millisecond
+		httpClientTimeout = meta.Timeout
 	}
 
 	httpClient := kedautil.CreateHTTPClient(httpClientTimeout, meta.UnsafeSSL)

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -259,7 +259,7 @@ func NewRabbitMQScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 
 	timeout := config.GlobalHTTPTimeout
 	if s.metadata.Timeout != 0 {
-		timeout = s.metadata.Timeout * time.Millisecond
+		timeout = s.metadata.Timeout
 	}
 
 	s.httpClient = kedautil.CreateHTTPClient(timeout, meta.UnsafeSsl)

--- a/pkg/scalers/scalersconfig/typed_config.go
+++ b/pkg/scalers/scalersconfig/typed_config.go
@@ -404,15 +404,15 @@ func setConfigValueHelper(params Params, valFromConfig string, field reflect.Val
 			field.Set(reflect.ValueOf(duration))
 			return nil
 		}
-		// If that fails, interpret as number of seconds
-		seconds, err := strconv.ParseInt(valFromConfig, 10, 64)
+		// If that fails, interpret as number of milliseconds
+		milliseconds, err := strconv.ParseInt(valFromConfig, 10, 64)
 		if err != nil {
-			return fmt.Errorf("unable to parse duration value %q: must be either a duration string (e.g. '30s', '5m') or a number of seconds", valFromConfig)
+			return fmt.Errorf("unable to parse duration value %q: must be either a duration string (e.g. '30s', '5m') or a number of milliseconds", valFromConfig)
 		}
-		if seconds < 0 {
-			return fmt.Errorf("duration cannot be negative: %d seconds", seconds)
+		if milliseconds < 0 {
+			return fmt.Errorf("duration cannot be negative: %d milliseconds", milliseconds)
 		}
-		field.Set(reflect.ValueOf(time.Duration(seconds) * time.Second))
+		field.Set(reflect.ValueOf(time.Duration(milliseconds) * time.Millisecond))
 		return nil
 	}
 	if field.Type() == reflect.TypeOf(url.Values{}) {

--- a/pkg/scalers/scalersconfig/typed_config_test.go
+++ b/pkg/scalers/scalersconfig/typed_config_test.go
@@ -637,7 +637,7 @@ func TestDurationParsing(t *testing.T) {
 	Expect(ts.TimeoutDuration).To(Equal(30 * time.Second))
 	Expect(ts.TimeoutZero).To(Equal(0 * time.Millisecond))
 }
-    
+
 // TestUnexpectedOptional tests the unexpected optional input
 func TestUnexpectedOptional(t *testing.T) {
 	RegisterTestingT(t)

--- a/pkg/scalers/scalersconfig/typed_config_test.go
+++ b/pkg/scalers/scalersconfig/typed_config_test.go
@@ -19,6 +19,7 @@ package scalersconfig
 import (
 	"net/url"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -608,6 +609,33 @@ func TestMultiName(t *testing.T) {
 	err = sc2.TypedConfig(&ts)
 	Expect(err).To(BeNil())
 	Expect(ts.Property).To(Equal("bbb"))
+}
+
+// TestDurationParsing tests the time.Duration parsing for both string and numeric values
+func TestDurationParsing(t *testing.T) {
+	RegisterTestingT(t)
+
+	sc := &ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"timeoutNumeric":  "1000", // milliseconds as number
+			"timeoutDuration": "30s",  // duration string
+			"timeoutZero":     "0",    // edge case
+		},
+	}
+
+	type testStruct struct {
+		TimeoutNumeric  time.Duration `keda:"name=timeoutNumeric,  order=triggerMetadata"`
+		TimeoutDuration time.Duration `keda:"name=timeoutDuration, order=triggerMetadata"`
+		TimeoutZero     time.Duration `keda:"name=timeoutZero,     order=triggerMetadata"`
+	}
+
+	ts := testStruct{}
+	err := sc.TypedConfig(&ts)
+	Expect(err).To(BeNil())
+
+	Expect(ts.TimeoutNumeric).To(Equal(1000 * time.Millisecond))
+	Expect(ts.TimeoutDuration).To(Equal(30 * time.Second))
+	Expect(ts.TimeoutZero).To(Equal(0 * time.Millisecond))
 }
 
 // MockEventRecorder is a mock implementation of record.EventRecorder


### PR DESCRIPTION
When refactoring the `Timeout` field from `int` to `time.Duration` (#6650), the parsing logic incorrectly interprets numeric configuration values as seconds instead of milliseconds. This changes the behavior of existing timeout configurations.

Thanks @arapulido for informing me about this issue.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
