### PR TITLE
chore(tests): replace test image short names with fqdn

### DIFF
--- a/tests/internals/cloudevent_source/cloudevent_source_test.go
+++ b/tests/internals/cloudevent_source/cloudevent_source_test.go
@@ -140,7 +140,7 @@ metadata:
 spec:
   containers:
   - name: {{.ClientName}}
-    image: curlimages/curl
+    image: docker.io/curlimages/curl
     command:
       - sh
       - -c

--- a/tests/internals/fallback/fallback.go
+++ b/tests/internals/fallback/fallback.go
@@ -467,7 +467,7 @@ spec:
     spec:
       containers:
       - name: job-curl
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never

--- a/tests/internals/global_custom_ca/global_custom_ca_test.go
+++ b/tests/internals/global_custom_ca/global_custom_ca_test.go
@@ -212,7 +212,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/internals/min_replica_sj/min_replica_sj_test.go
+++ b/tests/internals/min_replica_sj/min_replica_sj_test.go
@@ -127,7 +127,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
+++ b/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
@@ -176,7 +176,7 @@ spec:
     spec:
       containers:
       - name: job-curl
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: OnFailure

--- a/tests/internals/replica_update_so/replica_update_so_test.go
+++ b/tests/internals/replica_update_so/replica_update_so_test.go
@@ -186,7 +186,7 @@ spec:
     spec:
       containers:
       - name: job-curl
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never

--- a/tests/internals/scaling_modifiers/scaling_modifiers_test.go
+++ b/tests/internals/scaling_modifiers/scaling_modifiers_test.go
@@ -252,7 +252,7 @@ spec:
     spec:
       containers:
       - name: job-curl
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: OnFailure

--- a/tests/internals/scaling_strategies/eager_scaling_strategy_test.go
+++ b/tests/internals/scaling_strategies/eager_scaling_strategy_test.go
@@ -59,7 +59,7 @@ spec:
       spec:
         containers:
           - name: sleeper
-            image: busybox
+            image:  docker.io/library/busybox
             command:
             - sleep
             - "300"

--- a/tests/internals/scaling_strategies/eager_scaling_strategy_test.go
+++ b/tests/internals/scaling_strategies/eager_scaling_strategy_test.go
@@ -59,7 +59,7 @@ spec:
       spec:
         containers:
           - name: sleeper
-            image:  docker.io/library/busybox
+            image: docker.io/library/busybox
             command:
             - sleep
             - "300"

--- a/tests/internals/trigger_update_so/trigger_update_so_test.go
+++ b/tests/internals/trigger_update_so/trigger_update_so_test.go
@@ -285,7 +285,7 @@ spec:
     spec:
       containers:
       - name: job-curl
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never

--- a/tests/scalers/couchdb/couchdb_test.go
+++ b/tests/scalers/couchdb/couchdb_test.go
@@ -144,7 +144,7 @@ metadata:
 spec:
   containers:
   - name: {{.ClientName}}
-    image: curlimages/curl
+    image: docker.io/curlimages/curl
     command:
       - sh
       - -c

--- a/tests/scalers/external_push_scaler/external_push_scaler_test.go
+++ b/tests/scalers/external_push_scaler/external_push_scaler_test.go
@@ -149,7 +149,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/scalers/external_push_scaler_old_proto/external_push_scaler_old_proto_test.go
+++ b/tests/scalers/external_push_scaler_old_proto/external_push_scaler_old_proto_test.go
@@ -140,7 +140,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
+++ b/tests/scalers/external_scaler_sj/external_scaler_sj_test.go
@@ -124,7 +124,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/scalers/external_scaler_so/external_scaler_so_test.go
+++ b/tests/scalers/external_scaler_so/external_scaler_so_test.go
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/scalers/ibmmq/ibmmq_test.go
+++ b/tests/scalers/ibmmq/ibmmq_test.go
@@ -89,7 +89,7 @@ spec:
     spec:
       containers:
         - name: check-qmgr-running-status
-          image: curlimages/curl
+          image: docker.io/curlimages/curl
           command:
             - sh
             - -c

--- a/tests/scalers/metrics_api/metrics_api_test.go
+++ b/tests/scalers/metrics_api/metrics_api_test.go
@@ -181,7 +181,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/scalers/prometheus/prometheus_helper.go
+++ b/tests/scalers/prometheus/prometheus_helper.go
@@ -376,7 +376,7 @@ spec:
       serviceAccountName: {{.PrometheusServerName}}
       containers:
         - name: prometheus-server-configmap-reload
-          image: "jimmidyson/configmap-reload:v0.3.0"
+          image: "docker.io/jimmidyson/configmap-reload:v0.3.0"
           imagePullPolicy: "IfNotPresent"
           args:
             - --volume-dir=/etc/config
@@ -388,7 +388,7 @@ spec:
               readOnly: true
 
         - name: prometheus-server
-          image: "prom/prometheus:v2.47.1"
+          image: "docker.io/prom/prometheus:v2.47.1"
           imagePullPolicy: "IfNotPresent"
           args:
             - --storage.tsdb.retention.time=15d

--- a/tests/scalers/rabbitmq/rabbitmq_helper.go
+++ b/tests/scalers/rabbitmq/rabbitmq_helper.go
@@ -123,7 +123,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-u", "{{.Username}}:{{.Password}}", "-X", "PUT", "http://{{.HostName}}/api/vhosts/{{.VHostName}}"]
       restartPolicy: Never
@@ -173,7 +173,7 @@ spec:
       namespace: {{.Namespace}}
     spec:
       containers:
-      - image: rabbitmq:3.12-management
+      - image: docker.io/library/rabbitmq:3.12-management
         name: rabbitmq
         volumeMounts:
           - mountPath: /etc/rabbitmq

--- a/tests/secret-providers/trigger_auth_bound_service_account_token/trigger_auth_bound_service_account_token_test.go
+++ b/tests/secret-providers/trigger_auth_bound_service_account_token/trigger_auth_bound_service_account_token_test.go
@@ -272,7 +272,7 @@ spec:
     spec:
       containers:
       - name: curl-client
-        image: curlimages/curl
+        image: docker.io/curlimages/curl
         imagePullPolicy: Always
         command: ["curl", "-X", "POST", "{{.MetricsServerEndpoint}}/{{.MetricValue}}"]
       restartPolicy: Never`

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -307,7 +307,7 @@ metadata:
 spec:
   containers:
   - name: {{.ClientName}}
-    image: curlimages/curl
+    image: docker.io/curlimages/curl
     command:
       - sh
       - -c

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -277,7 +277,7 @@ metadata:
 spec:
   containers:
   - name: {{.ClientName}}
-    image: curlimages/curl
+    image: docker.io/curlimages/curl
     command:
       - sh
       - -c


### PR DESCRIPTION
Replaces some test image short names with their fully qualified domain names instead so the tests can be more explicit about which registry the image is pulled from.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
