### PR TITLE
fix: raw metrics over gRPC (sending to closed channel)

### DIFF
--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -106,8 +106,10 @@ func (s *GrpcServer) GetRawMetricsStream(request *api.RawMetricsRequest, stream 
 					return err
 				}
 			}
-		case <-doneCh:
-			logger.V(10).Info(fmt.Sprintf("Channel closed for subscriber %s", request.GetSubscriber()))
+		case val, open := <-doneCh:
+			if open && !val {
+				logger.V(10).Info(fmt.Sprintf("Channel closed for subscriber %s", request.GetSubscriber()))
+			}
 		}
 	}
 }

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -878,6 +878,10 @@ func (h *scaleHandler) getScaledJobMetrics(ctx context.Context, scaledJob *kedav
 				isError = true
 				continue
 			}
+			if sendRawMetrics {
+				// send the raw metric to all subscribed clients in a non-blocking fashion
+				go h.sendWhenSubscribed(scaledJob.Name, scaledJob.Namespace, scalerName, metrics)
+			}
 			if isTriggerActive {
 				isActive = true
 			}


### PR DESCRIPTION
I found a bug in my previous [PR](https://github.com/kedacore/keda/pull/7093) (only after it got merged ;), sry)