### PR TITLE
Remove deprecated 'tls' setting from IBMMQ scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ New deprecation(s):
 
 ### Breaking Changes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **IBM MQ scaler**: The `tls` setting code is removed ([#6094](https://github.com/kedacore/keda/issues/6094))
 
 ### Other
 

--- a/pkg/scalers/ibmmq_scaler.go
+++ b/pkg/scalers/ibmmq_scaler.go
@@ -34,7 +34,6 @@ type ibmmqMetadata struct {
 	Username             string   `keda:"name=username,             order=authParams;resolvedEnv;triggerMetadata"`
 	Password             string   `keda:"name=password,             order=authParams;resolvedEnv;triggerMetadata"`
 	UnsafeSsl            bool     `keda:"name=unsafeSsl,            order=triggerMetadata, default=false"`
-	TLS                  bool     `keda:"name=tls,                  order=triggerMetadata, default=false, deprecated=The 'tls' setting is DEPRECATED and is removed in v2.18 - Use 'unsafeSsl' instead"`
 	CA                   string   `keda:"name=ca,                   order=authParams, optional"`
 	Cert                 string   `keda:"name=cert,                 order=authParams, optional"`
 	Key                  string   `keda:"name=key,                  order=authParams, optional"`

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2325,13 +2325,6 @@
                     "metadataVariableReadable": true
                 },
                 {
-                    "name": "tls",
-                    "type": "string",
-                    "default": "false",
-                    "deprecated": "The 'tls' setting is DEPRECATED and is removed in v2.18 - Use 'unsafeSsl' instead",
-                    "metadataVariableReadable": true
-                },
-                {
                     "name": "ca",
                     "type": "string",
                     "optional": true,

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1515,11 +1515,6 @@ scalers:
           type: string
           default: "false"
           metadataVariableReadable: true
-        - name: tls
-          type: string
-          default: "false"
-          deprecated: The 'tls' setting is DEPRECATED and is removed in v2.18 - Use 'unsafeSsl' instead
-          metadataVariableReadable: true
         - name: ca
           type: string
           optional: true


### PR DESCRIPTION
Removed deprecated 'tls' setting from configuration.

As stated in the [deprecation policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md), the announcement is for two releases, the deprecation itself for two releases, and the code is then removed after two releases. This PR completes the final phase.

### Checklist

- [X] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes: #6094