### PR TITLE
fix: correctly count inactive jobs when pendingPodConditions not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Add missing omitempty json tags in the AuthPodIdentity struct ([#6779](https://github.com/kedacore/keda/issues/6779))
 - **General**: Correct pending pod condition logic for ScaledJobs ([#6727](https://github.com/kedacore/keda/issues/6727))
+- **General**: Correctly count inactive jobs when pendingPodConditions not set for ScaledJobs ([#6157](https://github.com/kedacore/keda/issues/6157))
 - **General**: Fix parse timeout config as milliseconds instead of seconds ([#6997](https://github.com/kedacore/keda/pull/6997))
 - **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **General**: Fix SIGSEGV when doing fallback of non-static behavior on any ScaleTargetRef that is neither a Deployment nor a StatefulSet ([#6992](https://github.com/kedacore/keda/pull/6992))


### PR DESCRIPTION
This PR fixes duplicate job creation in ScaledJobs with `accurate` scaling strategy when `pendingPodConditions` is not configured.

Jobs with pods in `PodPending` state were incorrectly counted as "pending jobs", causing the accurate scaling strategy to create duplicate jobs during pod startup delays. I have modified the job counting logic to consider jobs with `PodPending` pods as active. Also renamed `pendingJobCount` to `inactiveJobCount` for semantic clarity. Jobs are now only considered "inactive" if they haven't started.

Good to know now:
- Function `pendingJobCount` parameter renamed to `inactiveJobCount`
- Log messages now show "inactive jobs" instead of "pending jobs"

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6157
