### PR TITLE
fix: Update pre-commit config to check scalers_builder.go instead of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Apply fallback in polling loop to enable scaling from zero ([#7239](https://github.com/kedacore/keda/issues/7239))
-- **General**: Fix pre-commit config to reference correct filename in scaler sorting check ([#7373](https://github.com/kedacore/keda/pull/7373))
 - **General**: Replace deprecated `azure autorest` dependency to `azure sdk for go` ([#7073](https://github.com/kedacore/keda/issues/7073))
 - **IBMMQ Scaler**: Create new HTTP request for each queue query in IBMMQ scaler ([#7202](https://github.com/kedacore/keda/pull/7202))
 


### PR DESCRIPTION
## Description

Fixed a configuration inconsistency in `.pre-commit-config.yaml` where the scaler sorting check hook referenced the wrong filename.

**What was wrong:**
- The pre-commit hook `sort-scalers` was configured to check `scale_handler.go`
- The actual script `tools/sort_scalers.sh` checks `scalers_builder.go`
- This mismatch caused confusion and the hook description was misleading

**What changed:**
- Updated the hook name/description to reference `scalers_builder.go`
- Updated the `files` pattern to match `scalers_builder.go` instead of `scale_handler.go`

**Impact:**
- No functional change - the script was already checking the correct file
- Improves documentation accuracy and developer experience
- Aligns configuration with actual implementation

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
