### PR TITLE
Properly return when closing raw metrics server

### DIFF
--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -110,6 +110,11 @@ func (s *GrpcServer) GetRawMetricsStream(request *api.RawMetricsRequest, stream 
 		case val, open := <-doneCh:
 			if open && !val {
 				logger.V(10).Info(fmt.Sprintf("Channel closed for subscriber %s", request.GetSubscriber()))
+				return nil
+			}
+			if !open {
+				logger.V(10).Info(fmt.Sprintf("Done channel closed for subscriber %s", request.GetSubscriber()))
+				return nil
 			}
 		}
 	}

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -107,15 +107,9 @@ func (s *GrpcServer) GetRawMetricsStream(request *api.RawMetricsRequest, stream 
 					return err
 				}
 			}
-		case val, open := <-doneCh:
-			if open && !val {
-				logger.V(10).Info(fmt.Sprintf("Channel closed for subscriber %s", request.GetSubscriber()))
-				return nil
-			}
-			if !open {
-				logger.V(10).Info(fmt.Sprintf("Done channel closed for subscriber %s", request.GetSubscriber()))
-				return nil
-			}
+		case <-doneCh:
+			logger.V(10).Info("Raw metrics stream terminated after subscriber unsubscribed", "subscriber", request.GetSubscriber())
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
Missing `return` statement causes raw metrics server hang when client unsubscribes from receiving metrics.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead.
-->
Fixes #7389


