### PR TITLE
fix(datadog): return request in cluster agent proxy without bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Apply fallback in polling loop to enable scaling from zero ([#7239](https://github.com/kedacore/keda/issues/7239))
 - **General**: Replace deprecated `azure autorest` dependency to `azure sdk for go` ([#7073](https://github.com/kedacore/keda/issues/7073))
+- **Datadog Scaler**: Return request in cluster agent proxy without bearer auth ([#7341](https://github.com/kedacore/keda/issues/7341))
 - **Datadog Scaler**: Use metricUnavailableValue for 422 errors in Datadog Cluster Agent ([#7246](https://github.com/kedacore/keda/issues/7246))
 - **IBMMQ Scaler**: Create new HTTP request for each queue query in IBMMQ scaler ([#7202](https://github.com/kedacore/keda/pull/7202))
 - **Temporal Scaler**: Fix TLS RootCAs initialization when using API key authentication with Temporal Cloud ([#7367](https://github.com/kedacore/keda/pull/7367))

--- a/pkg/scalers/datadog_scaler.go
+++ b/pkg/scalers/datadog_scaler.go
@@ -474,29 +474,16 @@ func (s *datadogScaler) getDatadogMetricValue(req *http.Request) (float64, error
 }
 
 func (s *datadogScaler) getDatadogClusterAgentHTTPRequest(ctx context.Context, url string) (*http.Request, error) {
-	var req *http.Request
-	var err error
-
-	switch {
-	case s.metadata.EnableBearerAuth:
-		req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.metadata.BearerToken))
-		if err != nil {
-			return nil, err
-		}
-		return req, nil
-
-	default:
-		req, err = http.NewRequestWithContext(ctx, "GET", url, nil)
-		if err != nil {
-			return req, err
-		}
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, nil
+	if s.metadata.EnableBearerAuth {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.metadata.BearerToken))
+	}
+
+	return req, nil
 }
 
 // GetMetricSpecForScaling returns the MetricSpec for the Horizontal Pod Autoscaler

--- a/pkg/scalers/datadog_scaler_test.go
+++ b/pkg/scalers/datadog_scaler_test.go
@@ -409,3 +409,55 @@ func TestDatadogMetadataValidateUseFiller(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDatadogClusterAgentHTTPRequest(t *testing.T) {
+	testCases := []struct {
+		name               string
+		enableBearerAuth   bool
+		bearerToken        string
+		expectedAuthHeader bool
+	}{
+		{
+			name:               "with bearer auth",
+			enableBearerAuth:   true,
+			bearerToken:        "test-token",
+			expectedAuthHeader: true,
+		},
+		{
+			name:               "without bearer auth",
+			enableBearerAuth:   false,
+			bearerToken:        "",
+			expectedAuthHeader: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scaler := &datadogScaler{
+				metadata: &datadogMetadata{
+					EnableBearerAuth: tc.enableBearerAuth,
+					BearerToken:      tc.bearerToken,
+				},
+			}
+
+			req, err := scaler.getDatadogClusterAgentHTTPRequest(
+				context.Background(),
+				"https://test.example.com",
+			)
+
+			if req == nil && err == nil {
+				t.Error("Expected request, got nil")
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if tc.expectedAuthHeader {
+				if auth := req.Header.Get("Authorization"); auth == "" {
+					t.Error("Expected Authorization header")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes a bug in `getDatadogClusterAgentHTTPRequest` where the function returns `nil` instead of the HTTP request when bearer authentication is disabled. Also was the function calling `http.NewRequestWithContext` in both the bearer auth case and the default case, but the default case didn't return the request and fell through to `return nil, nil`. 

Changed to create the request once and add the Authorization header only when needed.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files.
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7341