### PR TITLE
fix: external push scaler deactivation behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Add missing omitempty json tags in the AuthPodIdentity struct ([#6779](https://github.com/kedacore/keda/issues/6779))
 - **General**: Correct pending pod condition logic for ScaledJobs ([#6727](https://github.com/kedacore/keda/issues/6727))
+- **General**: Fix external push scaler deactivation behavior ([#6986](https://github.com/kedacore/keda/issues/6986))
 - **General**: Fix parse timeout config as milliseconds instead of seconds ([#6997](https://github.com/kedacore/keda/pull/6997))
 - **General**: Fix prefixes on envFrom elements in a deployment spec aren't being interpreted and Environment variables are not prefixed with the prefix ([#6728](https://github.com/kedacore/keda/issues/6728))
 - **General**: Fix SIGSEGV when doing fallback of non-static behavior on any ScaleTargetRef that is neither a Deployment nor a StatefulSet ([#6992](https://github.com/kedacore/keda/pull/6992))


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
When `ScaledObject` defines a single external push scaler along other scalers, the deactivation becomes buggy. Every time there is `active=false` message over the external push scaler gRPC related to a particular `ScaledObject`, it gets deactivated immediately, regardless of other scaler statuses.

This PR will ensure only `active=true` messages are applied immediately, as those should be acted upon quickly - e.g. cold-starts with http-add-on where the request is cached in the interceptor. Messages `active=false` will be ignored and scale to zero will happen for external push scalers just like with any other scaler - based on the metrics being under their activation thresholds during the polling interval.

>  For scaling modifiers I'd just disable the active stream as we clearly explain the in this mode, triggers are just metric sources and not triggers as they were.

This is operational for scaling modifiers too and I would like to make an argument for allowing push activations for scaling modifiers because in cold starts with http scaler, it's really important to start scaling as soon as possible.

<details>

<summary>Scaled Object</summary>

```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: demo
  namespace: default
spec:
  cooldownPeriod: 5
  initialCooldownPeriod: 5
  advanced:
    restoreToOriginalReplicaCount: true
    scalingModifiers:
      activationTarget: "5"
      formula: 2*kw + rps
      target: "1"
    horizontalPodAutoscalerConfig:
      behavior:
        scaleDown:
          stabilizationWindowSeconds: 5
  maxReplicaCount: 10
  minReplicaCount: 0
  pollingInterval: 15
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: demo
  triggers:
  - metadata:
      httpScaledObject: demo
      scalerAddress: keda-add-ons-http-external-scaler.keda:9090
    name: rps
    type: external-push
  - metadata:
      activationValue: "0.9"
      podSelector: app=sleep
      value: "1"
    name: kw
    type: kubernetes-workload
```

</details>

in the example above, `spec.advanced.scalingModifiers.activationTarget: "5"` would be ignored because one of the scalers is http-add-on, but imho that is a better behavior and acceptable tradeoff.

<details>

<summary>all resources for testing</summary>

[externalservice.yaml.txt](https://github.com/user-attachments/files/22637611/externalservice.yaml.txt)
[httpscaledobject.yaml.txt](https://github.com/user-attachments/files/22637619/httpscaledobject.yaml.txt)
[ingress_app.yaml.txt](https://github.com/user-attachments/files/22637621/ingress_app.yaml.txt)
[scaled_app.yaml.txt](https://github.com/user-attachments/files/22637624/scaled_app.yaml.txt)
[sleep.yaml.txt](https://github.com/user-attachments/files/22637626/sleep.yaml.txt)
[so.yaml.txt](https://github.com/user-attachments/files/22637627/so.yaml.txt)
[svc_app.yaml.txt](https://github.com/user-attachments/files/22637629/svc_app.yaml.txt)

</details>

### Checklist

- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] docs PR - https://github.com/kedacore/keda-docs/pull/1632

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
fixes: https://github.com/kedacore/keda/issues/6986
closes: https://github.com/kedacore/keda/pull/7025
closes: https://github.com/kedacore/keda/pull/7098 