### PR TITLE
fix: restore HPA behavior when paused-scale-in/out annotation is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Fix HPA behavior not restored when paused-scale-in/out annotation is deleted without corresponding custom behavior ([#7291](https://github.com/kedacore/keda/pull/7291))
 - **General**: Fix nil reference panic when transfer-hpa-ownership is set but no hpa name is provided ([#7254](https://github.com/kedacore/keda/issues/7254))
 - **General**: Fix race condition in paused-replicas annotation causing ScaledObject to get stuck ([#7231](https://github.com/kedacore/keda/issues/7231))
 - **General**: Use TriggerError when all ScaledJob triggers fail ([#7205](https://github.com/kedacore/keda/pull/7205))

--- a/tests/internals/pause_scale_in_restore/pause_scale_in_restore_test.go
+++ b/tests/internals/pause_scale_in_restore/pause_scale_in_restore_test.go
@@ -1,0 +1,163 @@
+//go:build e2e
+// +build e2e
+
+package pause_scale_in_restore_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
+)
+
+// Load environment variables from .env file
+
+const (
+	testName = "pause-scalein-restore-test"
+)
+
+var (
+	testNamespace           = fmt.Sprintf("%s-ns", testName)
+	deploymentName          = fmt.Sprintf("%s-deployment", testName)
+	monitoredDeploymentName = fmt.Sprintf("%s-monitored", testName)
+	scaledObjectName        = fmt.Sprintf("%s-so", testName)
+)
+
+type templateData struct {
+	TestNamespace           string
+	DeploymentName          string
+	ScaledObjectName        string
+	MonitoredDeploymentName string
+}
+
+const (
+	monitoredDeploymentTemplate = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.MonitoredDeploymentName}}
+  namespace: {{.TestNamespace}}
+  labels:
+    app: {{.MonitoredDeploymentName}}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: {{.MonitoredDeploymentName}}
+  template:
+    metadata:
+      labels:
+        app: {{.MonitoredDeploymentName}}
+    spec:
+      containers:
+        - name: {{.MonitoredDeploymentName}}
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
+`
+
+	deploymentTemplate = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.DeploymentName}}
+  namespace: {{.TestNamespace}}
+  labels:
+    app: {{.DeploymentName}}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: {{.DeploymentName}}
+  template:
+    metadata:
+      labels:
+        app: {{.DeploymentName}}
+    spec:
+      containers:
+        - name: {{.DeploymentName}}
+          image: ghcr.io/nginx/nginx-unprivileged:1.26
+`
+
+	scaledObjectTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+  annotations:
+    autoscaling.keda.sh/paused-scale-in: "true"
+    test-annotation: "preserve-this"
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  cooldownPeriod:  0
+  triggers:
+    - type: kubernetes-workload
+      metadata:
+        podSelector: 'app={{.MonitoredDeploymentName}}'
+        value: '1'
+`
+
+	scaledObjectWithoutPauseTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+  annotations:
+    test-annotation: "preserve-this"
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  cooldownPeriod:  0
+  triggers:
+    - type: kubernetes-workload
+      metadata:
+        podSelector: 'app={{.MonitoredDeploymentName}}'
+        value: '1'
+`
+)
+
+func TestScaler(t *testing.T) {
+	// setup
+	t.Log("--- setting up ---")
+
+	// Create kubernetes resources
+	kc := GetKubernetesClient(t)
+	data, templates := getTemplateData()
+
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
+
+	// assert that the deployment did not scale down after one minute (scale-in is paused)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 2, 60)
+
+	// remove the paused-scale-in annotation
+	KubectlReplaceWithTemplate(t, data, "scaledObjectWithoutPauseTemplate", scaledObjectWithoutPauseTemplate)
+
+	// assert that the deployment scales down to 0 after removing the annotation
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2),
+		"replica count should be 0 after removing paused-scale-in annotation")
+
+	// cleanup
+	DeleteKubernetesResources(t, testNamespace, data, templates)
+}
+
+func getTemplateData() (templateData, []Template) {
+	return templateData{
+			TestNamespace:           testNamespace,
+			DeploymentName:          deploymentName,
+			ScaledObjectName:        scaledObjectName,
+			MonitoredDeploymentName: monitoredDeploymentName,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "monitoredDeploymentTemplate", Config: monitoredDeploymentTemplate},
+			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		}
+}


### PR DESCRIPTION
## Summary

When `paused-scale-in` or `paused-scale-out` annotation is **deleted** (not set to `"false"`), the HPA's `SelectPolicy` remains stuck at `Disabled` instead of being restored to the default behavior. This occurs when `selectPolicy` is not explicitly defined in the ScaledObject spec, even if other behavior fields like `policies` or `stabilizationWindowSeconds` are configured.

## Problem Description

### Affected Scenario

A user pauses scale-in by setting `autoscaling.keda.sh/paused-scale-in=true` on a ScaledObject. KEDA correctly sets the HPA's `scaleDown.selectPolicy` to `Disabled`. However, when the user removes this annotation to resume normal scaling, the HPA's policy remains `Disabled` indefinitely.

### Root Cause

The HPA update logic uses `DeepDerivative` to compare the desired HPA spec with the existing one:

```go
!equality.Semantic.DeepDerivative(hpa.Spec, foundHpa.Spec)
```

`DeepDerivative` treats `nil` as "unset" and considers it a **subset of any value**. So when comparing:

- Desired: `Behavior.ScaleDown.SelectPolicy = nil`
- Existing: `Behavior.ScaleDown.SelectPolicy = Disabled`

`DeepDerivative` returns `true` (considers them equal), so no update is triggered.

## How to Reproduce

1. Create a ScaledObject with the `paused-scale-in` annotation and custom behavior where `selectPolicy` is **not** explicitly defined, along with a dummy deployment for KEDA to scale:

```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: my-scaledobject
  annotations:
    autoscaling.keda.sh/paused-scale-in: "true"
spec:
  scaleTargetRef:
    name: my-deployment
  minReplicaCount: 1
  maxReplicaCount: 10
  triggers:
    - type: cron
      metadata:
        timezone: UTC
        start: "0 * * * *"
        end: "1 * * * *"
        desiredReplicas: "2"
  advanced:
    horizontalPodAutoscalerConfig:
      behavior:
        scaleDown:
          # selectPolicy is NOT defined - this is the condition for the bug
          stabilizationWindowSeconds: 600
          policies:
            - type: Percent
              value: 5
              periodSeconds: 300
        scaleUp:
          policies:
            - type: Percent
              value: 10
              periodSeconds: 120
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: my-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: my-deployment
  template:
    metadata:
      labels:
        app: my-deployment
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
```

2. Verify the HPA has `Disabled` scale down policy:

```bash
kubectl get hpa keda-hpa-my-scaledobject -o jsonpath='{.spec.behavior.scaleDown.selectPolicy}'
Disabled
```

3. Remove the annotation (expecting behavior to be restored):

```bash
kubectl annotate scaledobject my-scaledobject autoscaling.keda.sh/paused-scale-in-
```

4. Check HPA behavior again - **BUG: still shows "Disabled"**

```bash
kubectl get hpa keda-hpa-my-scaledobject -o jsonpath='{.spec.behavior.scaleDown.selectPolicy}'
Disabled  ← Should be default
```

### Conditions for bug to manifest

- ScaledObject has `paused-scale-in=true` or `paused-scale-out=true` annotation
- The ScaledObject does **not** have an explicit `selectPolicy` defined in `spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown` (or `scaleUp` for paused-scale-out). Other fields like `stabilizationWindowSeconds` or `policies` can be defined - the bug still occurs.
- User **deletes** the annotation (vs. setting it to `"false"`)

## Solution

Add an explicit `DeepEqual` check for the `Behavior` field before the `DeepDerivative` check:

```go
if len(hpa.Spec.Metrics) != len(foundHpa.Spec.Metrics) ||
    !equality.Semantic.DeepEqual(hpa.Spec.Behavior, foundHpa.Spec.Behavior) ||
    !equality.Semantic.DeepDerivative(hpa.Spec, foundHpa.Spec) {
```

`DeepEqual` correctly identifies that `{SelectPolicy: nil}` and `{SelectPolicy: Disabled}` are different, triggering the HPA update.

This follows the existing pattern already used for the `Metrics` length check, which also works around a `DeepDerivative` limitation.

## Changes

| File | Change |
|------|--------|
| `controllers/keda/hpa.go` | Added `DeepEqual` check for `Behavior` field with explanatory comment |
| `controllers/keda/scaledobject_controller_test.go` | Added test case that verifies HPA behavior is restored when annotation is deleted |

## Testing

Added integration test `removes scale down disabled policy when annotation removed without custom scaledown behavior` that:

1. Creates a ScaledObject with `paused-scale-in=true` annotation and custom `ScaleUp` behavior (but no `ScaleDown` behavior)
2. Verifies HPA has `Disabled` ScaleDown policy
3. Deletes the annotation
4. Verifies HPA ScaleDown is no longer `Disabled` while custom `ScaleUp` config is preserved
