### PR TITLE
Fix accurateScalingStrategy ignoring pendingJobCount in maxReplicaCount check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Apply fallback in polling loop to enable scaling from zero ([#7239](https://github.com/kedacore/keda/issues/7239))
+- **General**: Fix accurateScalingStrategy ignoring pendingJobCount in maxReplicaCount check ([#7329](https://github.com/kedacore/keda/issues/7329))
 - **General**: Replace deprecated `azure autorest` dependency to `azure sdk for go` ([#7073](https://github.com/kedacore/keda/issues/7073))
 - **Datadog Scaler**: Return request in cluster agent proxy without bearer auth ([#7341](https://github.com/kedacore/keda/issues/7341))
 - **Datadog Scaler**: Use metricUnavailableValue for 422 errors in Datadog Cluster Agent ([#7246](https://github.com/kedacore/keda/issues/7246))

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -497,7 +497,7 @@ type accurateScalingStrategy struct {
 }
 
 func (s accurateScalingStrategy) GetEffectiveMaxScale(maxScale, runningJobCount, pendingJobCount, maxReplicaCount, scaleTo int64) (int64, int64) {
-	if (maxScale + runningJobCount) > maxReplicaCount {
+	if (maxScale + runningJobCount - pendingJobCount) > maxReplicaCount {
 		return maxReplicaCount - runningJobCount, scaleTo
 	}
 	return maxScale - pendingJobCount, scaleTo

--- a/pkg/scaling/executor/scale_jobs_test.go
+++ b/pkg/scaling/executor/scale_jobs_test.go
@@ -131,6 +131,7 @@ func TestCustomScalingStrategy(t *testing.T) {
 func TestAccurateScalingStrategy(t *testing.T) {
 	logger := logf.Log.WithName("ScaledJobTest")
 	strategy := NewScalingStrategy(logger, getMockScaledJobWithStrategy("accurate", "accurate", 0, "0"))
+
 	// maxScale doesn't exceed MaxReplicaCount. You can ignore on this sceanrio
 	assert.Equal(t, int64(3), maxScaleValue(strategy.GetEffectiveMaxScale(3, 2, 0, 5, 1)))
 	assert.Equal(t, int64(3), maxScaleValue(strategy.GetEffectiveMaxScale(5, 2, 0, 5, 1)))
@@ -138,6 +139,18 @@ func TestAccurateScalingStrategy(t *testing.T) {
 	// Test with 2 pending jobs
 	assert.Equal(t, int64(1), maxScaleValue(strategy.GetEffectiveMaxScale(3, 4, 2, 10, 1)))
 	assert.Equal(t, int64(1), maxScaleValue(strategy.GetEffectiveMaxScale(5, 4, 2, 5, 1)))
+
+	// Test with 3 running jobs are pending
+	assert.Equal(t, int64(0), maxScaleValue(strategy.GetEffectiveMaxScale(3, 3, 3, 5, 1)))
+
+	// Test with running jobs are pending with higher numbers
+	assert.Equal(t, int64(0), maxScaleValue(strategy.GetEffectiveMaxScale(15, 15, 15, 20, 1)))
+
+	// Similar scenario, but with different numbers
+	assert.Equal(t, int64(0), maxScaleValue(strategy.GetEffectiveMaxScale(10, 10, 10, 15, 1)))
+
+	// Partial pending jobs scenario
+	assert.Equal(t, int64(5), maxScaleValue(strategy.GetEffectiveMaxScale(20, 15, 10, 20, 1)))
 }
 
 func TestEagerScalingStrategy(t *testing.T) {


### PR DESCRIPTION
The `accurateScalingStrategy` was not considering `pendingJobCount` when checking if `maxReplicaCount` would be exceeded. This caused redundant jobs which are "idle".


### Checklist

- [X] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7329 
