### PR TITLE
WIP: Do Not Merge - Issue #6986

### DIFF
--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -82,9 +82,11 @@ func (c *ScalersCache) GetPushScalers() []scalers.PushScaler {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	var result []scalers.PushScaler
-	for _, s := range c.Scalers {
-		if ps, ok := s.Scaler.(scalers.PushScaler); ok {
-			result = append(result, ps)
+	if !c.ScaledObject.IsUsingModifiers() {
+		for _, s := range c.Scalers {
+			if ps, ok := s.Scaler.(scalers.PushScaler); ok {
+				result = append(result, ps)
+			}
 		}
 	}
 	return result

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -82,11 +82,9 @@ func (c *ScalersCache) GetPushScalers() []scalers.PushScaler {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	var result []scalers.PushScaler
-	if !c.ScaledObject.IsUsingModifiers() {
-		for _, s := range c.Scalers {
-			if ps, ok := s.Scaler.(scalers.PushScaler); ok {
-				result = append(result, ps)
-			}
+	for _, s := range c.Scalers {
+		if ps, ok := s.Scaler.(scalers.PushScaler); ok {
+			result = append(result, ps)
 		}
 	}
 	return result


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
WIP, not to merge

This PR is to propose another way of solving the scale to 0 issue presented in #6986. The main point for this proposal is to not to change the GetPushScalers function, given that as a global function it might be used in other places in codebase and might affect functionality then. Instead, I propose to validate the scalingmodifiers cases inside the for loop in the goroutine, and each time and activeCh is triggered, it could evaluate the formula. Additionally, it might be good to consider the break task in the "active" conditional given that it might break in scaling from 0 scenarios.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #6986
