### PR TITLE
ci: clear some disk space for PR validation step

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,7 +10,11 @@ jobs:
   validate:
     name: validate - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    container: ghcr.io/kedacore/keda-tools:1.23.8
+    container:
+      image: ghcr.io/kedacore/keda-tools:1.23.8
+      volumes:
+        - /usr:/host/usr
+        - /opt:/host/opt
     strategy:
       matrix:
         include:
@@ -24,12 +28,15 @@ jobs:
 
       - name: Maximize disk space
         if: ${{ matrix.name == 'amd64' }}
-        uses: easimon/maximize-build-space@master
-        with:
-          overprovision-lvm: 'true'
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
+        run: |
+          # inspired by easimon/maximize-build-space action but it can't be easily used because this runs in a container
+          # https://github.com/easimon/maximize-build-space/blob/c28619d8999a147d5e09c1199f84ff6af6ad5794/action.yml#L41-L60
+          # remove android sdk => ~11GB
+          rm -rf /host/usr/local/lib/android
+          # remove .NET => ~17GB
+          rm -rf /host/usr/share/dotnet
+          # remove haskell => ~2.7GB
+          rm -rf /host/opt/ghc
 
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,6 +21,16 @@ jobs:
           - runner: s390x
             name: s390x
     steps:
+
+      - name: Maximize disk space
+        if: ${{ matrix.name == 'amd64' }}
+        uses: easimon/maximize-build-space@master
+        with:
+          overprovision-lvm: 'true'
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

**tl;dr**: this prolongs the step execution by ~4 minutes but frees up ~13 GB space, which means tests don't run out of disk space.
___

There is a number of PRs that fail the PR validation step on amd64 runner due to low disk space
```
# github.com/kedacore/keda/v2/controllers/keda [github.com/kedacore/keda/v2/controllers/keda.test]
compile: writing output: write $WORK/b2581/_pkg_.a: no space left on device
FAIL	github.com/kedacore/keda/v2/controllers/keda [build failed]
# github.com/kedacore/keda/v2/controllers/keda/util
# [github.com/kedacore/keda/v2/controllers/keda/util]
vet: failed to export analysis facts: write $WORK/b2588/vet.out: no space left on device
github.com/kedacore/keda/v2/pkg/mock/mock_eventemitter: mkdir /tmp/go-build1683534545/b2594/: no space left on device
```
* https://github.com/kedacore/keda/actions/runs/18184713554/job/51770792105?pr=6534
* https://github.com/kedacore/keda/actions/runs/18134343508/job/51609166097?pr=7115


For a quick fix to unblock PRs from merging, I would like to propose adding a step that removes some unnecessary software from GH actions runner. Later, we can explore why the disk space usage grew above the allocated limit.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))