### PR TITLE
Add paths-filter action to PR validation workflow

### DIFF
--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -1,14 +1,18 @@
 name: "CodeQL"
+
 on:
   push:
     branches: ["main"]
   pull_request: {}
+
 permissions:
   contents: read
   security-events: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+
 jobs:
   codeQl:
     name: Analyze CodeQL Go
@@ -18,26 +22,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: filter
-        if: github.event_name == 'pull_request'
-        with:
-          filters: |
-            go:
-              - '**/*.go'
-              - 'go.mod'
-              - 'go.sum'
-              - 'Makefile'
-              - '**/*.proto'
-              - 'hack/*.sh'
-
       - name: Register workspace path
-        if: github.event_name == 'push' || steps.filter.outputs.go == 'true'
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Initialize CodeQL
-        if: github.event_name == 'push' || steps.filter.outputs.go == 'true'
         uses: github/codeql-action/init@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
           languages: go
@@ -45,11 +33,9 @@ jobs:
           queries: +security-and-quality
 
       - name: Autobuild
-        if: github.event_name == 'push' || steps.filter.outputs.go == 'true'
         uses: github/codeql-action/autobuild@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
 
       - name: Perform CodeQL Analysis
-        if: github.event_name == 'push' || steps.filter.outputs.go == 'true'
         uses: github/codeql-action/analyze@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
         with:
           category: "/language:go"


### PR DESCRIPTION
Occasionally, we have changes that don't involve any Go code, such as multiple PRs for a release involving only documentation.
With this PR, I want to optimize some workflow jobs by adding path filtering to skip unnecessary Go build/test steps when only non-Go files are modified.

If I have overlooked something, please let me know.

### Checklist

- [X] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))