### PR TITLE
Add gRPC service that allows subscribing to a raw metric values for given ns,SO&triggerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ New deprecation(s):
 
 ### Other
 
+- **General**: Add gRPC service that allows subscribing to a raw metric values ([#7094](https://github.com/kedacore/keda/issues/7094))
 - **General**: Bump Controller Runtime version to v0.20.4 ([#7081](https://github.com/kedacore/keda/pull/7081))
 - **General**: Fix several typos ([#6909](https://github.com/kedacore/keda/pull/6909))
 - **General**: Replace deprecated webhook.Validator with webhook.CustomValidator ([#6660](https://github.com/kedacore/keda/issues/6660))

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-HAS_GOLANGCI_VERSION:=$(shell $(GOPATH)/bin/golangci-lint version --format=short)
+HAS_GOLANGCI_VERSION:=$(shell $(GOPATH)/bin/golangci-lint version --short)
 .PHONY: golangci
 golangci: ## Run golangci against code.
 ifneq ($(HAS_GOLANGCI_VERSION), $(GOLANGCI_VERSION))

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -109,7 +109,8 @@ func (a *Adapter) makeProvider(ctx context.Context) (provider.ExternalMetricsPro
 	}
 
 	setupLog.Info("Connecting Metrics Service gRPC client to the server", "address", metricsServiceAddr)
-	grpcClient, err := metricsservice.NewGrpcClient(ctx, metricsServiceAddr, a.SecureServing.ServerCert.CertDirectory, metricsServiceGRPCAuthority, clientMetrics)
+	defaultConnectionCfg := ""
+	grpcClient, err := metricsservice.NewGrpcClient(ctx, metricsServiceAddr, a.SecureServing.ServerCert.CertDirectory, metricsServiceGRPCAuthority, defaultConnectionCfg, clientMetrics, false)
 	if err != nil {
 		setupLog.Error(err, "error connecting Metrics Service gRPC client to the server", "address", metricsServiceAddr)
 		return nil, err

--- a/pkg/metricsservice/api/metrics.pb.go
+++ b/pkg/metricsservice/api/metrics.pb.go
@@ -24,6 +24,7 @@ package api
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	v1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 	reflect "reflect"
 	sync "sync"
@@ -97,20 +98,296 @@ func (x *ScaledObjectRef) GetMetricName() string {
 	return ""
 }
 
+type RawMetricsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Subscriber    string                 `protobuf:"bytes,1,opt,name=subscriber,proto3" json:"subscriber,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RawMetricsRequest) Reset() {
+	*x = RawMetricsRequest{}
+	mi := &file_metrics_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RawMetricsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RawMetricsRequest) ProtoMessage() {}
+
+func (x *RawMetricsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_metrics_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RawMetricsRequest.ProtoReflect.Descriptor instead.
+func (*RawMetricsRequest) Descriptor() ([]byte, []int) {
+	return file_metrics_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RawMetricsRequest) GetSubscriber() string {
+	if x != nil {
+		return x.Subscriber
+	}
+	return ""
+}
+
+type SubscriptionRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Subscriber     string                 `protobuf:"bytes,1,opt,name=subscriber,proto3" json:"subscriber,omitempty"`
+	MetricMetadata *ScaledObjectRef       `protobuf:"bytes,2,opt,name=metricMetadata,proto3" json:"metricMetadata,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SubscriptionRequest) Reset() {
+	*x = SubscriptionRequest{}
+	mi := &file_metrics_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscriptionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscriptionRequest) ProtoMessage() {}
+
+func (x *SubscriptionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_metrics_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscriptionRequest.ProtoReflect.Descriptor instead.
+func (*SubscriptionRequest) Descriptor() ([]byte, []int) {
+	return file_metrics_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *SubscriptionRequest) GetSubscriber() string {
+	if x != nil {
+		return x.Subscriber
+	}
+	return ""
+}
+
+func (x *SubscriptionRequest) GetMetricMetadata() *ScaledObjectRef {
+	if x != nil {
+		return x.MetricMetadata
+	}
+	return nil
+}
+
+type SubscriptionAck struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	WasSubscribed bool                   `protobuf:"varint,1,opt,name=wasSubscribed,proto3" json:"wasSubscribed,omitempty"`
+	Message       *string                `protobuf:"bytes,2,opt,name=message,proto3,oneof" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SubscriptionAck) Reset() {
+	*x = SubscriptionAck{}
+	mi := &file_metrics_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscriptionAck) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscriptionAck) ProtoMessage() {}
+
+func (x *SubscriptionAck) ProtoReflect() protoreflect.Message {
+	mi := &file_metrics_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscriptionAck.ProtoReflect.Descriptor instead.
+func (*SubscriptionAck) Descriptor() ([]byte, []int) {
+	return file_metrics_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *SubscriptionAck) GetWasSubscribed() bool {
+	if x != nil {
+		return x.WasSubscribed
+	}
+	return false
+}
+
+func (x *SubscriptionAck) GetMessage() string {
+	if x != nil && x.Message != nil {
+		return *x.Message
+	}
+	return ""
+}
+
+type RawMetricsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Metrics       []*RawMetric           `protobuf:"bytes,1,rep,name=metrics,proto3" json:"metrics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RawMetricsResponse) Reset() {
+	*x = RawMetricsResponse{}
+	mi := &file_metrics_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RawMetricsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RawMetricsResponse) ProtoMessage() {}
+
+func (x *RawMetricsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_metrics_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RawMetricsResponse.ProtoReflect.Descriptor instead.
+func (*RawMetricsResponse) Descriptor() ([]byte, []int) {
+	return file_metrics_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *RawMetricsResponse) GetMetrics() []*RawMetric {
+	if x != nil {
+		return x.Metrics
+	}
+	return nil
+}
+
+type RawMetric struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Value         float64                `protobuf:"fixed64,1,opt,name=value,proto3" json:"value,omitempty"`
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Metadata      *ScaledObjectRef       `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RawMetric) Reset() {
+	*x = RawMetric{}
+	mi := &file_metrics_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RawMetric) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RawMetric) ProtoMessage() {}
+
+func (x *RawMetric) ProtoReflect() protoreflect.Message {
+	mi := &file_metrics_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RawMetric.ProtoReflect.Descriptor instead.
+func (*RawMetric) Descriptor() ([]byte, []int) {
+	return file_metrics_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *RawMetric) GetValue() float64 {
+	if x != nil {
+		return x.Value
+	}
+	return 0
+}
+
+func (x *RawMetric) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+func (x *RawMetric) GetMetadata() *ScaledObjectRef {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 var File_metrics_proto protoreflect.FileDescriptor
 
 const file_metrics_proto_rawDesc = "" +
 	"\n" +
-	"\rmetrics.proto\x12\x03api\x1a@k8s.io/metrics/pkg/apis/external_metrics/v1beta1/generated.proto\"c\n" +
+	"\rmetrics.proto\x12\x03api\x1a\x1fgoogle/protobuf/timestamp.proto\x1a@k8s.io/metrics/pkg/apis/external_metrics/v1beta1/generated.proto\"c\n" +
 	"\x0fScaledObjectRef\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
 	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x1e\n" +
 	"\n" +
 	"metricName\x18\x03 \x01(\tR\n" +
-	"metricName2\x81\x01\n" +
+	"metricName\"3\n" +
+	"\x11RawMetricsRequest\x12\x1e\n" +
+	"\n" +
+	"subscriber\x18\x01 \x01(\tR\n" +
+	"subscriber\"s\n" +
+	"\x13SubscriptionRequest\x12\x1e\n" +
+	"\n" +
+	"subscriber\x18\x01 \x01(\tR\n" +
+	"subscriber\x12<\n" +
+	"\x0emetricMetadata\x18\x02 \x01(\v2\x14.api.ScaledObjectRefR\x0emetricMetadata\"b\n" +
+	"\x0fSubscriptionAck\x12$\n" +
+	"\rwasSubscribed\x18\x01 \x01(\bR\rwasSubscribed\x12\x1d\n" +
+	"\amessage\x18\x02 \x01(\tH\x00R\amessage\x88\x01\x01B\n" +
+	"\n" +
+	"\b_message\">\n" +
+	"\x12RawMetricsResponse\x12(\n" +
+	"\ametrics\x18\x01 \x03(\v2\x0e.api.RawMetricR\ametrics\"\x8d\x01\n" +
+	"\tRawMetric\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\x01R\x05value\x128\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x120\n" +
+	"\bmetadata\x18\x03 \x01(\v2\x14.api.ScaledObjectRefR\bmetadata2\x81\x01\n" +
 	"\x0eMetricsService\x12o\n" +
 	"\n" +
-	"GetMetrics\x12\x14.api.ScaledObjectRef\x1aI.k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList\"\x00B\aZ\x05.;apib\x06proto3"
+	"GetMetrics\x12\x14.api.ScaledObjectRef\x1aI.k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList\"\x002\xeb\x01\n" +
+	"\x11RawMetricsService\x12J\n" +
+	"\x13GetRawMetricsStream\x12\x16.api.RawMetricsRequest\x1a\x17.api.RawMetricsResponse\"\x000\x01\x12C\n" +
+	"\x0fSubscribeMetric\x12\x18.api.SubscriptionRequest\x1a\x14.api.SubscriptionAck\"\x00\x12E\n" +
+	"\x11UnsubscribeMetric\x12\x18.api.SubscriptionRequest\x1a\x14.api.SubscriptionAck\"\x00B\aZ\x05.;apib\x06proto3"
 
 var (
 	file_metrics_proto_rawDescOnce sync.Once
@@ -124,19 +401,35 @@ func file_metrics_proto_rawDescGZIP() []byte {
 	return file_metrics_proto_rawDescData
 }
 
-var file_metrics_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_metrics_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_metrics_proto_goTypes = []any{
 	(*ScaledObjectRef)(nil),                 // 0: api.ScaledObjectRef
-	(*v1beta1.ExternalMetricValueList)(nil), // 1: k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList
+	(*RawMetricsRequest)(nil),               // 1: api.RawMetricsRequest
+	(*SubscriptionRequest)(nil),             // 2: api.SubscriptionRequest
+	(*SubscriptionAck)(nil),                 // 3: api.SubscriptionAck
+	(*RawMetricsResponse)(nil),              // 4: api.RawMetricsResponse
+	(*RawMetric)(nil),                       // 5: api.RawMetric
+	(*timestamppb.Timestamp)(nil),           // 6: google.protobuf.Timestamp
+	(*v1beta1.ExternalMetricValueList)(nil), // 7: k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList
 }
 var file_metrics_proto_depIdxs = []int32{
-	0, // 0: api.MetricsService.GetMetrics:input_type -> api.ScaledObjectRef
-	1, // 1: api.MetricsService.GetMetrics:output_type -> k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	0, // 0: api.SubscriptionRequest.metricMetadata:type_name -> api.ScaledObjectRef
+	5, // 1: api.RawMetricsResponse.metrics:type_name -> api.RawMetric
+	6, // 2: api.RawMetric.timestamp:type_name -> google.protobuf.Timestamp
+	0, // 3: api.RawMetric.metadata:type_name -> api.ScaledObjectRef
+	0, // 4: api.MetricsService.GetMetrics:input_type -> api.ScaledObjectRef
+	1, // 5: api.RawMetricsService.GetRawMetricsStream:input_type -> api.RawMetricsRequest
+	2, // 6: api.RawMetricsService.SubscribeMetric:input_type -> api.SubscriptionRequest
+	2, // 7: api.RawMetricsService.UnsubscribeMetric:input_type -> api.SubscriptionRequest
+	7, // 8: api.MetricsService.GetMetrics:output_type -> k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList
+	4, // 9: api.RawMetricsService.GetRawMetricsStream:output_type -> api.RawMetricsResponse
+	3, // 10: api.RawMetricsService.SubscribeMetric:output_type -> api.SubscriptionAck
+	3, // 11: api.RawMetricsService.UnsubscribeMetric:output_type -> api.SubscriptionAck
+	8, // [8:12] is the sub-list for method output_type
+	4, // [4:8] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_metrics_proto_init() }
@@ -144,15 +437,16 @@ func file_metrics_proto_init() {
 	if File_metrics_proto != nil {
 		return
 	}
+	file_metrics_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_metrics_proto_rawDesc), len(file_metrics_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   6,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   2,
 		},
 		GoTypes:           file_metrics_proto_goTypes,
 		DependencyIndexes: file_metrics_proto_depIdxs,

--- a/pkg/metricsservice/api/metrics.proto
+++ b/pkg/metricsservice/api/metrics.proto
@@ -19,14 +19,45 @@ syntax = "proto3";
 package api;
 option go_package = ".;api";
 
+import "google/protobuf/timestamp.proto";
 import "k8s.io/metrics/pkg/apis/external_metrics/v1beta1/generated.proto";
 
 service MetricsService {
     rpc GetMetrics (ScaledObjectRef) returns (k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList) {};
 }
 
+service RawMetricsService {
+    rpc GetRawMetricsStream (RawMetricsRequest) returns (stream RawMetricsResponse) {};
+    rpc SubscribeMetric (SubscriptionRequest) returns (SubscriptionAck) {};
+    rpc UnsubscribeMetric (SubscriptionRequest) returns (SubscriptionAck) {};
+}
+
 message ScaledObjectRef {
     string name = 1;
     string namespace = 2;
     string metricName = 3;
+}
+
+message RawMetricsRequest {
+    string subscriber = 1;
+}
+
+message SubscriptionRequest {
+    string subscriber = 1;
+    ScaledObjectRef metricMetadata = 2;
+}
+
+message SubscriptionAck {
+    bool wasSubscribed = 1;
+    optional string message = 2;
+}
+
+message RawMetricsResponse {
+    repeated RawMetric metrics = 1;
+}
+
+message RawMetric {
+    double value = 1;
+    google.protobuf.Timestamp timestamp = 2;
+    ScaledObjectRef metadata = 3;
 }

--- a/pkg/metricsservice/api/metrics_grpc.pb.go
+++ b/pkg/metricsservice/api/metrics_grpc.pb.go
@@ -135,3 +135,185 @@ var MetricsService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "metrics.proto",
 }
+
+const (
+	RawMetricsService_GetRawMetricsStream_FullMethodName = "/api.RawMetricsService/GetRawMetricsStream"
+	RawMetricsService_SubscribeMetric_FullMethodName     = "/api.RawMetricsService/SubscribeMetric"
+	RawMetricsService_UnsubscribeMetric_FullMethodName   = "/api.RawMetricsService/UnsubscribeMetric"
+)
+
+// RawMetricsServiceClient is the client API for RawMetricsService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+type RawMetricsServiceClient interface {
+	GetRawMetricsStream(ctx context.Context, in *RawMetricsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RawMetricsResponse], error)
+	SubscribeMetric(ctx context.Context, in *SubscriptionRequest, opts ...grpc.CallOption) (*SubscriptionAck, error)
+	UnsubscribeMetric(ctx context.Context, in *SubscriptionRequest, opts ...grpc.CallOption) (*SubscriptionAck, error)
+}
+
+type rawMetricsServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewRawMetricsServiceClient(cc grpc.ClientConnInterface) RawMetricsServiceClient {
+	return &rawMetricsServiceClient{cc}
+}
+
+func (c *rawMetricsServiceClient) GetRawMetricsStream(ctx context.Context, in *RawMetricsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RawMetricsResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &RawMetricsService_ServiceDesc.Streams[0], RawMetricsService_GetRawMetricsStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[RawMetricsRequest, RawMetricsResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RawMetricsService_GetRawMetricsStreamClient = grpc.ServerStreamingClient[RawMetricsResponse]
+
+func (c *rawMetricsServiceClient) SubscribeMetric(ctx context.Context, in *SubscriptionRequest, opts ...grpc.CallOption) (*SubscriptionAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SubscriptionAck)
+	err := c.cc.Invoke(ctx, RawMetricsService_SubscribeMetric_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *rawMetricsServiceClient) UnsubscribeMetric(ctx context.Context, in *SubscriptionRequest, opts ...grpc.CallOption) (*SubscriptionAck, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SubscriptionAck)
+	err := c.cc.Invoke(ctx, RawMetricsService_UnsubscribeMetric_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// RawMetricsServiceServer is the server API for RawMetricsService service.
+// All implementations must embed UnimplementedRawMetricsServiceServer
+// for forward compatibility.
+type RawMetricsServiceServer interface {
+	GetRawMetricsStream(*RawMetricsRequest, grpc.ServerStreamingServer[RawMetricsResponse]) error
+	SubscribeMetric(context.Context, *SubscriptionRequest) (*SubscriptionAck, error)
+	UnsubscribeMetric(context.Context, *SubscriptionRequest) (*SubscriptionAck, error)
+	mustEmbedUnimplementedRawMetricsServiceServer()
+}
+
+// UnimplementedRawMetricsServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedRawMetricsServiceServer struct{}
+
+func (UnimplementedRawMetricsServiceServer) GetRawMetricsStream(*RawMetricsRequest, grpc.ServerStreamingServer[RawMetricsResponse]) error {
+	return status.Errorf(codes.Unimplemented, "method GetRawMetricsStream not implemented")
+}
+func (UnimplementedRawMetricsServiceServer) SubscribeMetric(context.Context, *SubscriptionRequest) (*SubscriptionAck, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SubscribeMetric not implemented")
+}
+func (UnimplementedRawMetricsServiceServer) UnsubscribeMetric(context.Context, *SubscriptionRequest) (*SubscriptionAck, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UnsubscribeMetric not implemented")
+}
+func (UnimplementedRawMetricsServiceServer) mustEmbedUnimplementedRawMetricsServiceServer() {}
+func (UnimplementedRawMetricsServiceServer) testEmbeddedByValue()                           {}
+
+// UnsafeRawMetricsServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to RawMetricsServiceServer will
+// result in compilation errors.
+type UnsafeRawMetricsServiceServer interface {
+	mustEmbedUnimplementedRawMetricsServiceServer()
+}
+
+func RegisterRawMetricsServiceServer(s grpc.ServiceRegistrar, srv RawMetricsServiceServer) {
+	// If the following call pancis, it indicates UnimplementedRawMetricsServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&RawMetricsService_ServiceDesc, srv)
+}
+
+func _RawMetricsService_GetRawMetricsStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(RawMetricsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(RawMetricsServiceServer).GetRawMetricsStream(m, &grpc.GenericServerStream[RawMetricsRequest, RawMetricsResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type RawMetricsService_GetRawMetricsStreamServer = grpc.ServerStreamingServer[RawMetricsResponse]
+
+func _RawMetricsService_SubscribeMetric_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SubscriptionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RawMetricsServiceServer).SubscribeMetric(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RawMetricsService_SubscribeMetric_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RawMetricsServiceServer).SubscribeMetric(ctx, req.(*SubscriptionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RawMetricsService_UnsubscribeMetric_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SubscriptionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RawMetricsServiceServer).UnsubscribeMetric(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RawMetricsService_UnsubscribeMetric_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RawMetricsServiceServer).UnsubscribeMetric(ctx, req.(*SubscriptionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// RawMetricsService_ServiceDesc is the grpc.ServiceDesc for RawMetricsService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var RawMetricsService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "api.RawMetricsService",
+	HandlerType: (*RawMetricsServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "SubscribeMetric",
+			Handler:    _RawMetricsService_SubscribeMetric_Handler,
+		},
+		{
+			MethodName: "UnsubscribeMetric",
+			Handler:    _RawMetricsService_UnsubscribeMetric_Handler,
+		},
+	},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "GetRawMetricsStream",
+			Handler:       _RawMetricsService_GetRawMetricsStream_Handler,
+			ServerStreams: true,
+		},
+	},
+	Metadata: "metrics.proto",
+}

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -18,7 +18,9 @@ package metricsservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -33,11 +35,18 @@ import (
 )
 
 type GrpcClient struct {
-	client     api.MetricsServiceClient
-	connection *grpc.ClientConn
+	client           api.MetricsServiceClient
+	rawMetricsClient api.RawMetricsServiceClient
+	connection       *grpc.ClientConn
 }
 
-func NewGrpcClient(ctx context.Context, url, certDir, authority string, clientMetrics *grpcprom.ClientMetrics) (*GrpcClient, error) {
+type Measurement struct {
+	Name      string
+	Value     float64
+	Timestamp *time.Time
+}
+
+func NewGrpcClient(ctx context.Context, url, certDir, authority, confOptions string, clientMetrics *grpcprom.ClientMetrics, rawStream bool) (*GrpcClient, error) {
 	defaultConfig := `{
 		"methodConfig": [{
 		  "timeout": "3s",
@@ -49,6 +58,9 @@ func NewGrpcClient(ctx context.Context, url, certDir, authority string, clientMe
 			  "RetryableStatusCodes": [ "UNAVAILABLE" ]
 		  }
 		}]}`
+	if confOptions == "" {
+		confOptions = defaultConfig
+	}
 
 	creds, err := utils.LoadGrpcTLSCredentials(ctx, certDir, false)
 	if err != nil {
@@ -56,7 +68,7 @@ func NewGrpcClient(ctx context.Context, url, certDir, authority string, clientMe
 	}
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
-		grpc.WithDefaultServiceConfig(defaultConfig),
+		grpc.WithDefaultServiceConfig(confOptions),
 	}
 
 	opts = append(
@@ -76,8 +88,12 @@ func NewGrpcClient(ctx context.Context, url, certDir, authority string, clientMe
 	if err != nil {
 		return nil, err
 	}
+	grpcClient := GrpcClient{client: api.NewMetricsServiceClient(conn), connection: conn}
+	if rawStream {
+		grpcClient.rawMetricsClient = api.NewRawMetricsServiceClient(conn)
+	}
 
-	return &GrpcClient{client: api.NewMetricsServiceClient(conn), connection: conn}, nil
+	return &grpcClient, nil
 }
 
 func (c *GrpcClient) GetMetrics(ctx context.Context, scaledObjectName, scaledObjectNamespace, metricName string) (*external_metrics.ExternalMetricValueList, error) {
@@ -93,6 +109,108 @@ func (c *GrpcClient) GetMetrics(ctx context.Context, scaledObjectName, scaledObj
 	}
 
 	return extMetrics, nil
+}
+
+// Subscribe will create a subscription on KEDA side indicating that this particular metric (identified by SO's ns, SO's name and trigger name)
+// should be sent in the raw metric stream
+func (c *GrpcClient) Subscribe(ctx context.Context, subscriber, scaledObjectName, scaledObjectNamespace, metricName string) (bool, error) {
+	if c.rawMetricsClient == nil {
+		return false, errors.New("rawMetricsClient is not initialized, initialize the client using NewGrpcClient(...,true)")
+	}
+	req := &api.SubscriptionRequest{
+		Subscriber: subscriber,
+		MetricMetadata: &api.ScaledObjectRef{
+			Name:       scaledObjectName,
+			Namespace:  scaledObjectNamespace,
+			MetricName: metricName,
+		},
+	}
+	ack, err := c.rawMetricsClient.SubscribeMetric(ctx, req)
+	if err != nil {
+		return false, err
+	}
+	return ack.WasSubscribed, nil
+}
+
+// Unsubscribe cancels the subscription on KEDA side -> will stop sending the metric
+func (c *GrpcClient) Unsubscribe(ctx context.Context, subscriber, scaledObjectName, scaledObjectNamespace, metricName string) (bool, error) {
+	if c.rawMetricsClient == nil {
+		return false, errors.New("rawMetricsClient is not initialized, initialize the client using NewGrpcClient(...,true)")
+	}
+	req := &api.SubscriptionRequest{
+		Subscriber: subscriber,
+		MetricMetadata: &api.ScaledObjectRef{
+			Name:       scaledObjectName,
+			Namespace:  scaledObjectNamespace,
+			MetricName: metricName,
+		},
+	}
+	ack, err := c.rawMetricsClient.UnsubscribeMetric(ctx, req)
+	if err != nil {
+		return false, err
+	}
+	return ack.WasSubscribed, nil
+}
+
+// GetRawMetricsStream opens the gRPC connection for receiving the raw metrics from KEDA
+// channel with metrics is returned as well as the channel that indicates closed connection or error
+// it is up to the caller to make sure the connection is reopened in case of error
+// if true is sent to done channel the connection was closed by server
+// false represents the gRPC connection error
+// note: no metrics will be sent until Subscribe is called
+func (c *GrpcClient) GetRawMetricsStream(ctx context.Context, subscriber string) (chan Measurement, chan bool, error) {
+	if c.rawMetricsClient == nil {
+		return nil, nil, errors.New("rawMetricsClient is not initialized, initialize the client using NewGrpcClient(...,true)")
+	}
+	logger := log.WithName("GrpcClient").WithValues("subscriber", subscriber)
+	req := &api.RawMetricsRequest{
+		Subscriber: subscriber,
+	}
+	metricStream, err := c.rawMetricsClient.GetRawMetricsStream(ctx, req)
+	doneChan := make(chan bool)
+	metricsChan := make(chan Measurement)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	go func() {
+		for {
+			resp, e := metricStream.Recv()
+			if e == io.EOF {
+				logger.Info("Received EOF - stream was closed by server")
+				select {
+				case doneChan <- true:
+				default:
+				}
+				break
+			}
+			if e != nil {
+				logger.Error(e, "error receiving metric response")
+				select {
+				case doneChan <- false:
+				default:
+				}
+				break
+			}
+			for _, m := range resp.Metrics {
+				if m == nil {
+					continue
+				}
+				measurement := Measurement{
+					Name:  m.Metadata.MetricName,
+					Value: m.Value,
+				}
+				if m.Timestamp != nil {
+					t := m.Timestamp.AsTime()
+					measurement.Timestamp = &t
+				}
+				metricsChan <- measurement
+				logger.V(10).Info("Received raw metric", "name", m.Metadata.MetricName, "value", m.Value)
+			}
+		}
+	}()
+
+	return metricsChan, doneChan, nil
 }
 
 // WaitForConnectionReady waits for gRPC connection to be ready

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -22,6 +22,9 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -40,6 +43,7 @@ type GrpcServer struct {
 	certsReady    chan struct{}
 	scalerHandler *scaling.ScaleHandler
 	api.UnimplementedMetricsServiceServer
+	api.UnimplementedRawMetricsServiceServer
 }
 
 // GetMetrics returns metrics values in form of ExternalMetricValueList for specified ScaledObject reference
@@ -58,6 +62,72 @@ func (s *GrpcServer) GetMetrics(ctx context.Context, in *api.ScaledObjectRef) (*
 	log.V(1).WithValues("scaledObjectName", in.Name, "scaledObjectNamespace", in.Namespace, "metrics", v1beta1ExtMetrics).Info("Providing metrics")
 
 	return v1beta1ExtMetrics, nil
+}
+
+// GetRawMetricsStream opens the gRPC stream for sending metrics
+func (s *GrpcServer) GetRawMetricsStream(request *api.RawMetricsRequest, stream grpc.ServerStreamingServer[api.RawMetricsResponse]) error {
+	logger := log.WithName("GetRawMetricsStream").WithValues("subscriber", request.GetSubscriber())
+	if request.GetSubscriber() == "" {
+		return fmt.Errorf("subscriber must be specified, request: %+v", request)
+	}
+	// create a channel that will be receiving the metrics and for each metric on that channel, send it to the client
+	rawMetricsCh, doneCh := (*s.scalerHandler).GetRawMetricsChan(request.GetSubscriber())
+	for {
+		select {
+		case <-stream.Context().Done():
+			// client went away or canceled
+			return status.FromContextError(stream.Context().Err()).Err()
+		case rm, ok := <-rawMetricsCh:
+			if !ok {
+				return nil
+			}
+			resp := &api.RawMetricsResponse{}
+			var metrics []*api.RawMetric
+			for _, v := range rm.Values {
+				logger.V(10).Info("Sending raw metric", "MetricName", v.MetricName, "Time", v.Timestamp.String(), "Value", v.Value.AsApproximateFloat64())
+				metrics = append(metrics, &api.RawMetric{
+					Value:     v.Value.AsApproximateFloat64(),
+					Timestamp: timestamppb.New(v.Timestamp.Time),
+					Metadata: &api.ScaledObjectRef{
+						Name:       rm.Meta.ScaledObjectName,
+						Namespace:  rm.Meta.Namespace,
+						MetricName: rm.Meta.TriggerName,
+					},
+				})
+			}
+			resp.Metrics = metrics
+			if err := stream.Send(resp); err != nil {
+				st, _ := status.FromError(err)
+				switch st.Code() {
+				case codes.Canceled, codes.Unavailable:
+					return nil
+				default:
+					// genuine server-side send error
+					return err
+				}
+			}
+		case <-doneCh:
+			logger.V(10).Info(fmt.Sprintf("Channel closed for subscriber %s", request.GetSubscriber()))
+		}
+	}
+}
+
+// SubscribeMetric returns true in SubscriptionAck.WasSubscribed is the metric has been already subscribed
+// false for new a subscription
+func (s *GrpcServer) SubscribeMetric(ctx context.Context, request *api.SubscriptionRequest) (*api.SubscriptionAck, error) {
+	alreadySubscribed := (*s.scalerHandler).SubscribeMetric(ctx, request.GetSubscriber(), request.GetMetricMetadata())
+	return &api.SubscriptionAck{
+		WasSubscribed: alreadySubscribed,
+	}, nil
+}
+
+// UnsubscribeMetric returns true in SubscriptionAck.WasSubscribed is the metric has been successfully unsubscribed
+// false if it wasn't subscribed
+func (s *GrpcServer) UnsubscribeMetric(ctx context.Context, request *api.SubscriptionRequest) (*api.SubscriptionAck, error) {
+	wasSubscribed := (*s.scalerHandler).UnsubscribeMetric(ctx, request.GetSubscriber(), request.GetMetricMetadata())
+	return &api.SubscriptionAck{
+		WasSubscribed: wasSubscribed,
+	}, nil
 }
 
 // NewGrpcServer creates a new instance of GrpcServer
@@ -107,6 +177,7 @@ func (s *GrpcServer) Start(ctx context.Context) error {
 
 		s.server = grpc.NewServer(grpcServerOpts...)
 		api.RegisterMetricsServiceServer(s.server, s)
+		api.RegisterRawMetricsServiceServer(s.server, s)
 	}
 
 	errChan := make(chan error)

--- a/pkg/mock/mock_scaling/mock_interface.go
+++ b/pkg/mock/mock_scaling/mock_interface.go
@@ -13,6 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	api "github.com/kedacore/keda/v2/pkg/metricsservice/api"
+	scaling "github.com/kedacore/keda/v2/pkg/scaling"
 	cache "github.com/kedacore/keda/v2/pkg/scaling/cache"
 	gomock "go.uber.org/mock/gomock"
 	external_metrics "k8s.io/metrics/pkg/apis/external_metrics"
@@ -22,7 +24,6 @@ import (
 type MockScaleHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockScaleHandlerMockRecorder
-	isgomock struct{}
 }
 
 // MockScaleHandlerMockRecorder is the mock recorder for MockScaleHandler.
@@ -70,6 +71,21 @@ func (mr *MockScaleHandlerMockRecorder) DeleteScalableObject(ctx, scalableObject
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteScalableObject", reflect.TypeOf((*MockScaleHandler)(nil).DeleteScalableObject), ctx, scalableObject)
 }
 
+// GetRawMetricsChan mocks base method.
+func (m *MockScaleHandler) GetRawMetricsChan(subscriber string) (chan scaling.RawMetrics, chan bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRawMetricsChan", subscriber)
+	ret0, _ := ret[0].(chan scaling.RawMetrics)
+	ret1, _ := ret[1].(chan bool)
+	return ret0, ret1
+}
+
+// GetRawMetricsChan indicates an expected call of GetRawMetricsChan.
+func (mr *MockScaleHandlerMockRecorder) GetRawMetricsChan(subscriber any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawMetricsChan", reflect.TypeOf((*MockScaleHandler)(nil).GetRawMetricsChan), subscriber)
+}
+
 // GetScaledObjectMetrics mocks base method.
 func (m *MockScaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectName, scaledObjectNamespace, metricName string) (*external_metrics.ExternalMetricValueList, error) {
 	m.ctrl.T.Helper()
@@ -112,4 +128,32 @@ func (m *MockScaleHandler) HandleScalableObject(ctx context.Context, scalableObj
 func (mr *MockScaleHandlerMockRecorder) HandleScalableObject(ctx, scalableObject any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleScalableObject", reflect.TypeOf((*MockScaleHandler)(nil).HandleScalableObject), ctx, scalableObject)
+}
+
+// SubscribeMetric mocks base method.
+func (m *MockScaleHandler) SubscribeMetric(ctx context.Context, subscriber string, metricMetadata *api.ScaledObjectRef) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubscribeMetric", ctx, subscriber, metricMetadata)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SubscribeMetric indicates an expected call of SubscribeMetric.
+func (mr *MockScaleHandlerMockRecorder) SubscribeMetric(ctx, subscriber, metricMetadata any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeMetric", reflect.TypeOf((*MockScaleHandler)(nil).SubscribeMetric), ctx, subscriber, metricMetadata)
+}
+
+// UnsubscribeMetric mocks base method.
+func (m *MockScaleHandler) UnsubscribeMetric(ctx context.Context, subscriber string, metadata *api.ScaledObjectRef) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnsubscribeMetric", ctx, subscriber, metadata)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// UnsubscribeMetric indicates an expected call of UnsubscribeMetric.
+func (mr *MockScaleHandlerMockRecorder) UnsubscribeMetric(ctx, subscriber, metadata any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsubscribeMetric", reflect.TypeOf((*MockScaleHandler)(nil).UnsubscribeMetric), ctx, subscriber, metadata)
 }

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -19,6 +19,7 @@ package scaling
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -40,6 +41,7 @@ import (
 	"github.com/kedacore/keda/v2/pkg/eventreason"
 	"github.com/kedacore/keda/v2/pkg/fallback"
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
+	"github.com/kedacore/keda/v2/pkg/metricsservice/api"
 	"github.com/kedacore/keda/v2/pkg/scalers"
 	"github.com/kedacore/keda/v2/pkg/scalers/authentication"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -51,7 +53,12 @@ import (
 	"github.com/kedacore/keda/v2/pkg/scaling/scaledjob"
 )
 
-var log = logf.Log.WithName("scale_handler")
+var (
+	log = logf.Log.WithName("scale_handler")
+
+	// sendRawMetrics is a feature flag that enables sending the raw metric values to all subscribed parties
+	sendRawMetrics = os.Getenv("RAW_METRICS_GRPC_PROTOCOL") == "enabled"
+)
 
 // ScaleHandler encapsulates the logic of calling the right scalers for
 // each ScaledObject and making the final scale decision and operation
@@ -62,6 +69,9 @@ type ScaleHandler interface {
 	ClearScalersCache(ctx context.Context, scalableObject interface{}) error
 
 	GetScaledObjectMetrics(ctx context.Context, scaledObjectName, scaledObjectNamespace, metricName string) (*external_metrics.ExternalMetricValueList, error)
+	SubscribeMetric(ctx context.Context, subscriber string, metricMetadata *api.ScaledObjectRef) bool
+	UnsubscribeMetric(ctx context.Context, subscriber string, metadata *api.ScaledObjectRef) bool
+	GetRawMetricsChan(subscriber string) (rawMetrics chan RawMetrics, done chan bool)
 }
 
 type scaleHandler struct {
@@ -75,6 +85,10 @@ type scaleHandler struct {
 	scalerCachesLock         *sync.RWMutex
 	scaledObjectsMetricCache metricscache.MetricsCache
 	authClientSet            *authentication.AuthClientSet
+	rawMetricsSubscriptions  map[string]*RawMetricSubscriptions
+	// redundant, but it will speed up the lookups
+	metricToSubscriptions map[metricMeta][]*RawMetricSubscriptions
+	subsLock              *sync.RWMutex
 }
 
 // NewScaleHandler creates a ScaleHandler object
@@ -90,6 +104,9 @@ func NewScaleHandler(client client.Client, scaleClient scale.ScalesGetter, recon
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
 		authClientSet:            authClientSet,
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 }
 
@@ -557,6 +574,10 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 			for _, metric := range metrics {
 				metricValue := metric.Value.AsApproximateFloat64()
 				metricscollector.RecordScalerMetric(scaledObjectNamespace, scaledObjectName, result.triggerName, result.triggerIndex, metric.MetricName, true, metricValue)
+			}
+			if sendRawMetrics {
+				// send the raw metric to all subscribed clients in a non-blocking fashion
+				go h.sendWhenSubscribed(scaledObjectName, scaledObjectNamespace, result.triggerName, metrics)
 			}
 		}
 		if fallbackActive {

--- a/pkg/scaling/scale_handler_raw_metrics.go
+++ b/pkg/scaling/scale_handler_raw_metrics.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2025 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaling
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"k8s.io/metrics/pkg/apis/external_metrics"
+
+	"github.com/kedacore/keda/v2/pkg/metricsservice/api"
+)
+
+type metricMeta struct {
+	TriggerName      string
+	ScaledObjectName string
+	Namespace        string
+}
+
+type RawMetrics struct {
+	Meta   metricMeta
+	Values []external_metrics.ExternalMetricValue
+}
+
+type RawMetricSubscriptions struct {
+	id            string
+	subscriptions []metricMeta
+	rawMetrics    chan RawMetrics
+	done          chan bool
+}
+
+const (
+	// KEDA will keep this many measurements on the channel (each collected in 15s interval), then sendTimeout will start ticking
+	// if client isn't able to consume the message within that period, it will be automatically unsubscribed
+	rawMetricsChannelCapacity = 16
+
+	// timeout after which all the metrics for the subscriber will be unsubscribed (if these are not being consumed by client)
+	unsubscribeTimeout = 1 * time.Minute
+)
+
+func (h *scaleHandler) UnsubscribeMetric(_ context.Context, subscriber string, sor *api.ScaledObjectRef) bool {
+	toDel := toMetricMeta(sor)
+	log.Info("Unsubscribing metric", "subscriber", subscriber, "metric", toDel)
+	h.subsLock.Lock()
+	defer h.subsLock.Unlock()
+	if _, found := h.rawMetricsSubscriptions[subscriber]; !found || !h.isSubscribed(subscriber, sor) {
+		log.V(10).Info("Unsubscribing metric - noop")
+		return false
+	}
+
+	// 1. update metricToSubscriptions map
+	if allSubsOfMetric, found := h.metricToSubscriptions[toDel]; found {
+		updatedAllSubs := slices.DeleteFunc(allSubsOfMetric, func(item *RawMetricSubscriptions) bool {
+			return item != nil && item.id == subscriber
+		})
+		if len(updatedAllSubs) == 0 {
+			delete(h.metricToSubscriptions, toDel)
+		} else {
+			h.metricToSubscriptions[toDel] = updatedAllSubs
+		}
+	}
+
+	// 2. update rawMetricsSubscriptions map
+	remainingMetricsOfSub := slices.DeleteFunc(h.rawMetricsSubscriptions[subscriber].subscriptions, func(item metricMeta) bool {
+		return item.equal(toDel)
+	})
+
+	// (3). subscriber has no other metrics -> close the channels
+	if len(remainingMetricsOfSub) == 0 {
+		close(h.rawMetricsSubscriptions[subscriber].rawMetrics)
+		select {
+		case h.rawMetricsSubscriptions[subscriber].done <- true:
+		default:
+		}
+		close(h.rawMetricsSubscriptions[subscriber].done)
+		delete(h.rawMetricsSubscriptions, subscriber)
+	} else {
+		h.rawMetricsSubscriptions[subscriber].subscriptions = remainingMetricsOfSub
+	}
+	log.V(10).Info("All subscribed metrics", "subscriber", subscriber, "subscribersMetrics", remainingMetricsOfSub)
+	return true
+}
+
+func (h *scaleHandler) SubscribeMetric(_ context.Context, subscriber string, sor *api.ScaledObjectRef) bool {
+	toAdd := toMetricMeta(sor)
+	log.Info("Subscribing metric", "subscriber", subscriber, "metric", toAdd)
+	h.subsLock.Lock()
+	defer h.subsLock.Unlock()
+
+	if _, found := h.rawMetricsSubscriptions[subscriber]; !found {
+		h.rawMetricsSubscriptions[subscriber] = makeEmptySubscriptions(subscriber)
+	} else if h.isSubscribed(subscriber, sor) {
+		log.V(10).Info("Subscribing metric - noop")
+		return true
+	}
+
+	// 1. update rawMetricsSubscriptions map
+	h.rawMetricsSubscriptions[subscriber].subscriptions = append(h.rawMetricsSubscriptions[subscriber].subscriptions, toAdd)
+
+	// 2. update metricToSubscriptions map
+	allSubsOfMetric, found := h.metricToSubscriptions[toAdd]
+	if !found {
+		h.metricToSubscriptions[toAdd] = make([]*RawMetricSubscriptions, 1)
+	}
+	if !slices.ContainsFunc(allSubsOfMetric, func(sub *RawMetricSubscriptions) bool {
+		return sub != nil && sub.id == subscriber
+	}) {
+		h.metricToSubscriptions[toAdd] = append(h.metricToSubscriptions[toAdd], h.rawMetricsSubscriptions[subscriber])
+	}
+
+	mm := h.rawMetricsSubscriptions[subscriber].subscriptions
+	log.V(10).Info("All subscribed metrics", "subscriber", subscriber, "subscribersMetrics", mm)
+	return false
+}
+
+func (h *scaleHandler) GetRawMetricsChan(subscriber string) (chan RawMetrics, chan bool) {
+	h.subsLock.Lock()
+	defer h.subsLock.Unlock()
+	if _, found := h.rawMetricsSubscriptions[subscriber]; !found {
+		h.rawMetricsSubscriptions[subscriber] = makeEmptySubscriptions(subscriber)
+	}
+	return h.rawMetricsSubscriptions[subscriber].rawMetrics, h.rawMetricsSubscriptions[subscriber].done
+}
+
+func (h *scaleHandler) sendWhenSubscribed(soName, ns, triggerName string, metrics []external_metrics.ExternalMetricValue) {
+	mm := metricMeta{
+		TriggerName:      triggerName,
+		ScaledObjectName: soName,
+		Namespace:        ns,
+	}
+	var targets []RawMetricSubscriptions
+	h.subsLock.RLock()
+	for _, t := range h.metricToSubscriptions[mm] {
+		if t != nil {
+			targets = append(targets, *t)
+		}
+	}
+	h.subsLock.RUnlock()
+
+	if len(targets) > 0 {
+		vals := make([]external_metrics.ExternalMetricValue, len(metrics))
+		copy(vals, metrics)
+		msg := RawMetrics{Meta: mm, Values: vals}
+
+		for _, t := range targets {
+			select {
+			case <-t.done:
+				// subscriber closed
+				return
+			case t.rawMetrics <- msg:
+				// sent ok
+			case <-time.After(unsubscribeTimeout):
+				// timed out -> drop & unsubscribe
+				log.V(10).Info("Raw metric channel has reached its capacity and timeout has passed."+
+					" Unsubscribing all the metrics for this subscriber.",
+					"subscriber", t.id,
+					"subscribedMetricsCount", len(t.subscriptions),
+					"channelCapacity", rawMetricsChannelCapacity,
+					"timeout", unsubscribeTimeout)
+				for _, sub := range t.subscriptions {
+					h.UnsubscribeMetric(context.Background(), t.id, &api.ScaledObjectRef{
+						Name:       sub.ScaledObjectName,
+						Namespace:  sub.Namespace,
+						MetricName: sub.TriggerName,
+					})
+				}
+			}
+		}
+	}
+}
+
+// make sure this is being called only from critical section
+func (h *scaleHandler) isSubscribed(subscriber string, sor *api.ScaledObjectRef) bool {
+	toFind := toMetricMeta(sor)
+	return slices.ContainsFunc(h.rawMetricsSubscriptions[subscriber].subscriptions, func(mm metricMeta) bool {
+		return mm.equal(toFind)
+	})
+}
+
+func (a metricMeta) equal(b metricMeta) bool {
+	return a.TriggerName == b.TriggerName && a.ScaledObjectName == b.ScaledObjectName && a.Namespace == b.Namespace
+}
+
+func toMetricMeta(sor *api.ScaledObjectRef) metricMeta {
+	return metricMeta{
+		TriggerName:      sor.MetricName,
+		ScaledObjectName: sor.Name,
+		Namespace:        sor.Namespace,
+	}
+}
+
+func makeEmptySubscriptions(id string) *RawMetricSubscriptions {
+	return &RawMetricSubscriptions{
+		id:            id,
+		subscriptions: []metricMeta{},
+		rawMetrics:    make(chan RawMetrics, rawMetricsChannelCapacity),
+		done:          make(chan bool),
+	}
+}

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -122,6 +122,9 @@ func TestGetScaledObjectMetrics_DirectCall(t *testing.T) {
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -211,6 +214,9 @@ func TestGetScaledObjectMetrics_FromCache(t *testing.T) {
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -333,6 +339,9 @@ func TestGetScaledObjectMetrics_InParallel(t *testing.T) {
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -420,6 +429,9 @@ func TestCheckScaledObjectScalersWithError(t *testing.T) {
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 
 	isActive, isError, _, activeTriggers, _ := sh.getScaledObjectState(context.TODO(), &scaledObject)
@@ -540,6 +552,9 @@ func TestCheckScaledObjectScalersWithTriggerAuthError(t *testing.T) {
 		authClientSet: &authentication.AuthClientSet{
 			SecretLister: nil,
 		},
+		rawMetricsSubscriptions: map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:   map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                &sync.RWMutex{},
 	}
 
 	isActive, isError, _, activeTriggers, _ := sh.getScaledObjectState(context.TODO(), &scaledObject)
@@ -620,6 +635,9 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 
 	isActive, isError, _, activeTriggers, _ := sh.getScaledObjectState(context.TODO(), &scaledObject)
@@ -657,6 +675,9 @@ func TestIsScaledJobActive(t *testing.T) {
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 	// nosemgrep: context-todo
 	isActive, isError, queueLength, maxValue := sh.isScaledJobActive(context.TODO(), scaledJobSingle)
@@ -714,6 +735,9 @@ func TestIsScaledJobActive(t *testing.T) {
 			scalerCaches:             caches,
 			scalerCachesLock:         &sync.RWMutex{},
 			scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+			rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+			metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+			subsLock:                 &sync.RWMutex{},
 		}
 		fmt.Printf("index: %d", index)
 		// nosemgrep: context-todo
@@ -756,6 +780,9 @@ func TestIsScaledJobActiveIfQueueEmptyButMinReplicaCountGreaterZero(t *testing.T
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 
 	// nosemgrep: context-todo
@@ -993,6 +1020,9 @@ func TestScalingModifiersFormula(t *testing.T) {
 		scalerCaches:             caches,
 		scalerCachesLock:         &sync.RWMutex{},
 		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
 	}
 
 	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)


### PR DESCRIPTION
### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) - https://github.com/kedacore/keda-docs/pull/1627
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes [#7094](https://github.com/kedacore/keda/issues/7094)

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
