### PR TITLE
feat(nats-jetstream): Add leaderOnly parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **General**: Correct error message when awsSecretAccessKey is missing in credential-based authentication ([#7265](https://github.com/kedacore/keda/pull/7265))
+- **NATS JetStream Scaler**: Add `leaderOnly` parameter to query only the stream leader node ([#7322](https://github.com/kedacore/keda/issues/7322))
 - **AWS CloudWatch Scaler**: Add cross-account observability support ([#7189](https://github.com/kedacore/keda/issues/7189))
 - **Dynamodb Scaler**: Add FilterExpression support ([#7102](https://github.com/kedacore/keda/issues/7102))
 

--- a/pkg/scalers/nats_jetstream_scaler_test.go
+++ b/pkg/scalers/nats_jetstream_scaler_test.go
@@ -41,6 +41,8 @@ var testNATSJetStreamMetadata = []parseNATSJetStreamMetadataTestData{
 	{map[string]string{"natsServerMonitoringEndpoint": "localhost:8222", "account": "$G", "accountID": "$G", "stream": "mystream", "consumer": "pull_consumer", "useHttps": "false"}, map[string]string{}, false},
 	// All good url.
 	{map[string]string{"natsServerMonitoringEndpoint": "nats.nats:8222", "account": "$G", "stream": "mystream", "consumer": "pull_consumer", "useHttps": "true"}, map[string]string{}, false},
+	// All good with leaderOnly.
+	{map[string]string{"natsServerMonitoringEndpoint": "nats.nats:8222", "account": "$G", "stream": "mystream", "consumer": "pull_consumer", "leaderOnly": "true"}, map[string]string{}, false},
 	// All good uses ID over name
 	{map[string]string{"natsServerMonitoringEndpoint": "localhost:8222", "accountID": "$G", "stream": "mystream", "consumer": "pull_consumer", "useHttps": "false"}, map[string]string{}, false},
 	// nothing passed
@@ -111,15 +113,27 @@ func TestNATSJetStreamGetMetricSpecForScaling(t *testing.T) {
 }
 
 func TestGetNATSJetStreamEndpointHTTPS(t *testing.T) {
-	endpoint := getNATSJetStreamMonitoringURL(true, "nats.nats:8222", "$G")
+	endpoint := getNATSJetStreamMonitoringURL(true, "nats.nats:8222", "$G", false)
 
 	assert.True(t, strings.HasPrefix(endpoint, "https:"))
 }
 
 func TestGetNATSJetStreamEndpointHTTP(t *testing.T) {
-	endpoint := getNATSJetStreamMonitoringURL(false, "nats.nats:8222", "$G")
+	endpoint := getNATSJetStreamMonitoringURL(false, "nats.nats:8222", "$G", false)
 
 	assert.True(t, strings.HasPrefix(endpoint, "http:"))
+}
+
+func TestGetNATSJetStreamEndpointLeaderOnly(t *testing.T) {
+	endpoint := getNATSJetStreamMonitoringURL(false, "nats.nats:8222", "$G", true)
+
+	assert.True(t, strings.Contains(endpoint, "leader-only=true"))
+}
+
+func TestGetNATSJetStreamEndpointWithoutLeaderOnly(t *testing.T) {
+	endpoint := getNATSJetStreamMonitoringURL(false, "nats.nats:8222", "$G", false)
+
+	assert.False(t, strings.Contains(endpoint, "leader-only"))
 }
 
 var testNATSJetStreamGoodMetadata = map[string]string{"natsServerMonitoringEndpoint": "localhost:8222", "account": "$G", "stream": "mystream", "consumer": "pull_consumer", "useHttps": "false", "activationLagThreshold": "10"}

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2836,6 +2836,13 @@
                     "metadataVariableReadable": true
                 },
                 {
+                    "name": "leaderOnly",
+                    "type": "string",
+                    "optional": true,
+                    "default": "false",
+                    "metadataVariableReadable": true
+                },
+                {
                     "name": "natsServerMonitoringEndpoint",
                     "type": "string",
                     "metadataVariableReadable": true,

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1849,6 +1849,11 @@ scalers:
           optional: true
           default: "false"
           metadataVariableReadable: true
+        - name: leaderOnly
+          type: string
+          optional: true
+          default: "false"
+          metadataVariableReadable: true
         - name: natsServerMonitoringEndpoint
           type: string
           metadataVariableReadable: true


### PR DESCRIPTION
Add leaderOnly parameter to query only stream leader

This adds a new optional 'leaderOnly' parameter to the NATS JetStream scaler that appends '&leader-only=true' to the monitoring URL when enabled. This is useful in clustered NATS deployments to ensure metrics are fetched only from the stream leader node.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files.
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #7322 

