### PR TITLE
Add retry logic to Azure Service Bus scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Correct error message when awsSecretAccessKey is missing in credential-based authentication ([#7265](https://github.com/kedacore/keda/pull/7265))
 - **AWS CloudWatch Scaler**: Add cross-account observability support ([#7189](https://github.com/kedacore/keda/issues/7189))
+- **Azure Service Bus Scaler**: Add configurable retry logic with exponential backoff to handle transient API failures ([#7338](https://github.com/kedacore/keda/issues/7338))
 - **Dynamodb Scaler**: Add FilterExpression support ([#7102](https://github.com/kedacore/keda/issues/7102))
 
 ### Fixes

--- a/pkg/scalers/azure_servicebus_scaler_test.go
+++ b/pkg/scalers/azure_servicebus_scaler_test.go
@@ -247,3 +247,37 @@ func TestAzServiceBusGetMetricSpecForScaling(t *testing.T) {
 		}
 	}
 }
+
+func TestParseMaxRetriesMetadata(t *testing.T) {
+	// Test default maxRetries value (0)
+	meta, err := parseAzureServiceBusMetadata(&scalersconfig.ScalerConfig{
+		ResolvedEnv:     sampleResolvedEnv,
+		TriggerMetadata: map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting},
+		AuthParams:      map[string]string{},
+		PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: ""},
+		TriggerIndex:    0,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, meta.MaxRetries, "Expected default maxRetries to be 0")
+
+	// Test explicit maxRetries value
+	meta, err = parseAzureServiceBusMetadata(&scalersconfig.ScalerConfig{
+		ResolvedEnv:     sampleResolvedEnv,
+		TriggerMetadata: map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting, "maxRetries": "3"},
+		AuthParams:      map[string]string{},
+		PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: ""},
+		TriggerIndex:    0,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, meta.MaxRetries, "Expected maxRetries to be 3")
+
+	// Test invalid maxRetries value (non-numeric)
+	_, err = parseAzureServiceBusMetadata(&scalersconfig.ScalerConfig{
+		ResolvedEnv:     sampleResolvedEnv,
+		TriggerMetadata: map[string]string{"queueName": queueName, "connectionFromEnv": connectionSetting, "maxRetries": "invalid"},
+		AuthParams:      map[string]string{},
+		PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: ""},
+		TriggerIndex:    0,
+	})
+	assert.Error(t, err, "Expected error for invalid maxRetries value")
+}

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -1072,6 +1072,13 @@
                         "avg"
                     ],
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "maxRetries",
+                    "type": "string",
+                    "optional": true,
+                    "default": "0",
+                    "metadataVariableReadable": true
                 }
             ]
         },

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -702,6 +702,11 @@ scalers:
             - max
             - avg
           metadataVariableReadable: true
+        - name: maxRetries
+          type: string
+          optional: true
+          default: "0"
+          metadataVariableReadable: true
     - type: beanstalkd
       parameters:
         - name: server


### PR DESCRIPTION
  - Add configurable maxRetries parameter (default: 0)
  - Implement exponential backoff (2s → 60s cap)
  - Add unit tests for metadata parsing
  - Update schema files
  - Respect context cancellation

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #7338 
 
<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda-docs/pull/1677

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files.
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
