### PR TITLE
Include trigger actvivity in raw metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,9 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **General**: Correct error message when awsSecretAccessKey is missing in credential-based authentication ([#7265](https://github.com/kedacore/keda/pull/7265))
+- **General**: Raw metrics stream - include trigger activity status in response ([#7369](https://github.com/kedacore/keda/issues/7369))
 - **AWS CloudWatch Scaler**: Add cross-account observability support ([#7189](https://github.com/kedacore/keda/issues/7189))
 - **Dynamodb Scaler**: Add FilterExpression support ([#7102](https://github.com/kedacore/keda/issues/7102))
-- **General**: Raw metrics stream - include trigger activity status in response ([#7369](https://github.com/kedacore/keda/issues/7369)) 
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Correct error message when awsSecretAccessKey is missing in credential-based authentication ([#7265](https://github.com/kedacore/keda/pull/7265))
 - **AWS CloudWatch Scaler**: Add cross-account observability support ([#7189](https://github.com/kedacore/keda/issues/7189))
 - **Dynamodb Scaler**: Add FilterExpression support ([#7102](https://github.com/kedacore/keda/issues/7102))
+- **General**: Raw metrics stream - include trigger activity status in response ([#7369](https://github.com/kedacore/keda/issues/7369)) 
 
 ### Fixes
 

--- a/pkg/metricsservice/api/metrics.pb.go
+++ b/pkg/metricsservice/api/metrics.pb.go
@@ -296,6 +296,7 @@ type RawMetric struct {
 	Value         float64                `protobuf:"fixed64,1,opt,name=value,proto3" json:"value,omitempty"`
 	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	Metadata      *ScaledObjectRef       `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	IsActive      bool                   `protobuf:"varint,4,opt,name=isActive,proto3" json:"isActive,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -351,6 +352,13 @@ func (x *RawMetric) GetMetadata() *ScaledObjectRef {
 	return nil
 }
 
+func (x *RawMetric) GetIsActive() bool {
+	if x != nil {
+		return x.IsActive
+	}
+	return false
+}
+
 var File_metrics_proto protoreflect.FileDescriptor
 
 const file_metrics_proto_rawDesc = "" +
@@ -377,11 +385,12 @@ const file_metrics_proto_rawDesc = "" +
 	"\n" +
 	"\b_message\">\n" +
 	"\x12RawMetricsResponse\x12(\n" +
-	"\ametrics\x18\x01 \x03(\v2\x0e.api.RawMetricR\ametrics\"\x8d\x01\n" +
+	"\ametrics\x18\x01 \x03(\v2\x0e.api.RawMetricR\ametrics\"\xa9\x01\n" +
 	"\tRawMetric\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\x01R\x05value\x128\n" +
 	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x120\n" +
-	"\bmetadata\x18\x03 \x01(\v2\x14.api.ScaledObjectRefR\bmetadata2\x81\x01\n" +
+	"\bmetadata\x18\x03 \x01(\v2\x14.api.ScaledObjectRefR\bmetadata\x12\x1a\n" +
+	"\bisActive\x18\x04 \x01(\bR\bisActive2\x81\x01\n" +
 	"\x0eMetricsService\x12o\n" +
 	"\n" +
 	"GetMetrics\x12\x14.api.ScaledObjectRef\x1aI.k8s.io.metrics.pkg.apis.external_metrics.v1beta1.ExternalMetricValueList\"\x002\xeb\x01\n" +

--- a/pkg/metricsservice/api/metrics.pb.go
+++ b/pkg/metricsservice/api/metrics.pb.go
@@ -22,14 +22,13 @@
 package api
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	v1beta1 "k8s.io/metrics/pkg/apis/external_metrics/v1beta1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (

--- a/pkg/metricsservice/api/metrics.proto
+++ b/pkg/metricsservice/api/metrics.proto
@@ -60,4 +60,5 @@ message RawMetric {
     double value = 1;
     google.protobuf.Timestamp timestamp = 2;
     ScaledObjectRef metadata = 3;
+    bool isActive = 4;
 }

--- a/pkg/metricsservice/api/metrics_grpc.pb.go
+++ b/pkg/metricsservice/api/metrics_grpc.pb.go
@@ -23,7 +23,6 @@ package api
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -88,6 +88,7 @@ func (s *GrpcServer) GetRawMetricsStream(request *api.RawMetricsRequest, stream 
 				metrics = append(metrics, &api.RawMetric{
 					Value:     v.Value.AsApproximateFloat64(),
 					Timestamp: timestamppb.New(v.Timestamp.Time),
+					IsActive:  rm.IsActive,
 					Metadata: &api.ScaledObjectRef{
 						Name:       rm.Meta.ScaledObjectName,
 						Namespace:  rm.Meta.Namespace,

--- a/pkg/scalers/externalscaler/externalscaler.pb.go
+++ b/pkg/scalers/externalscaler/externalscaler.pb.go
@@ -7,12 +7,11 @@
 package externalscaler
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/scalers/externalscaler/externalscaler_grpc.pb.go
+++ b/pkg/scalers/externalscaler/externalscaler_grpc.pb.go
@@ -8,7 +8,6 @@ package externalscaler
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/scalers/liiklus/LiiklusService.pb.go
+++ b/pkg/scalers/liiklus/LiiklusService.pb.go
@@ -7,14 +7,13 @@
 package liiklus
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (

--- a/pkg/scalers/liiklus/LiiklusService_grpc.pb.go
+++ b/pkg/scalers/liiklus/LiiklusService_grpc.pb.go
@@ -8,7 +8,6 @@ package liiklus
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Include information about trigger activity in raw metrics. This is useful when a trigger defines `activityThreshold`, where non-zero value does not necessarily mean that the trigger is active.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/pull/7093, https://github.com/kedacore/keda/issues/7094
