### PR TITLE
Emit deprecation warning when deprecated log flags used in adapter

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -272,6 +272,17 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zapOpts...))
 
+	// Warn about deprecated logging flags
+	if cmd.Flags().Changed("v") {
+		setupLog.Info("DEPRECATION WARNING: The '-v' flag is deprecated and will be removed in a future release. Please use '--zap-log-level' instead (e.g., '--zap-log-level=-1' for info, '--zap-log-level=-2' for debug)")
+	}
+	if cmd.Flags().Changed("logtostderr") {
+		setupLog.Info("DEPRECATION WARNING: The '--logtostderr' flag is deprecated and will be removed in a future release. Please use '--zap-encoder=console' instead")
+	}
+	if cmd.Flags().Changed("stderrthreshold") {
+		setupLog.Info("DEPRECATION WARNING: The '--stderrthreshold' flag is deprecated and has no equivalent in the new logging system. This flag is a no-op and will be removed in a future release")
+	}
+
 	err = printWelcomeMsg(cmd)
 	if err != nil {
 		return


### PR DESCRIPTION


<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
If you'd rather not have the noise here, I can just carry this downstream but I thought I'd at least offer :smile: 

- I'm trying to prevent any user surprise from the log migration 

- We migrated to zap logs in the metrics adapter over in https://github.com/kedacore/keda/pull/6578 , and as part of that we translated the old log args to zap args, which avoids hard breaking users, but which will potentially also result in users having their log output change.

- This just emits explicit log messages when using the old log flags explaining that the old log flags were deprecated so folks who are concerned can see why at the top of their logs.

Over in the olm operator we have that kedacontroller object that governs KEDA deployment and allows overriding args, Kedacontrollers persist across upgrades, and rather than rewrite the user's override args to be proper on the kedacontroller (and upset gitops systems since that's a user-set field) we thought it more straightforward to just signal it here since this is where they would look -- in the log whose output was different. 

### Checklist

- ~~[ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)~~
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- ~~[ ] Tests have been added~~
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files.
- ~~[ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)~~
- ~~[ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~~
- ~~[ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*~~
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
