### PR TITLE
chore: use ARM64 machine to build e2e test images

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -69,7 +69,7 @@ jobs:
 
   build-test-images:
     needs: triage
-    runs-on: ubuntu-latest
+    runs-on: ARM64
     name: Build images
     container: ghcr.io/kedacore/keda-tools:1.23.8
     if: needs.triage.outputs.run-e2e == 'true'


### PR DESCRIPTION
As we are building images for (PR) e2e tests using buildx to test also ARM64 and s390x arch, this PR changes the runner that we use to generate the images because the ARM64 runner is significantly more powerful than the GH hosted runner for AMD64. This should improve the generation time (I hope it so)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


