### PR TITLE
chore: require minimum Go 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kedacore/keda/v2
 
-go 1.25.6
+go 1.25.0
 
 replace (
 	// we need a version with a proper license


### PR DESCRIPTION
Specifying only major.minor for Go version improves compatibility when building or running KEDA and dependent repos (e.g. the HTTP Add-on) in downstream environments.
Being more lenient here would allow us at Red Hat to build packages depending on the HTTP Add-on and KEDA in environments that don't support go 1.25.5 yet.

This change should not have any effect on the artifacts at all as it only specifies the minimum version we requirem, KEDA does also probably not depend on a specific patch version of go I guess.

go mod tidy resolved 1.25 to 1.25.0 as some dependencies like controller-tools require 1.25.0 explicitely.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

fyi @matejvasek