### PR TITLE
fix(cron): handle comma in cron expressions for metric name generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
 ### Deprecations

--- a/pkg/scalers/cron_scaler.go
+++ b/pkg/scalers/cron_scaler.go
@@ -103,6 +103,7 @@ func parseCronTimeFormat(s string) string {
 	s = strings.ReplaceAll(s, "*", "x")
 	s = strings.ReplaceAll(s, "/", "Sl")
 	s = strings.ReplaceAll(s, "?", "Qm")
+	s = strings.ReplaceAll(s, ",", "Cm")
 	return s
 }
 

--- a/pkg/scalers/cron_scaler_test.go
+++ b/pkg/scalers/cron_scaler_test.go
@@ -39,10 +39,19 @@ var validCronMetadata2 = map[string]string{
 	"desiredReplicas": "10",
 }
 
+// A valid metadata example using comma-separated values
+var validCronMetadata3 = map[string]string{
+	"timezone":        "Etc/UTC",
+	"start":           "0,30 * * * *",  // Every hour at minute 0 and 30
+	"end":             "15,45 * * * *", // Every hour at minute 15 and 45
+	"desiredReplicas": "10",
+}
+
 var testCronMetadata = []parseCronMetadataTestData{
 	{map[string]string{}, true},
 	{validCronMetadata, false},
 	{validCronMetadata2, false},
+	{validCronMetadata3, false},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30 * * * *", "end": "45 * * * *"}, true},
 	{map[string]string{"start": "30 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, true},
 	{map[string]string{"timezone": "Asia/Kolkata", "start": "30-33 * * * *", "end": "45 * * * *", "desiredReplicas": "10"}, false},
@@ -56,6 +65,7 @@ var testCronMetadata = []parseCronMetadataTestData{
 var cronMetricIdentifiers = []cronMetricIdentifier{
 	{&testCronMetadata[1], 0, "s0-cron-Etc-UTC-00xxThu-5923xxThu"},
 	{&testCronMetadata[2], 1, "s1-cron-Etc-UTC-0xSl2xxx-01-23Sl2xxx"},
+	{&testCronMetadata[3], 2, "s2-cron-Etc-UTC-0Cm30xxxx-15Cm45xxxx"},
 }
 
 var tz, _ = time.LoadLocation(validCronMetadata2["timezone"])


### PR DESCRIPTION
## Description

Adds comma handling to the `parseCronTimeFormat` function to generate valid metric names when cron expressions contain comma-separated values (e.g., `0,30 * * * *`).

### Problem
Cron expressions using comma-separated values were generating invalid Kubernetes metric names containing commas, which violates the DNS label naming convention required for metric names.

### Solution
Added `s = strings.ReplaceAll(s, ",", "Cm")` to `parseCronTimeFormat`, following the existing pattern for other special characters:
- `*` → `x`
- `/` → `Sl`
- `?` → `Qm`
- `,` → `Cm` ✅ (new)

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7448