### PR TITLE
feat(azure_pipelines_scaler): add an option to enable demands to be case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Improve Events emitted from ScaledObject controller ([#6802](https://github.com/kedacore/keda/issues/6802))
 - **Apache Kafka Scaler**: Add support for even distribution of partitions to consumers ([#2581](https://github.com/kedacore/keda/issues/2581))
 - **AWS CloudWatch Scaler**: Add support for CloudWatch extended statistics (e.g P99 / TM90 and etc) ([#7109](https://github.com/kedacore/keda/issues/7109))
+- **Azure Pipelines Scaler**: Add new `caseInsensitiveDemandsProcessing` property to enable case-insensitive comparison of pipeline job demands ([#7111](https://github.com/kedacore/keda/issues/7111))
 - **Azure Pipelines Scaler**: Add new `fetchUnfinishedJobsOnly` property to fetch only unfinished pipeline jobs for a pool ([#6819](https://github.com/kedacore/keda/issues/6819))
 - **Datadog Scaler**: Add a specific timeout configuration parameter for the Datadog trigger ([#6999](https://github.com/kedacore/keda/pull/6999))
 - **Datadog Scaler**: Fix bug with datadogNamespace config ([#6828](https://github.com/kedacore/keda/pull/6828))

--- a/pkg/scalers/azure_pipelines_scaler.go
+++ b/pkg/scalers/azure_pipelines_scaler.go
@@ -148,6 +148,7 @@ type azurePipelinesMetadata struct {
 	triggerIndex                         int
 	RequireAllDemands                    bool `keda:"name=requireAllDemands,          order=triggerMetadata, default=false, optional"`
 	RequireAllDemandsAndIgnoreOthers     bool `keda:"name=requireAllDemandsAndIgnoreOthers,          order=triggerMetadata, default=false, optional"`
+	CaseInsensitiveDemandsProcessing     bool `keda:"name=caseInsensitiveDemandsProcessing,          order=triggerMetadata, default=false, optional"`
 }
 
 type authContext struct {
@@ -464,7 +465,13 @@ func getCanAgentDemandFulfilJob(jr JobRequest, metadata *azurePipelinesMetadata)
 
 	for _, demandInJob := range demandsInJob {
 		for _, demandInScaler := range demandsInScaler {
-			if demandInJob == demandInScaler {
+			var isMatch bool
+			if metadata.CaseInsensitiveDemandsProcessing {
+				isMatch = strings.EqualFold(demandInJob, demandInScaler)
+			} else {
+				isMatch = demandInJob == demandInScaler
+			}
+			if isMatch {
 				countDemands++
 			}
 		}

--- a/pkg/scalers/azure_pipelines_scaler_test.go
+++ b/pkg/scalers/azure_pipelines_scaler_test.go
@@ -412,6 +412,59 @@ func TestAzurePipelinesNotMatchedPartialRequiredTriggerDemands(t *testing.T) {
 	}
 }
 
+func TestAzurePipelinesDemandsComparisonDefaultCaseSensitive(t *testing.T) {
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buildLoadJSON())
+	}))
+
+	meta := getDemandJobMetaData(apiStub.URL)
+	meta.RequireAllDemands = true
+	meta.Demands = "KUBECTL"
+
+	mockAzurePipelinesScaler := azurePipelinesScaler{
+		metadata:   meta,
+		httpClient: http.DefaultClient,
+	}
+
+	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.Background())
+
+	if err != nil {
+		t.Fail()
+	}
+
+	if queuelen > 0 {
+		t.Fail()
+	}
+}
+
+func TestAzurePipelinesDemandsComparisonCaseInsensitive(t *testing.T) {
+	var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(buildLoadJSON())
+	}))
+
+	meta := getDemandJobMetaData(apiStub.URL)
+	meta.RequireAllDemands = true
+	meta.Demands = "KUBECTL"
+	meta.CaseInsensitiveDemandsProcessing = true
+
+	mockAzurePipelinesScaler := azurePipelinesScaler{
+		metadata:   meta,
+		httpClient: http.DefaultClient,
+	}
+
+	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.Background())
+
+	if err != nil {
+		t.Fail()
+	}
+
+	if queuelen < 1 {
+		t.Fail()
+	}
+}
+
 func buildLoadJSON() []byte {
 	output := testJobRequestResponse[0 : len(testJobRequestResponse)-2]
 	for i := 1; i < loadCount; i++ {

--- a/pkg/scalers/azure_pipelines_scaler_test.go
+++ b/pkg/scalers/azure_pipelines_scaler_test.go
@@ -430,11 +430,11 @@ func TestAzurePipelinesDemandsComparisonDefaultCaseSensitive(t *testing.T) {
 	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.Background())
 
 	if err != nil {
-		t.Fail()
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if queuelen > 0 {
-		t.Fail()
+		t.Fatalf("expected queue length to be 0, got %d", queuelen)
 	}
 }
 
@@ -457,11 +457,11 @@ func TestAzurePipelinesDemandsComparisonCaseInsensitive(t *testing.T) {
 	queuelen, err := mockAzurePipelinesScaler.GetAzurePipelinesQueueLength(context.Background())
 
 	if err != nil {
-		t.Fail()
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if queuelen < 1 {
-		t.Fail()
+		t.Fatalf("expected queue length to be >= 1, got %d", queuelen)
 	}
 }
 

--- a/schema/generated/scalers-metadata-schema.json
+++ b/schema/generated/scalers-metadata-schema.json
@@ -853,6 +853,13 @@
                     "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "caseInsensitiveDemandsProcessing",
+                    "type": "string",
+                    "optional": true,
+                    "default": "false",
+                    "metadataVariableReadable": true
                 }
             ]
         },

--- a/schema/generated/scalers-metadata-schema.yaml
+++ b/schema/generated/scalers-metadata-schema.yaml
@@ -559,6 +559,11 @@ scalers:
           optional: true
           default: "false"
           metadataVariableReadable: true
+        - name: caseInsensitiveDemandsProcessing
+          type: string
+          optional: true
+          default: "false"
+          metadataVariableReadable: true
     - type: azure-queue
       parameters:
         - name: activationQueueLength


### PR DESCRIPTION
feat(azure_pipelines_scaler): add an option to enable demands to be case insensitive

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Azure Devops is case insensitive, scaler is not

When you have an Azure DevOps job with demands written in uppercase, Azure Pipelines tends to ignore them if they are configured in lowercase, and vice versa.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) https://github.com/kedacore/keda-docs/pull/1629
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #7111

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
