### PR TITLE
Allow specifying certificates for TLS communication between KEDA and external scalers

### DIFF
--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -59,6 +59,10 @@ mauSvQwA0SRKECr46F8dSeFE1uIbN4ZNgrisBTVkoPYZuF7pAsSsjqGM0phUKiI8
 -----END CERTIFICATE-----
 `
 
+var clientCaPath = "/etc/tls/ca.crt"
+var clientCertPath = "/etc/tls/tls.crt"
+var clientKeyPath = "/etc/tls/tls.key"
+
 type parseExternalScalerMetadataTestData struct {
 	metadata   map[string]string
 	isError    bool
@@ -67,8 +71,10 @@ type parseExternalScalerMetadataTestData struct {
 
 var testExternalScalerMetadata = []parseExternalScalerMetadataTestData{
 	{map[string]string{}, true, map[string]string{}},
-	// all properly formed
+	// all properly formed 1
 	{map[string]string{"scalerAddress": "myservice", "test1": "7", "test2": "SAMPLE_CREDS", "enableTLS": "true", "insecureSkipVerify": "true"}, false, map[string]string{"caCert": serverRootCA, "tlsClientCert": clientCert}},
+	// all properly formed 2
+	{map[string]string{"scalerAddress": "myservice", "enableTLS": "true", "insecureSkipVerify": "true"}, false, map[string]string{"caCertFile": clientCaPath, "tlsClientCertFile": clientCertPath, "tlsClientKeyFile": clientKeyPath}},
 	// missing scalerAddress
 	{map[string]string{"test1": "1", "test2": "SAMPLE_CREDS"}, true, map[string]string{}},
 }

--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/youmark/pkcs8"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kedacore/keda/v2/pkg/metricsservice/utils"
 )
 
 var minTLSVersion uint16
@@ -71,6 +74,13 @@ func NewTLSConfigWithPassword(clientCert, clientKey, clientKeyPassword, caCert s
 // and CA certificate. If none are appropriate, a nil *tls.Config is returned.
 func NewTLSConfig(clientCert, clientKey, caCert string, unsafeSsl bool) (*tls.Config, error) {
 	return NewTLSConfigWithPassword(clientCert, clientKey, "", caCert, unsafeSsl)
+}
+
+// NewTLSConfigFromFiles returns a *tls.Config using the given the paths to key, cert and ca cert. If caCertPem is not empty,
+// the cert will be loaded from this in-memory representation, otherwise the caCertFile file will be tried.
+// If none are appropriate, a nil *tls.Config is returned.
+func NewTLSConfigFromFiles(clientCertFile, clientKeyFile, caCertFile string, unsafeSsl bool) (*tls.Config, error) {
+	return utils.LoadGrpcTLSConfig(context.Background(), caCertFile, clientCertFile, clientKeyFile, false, unsafeSsl)
 }
 
 // CreateTLSClientConfig returns a new TLS Config


### PR DESCRIPTION
Certs for triggers that use external scaler pattern can be provided as file paths inside the ScaledObject's definition. These should be mounted and accessible by KEDA. It uses the prepared infrastructure that reloads the certs if there is a change on FS (fsnotify).

Ideally, I'd rename the existing fields from `caCert`, `tlsClientCert` and `tlsClientKey` to `caCertPem`, `tlsClientKeyPem` and `tlsClientKeyPem`, so it's the same nomenclature as in [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md), but this would break the backward compatibility. So there are 3 new fields called:
- `caCertFile`
- `tlsClientCertFile`
- `tlsClientKeyFile`

Also if both sets of params are specified, the in-memory ones (`caCert`..) win.

todo:
- [ ] create issue
- [ ] tests
- [ ] remove this todo ;)