### PR TITLE
fix: resolve race condition when removing paused-replicas annotation from ScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix parse timeout config as milliseconds instead of seconds ([#6997](https://github.com/kedacore/keda/pull/6997))
 - **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **General**: Remove klogr dependency and replace with zap ([#5732](https://github.com/kedacore/keda/issues/5732))
+- **General**: Resolve race condition when removing paused-replicas annotation from ScaledObject ([#6982](https://github.com/kedacore/keda/issues/6982))
 - **General**: Sets hpaName in Status when ScaledObject adopts/finds an existing HPA ([#6336](https://github.com/kedacore/keda/issues/6336))
 - **Cron Scaler**: Fix cron scaler to return zero metric value by default([#6886](https://github.com/kedacore/keda/issues/6886))
 - **RabbitMQ Scaler**: Fix incorrect URL encoding in RabbitMQ vhosts containing %2f ([#6963](https://github.com/kedacore/keda/issues/6963))

--- a/apis/keda/v1alpha1/scaledobject_types.go
+++ b/apis/keda/v1alpha1/scaledobject_types.go
@@ -211,11 +211,6 @@ func (so *ScaledObject) GenerateIdentifier() string {
 	return GenerateIdentifier("ScaledObject", so.Namespace, so.Name)
 }
 
-func (so *ScaledObject) HasPausedReplicaAnnotation() bool {
-	_, pausedReplicasAnnotationFound := so.GetAnnotations()[PausedReplicasAnnotation]
-	return pausedReplicasAnnotationFound
-}
-
 // HasPausedAnnotation returns whether this ScaledObject has PausedAnnotation or PausedReplicasAnnotation
 func (so *ScaledObject) HasPausedAnnotation() bool {
 	_, pausedAnnotationFound := so.GetAnnotations()[PausedAnnotation]
@@ -227,7 +222,7 @@ func (so *ScaledObject) HasPausedAnnotation() bool {
 func (so *ScaledObject) NeedToBePausedByAnnotation() bool {
 	_, pausedReplicasAnnotationFound := so.GetAnnotations()[PausedReplicasAnnotation]
 	if pausedReplicasAnnotationFound {
-		return so.Status.PausedReplicaCount != nil
+		return true
 	}
 
 	pausedAnnotationValue, pausedAnnotationFound := so.GetAnnotations()[PausedAnnotation]

--- a/apis/keda/v1alpha1/scaledobject_types_test.go
+++ b/apis/keda/v1alpha1/scaledobject_types_test.go
@@ -290,44 +290,6 @@ func TestCheckFallbackValid(t *testing.T) {
 	}
 }
 
-func TestHasPausedReplicaAnnotation(t *testing.T) {
-	tests := []struct {
-		name         string
-		annotations  map[string]string
-		expectResult bool
-	}{
-		{
-			name:         "No annotations",
-			annotations:  nil,
-			expectResult: false,
-		},
-		{
-			name:         "Has PausedReplicasAnnotation",
-			annotations:  map[string]string{PausedReplicasAnnotation: "5"},
-			expectResult: true,
-		},
-		{
-			name:         "Has other annotations but not PausedReplicasAnnotation",
-			annotations:  map[string]string{"some-other-annotation": "value"},
-			expectResult: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			so := &ScaledObject{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: test.annotations,
-				},
-			}
-			result := so.HasPausedReplicaAnnotation()
-			if result != test.expectResult {
-				t.Errorf("Expected HasPausedReplicaAnnotation to return %v, got %v", test.expectResult, result)
-			}
-		})
-	}
-}
-
 func TestHasPausedAnnotation(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -419,13 +381,19 @@ func TestNeedToBePausedByAnnotation(t *testing.T) {
 			name:               "PausedReplicasAnnotation with value but no status set",
 			annotations:        map[string]string{PausedReplicasAnnotation: "5"},
 			pausedReplicaCount: nil,
-			expectResult:       false,
+			expectResult:       true,
 		},
 		{
 			name:               "Both annotations set",
 			annotations:        map[string]string{PausedAnnotation: "true", PausedReplicasAnnotation: "5"},
 			pausedReplicaCount: &pausedReplicaCount,
 			expectResult:       true, // PausedReplicasAnnotation has precedence
+		},
+		{
+			name:               "Both annotations set, PausedAnnotation false",
+			annotations:        map[string]string{PausedAnnotation: "false", PausedReplicasAnnotation: "5"},
+			pausedReplicaCount: &pausedReplicaCount,
+			expectResult:       true,
 		},
 	}
 

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -311,7 +311,7 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(ctx context.Context, logg
 		}
 		logger.Info("Initializing Scaling logic according to ScaledObject Specification")
 	}
-	if scaledObject.HasPausedReplicaAnnotation() && conditions.GetPausedCondition().Status != metav1.ConditionTrue {
+	if scaledObject.NeedToBePausedByAnnotation() && conditions.GetPausedCondition().Status != metav1.ConditionTrue {
 		return "ScaledObject paused replicas are being scaled", fmt.Errorf("ScaledObject paused replicas are being scaled")
 	}
 	return kedav1alpha1.ScaledObjectConditionReadySuccessMessage, nil


### PR DESCRIPTION
There is race condition when removing the `autoscaling.keda.sh/paused-replicas` annotation. The ScaledObject sometimes remains `Paused=True`, even though the annotation is gone. `NeedToBePausedByAnnotation()` checked `Status.PausedReplicaCount` instead of just annotation presence.

I have modified the `NeedToBePausedByAnnotation()` to check only annotation, not status. Also removed the unnecessary `HasPausedReplicaAnnotation()` function.

I have also changed the test. The "old" `NeedToBePausedByAnnotation()` implementation checked both annotation presence and status field. The "new" implementation only checks annotation presence.
The test case previously expected `false` because the annotation existed but the status field was nil. Now it correctly returns `true` because the annotation represents the desired state. If the annotation is present, the ScaledObject should be paused regardless of current status. This fixes the race condition where status updates lagged behind annotation changes, causing ScaledObjects to get stuck in incorrect pause states.



### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6982