### PR TITLE
fix: e2e test on PR doesn't fail because missing docker

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   triage:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     name: Comment evaluate
     container: ghcr.io/kedacore/keda-tools:1.25.5
     outputs:


### PR DESCRIPTION
it looks like the `ubuntu-slim` runner doesn't support docker and our e2e on pr flow requires docker for the actions

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

