### PR TITLE
feat(util): add log when Kubernetes minor version parsing fails

### DIFF
--- a/pkg/util/k8sversion.go
+++ b/pkg/util/k8sversion.go
@@ -20,7 +20,10 @@ import (
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/version"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+var versionLog = ctrl.Log.WithName("k8s_version")
 
 // K8sVersion holds parsed data from a K8s version
 type K8sVersion struct {
@@ -43,6 +46,9 @@ func NewK8sVersion(version *version.Info) K8sVersion {
 	minor, err := strconv.Atoi(minorTrimmed)
 	if err == nil {
 		parsed = true
+	} else {
+		versionLog.Error(err, "Could not parse Kubernetes minor version",
+			"minorTrimmed", minorTrimmed, "rawMinor", version.Minor)
 	}
 
 	k8sVersion := new(K8sVersion)


### PR DESCRIPTION
### What this PR does

This pull request adds a log when the Kubernetes minor version cannot be parsed in the `NewK8sVersion()` function. Currently, the code silently sets `Parsed` to `false` without any log output, which could make debugging difficult when the version string is incorrect or unexpected.

By adding a warning log, users and developers will be better informed when parsing fails, making it easier to detect and resolve potential issues related to Kubernetes version detection.

### Why it's needed

Closes [#7262](https://github.com/kedacore/keda/issues/7262).

This change improves observability and helps users understand why certain features may not be working if version parsing fails.
