### PR TITLE
fix: make golangci-lint check lazy to avoid errors on unrelated targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,12 +155,12 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-HAS_GOLANGCI_VERSION:=$(shell $(GOPATH)/bin/golangci-lint version --short)
 .PHONY: golangci
 golangci: ## Run golangci against code.
-ifneq ($(HAS_GOLANGCI_VERSION), $(GOLANGCI_VERSION))
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v$(GOLANGCI_VERSION)
-endif
+	@HAS_GOLANGCI_VERSION=$$($(GOPATH)/bin/golangci-lint version --short 2>/dev/null || echo ""); \
+	if [ "$$HAS_GOLANGCI_VERSION" != "$(GOLANGCI_VERSION)" ]; then \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v$(GOLANGCI_VERSION); \
+	fi
 	golangci-lint run
 
 verify-manifests: ## Verify manifests are up to date.


### PR DESCRIPTION
fix: make golangci-lint check lazy to avoid errors on unrelated targets

### Checklist

- [ X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes # "bash: line ***: /go/bin/golangci-lint: No such file or directory" by
- moving the version check inside the golangci target so it only runs when that target is executed
- adding error suppression (2>/dev/null) so the check doesn't fail if golangci-lint isn't installed


