### PR TITLE
Temporal Scaler: add composite metric (backlog + running workflow count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **Kafka Scaler**: Add optional `fullMetadata` trigger metadata field to control Sarama's full cluster metadata refresh, reducing operator memory for topic scoped triggers ([#7453](https://github.com/kedacore/keda/issues/7453))
+- **Temporal Scaler**: Add opt-in `includeRunningWorkflowCount` (with optional `workflowTaskQueueForCount`) to block premature scale-down when the backlog is momentarily zero but Workflow workers are still busy. Worker Deployment Version scalers short-circuit on Version status (`DRAINING` stays active, `DRAINED`/`INACTIVE` scale down); other modes issue a scoped `CountWorkflow` visibility query — including `TemporalWorkerDeploymentVersion is null` for unversioned workers. ([#7459](https://github.com/kedacore/keda/issues/7459))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
 ### Fixes

--- a/pkg/scalers/temporal_scaler.go
+++ b/pkg/scalers/temporal_scaler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -30,7 +31,21 @@ var (
 		sdk.TaskQueueTypeWorkflow,
 		sdk.TaskQueueTypeNexus,
 	}
+
+	// validVisibilityQueryLiteral matches values that are safe to interpolate into a Temporal
+	// visibility query. Temporal task queue and deployment identifiers permit alphanumerics,
+	// hyphens, underscores, dots, forward slashes, and colons. Rejecting anything outside this
+	// set prevents query injection since the SDK offers no parameterized visibility queries.
+	validVisibilityQueryLiteral = regexp.MustCompile(`^[a-zA-Z0-9\-_./:]+$`)
 )
+
+// workerDeploymentVersionSeparator joins deployment name and build id to form the
+// TemporalWorkerDeploymentVersion search attribute value (e.g. "my-deploy:v1").
+// This matches the modern (v1.32+) Temporal server format written by
+// ExternalWorkerDeploymentVersionToString in temporal/common/worker_versioning.
+// The legacy v0.31 delimiter ('.') is not used here — visibility queries against
+// modern servers will not match values written with the old delimiter.
+const workerDeploymentVersionSeparator = ":"
 
 type temporalScaler struct {
 	metricType v2.MetricTargetType
@@ -51,8 +66,15 @@ type temporalMetadata struct {
 	WorkerDeploymentBuildID   string   `keda:"name=workerDeploymentBuildId,   order=triggerMetadata;resolvedEnv, optional"`
 	AllActive                 bool     `keda:"name=selectAllActive,           order=triggerMetadata, default=false, deprecatedAnnounce=The 'selectAllActive' setting is DEPRECATED and will be removed in v2.21 because Temporal Server is dropping support for the Rules-Based Versioning APIs - Use 'workerDeploymentName' and 'workerDeploymentBuildId' instead"`
 	Unversioned               bool     `keda:"name=selectUnversioned,         order=triggerMetadata, default=false, deprecatedAnnounce=The 'selectUnversioned' setting is DEPRECATED and will be removed in v2.21 because Temporal Server is dropping support for the Rules-Based Versioning APIs - Remove it if your workers are unversioned. Or use 'workerDeploymentName' and 'workerDeploymentBuildId' if you're migrating to Worker Deployment Versioning"`
-	APIKey                    string   `keda:"name=apiKey,                    order=authParams;resolvedEnv, optional"`
-	MinConnectTimeout         int      `keda:"name=minConnectTimeout,         order=triggerMetadata, default=5"`
+	// IncludeRunningWorkflowCount, when true, keeps the scaler active if there are running
+	// workflows on the task queue even after the backlog drains to zero. It only affects the
+	// activity decision, never the reported metric value. Defaults to false to preserve prior
+	// behavior. Activity-worker scalers can still use this by pointing WorkflowTaskQueueForCount
+	// at the workflow task queue whose in-flight workflows should keep the activity workers alive.
+	IncludeRunningWorkflowCount bool   `keda:"name=includeRunningWorkflowCount, order=triggerMetadata, default=false"`
+	WorkflowTaskQueueForCount   string `keda:"name=workflowTaskQueueForCount,   order=triggerMetadata;resolvedEnv, optional"`
+	APIKey                      string `keda:"name=apiKey,                    order=authParams;resolvedEnv, optional"`
+	MinConnectTimeout           int    `keda:"name=minConnectTimeout,         order=triggerMetadata, default=5"`
 
 	UnsafeSsl     bool   `keda:"name=unsafeSsl,                 order=triggerMetadata, optional"`
 	Cert          string `keda:"name=cert,                      order=authParams, optional"`
@@ -85,6 +107,17 @@ func (a *temporalMetadata) Validate() error {
 	}
 	if a.WorkerDeploymentName != "" && (a.BuildID != "" || a.AllActive || a.Unversioned) {
 		return fmt.Errorf("workerDeploymentName/workerDeploymentBuildId cannot be combined with buildId, selectAllActive, or selectUnversioned")
+	}
+
+	if a.WorkflowTaskQueueForCount != "" && !a.IncludeRunningWorkflowCount {
+		return fmt.Errorf("workflowTaskQueueForCount has no effect unless includeRunningWorkflowCount is true")
+	}
+	if a.IncludeRunningWorkflowCount {
+		for _, name := range []string{a.TaskQueue, a.WorkflowTaskQueueForCount, a.WorkerDeploymentName, a.WorkerDeploymentBuildID} {
+			if name != "" && !validVisibilityQueryLiteral.MatchString(name) {
+				return fmt.Errorf("value %q contains characters not allowed in Temporal visibility queries when includeRunningWorkflowCount is enabled", name)
+			}
+		}
 	}
 
 	return nil
@@ -172,12 +205,15 @@ func (s *temporalScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpe
 
 func (s *temporalScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
 	var (
-		backlogCount int64
-		err          error
+		backlogCount  int64
+		versionStatus enumspb.WorkerDeploymentVersionStatus
+		hasStatus     bool
+		err           error
 	)
 	switch {
 	case s.metadata.WorkerDeploymentName != "":
-		backlogCount, err = s.getDeploymentBacklogCount(ctx)
+		backlogCount, versionStatus, err = s.getDeploymentBacklogCountAndStatus(ctx)
+		hasStatus = true
 	case s.metadata.BuildID != "" || s.metadata.AllActive || s.metadata.Unversioned:
 		backlogCount, err = s.getBuildIDBacklogCount(ctx)
 	default:
@@ -194,6 +230,9 @@ func (s *temporalScaler) GetMetricsAndActivity(ctx context.Context, metricName s
 
 	metric := GenerateMetricInMili(metricName, float64(backlogCount))
 	isActive := backlogCount > s.metadata.ActivationTargetQueueSize
+	if !isActive && s.metadata.IncludeRunningWorkflowCount {
+		isActive = s.isActiveWithoutBacklog(ctx, hasStatus, versionStatus)
+	}
 
 	s.logger.V(1).Info("polled Temporal backlog",
 		"mode", scalerMode(s.metadata),
@@ -202,11 +241,56 @@ func (s *temporalScaler) GetMetricsAndActivity(ctx context.Context, metricName s
 		"buildId", s.metadata.BuildID,
 		"workerDeploymentName", s.metadata.WorkerDeploymentName,
 		"workerDeploymentBuildId", s.metadata.WorkerDeploymentBuildID,
+		"workerDeploymentVersionStatus", versionStatus.String(),
 		"backlogCount", backlogCount,
 		"activationThreshold", s.metadata.ActivationTargetQueueSize,
 		"isActive", isActive)
 
 	return []external_metrics.ExternalMetricValue{metric}, isActive, nil
+}
+
+// isActiveWithoutBacklog decides whether the scaler should remain active when the
+// backlog is at or below the activation threshold. It is only invoked when the user
+// has opted in via includeRunningWorkflowCount.
+//
+// For deployment-version scalers the Worker Deployment Version status short-circuits:
+//   - DRAINING versions are kept active because Temporal keeps replaying workflows
+//     pinned to that version until they complete, and the server checks completion
+//     periodically (roughly every 3 minutes); polling visibility here would just
+//     duplicate that signal at the risk of a false negative during eventual consistency.
+//   - CURRENT / RAMPING versions fall through to a visibility count; new work can
+//     land on these versions, so the running-count check is the only signal available.
+//   - DRAINED / INACTIVE / UNSPECIFIED versions are safe to scale down.
+//
+// For every other mode (build-id, unversioned) we always fall through to the
+// visibility count.
+//
+// Callers should be aware that this signal is approximate: it does not cover
+// activity-only workers, visibility indexing has no SLA (eventual consistency is
+// typically a few seconds but has no upper bound), CountWorkflow itself is
+// documented as approximate, and the Temporal frontend rate-limits all visibility
+// calls to roughly 10 RPS per namespace per instance.
+func (s *temporalScaler) isActiveWithoutBacklog(ctx context.Context, hasStatus bool, versionStatus enumspb.WorkerDeploymentVersionStatus) bool {
+	if hasStatus {
+		switch versionStatus {
+		case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING:
+			return true
+		case enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT,
+			enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING:
+			// fall through to the visibility count
+		default:
+			return false
+		}
+	}
+
+	runningCount, err := s.getRunningWorkflowCount(ctx)
+	if err != nil {
+		s.logger.V(1).Info("failed to get running workflow count, treating as no-signal",
+			"mode", scalerMode(s.metadata),
+			"error", err)
+		return false
+	}
+	return runningCount > 0
 }
 
 func (s *temporalScaler) getBuildIDBacklogCount(ctx context.Context) (int64, error) {
@@ -253,7 +337,7 @@ func (s *temporalScaler) getUnversionedBacklogCount(ctx context.Context) (int64,
 	return total, nil
 }
 
-func (s *temporalScaler) getDeploymentBacklogCount(ctx context.Context) (int64, error) {
+func (s *temporalScaler) getDeploymentBacklogCountAndStatus(ctx context.Context) (int64, enumspb.WorkerDeploymentVersionStatus, error) {
 	resp, err := s.tcl.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
 		&workflowservice.DescribeWorkerDeploymentVersionRequest{
 			Namespace: s.metadata.Namespace,
@@ -265,11 +349,73 @@ func (s *temporalScaler) getDeploymentBacklogCount(ctx context.Context) (int64, 
 		},
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to describe worker deployment version (deploymentName=%q, buildId=%q): %w",
-			s.metadata.WorkerDeploymentName, s.metadata.WorkerDeploymentBuildID, err)
+		return 0, enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_UNSPECIFIED,
+			fmt.Errorf("failed to describe worker deployment version (deploymentName=%q, buildId=%q): %w",
+				s.metadata.WorkerDeploymentName, s.metadata.WorkerDeploymentBuildID, err)
 	}
 
-	return sumDeploymentBacklog(resp.GetVersionTaskQueues(), s.metadata.TaskQueue, s.metadata.QueueTypes), nil
+	backlog := sumDeploymentBacklog(resp.GetVersionTaskQueues(), s.metadata.TaskQueue, s.metadata.QueueTypes)
+	return backlog, resp.GetWorkerDeploymentVersionInfo().GetStatus(), nil
+}
+
+// getRunningWorkflowCount queries the Temporal Visibility Count API for running workflow
+// executions owned by this scaler. It is only called when includeRunningWorkflowCount is
+// enabled and the backlog signal alone says "scale to zero" — its role is to block premature
+// scale-down when the queue is momentarily empty but workers are still busy.
+//
+// Scoping rules:
+//   - deployment-version mode restricts by TemporalWorkerDeploymentVersion so that a
+//     draining version's workflows do not keep a newer version alive, and vice versa.
+//   - the default (unversioned) mode restricts by "TemporalWorkerDeploymentVersion is null"
+//     so it never picks up workflows owned by versioned workers on the same task queue.
+//   - the deprecated build-id selectors (buildId / selectAllActive / selectUnversioned)
+//     do not map cleanly to Worker Deployment Version search attributes, so the query
+//     falls back to task-queue scoping only. This is intentional: the parameter is meant
+//     for users on the modern Worker Deployment Versioning path.
+func (s *temporalScaler) getRunningWorkflowCount(ctx context.Context) (int64, error) {
+	query, err := s.runningWorkflowCountQuery()
+	if err != nil {
+		return 0, err
+	}
+	resp, err := s.tcl.CountWorkflow(ctx, &workflowservice.CountWorkflowExecutionsRequest{
+		Namespace: s.metadata.Namespace,
+		Query:     query,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count workflow: %w", err)
+	}
+	return resp.GetCount(), nil
+}
+
+// runningWorkflowCountQuery builds the visibility query used by getRunningWorkflowCount.
+// Values that reach this method must already have passed the Validate() literal check,
+// but we re-validate defensively in case a caller constructs a scaler outside the normal
+// factory path.
+func (s *temporalScaler) runningWorkflowCountQuery() (string, error) {
+	taskQueue := s.metadata.WorkflowTaskQueueForCount
+	if taskQueue == "" {
+		taskQueue = s.metadata.TaskQueue
+	}
+	if !validVisibilityQueryLiteral.MatchString(taskQueue) {
+		return "", fmt.Errorf("task queue name %q contains characters not allowed in visibility queries", taskQueue)
+	}
+
+	query := fmt.Sprintf("ExecutionStatus = 'Running' AND TaskQueue = '%s'", taskQueue)
+	switch {
+	case s.metadata.WorkerDeploymentName != "":
+		if !validVisibilityQueryLiteral.MatchString(s.metadata.WorkerDeploymentName) ||
+			!validVisibilityQueryLiteral.MatchString(s.metadata.WorkerDeploymentBuildID) {
+			return "", fmt.Errorf("workerDeploymentName/workerDeploymentBuildId contain characters not allowed in visibility queries")
+		}
+		version := s.metadata.WorkerDeploymentName + workerDeploymentVersionSeparator + s.metadata.WorkerDeploymentBuildID
+		query = fmt.Sprintf("%s AND TemporalWorkerDeploymentVersion = '%s'", query, version)
+	case s.metadata.BuildID != "" || s.metadata.AllActive || s.metadata.Unversioned:
+		// Deprecated Build ID selectors do not map to Worker Deployment Version search
+		// attributes; leave the query scoped by task queue only.
+	default:
+		query += " AND TemporalWorkerDeploymentVersion is null"
+	}
+	return query, nil
 }
 
 // sumDeploymentBacklog sums ApproximateBacklogCount across the provided task

--- a/pkg/scalers/temporal_scaler_test.go
+++ b/pkg/scalers/temporal_scaler_test.go
@@ -59,6 +59,14 @@ var testTemporalMetadata = []parseTemporalMetadataTestData{
 	{map[string]string{"endpoint": temporalEndpoint, "taskQueue": temporalQueueName, "namespace": temporalNamespace, "workerDeploymentName": "my-deploy", "workerDeploymentBuildId": "v1"}, false},
 	// valid legacy buildId config
 	{map[string]string{"endpoint": temporalEndpoint, "taskQueue": temporalQueueName, "namespace": temporalNamespace, "buildId": "v1"}, false},
+	// workflowTaskQueueForCount without includeRunningWorkflowCount
+	{map[string]string{"endpoint": temporalEndpoint, "taskQueue": temporalQueueName, "namespace": temporalNamespace, "workflowTaskQueueForCount": "wf-queue"}, true},
+	// includeRunningWorkflowCount alone is valid
+	{map[string]string{"endpoint": temporalEndpoint, "taskQueue": temporalQueueName, "namespace": temporalNamespace, "includeRunningWorkflowCount": "true"}, false},
+	// includeRunningWorkflowCount + workflowTaskQueueForCount is valid
+	{map[string]string{"endpoint": temporalEndpoint, "taskQueue": temporalQueueName, "namespace": temporalNamespace, "includeRunningWorkflowCount": "true", "workflowTaskQueueForCount": "wf-queue"}, false},
+	// includeRunningWorkflowCount rejects unsafe characters in taskQueue
+	{map[string]string{"endpoint": temporalEndpoint, "taskQueue": "bad queue' OR '1'='1", "namespace": temporalNamespace, "includeRunningWorkflowCount": "true"}, true},
 }
 
 var temporalMetricIdentifiers = []temporalMetricIdentifier{
@@ -474,6 +482,86 @@ func TestScalerMode(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, scalerMode(&tc.meta))
+		})
+	}
+}
+
+func TestRunningWorkflowCountQuery(t *testing.T) {
+	cases := []struct {
+		name    string
+		meta    temporalMetadata
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "unversioned scopes with is null",
+			meta: temporalMetadata{TaskQueue: "orders"},
+			want: "ExecutionStatus = 'Running' AND TaskQueue = 'orders' AND TemporalWorkerDeploymentVersion is null",
+		},
+		{
+			name: "deployment version scopes by TemporalWorkerDeploymentVersion using the v1.32+ colon delimiter",
+			meta: temporalMetadata{TaskQueue: "orders", WorkerDeploymentName: "orders-svc", WorkerDeploymentBuildID: "v1"},
+			want: "ExecutionStatus = 'Running' AND TaskQueue = 'orders' AND TemporalWorkerDeploymentVersion = 'orders-svc:v1'",
+		},
+		{
+			name: "workflowTaskQueueForCount overrides taskQueue",
+			meta: temporalMetadata{TaskQueue: "activities", WorkflowTaskQueueForCount: "workflows"},
+			want: "ExecutionStatus = 'Running' AND TaskQueue = 'workflows' AND TemporalWorkerDeploymentVersion is null",
+		},
+		{
+			name: "deprecated buildId omits deployment version predicate",
+			meta: temporalMetadata{TaskQueue: "orders", BuildID: "v1"},
+			want: "ExecutionStatus = 'Running' AND TaskQueue = 'orders'",
+		},
+		{
+			name: "selectUnversioned (deprecated) omits deployment version predicate",
+			meta: temporalMetadata{TaskQueue: "orders", Unversioned: true},
+			want: "ExecutionStatus = 'Running' AND TaskQueue = 'orders'",
+		},
+		{
+			name:    "unsafe task queue is rejected",
+			meta:    temporalMetadata{TaskQueue: "bad' OR '1"},
+			wantErr: true,
+		},
+		{
+			name:    "unsafe deployment name is rejected",
+			meta:    temporalMetadata{TaskQueue: "orders", WorkerDeploymentName: "bad name", WorkerDeploymentBuildID: "v1"},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &temporalScaler{metadata: &tc.meta}
+			got, err := s.runningWorkflowCountQuery()
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIsActiveWithoutBacklogVersionStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status enumspb.WorkerDeploymentVersionStatus
+		want   bool
+	}{
+		{"draining stays active without hitting visibility", enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING, true},
+		{"drained scales down", enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED, false},
+		{"inactive scales down", enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE, false},
+		{"unspecified scales down", enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_UNSPECIFIED, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &temporalScaler{
+				metadata: &temporalMetadata{TaskQueue: "orders", WorkerDeploymentName: "orders-svc", WorkerDeploymentBuildID: "v1"},
+				logger:   logger,
+			}
+			got := s.isActiveWithoutBacklog(context.Background(), true, tc.status)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -6022,6 +6022,19 @@
                     "metadataVariableReadable": true
                 },
                 {
+                    "name": "includeRunningWorkflowCount",
+                    "type": "string",
+                    "default": "false",
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "workflowTaskQueueForCount",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "envVariableReadable": true
+                },
+                {
                     "name": "apiKey",
                     "type": "string",
                     "optional": true,

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -3953,6 +3953,15 @@ scalers:
           default: "false"
           deprecatedAnnounce: The 'selectUnversioned' setting is DEPRECATED and will be removed in v2.21 because Temporal Server is dropping support for the Rules-Based Versioning APIs - Remove it if your workers are unversioned. Or use 'workerDeploymentName' and 'workerDeploymentBuildId' if you're migrating to Worker Deployment Versioning
           metadataVariableReadable: true
+        - name: includeRunningWorkflowCount
+          type: string
+          default: "false"
+          metadataVariableReadable: true
+        - name: workflowTaskQueueForCount
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          envVariableReadable: true
         - name: apiKey
           type: string
           optional: true


### PR DESCRIPTION
### What this PR does

Adds two opt-in trigger metadata fields to the Temporal scaler so users can prevent premature scale-down when workers are still executing already-running workflows but the backlog is momentarily zero:

- **`includeRunningWorkflowCount`** (default: **`false`** — existing behavior is unchanged; users must opt in)
- **`workflowTaskQueueForCount`** (optional; overrides which task queue is used for the running-workflow visibility count, useful when scaling activity workers off a workflow-owned queue)

Note on scope: the emitted metric value is still `backlogCount` only. When `includeRunningWorkflowCount` is enabled and the backlog is `<=` the activation threshold, the running-workflow-count check only affects `isActive` (i.e. whether the scaler stays warm). It does not change the metric value used for HPA scaling math.

Activity decision is unchanged by default. When opted in and the backlog is `<=` the activation threshold:

- For `workerDeploymentName` scalers, the Worker Deployment Version status returned by `DescribeWorkerDeploymentVersion` short-circuits the visibility call:
  - `DRAINING` → active (Temporal keeps replaying pinned workflows here; the server tracks completion, so hitting visibility would just duplicate that signal at risk of a false negative during eventual consistency).
  - `DRAINED` / `INACTIVE` / `UNSPECIFIED` → not active.
  - `CURRENT` / `RAMPING` → fall through to a scoped visibility count.
- Other modes (unversioned, deprecated build-id selectors) always fall through to the visibility count.

The visibility count is scoped:

- **Deployment-version mode:** `TemporalWorkerDeploymentVersion = 'name:buildId'` (uses the modern v1.32+ colon delimiter written by `ExternalWorkerDeploymentVersionToString` in Temporal's `common/worker_versioning` package; the legacy `.` delimiter is not used because it will not match values written by post-v1.32 servers).
- **Unversioned mode:** `TemporalWorkerDeploymentVersion is null`, so it does not pick up workflows owned by versioned workers on the same task queue.
- **Deprecated build-id selectors** (`buildId` / `selectAllActive` / `selectUnversioned`): task-queue scope only. These selectors do not map to Worker Deployment Version search attributes; users on this path are already on a deprecation road.

`Validate()` rejects `workflowTaskQueueForCount` without `includeRunningWorkflowCount`, and rejects unsafe characters in any value that would be interpolated into a visibility query.

### Signal caveats (also documented in the keda-docs PR)

The running-workflow-count signal is approximate: it does not cover activity-only workers unless `workflowTaskQueueForCount` is set to a workflow queue; visibility has eventual consistency with no SLA; `CountWorkflow` is documented as approximate; visibility APIs have a per-namespace frontend rate limit of ~10 RPS. Users who need a strict guarantee should combine this with worker-utilization metrics.

### Design credit

The version-status short-circuit and version-scoped visibility query design come from the Temporal matching team's proposal at [Shivs11/keda#1](https://github.com/Shivs11/keda/pull/1). This PR follows that shape with two differences: (a) the delimiter is `:` to match the modern SA value format, and (b) an explicit unsafe-character validation for interpolated literals.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs))
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Fixes #7459
Docs: https://github.com/kedacore/keda-docs/pull/1808