### PR TITLE
feat: add contributing question in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report.yml
@@ -105,6 +105,15 @@ body:
     placeholder: ie. Azure Service Bus, Kafka, ...
   validations:
     required: false
+- type: dropdown
+  attributes:
+    label: Would you be open to contributing a fix?
+    options:
+      - "Yes"
+      - "No"
+      - "Maybe"
+  validations:
+    required: false
 - type: textarea
   id: anything-else
   attributes:


### PR DESCRIPTION
Sometimes someone reports a bug, even explaining where the bug is and possibly suggesting a fix. However, it's unclear whether they intend to fix it themselves or expect the community to do so.

I think a question like this helps determine whether a fix is ​​expected or whether the person will do it.

So, with this PR i want to add a question to the bug template that clarifies whether the reporter intends to implement the fix or expects the community to handle it.
This removes ambiguity and improves triage flow. 

The maintainers may disagree with this, with good reason, regarding what should be included in a bug report. That's perfectly fine. Closing the PR is fine in that case.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))