### PR TITLE
add `kubernetes-resource` scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### New
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **General**: Introduce new Kubernetes Resource Scaler ([#7212](https://github.com/kedacore/keda/issues/7212))
 
 #### Experimental
 

--- a/pkg/scalers/kubernetes_resource_scaler.go
+++ b/pkg/scalers/kubernetes_resource_scaler.go
@@ -1,0 +1,328 @@
+package scalers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/tidwall/gjson"
+	"gopkg.in/yaml.v3"
+	v2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+)
+
+type kubernetesResourceScaler struct {
+	metricType v2.MetricTargetType
+	metadata   *kubernetesResourceMetadata
+	kubeClient client.Client
+	logger     logr.Logger
+}
+
+type kubernetesResourceMetadata struct {
+	// Resource identification
+	ResourceKind resourceKind `keda:"name=resourceKind,order=triggerMetadata,enum=ConfigMap;Secret"`
+	ResourceName string       `keda:"name=resourceName,order=triggerMetadata"`
+	Key          string       `keda:"name=key,order=triggerMetadata"`
+
+	// Value extraction
+	Format        resourceFormat `keda:"name=format,order=triggerMetadata,default=number,enum=number;json;yaml"`
+	ValueLocation string         `keda:"name=valueLocation,order=triggerMetadata,optional"`
+	ValueType     valueType      `keda:"name=valueType,order=triggerMetadata,default=float64,enum=float64;int64;quantity"`
+
+	// Scaling thresholds
+	TargetValue           float64 `keda:"name=targetValue,order=triggerMetadata"`
+	ActivationTargetValue float64 `keda:"name=activationTargetValue,order=triggerMetadata,default=0"`
+
+	// Internal fields
+	namespace      string
+	triggerIndex   int
+	asMetricSource bool
+}
+
+type resourceKind string
+
+const (
+	configMapKind resourceKind = "ConfigMap"
+	secretKind    resourceKind = "Secret"
+)
+
+type resourceFormat string
+
+const (
+	numberFormat resourceFormat = "number"
+	jsonFormat   resourceFormat = "json"
+	yamlFormat   resourceFormat = "yaml"
+)
+
+type valueType string
+
+const (
+	float64Type  valueType = "float64"
+	int64Type    valueType = "int64"
+	quantityType valueType = "quantity"
+)
+
+const (
+	kubernetesResourceMetricType = "External"
+	valueTypeErrorMsg            = "valueLocation must point to value of type number or a string representing a Quantity, got: '%s'"
+	valueLocationRequiredMsg     = "valueLocation is required for %s format"
+	resourceKindUnsupportedMsg   = "unsupported resourceKind: %s"
+	keyNotFoundMsg               = "key %s not found in %s %s/%s"
+	pathNotFoundMsg              = "path %s not found in %s"
+)
+
+func (m *kubernetesResourceMetadata) Validate() error {
+	if m.TargetValue <= 0 && !m.asMetricSource {
+		return fmt.Errorf("targetValue must be a float greater than 0")
+	}
+
+	if m.Format == numberFormat && m.ValueLocation != "" {
+		return fmt.Errorf("valueLocation is only supported with json or yaml format")
+	}
+
+	if (m.Format == jsonFormat || m.Format == yamlFormat) && m.ValueLocation == "" {
+		return fmt.Errorf(valueLocationRequiredMsg, m.Format)
+	}
+
+	return nil
+}
+
+// NewKubernetesResourceScaler creates a new kubernetesResourceScaler
+func NewKubernetesResourceScaler(kubeClient client.Client, config *scalersconfig.ScalerConfig) (Scaler, error) {
+	metricType, err := GetMetricTargetType(config)
+	if err != nil {
+		return nil, fmt.Errorf("error getting scaler metric type: %w", err)
+	}
+
+	meta, err := parseKubernetesResourceMetadata(config)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubernetes resource metadata: %w", err)
+	}
+
+	return &kubernetesResourceScaler{
+		metricType: metricType,
+		metadata:   meta,
+		kubeClient: kubeClient,
+		logger:     InitializeLogger(config, "kubernetes_resource_scaler"),
+	}, nil
+}
+
+func parseKubernetesResourceMetadata(config *scalersconfig.ScalerConfig) (*kubernetesResourceMetadata, error) {
+	meta := &kubernetesResourceMetadata{}
+	meta.namespace = config.ScalableObjectNamespace
+	meta.triggerIndex = config.TriggerIndex
+	meta.asMetricSource = config.AsMetricSource
+
+	err := config.TypedConfig(meta)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubernetes resource metadata: %w", err)
+	}
+
+	return meta, nil
+}
+
+func (s *kubernetesResourceScaler) Close(context.Context) error {
+	return nil
+}
+
+// GetMetricSpecForScaling returns the metric spec for the HPA
+func (s *kubernetesResourceScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	metricName := kedautil.NormalizeString(fmt.Sprintf("%s-%s-%s", strings.ToLower(string(s.metadata.ResourceKind)), s.metadata.ResourceName, s.metadata.Key))
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
+			Name: GenerateMetricNameWithIndex(s.metadata.triggerIndex, metricName),
+		},
+		Target: GetMetricTargetMili(s.metricType, s.metadata.TargetValue),
+	}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: kubernetesResourceMetricType}
+	return []v2.MetricSpec{metricSpec}
+}
+
+// GetMetricsAndActivity returns value for a supported metric
+func (s *kubernetesResourceScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
+	value, err := s.getMetricValue(ctx)
+	if err != nil {
+		return []external_metrics.ExternalMetricValue{}, false, fmt.Errorf("error getting metric value from %s: %w", s.metadata.ResourceKind, err)
+	}
+
+	metric := GenerateMetricInMili(metricName, value)
+
+	return []external_metrics.ExternalMetricValue{metric}, value > s.metadata.ActivationTargetValue, nil
+}
+
+func (s *kubernetesResourceScaler) getMetricValue(ctx context.Context) (float64, error) {
+	switch s.metadata.ResourceKind {
+	case configMapKind:
+		return s.getValueFromConfigMap(ctx)
+	case secretKind:
+		return s.getValueFromSecret(ctx)
+	default:
+		return 0, fmt.Errorf(resourceKindUnsupportedMsg, s.metadata.ResourceKind)
+	}
+}
+
+func (s *kubernetesResourceScaler) getValueFromConfigMap(ctx context.Context) (float64, error) {
+	configMap := &corev1.ConfigMap{}
+	err := s.kubeClient.Get(ctx, client.ObjectKey{
+		Name:      s.metadata.ResourceName,
+		Namespace: s.metadata.namespace,
+	}, configMap)
+	if err != nil {
+		return 0, fmt.Errorf("error getting ConfigMap %s/%s: %w", s.metadata.namespace, s.metadata.ResourceName, err)
+	}
+
+	value, exists := configMap.Data[s.metadata.Key]
+	if !exists {
+		return 0, fmt.Errorf(keyNotFoundMsg, s.metadata.Key, configMapKind, s.metadata.namespace, s.metadata.ResourceName)
+	}
+
+	return s.parseValue(value)
+}
+
+func (s *kubernetesResourceScaler) getValueFromSecret(ctx context.Context) (float64, error) {
+	secret := &corev1.Secret{}
+	err := s.kubeClient.Get(ctx, client.ObjectKey{
+		Name:      s.metadata.ResourceName,
+		Namespace: s.metadata.namespace,
+	}, secret)
+	if err != nil {
+		return 0, fmt.Errorf("error getting Secret %s/%s: %w", s.metadata.namespace, s.metadata.ResourceName, err)
+	}
+
+	valueBytes, exists := secret.Data[s.metadata.Key]
+	if !exists {
+		return 0, fmt.Errorf(keyNotFoundMsg, s.metadata.Key, secretKind, s.metadata.namespace, s.metadata.ResourceName)
+	}
+
+	return s.parseValue(string(valueBytes))
+}
+
+func (s *kubernetesResourceScaler) parseValue(rawValue string) (float64, error) {
+	switch s.metadata.Format {
+	case numberFormat:
+		return s.parseNumericValue(rawValue)
+	case jsonFormat:
+		return s.parseJSONValue(rawValue)
+	case yamlFormat:
+		return s.parseYAMLValue(rawValue)
+	default:
+		return 0, fmt.Errorf("unsupported format: %s", s.metadata.Format)
+	}
+}
+
+func (s *kubernetesResourceScaler) parseNumericValue(value string) (float64, error) {
+	switch s.metadata.ValueType {
+	case float64Type:
+		var floatVal float64
+		_, err := fmt.Sscanf(value, "%f", &floatVal)
+		if err != nil {
+			return 0, fmt.Errorf("error parsing value as float64: %w", err)
+		}
+		return floatVal, nil
+	case int64Type:
+		var intVal int64
+		_, err := fmt.Sscanf(value, "%d", &intVal)
+		if err != nil {
+			return 0, fmt.Errorf("error parsing value as int64: %w", err)
+		}
+		return float64(intVal), nil
+	case quantityType:
+		return s.parseQuantity(value)
+	default:
+		return 0, fmt.Errorf("unsupported value type: %s", s.metadata.ValueType)
+	}
+}
+
+func (s *kubernetesResourceScaler) parseJSONValue(value string) (float64, error) {
+	result := gjson.Get(value, s.metadata.ValueLocation)
+	if !result.Exists() {
+		return 0, fmt.Errorf(pathNotFoundMsg, s.metadata.ValueLocation, jsonFormat)
+	}
+
+	return s.convertGjsonResultToFloat(result)
+}
+
+func (s *kubernetesResourceScaler) convertGjsonResultToFloat(result gjson.Result) (float64, error) {
+	switch s.metadata.ValueType {
+	case float64Type:
+		if result.Type == gjson.Number {
+			return result.Float(), nil
+		}
+		if result.Type == gjson.String {
+			return s.parseQuantity(result.String())
+		}
+		return 0, fmt.Errorf(valueTypeErrorMsg, result.Type.String())
+	case int64Type:
+		if result.Type == gjson.Number {
+			return float64(result.Int()), nil
+		}
+		return 0, fmt.Errorf(valueTypeErrorMsg, result.Type.String())
+	case quantityType:
+		if result.Type == gjson.String {
+			return s.parseQuantity(result.String())
+		}
+		if result.Type == gjson.Number {
+			return result.Float(), nil
+		}
+		return 0, fmt.Errorf(valueTypeErrorMsg, result.Type.String())
+	default:
+		return 0, fmt.Errorf("unsupported value type: %s", s.metadata.ValueType)
+	}
+}
+
+func (s *kubernetesResourceScaler) parseYAMLValue(value string) (float64, error) {
+	var yamlMap map[string]interface{}
+	err := yaml.Unmarshal([]byte(value), &yamlMap)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing YAML: %w", err)
+	}
+
+	// Use kedautil.GetValueByPath like metrics-api scaler does
+	pathValue, err := kedautil.GetValueByPath(yamlMap, s.metadata.ValueLocation)
+	if err != nil {
+		return 0, fmt.Errorf(pathNotFoundMsg, s.metadata.ValueLocation, yamlFormat)
+	}
+
+	return s.convertValueToFloat(pathValue)
+}
+
+// convertValueToFloat converts various types to float64, similar to metrics-api scaler
+func (s *kubernetesResourceScaler) convertValueToFloat(value interface{}) (float64, error) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case float64:
+		return v, nil
+	case string:
+		if s.metadata.ValueType == quantityType {
+			return s.parseQuantity(v)
+		}
+		// Try to parse as number
+		var floatVal float64
+		_, err := fmt.Sscanf(v, "%f", &floatVal)
+		if err != nil {
+			return 0, fmt.Errorf(valueTypeErrorMsg, v)
+		}
+		return floatVal, nil
+	default:
+		return 0, fmt.Errorf(valueTypeErrorMsg, v)
+	}
+}
+
+// parseQuantity is a helper function to parse quantity strings
+func (s *kubernetesResourceScaler) parseQuantity(value string) (float64, error) {
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing value as quantity: %w", err)
+	}
+	return quantity.AsApproximateFloat64(), nil
+}

--- a/pkg/scalers/kubernetes_resource_scaler_test.go
+++ b/pkg/scalers/kubernetes_resource_scaler_test.go
@@ -1,0 +1,400 @@
+package scalers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+)
+
+type kubernetesResourceMetadataTestData struct {
+	metadata  map[string]string
+	namespace string
+	isError   bool
+	errorMsg  string
+}
+
+var parseKubernetesResourceMetadataTestDataset = []kubernetesResourceMetadataTestData{
+	// Valid ConfigMap
+	{map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10"}, "test", false, ""},
+	// Valid Secret
+	{map[string]string{"resourceKind": "Secret", "resourceName": "my-secret", "key": "threshold", "targetValue": "10"}, "test", false, ""},
+	// Valid with all optional fields
+	{map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "data", "valueLocation": "metrics.threshold", "targetValue": "10", "activationTargetValue": "5", "format": "json", "valueType": "float64"}, "test", false, ""},
+	// Missing resourceKind
+	{map[string]string{"resourceName": "my-config", "key": "threshold", "targetValue": "10"}, "test", true, "resourceKind"},
+	// Missing resourceName
+	{map[string]string{"resourceKind": "ConfigMap", "key": "threshold", "targetValue": "10"}, "test", true, "resourceName"},
+	// Missing key
+	{map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "targetValue": "10"}, "test", true, "key"},
+	// Missing targetValue
+	{map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold"}, "test", true, "targetValue"},
+	// Invalid resourceKind
+	{map[string]string{"resourceKind": "Pod", "resourceName": "my-pod", "key": "threshold", "targetValue": "10"}, "test", true, ""},
+	// Invalid format
+	{map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "format": "xml"}, "test", true, ""},
+	// Invalid valueType
+	{map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "valueType": "string"}, "test", true, ""},
+	// valueLocation with number format (should fail validation)
+	{map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "format": "number", "valueLocation": "some.path"}, "test", true, "valueLocation"},
+}
+
+func TestParseKubernetesResourceMetadata(t *testing.T) {
+	for idx, testData := range parseKubernetesResourceMetadataTestDataset {
+		t.Run(fmt.Sprintf("Test %d", idx), func(t *testing.T) {
+			_, err := NewKubernetesResourceScaler(
+				fake.NewClientBuilder().Build(),
+				&scalersconfig.ScalerConfig{
+					TriggerMetadata:         testData.metadata,
+					ScalableObjectNamespace: testData.namespace,
+				},
+			)
+			if testData.isError {
+				if err == nil {
+					t.Errorf("Expected error but got success")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected success but got error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+type kubernetesResourceIsActiveTestData struct {
+	metadata       map[string]string
+	namespace      string
+	configMapData  map[string]string
+	secretData     map[string][]byte
+	expectedActive bool
+	expectedValue  float64
+}
+
+var isActiveKubernetesResourceTestDataset = []kubernetesResourceIsActiveTestData{
+	// ConfigMap with simple number - inactive
+	{
+		metadata:       map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "activationTargetValue": "5"},
+		namespace:      "test",
+		configMapData:  map[string]string{"threshold": "3"},
+		expectedActive: false,
+		expectedValue:  3,
+	},
+	// ConfigMap with simple number - active
+	{
+		metadata:       map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "activationTargetValue": "5"},
+		namespace:      "test",
+		configMapData:  map[string]string{"threshold": "8"},
+		expectedActive: true,
+		expectedValue:  8,
+	},
+	// ConfigMap with JSON format
+	{
+		metadata:       map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "data", "valueLocation": "metrics.threshold", "targetValue": "10", "format": "json"},
+		namespace:      "test",
+		configMapData:  map[string]string{"data": `{"metrics": {"threshold": 15}}`},
+		expectedActive: true,
+		expectedValue:  15,
+	},
+	// ConfigMap with YAML format
+	{
+		metadata:       map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "data", "valueLocation": "metrics.threshold", "targetValue": "10", "format": "yaml"},
+		namespace:      "test",
+		configMapData:  map[string]string{"data": "metrics:\n  threshold: 20\n"},
+		expectedActive: true,
+		expectedValue:  20,
+	},
+	// ConfigMap with quantity type
+	{
+		metadata:       map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "valueType": "quantity"},
+		namespace:      "test",
+		configMapData:  map[string]string{"threshold": "500m"},
+		expectedActive: true, // 0.5 > 0 (default activationValue)
+		expectedValue:  0.5,
+	},
+	// ConfigMap with int64 type
+	{
+		metadata:       map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "valueType": "int64"},
+		namespace:      "test",
+		configMapData:  map[string]string{"threshold": "42"},
+		expectedActive: true,
+		expectedValue:  42,
+	},
+	// Secret with simple number
+	{
+		metadata:       map[string]string{"resourceKind": "Secret", "resourceName": "my-secret", "key": "threshold", "targetValue": "10"},
+		namespace:      "test",
+		secretData:     map[string][]byte{"threshold": []byte("25")},
+		expectedActive: true,
+		expectedValue:  25,
+	},
+	// Secret with JSON format
+	{
+		metadata:       map[string]string{"resourceKind": "Secret", "resourceName": "my-secret", "key": "data", "valueLocation": "limit", "targetValue": "100", "format": "json"},
+		namespace:      "test",
+		secretData:     map[string][]byte{"data": []byte(`{"limit": 150}`)},
+		expectedActive: true,
+		expectedValue:  150,
+	},
+}
+
+func TestKubernetesResourceIsActive(t *testing.T) {
+	for idx, testData := range isActiveKubernetesResourceTestDataset {
+		t.Run(fmt.Sprintf("Test %d", idx), func(t *testing.T) {
+			clientBuilder := fake.NewClientBuilder()
+
+			if testData.configMapData != nil {
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testData.metadata["resourceName"],
+						Namespace: testData.namespace,
+					},
+					Data: testData.configMapData,
+				}
+				clientBuilder = clientBuilder.WithRuntimeObjects(cm)
+			}
+
+			if testData.secretData != nil {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testData.metadata["resourceName"],
+						Namespace: testData.namespace,
+					},
+					Data: testData.secretData,
+				}
+				clientBuilder = clientBuilder.WithRuntimeObjects(secret)
+			}
+
+			s, err := NewKubernetesResourceScaler(
+				clientBuilder.Build(),
+				&scalersconfig.ScalerConfig{
+					TriggerMetadata:         testData.metadata,
+					AuthParams:              map[string]string{},
+					GlobalHTTPTimeout:       1000 * time.Millisecond,
+					ScalableObjectNamespace: testData.namespace,
+				},
+			)
+			if err != nil {
+				t.Errorf("Error creating scaler: %v", err)
+				return
+			}
+
+			metrics, isActive, err := s.GetMetricsAndActivity(context.TODO(), "test-metric")
+			if err != nil {
+				t.Errorf("Error getting metrics: %v", err)
+				return
+			}
+
+			if testData.expectedActive && !isActive {
+				t.Error("Expected active but got inactive")
+			}
+			if !testData.expectedActive && isActive {
+				t.Error("Expected inactive but got active")
+			}
+
+			// Check metric value
+			if len(metrics) != 1 {
+				t.Errorf("Expected 1 metric, got %d", len(metrics))
+				return
+			}
+
+			// AsApproximateFloat64() returns the value as base units
+			// GenerateMetricInMili stores value*1000 as milli units
+			// So AsApproximateFloat64() gives us back the original value
+			actualValue := metrics[0].Value.AsApproximateFloat64()
+			if actualValue != testData.expectedValue {
+				t.Errorf("Expected metric value %f, got %f", testData.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
+type kubernetesResourceGetMetricSpecTestData struct {
+	metadata     map[string]string
+	namespace    string
+	triggerIndex int
+	expectedName string
+}
+
+var getMetricSpecKubernetesResourceTestDataset = []kubernetesResourceGetMetricSpecTestData{
+	{
+		metadata:     map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10"},
+		namespace:    "test",
+		triggerIndex: 0,
+		expectedName: "s0-configmap-my-config-threshold",
+	},
+	{
+		metadata:     map[string]string{"resourceKind": "Secret", "resourceName": "my-secret", "key": "limit", "targetValue": "100"},
+		namespace:    "default",
+		triggerIndex: 1,
+		expectedName: "s1-secret-my-secret-limit",
+	},
+	{
+		metadata:     map[string]string{"resourceKind": "ConfigMap", "resourceName": "scaling-config", "key": "queue_length", "targetValue": "50"},
+		namespace:    "production",
+		triggerIndex: 2,
+		expectedName: "s2-configmap-scaling-config-queue_length",
+	},
+}
+
+func TestKubernetesResourceGetMetricSpecForScaling(t *testing.T) {
+	for idx, testData := range getMetricSpecKubernetesResourceTestDataset {
+		t.Run(fmt.Sprintf("Test %d", idx), func(t *testing.T) {
+			s, err := NewKubernetesResourceScaler(
+				fake.NewClientBuilder().Build(),
+				&scalersconfig.ScalerConfig{
+					TriggerMetadata:         testData.metadata,
+					AuthParams:              map[string]string{},
+					GlobalHTTPTimeout:       1000 * time.Millisecond,
+					ScalableObjectNamespace: testData.namespace,
+					TriggerIndex:            testData.triggerIndex,
+				},
+			)
+			if err != nil {
+				t.Errorf("Error creating scaler: %v", err)
+				return
+			}
+
+			metricSpecs := s.GetMetricSpecForScaling(context.Background())
+
+			if len(metricSpecs) != 1 {
+				t.Errorf("Expected 1 metric spec, got %d", len(metricSpecs))
+				return
+			}
+
+			if metricSpecs[0].External.Metric.Name != testData.expectedName {
+				t.Errorf("Expected metric name '%s', got '%s'", testData.expectedName, metricSpecs[0].External.Metric.Name)
+			}
+		})
+	}
+}
+
+func TestKubernetesResourceErrorCases(t *testing.T) {
+	testCases := []struct {
+		name          string
+		metadata      map[string]string
+		configMapData map[string]string
+		secretData    map[string][]byte
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "ConfigMap not found",
+			metadata:      map[string]string{"resourceKind": "ConfigMap", "resourceName": "missing-config", "key": "threshold", "targetValue": "10"},
+			configMapData: nil,
+			expectError:   true,
+			errorContains: "not found",
+		},
+		{
+			name:          "Key not found in ConfigMap",
+			metadata:      map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "missing-key", "targetValue": "10"},
+			configMapData: map[string]string{"threshold": "10"},
+			expectError:   true,
+			errorContains: "key missing-key not found",
+		},
+		{
+			name:          "Secret not found",
+			metadata:      map[string]string{"resourceKind": "Secret", "resourceName": "missing-secret", "key": "threshold", "targetValue": "10"},
+			secretData:    nil,
+			expectError:   true,
+			errorContains: "not found",
+		},
+		{
+			name:          "Invalid number format",
+			metadata:      map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10"},
+			configMapData: map[string]string{"threshold": "not-a-number"},
+			expectError:   true,
+			errorContains: "parsing",
+		},
+		{
+			name:          "Invalid JSON",
+			metadata:      map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "data", "valueLocation": "metrics.threshold", "targetValue": "10", "format": "json"},
+			configMapData: map[string]string{"data": `{invalid json}`},
+			expectError:   true,
+			errorContains: "not found",
+		},
+		{
+			name:          "JSON path not found",
+			metadata:      map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "data", "valueLocation": "missing.path", "targetValue": "10", "format": "json"},
+			configMapData: map[string]string{"data": `{"metrics": {"threshold": 10}}`},
+			expectError:   true,
+			errorContains: "not found",
+		},
+		{
+			name:          "Invalid YAML",
+			metadata:      map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "data", "valueLocation": "metrics.threshold", "targetValue": "10", "format": "yaml"},
+			configMapData: map[string]string{"data": "invalid:\n  yaml\n    bad indent"},
+			expectError:   true,
+			errorContains: "parsing YAML",
+		},
+		{
+			name:          "Invalid quantity",
+			metadata:      map[string]string{"resourceKind": "ConfigMap", "resourceName": "my-config", "key": "threshold", "targetValue": "10", "valueType": "quantity"},
+			configMapData: map[string]string{"threshold": "invalid-quantity"},
+			expectError:   true,
+			errorContains: "quantity",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientBuilder := fake.NewClientBuilder()
+
+			if tc.configMapData != nil {
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tc.metadata["resourceName"],
+						Namespace: "test",
+					},
+					Data: tc.configMapData,
+				}
+				clientBuilder = clientBuilder.WithRuntimeObjects(cm)
+			}
+
+			if tc.secretData != nil {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tc.metadata["resourceName"],
+						Namespace: "test",
+					},
+					Data: tc.secretData,
+				}
+				clientBuilder = clientBuilder.WithRuntimeObjects(secret)
+			}
+
+			s, err := NewKubernetesResourceScaler(
+				clientBuilder.Build(),
+				&scalersconfig.ScalerConfig{
+					TriggerMetadata:         tc.metadata,
+					AuthParams:              map[string]string{},
+					GlobalHTTPTimeout:       1000 * time.Millisecond,
+					ScalableObjectNamespace: "test",
+				},
+			)
+			if err != nil {
+				// Some errors are expected during scaler creation
+				if !tc.expectError {
+					t.Errorf("Unexpected error creating scaler: %v", err)
+				}
+				return
+			}
+
+			_, _, err = s.GetMetricsAndActivity(context.TODO(), "test-metric")
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error containing '%s' but got success", tc.errorContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected success but got error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -206,6 +206,8 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 		return scalers.NewInfluxDBScaler(config)
 	case "kafka":
 		return scalers.NewKafkaScaler(ctx, config)
+	case "kubernetes-resource":
+		return scalers.NewKubernetesResourceScaler(client, config)
 	case "kubernetes-workload":
 		return scalers.NewKubernetesWorkloadScaler(client, config)
 	case "liiklus":

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2339,6 +2339,69 @@
             ]
         },
         {
+            "type": "kubernetes-resource",
+            "parameters": [
+                {
+                    "name": "resourceKind",
+                    "type": "string",
+                    "allowedValue": [
+                        "ConfigMap",
+                        "Secret"
+                    ],
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "resourceName",
+                    "type": "string",
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "format",
+                    "type": "string",
+                    "default": "number",
+                    "allowedValue": [
+                        "number",
+                        "json",
+                        "yaml"
+                    ],
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "valueLocation",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "valueType",
+                    "type": "string",
+                    "default": "float64",
+                    "allowedValue": [
+                        "float64",
+                        "int64",
+                        "quantity"
+                    ],
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "targetValue",
+                    "type": "string",
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "activationTargetValue",
+                    "type": "string",
+                    "default": "0",
+                    "metadataVariableReadable": true
+                }
+            ]
+        },
+        {
             "type": "kubernetes-workload",
             "parameters": [
                 {

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1524,6 +1524,47 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
+    - type: kubernetes-resource
+      parameters:
+        - name: resourceKind
+          type: string
+          allowedValue:
+            - ConfigMap
+            - Secret
+          metadataVariableReadable: true
+        - name: resourceName
+          type: string
+          metadataVariableReadable: true
+        - name: key
+          type: string
+          metadataVariableReadable: true
+        - name: format
+          type: string
+          default: number
+          allowedValue:
+            - number
+            - json
+            - yaml
+          metadataVariableReadable: true
+        - name: valueLocation
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: valueType
+          type: string
+          default: float64
+          allowedValue:
+            - float64
+            - int64
+            - quantity
+          metadataVariableReadable: true
+        - name: targetValue
+          type: string
+          metadataVariableReadable: true
+        - name: activationTargetValue
+          type: string
+          default: "0"
+          metadataVariableReadable: true
     - type: kubernetes-workload
       parameters:
         - name: podSelector

--- a/tests/scalers/kubernetes_resource/kubernetes_resource_test.go
+++ b/tests/scalers/kubernetes_resource/kubernetes_resource_test.go
@@ -1,0 +1,436 @@
+//go:build e2e
+// +build e2e
+
+package kubernetes_resource_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
+)
+
+const (
+	testName = "kubernetes-resource-test"
+)
+
+var (
+	testNamespace     = fmt.Sprintf("%s-ns", testName)
+	deploymentName    = fmt.Sprintf("%s-deployment", testName)
+	scaledObjectName  = fmt.Sprintf("%s-so", testName)
+	configMapName     = fmt.Sprintf("%s-cm", testName)
+	secretName        = fmt.Sprintf("%s-secret", testName)
+	configMapJSONName = fmt.Sprintf("%s-cm-json", testName)
+	secretJSONName    = fmt.Sprintf("%s-secret-json", testName)
+	minReplicaCount   = 0
+	maxReplicaCount   = 5
+)
+
+type templateData struct {
+	TestNamespace     string
+	DeploymentName    string
+	ScaledObjectName  string
+	ConfigMapName     string
+	SecretName        string
+	ConfigMapJSONName string
+	SecretJSONName    string
+	MinReplicaCount   int
+	MaxReplicaCount   int
+}
+
+const (
+	deploymentTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.DeploymentName}}
+  namespace: {{.TestNamespace}}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: {{.DeploymentName}}
+  template:
+    metadata:
+      labels:
+        app: {{.DeploymentName}}
+    spec:
+      containers:
+      - name: nginx
+        image: 'ghcr.io/nginx/nginx-unprivileged:1.26'`
+
+	configMapTemplate = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.ConfigMapName}}
+  namespace: {{.TestNamespace}}
+data:
+  threshold: "0"`
+
+	secretTemplate = `apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretName}}
+  namespace: {{.TestNamespace}}
+type: Opaque
+stringData:
+  limit: "0"`
+
+	configMapJSONTemplate = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.ConfigMapJSONName}}
+  namespace: {{.TestNamespace}}
+data:
+  metrics: |
+    {
+      "scaling": {
+        "threshold": 0
+      }
+    }`
+
+	secretJSONTemplate = `apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretJSONName}}
+  namespace: {{.TestNamespace}}
+type: Opaque
+stringData:
+  config: |
+    {
+      "limits": {
+        "requests": 0
+      }
+    }`
+
+	scaledObjectConfigMapTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  cooldownPeriod: 5
+  minReplicaCount: {{.MinReplicaCount}}
+  maxReplicaCount: {{.MaxReplicaCount}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  triggers:
+  - type: kubernetes-resource
+    metadata:
+      resourceKind: ConfigMap
+      resourceName: {{.ConfigMapName}}
+      key: threshold
+      targetValue: "3"
+      activationTargetValue: "1"`
+
+	scaledObjectSecretTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  cooldownPeriod: 5
+  minReplicaCount: {{.MinReplicaCount}}
+  maxReplicaCount: {{.MaxReplicaCount}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  triggers:
+  - type: kubernetes-resource
+    metadata:
+      resourceKind: Secret
+      resourceName: {{.SecretName}}
+      key: limit
+      targetValue: "5"
+      activationTargetValue: "2"`
+
+	scaledObjectConfigMapJSONTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  cooldownPeriod: 5
+  minReplicaCount: {{.MinReplicaCount}}
+  maxReplicaCount: {{.MaxReplicaCount}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  triggers:
+  - type: kubernetes-resource
+    metadata:
+      resourceKind: ConfigMap
+      resourceName: {{.ConfigMapJSONName}}
+      key: metrics
+      format: json
+      valueLocation: scaling.threshold
+      targetValue: "4"
+      activationTargetValue: "1"`
+
+	scaledObjectSecretJSONTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  cooldownPeriod: 5
+  minReplicaCount: {{.MinReplicaCount}}
+  maxReplicaCount: {{.MaxReplicaCount}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 5
+  triggers:
+  - type: kubernetes-resource
+    metadata:
+      resourceKind: Secret
+      resourceName: {{.SecretJSONName}}
+      key: config
+      format: json
+      valueLocation: limits.requests
+      targetValue: "3"
+      activationTargetValue: "1"`
+)
+
+func TestScaler(t *testing.T) {
+	kc := GetKubernetesClient(t)
+	data, templates := getTemplateData()
+
+	// Create kubernetes resources (namespace, deployment, configmap, secret)
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
+	defer DeleteKubernetesResources(t, testNamespace, data, templates)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
+		"replica count should be 0 after 1 minute")
+
+	// Test ConfigMap scaling
+	t.Run("ConfigMap simple value", func(t *testing.T) {
+		testConfigMapSimpleValue(t, kc, data)
+	})
+
+	// Test Secret scaling
+	t.Run("Secret simple value", func(t *testing.T) {
+		testSecretSimpleValue(t, kc, data)
+	})
+
+	// Test ConfigMap with JSON
+	t.Run("ConfigMap JSON value", func(t *testing.T) {
+		testConfigMapJSONValue(t, kc, data)
+	})
+
+	// Test Secret with JSON
+	t.Run("Secret JSON value", func(t *testing.T) {
+		testSecretJSONValue(t, kc, data)
+	})
+}
+
+func testConfigMapSimpleValue(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- test configmap simple value ---")
+
+	// Create ScaledObject
+	KubectlApplyWithTemplate(t, data, "scaledObjectConfigMapTemplate", scaledObjectConfigMapTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "scaledObjectConfigMapTemplate", scaledObjectConfigMapTemplate)
+
+	// Should remain at 0 (value=0, activationValue=1)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 30)
+
+	// Update ConfigMap to activation threshold (value=1)
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl patch configmap %s -n %s --type merge -p '{\"data\":{\"threshold\":\"1\"}}'", configMapName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should still be at 0 (value=1 equals activationValue, not greater)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 30)
+
+	// Update ConfigMap above activation threshold (value=2)
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl patch configmap %s -n %s --type merge -p '{\"data\":{\"threshold\":\"2\"}}'", configMapName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale to 1 (value=2, targetValue=3 -> desiredReplicas = ceil[2/3] = 1)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
+		"replica count should be 1")
+
+	// Update ConfigMap to target value (value=3)
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl patch configmap %s -n %s --type merge -p '{\"data\":{\"threshold\":\"3\"}}'", configMapName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale to 1 (value=3, targetValue=3 -> desiredReplicas = ceil[3/3] = 1)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
+		"replica count should be 1")
+
+	// Update ConfigMap above target value (value=9)
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl patch configmap %s -n %s --type merge -p '{\"data\":{\"threshold\":\"9\"}}'", configMapName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale to 3 (value=9, targetValue=3 -> desiredReplicas = ceil[9/3] = 3)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 3, 60, 2),
+		"replica count should be 3")
+
+	// Update ConfigMap to very high value (value=15)
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl patch configmap %s -n %s --type merge -p '{\"data\":{\"threshold\":\"15\"}}'", configMapName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale to maxReplicaCount (value=15, targetValue=3 -> desiredReplicas = ceil[15/3] = 5, capped at maxReplicaCount)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 2),
+		"replica count should be at max")
+
+	// Scale back down - update ConfigMap to 0
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl patch configmap %s -n %s --type merge -p '{\"data\":{\"threshold\":\"0\"}}'", configMapName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale back to 0
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 2),
+		"replica count should be 0")
+}
+
+func testSecretSimpleValue(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- test secret simple value ---")
+
+	// Create ScaledObject
+	KubectlApplyWithTemplate(t, data, "scaledObjectSecretTemplate", scaledObjectSecretTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "scaledObjectSecretTemplate", scaledObjectSecretTemplate)
+
+	// Should remain at 0 (value=0, activationValue=2)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 30)
+
+	// Update Secret above activation threshold (value=3)
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl patch secret %s -n %s --type merge -p '{\"stringData\":{\"limit\":\"3\"}}'", secretName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update secret - %s", err)
+
+	// Should scale to 1 (value=3, targetValue=5 -> desiredReplicas = ceil[3/5] = 1)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
+		"replica count should be 1")
+
+	// Update Secret to high value (value=10)
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl patch secret %s -n %s --type merge -p '{\"stringData\":{\"limit\":\"10\"}}'", secretName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update secret - %s", err)
+
+	// Should scale to 2 (value=10, targetValue=5 -> desiredReplicas = ceil[10/5] = 2)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
+		"replica count should be 2")
+
+	// Scale back down - update Secret to 0
+	_, err = ExecuteCommand(fmt.Sprintf("kubectl patch secret %s -n %s --type merge -p '{\"stringData\":{\"limit\":\"0\"}}'", secretName, testNamespace))
+	assert.NoErrorf(t, err, "cannot update secret - %s", err)
+
+	// Should scale back to 0
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 2),
+		"replica count should be 0")
+}
+
+func testConfigMapJSONValue(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- test configmap json value ---")
+
+	// Create ScaledObject
+	KubectlApplyWithTemplate(t, data, "scaledObjectConfigMapJSONTemplate", scaledObjectConfigMapJSONTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "scaledObjectConfigMapJSONTemplate", scaledObjectConfigMapJSONTemplate)
+
+	// Should remain at 0 (value=0, activationValue=1)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 30)
+
+	// Update ConfigMap JSON value (value=2)
+	jsonData := `{\"scaling\":{\"threshold\":2}}`
+	_, err := ExecuteCommand(fmt.Sprintf(`kubectl patch configmap %s -n %s --type merge -p '{"data":{"metrics":"%s"}}'`, configMapJSONName, testNamespace, jsonData))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale to 1 (value=2, targetValue=4 -> desiredReplicas = ceil[2/4] = 1)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
+		"replica count should be 1")
+
+	// Update ConfigMap JSON value (value=8)
+	jsonData = `{\"scaling\":{\"threshold\":8}}`
+	_, err = ExecuteCommand(fmt.Sprintf(`kubectl patch configmap %s -n %s --type merge -p '{"data":{"metrics":"%s"}}'`, configMapJSONName, testNamespace, jsonData))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale to 2 (value=8, targetValue=4 -> desiredReplicas = ceil[8/4] = 2)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
+		"replica count should be 2")
+
+	// Scale back down
+	jsonData = `{\"scaling\":{\"threshold\":0}}`
+	_, err = ExecuteCommand(fmt.Sprintf(`kubectl patch configmap %s -n %s --type merge -p '{"data":{"metrics":"%s"}}'`, configMapJSONName, testNamespace, jsonData))
+	assert.NoErrorf(t, err, "cannot update configmap - %s", err)
+
+	// Should scale back to 0
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 2),
+		"replica count should be 0")
+}
+
+func testSecretJSONValue(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- test secret json value ---")
+
+	// Create ScaledObject
+	KubectlApplyWithTemplate(t, data, "scaledObjectSecretJSONTemplate", scaledObjectSecretJSONTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "scaledObjectSecretJSONTemplate", scaledObjectSecretJSONTemplate)
+
+	// Should remain at 0 (value=0, activationValue=1)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 30)
+
+	// Update Secret JSON value (value=3)
+	jsonData := `{\"limits\":{\"requests\":3}}`
+	_, err := ExecuteCommand(fmt.Sprintf(`kubectl patch secret %s -n %s --type merge -p '{"stringData":{"config":"%s"}}'`, secretJSONName, testNamespace, jsonData))
+	assert.NoErrorf(t, err, "cannot update secret - %s", err)
+
+	// Should scale to 1 (value=3, targetValue=3 -> desiredReplicas = ceil[3/3] = 1)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
+		"replica count should be 1")
+
+	// Update Secret JSON value (value=9)
+	jsonData = `{\"limits\":{\"requests\":9}}`
+	_, err = ExecuteCommand(fmt.Sprintf(`kubectl patch secret %s -n %s --type merge -p '{"stringData":{"config":"%s"}}'`, secretJSONName, testNamespace, jsonData))
+	assert.NoErrorf(t, err, "cannot update secret - %s", err)
+
+	// Should scale to 3 (value=9, targetValue=3 -> desiredReplicas = ceil[9/3] = 3)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 3, 60, 2),
+		"replica count should be 3")
+
+	// Scale back down
+	jsonData = `{\"limits\":{\"requests\":0}}`
+	_, err = ExecuteCommand(fmt.Sprintf(`kubectl patch secret %s -n %s --type merge -p '{"stringData":{"config":"%s"}}'`, secretJSONName, testNamespace, jsonData))
+	assert.NoErrorf(t, err, "cannot update secret - %s", err)
+
+	// Should scale back to 0
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 2),
+		"replica count should be 0")
+}
+
+func getTemplateData() (templateData, []Template) {
+	return templateData{
+			TestNamespace:     testNamespace,
+			DeploymentName:    deploymentName,
+			ScaledObjectName:  scaledObjectName,
+			ConfigMapName:     configMapName,
+			SecretName:        secretName,
+			ConfigMapJSONName: configMapJSONName,
+			SecretJSONName:    secretJSONName,
+			MinReplicaCount:   minReplicaCount,
+			MaxReplicaCount:   maxReplicaCount,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "configMapTemplate", Config: configMapTemplate},
+			{Name: "secretTemplate", Config: secretTemplate},
+			{Name: "configMapJSONTemplate", Config: configMapJSONTemplate},
+			{Name: "secretJSONTemplate", Config: secretJSONTemplate},
+		}
+}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

The Kubernetes Resource scaler enables workloads to scale based on dynamic configuration stored directly in ConfigMaps or Secrets within your cluster.


```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: app-metrics
  namespace: default
data:
  task-count: "25"
---
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: worker-scaler
  namespace: default
spec:
  scaleTargetRef:
    name: worker-deployment
  minReplicaCount: 0
  maxReplicaCount: 10
  triggers:
  - type: kubernetes-resource
    metadata:
      resourceKind: ConfigMap
      resourceName: app-metrics
      key: task-count
      targetValue: "10"
```

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on https://github.com/kedacore/keda-docs/pull/1648
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->

Fixes https://github.com/kedacore/keda/issues/7212


