### PR TITLE
fix: update e2e test etcd to use legacy etcd image

### DIFF
--- a/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
+++ b/tests/scalers/etcd/etcd_cluster/etcd_cluster_test.go
@@ -179,7 +179,7 @@ func setVarValue(t *testing.T, value int) {
 }
 
 func InstallCluster(t *testing.T, kc *kubernetes.Clientset) {
-	_, err := ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set persistence.enabled=false --set resourcesPreset=none --set auth.rbac.create=false --set replicaCount=3 --namespace %s --wait etcd oci://registry-1.docker.io/bitnamicharts/etcd`,
+	_, err := ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set persistence.enabled=false --set resourcesPreset=none --set auth.rbac.create=false --set replicaCount=3 --namespace %s --wait etcd oci://registry-1.docker.io/bitnamicharts/etcd --set image.repository=bitnamilegacy/etcd`,
 		testNamespace))
 	require.NoErrorf(t, err, "cannot execute command - %s", err)
 }

--- a/tests/scalers/etcd/etcd_cluster_auth/etcd_cluster_auth_test.go
+++ b/tests/scalers/etcd/etcd_cluster_auth/etcd_cluster_auth_test.go
@@ -220,7 +220,7 @@ func setVarValue(t *testing.T, value int) {
 }
 
 func InstallCluster(t *testing.T, kc *kubernetes.Clientset) {
-	_, err := ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set persistence.enabled=false --set resourcesPreset=none --set auth.rbac.rootPassword=%s --set auth.rbac.allowNoneAuthentication=false --set replicaCount=3 --namespace %s --wait etcd oci://registry-1.docker.io/bitnamicharts/etcd`,
+	_, err := ExecuteCommand(fmt.Sprintf(`helm upgrade --install --set persistence.enabled=false --set resourcesPreset=none --set auth.rbac.rootPassword=%s --set auth.rbac.allowNoneAuthentication=false --set replicaCount=3 --namespace %s --wait etcd oci://registry-1.docker.io/bitnamicharts/etcd --set image.repository=bitnamilegacy/etcd`,
 		etcdPassword, testNamespace))
 	require.NoErrorf(t, err, "cannot execute command - %s", err)
 }


### PR DESCRIPTION
Fix e2e test etcd by using the bitnamilegacy repo.

Current test received unexpected error by pulling `registry-***.docker.io/bitnamicharts/etcd:***.0.***8` resulting in `Error: context deadline exceeded`

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Related: #7107 