### PR TITLE
fix: Resolve nil pointer dereference in Pulsar scaler redirect handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Sets hpaName in Status when ScaledObject adopts/finds an existing HPA ([#6336](https://github.com/kedacore/keda/issues/6336))
 - **Cron Scaler**: Fix cron scaler to return zero metric value by default([#6886](https://github.com/kedacore/keda/issues/6886))
 - **Hashicorp Vault**: Fix Vault PKI param using camel case param when making API call to Vault PKI endpoint ([#6864](https://github.com/kedacore/keda/issues/6864))
+- **Pulsar Scaler**: Resolve nil pointer dereference in Pulsar scaler redirect handling ([#7024](https://github.com/kedacore/keda/issues/7024))
 - **RabbitMQ Scaler**: Fix incorrect URL encoding in RabbitMQ vhosts containing %2f ([#6963](https://github.com/kedacore/keda/issues/6963))
 
 ### Deprecations

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -192,7 +192,7 @@ func NewPulsarScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 		if pulsarMetadata.pulsarAuth.EnableBearerAuth || pulsarMetadata.pulsarAuth.EnableBasicAuth {
 			// The pulsar broker redirects HTTP calls to other brokers and expects the Authorization header
 			client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-				if len(via) != 0 && via[0].Response.StatusCode == http.StatusTemporaryRedirect {
+				if len(via) != 0 && via[0] != nil && via[0].Response != nil && via[0].Response.StatusCode == http.StatusTemporaryRedirect {
 					addAuthHeaders(req, pulsarMetadata)
 				}
 				return nil


### PR DESCRIPTION
The Pulsar scaler crashes with a nil pointer dereference (when using Bearer or Basic authentication) in environments where the Pulsar broker sends HTTP redirects. This happens because the redirect handler tries to access the HTTP response status code without checking if the response object exists, causing the KEDA operator pods to restart.

This PR adding proper nil checks in the CheckRedirect function to verify that both the HTTP request and response objects exist before accessing the status code. This prevents the panic.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7024 
