### PR TITLE
fix: feature flag for unexpected scaler param check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Add feature flag `KEDA_CHECK_UNEXPECTED_SCALERS_PARAMS` for checking unexpected scaler parameters ([#6721](https://github.com/kedacore/keda/issues/6721))
 - **General**: Fix incorrect 'unmatched input property' notification ([#7174](https://github.com/kedacore/keda/issues/7174))
 
 ### Deprecations

--- a/pkg/scalers/scalersconfig/typed_config.go
+++ b/pkg/scalers/scalersconfig/typed_config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
+	"os"
 	"reflect"
 	"runtime/debug"
 	"slices"
@@ -35,6 +36,8 @@ import (
 
 	"github.com/kedacore/keda/v2/pkg/eventreason"
 )
+
+var checkUnexpectedParamEnabled = os.Getenv("KEDA_CHECK_UNEXPECTED_SCALERS_PARAMS") == "enabled"
 
 // CustomValidator is an interface that can be implemented to validate the configuration of the typed config
 type CustomValidator interface {
@@ -521,7 +524,11 @@ func (sc *ScalerConfig) configParamValue(params Params) (string, bool) {
 }
 
 // checkUnexpectedParameterExist is a function that checks if there are any unexpected parameters in the TriggerMetadata
+// this is controlled by a feature flag KEDA_CHECK_UNEXPECTED_SCALERS_PARAMS env variable. By default it's disabled.
 func (sc *ScalerConfig) checkUnexpectedParameterExist(parsedParamNames []string, logger logr.Logger) {
+	if !checkUnexpectedParamEnabled {
+		return
+	}
 	for k := range sc.TriggerMetadata {
 		suffix := "FromEnv"
 		if !strings.HasSuffix(k, "FromEnv") {

--- a/pkg/scalers/scalersconfig/typed_config_test.go
+++ b/pkg/scalers/scalersconfig/typed_config_test.go
@@ -665,6 +665,7 @@ func TestDurationParsing(t *testing.T) {
 // TestUnexpectedOptional tests the unexpected optional input
 func TestUnexpectedOptional(t *testing.T) {
 	RegisterTestingT(t)
+	checkUnexpectedParamEnabled = true
 
 	// Create a mock recorder to capture the event
 	mockRecorder := &MockEventRecorder{Messages: make([]string, 0)}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The check for unexpected scaler parameters is causing a flood of events in 2.18.0 release due to:
1) incomplete refactors
2) undocumented parameters
3) parameter is specified but contains `""` as value
4) deprecated parameters where users were not forced/active to cleanup their ScaledObjects

This PR proposes adding `KEDA_CHECK_UNEXPECTED_SCALERS_PARAMS` env variable, which is disabled by default, so we can release 2.18.1 not causing too many events getting created until 1., 2. and 3. are addressed.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on
  - https://github.com/kedacore/keda-docs/pull/1646
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
see also: https://github.com/kedacore/keda/pull/6763
see also: https://github.com/kedacore/keda/pull/7188
see also: https://github.com/kedacore/keda/issues/7179
