### PR TITLE
Add proxy option for prometheus scaler

### DIFF
--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -53,6 +53,7 @@ type prometheusMetadata struct {
 	Timeout             time.Duration          `keda:"name=timeout,             order=triggerMetadata,            optional"` // custom HTTP client timeout
 	IdentityOwner       string                 `keda:"name=identityOwner,       order=triggerMetadata,            optional"`
 	AuthModes           string                 `keda:"name=authModes,           order=triggerMetadata,            optional"`
+	ProxyAddress        string                 `keda:"name=proxyAddress,        order=triggerMetadata,            optional"` // HTTP proxy address for Prometheus requests
 }
 
 type promQueryResult struct {
@@ -88,6 +89,17 @@ func NewPrometheusScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	}
 
 	httpClient := kedautil.CreateHTTPClient(httpClientTimeout, meta.UnsafeSSL)
+
+	// Configure proxy if proxyAddress is specified
+	if meta.ProxyAddress != "" {
+		proxyURL, err := url_pkg.Parse(meta.ProxyAddress)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing proxy address: %w", err)
+		}
+		if transport, ok := httpClient.Transport.(*http.Transport); ok {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		}
+	}
 
 	if !meta.PrometheusAuth.Disabled() {
 		if meta.PrometheusAuth.CA != "" || meta.PrometheusAuth.EnabledTLS() {

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -70,6 +70,10 @@ var testPromMetadata = []parsePrometheusMetadataTestData{
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "timeout": "-1"}, true},
 	// invalid - not a number - custom http client timeout with milliseconds
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "timeout": "a"}, true},
+	// valid proxyAddress
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "proxyAddress": "http://proxy.example.com:8080"}, false},
+	// valid proxyAddress with https
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "proxyAddress": "https://proxy.example.com:8080"}, false},
 }
 
 var prometheusMetricIdentifiers = []prometheusMetricIdentifier{
@@ -565,6 +569,80 @@ h+VRH7M7/22LuSxeKoQaRqeBRbvGup/oHGr9Ks/sVi0EQRUqwB45QLNiF1bi
 			got, err := s.ExecutePromQuery(context.TODO())
 			require.NoError(t, err)
 			assert.Equal(t, float64(777), got)
+		})
+	}
+}
+
+func TestPrometheusScalerProxyAddress(t *testing.T) {
+	tests := []struct {
+		name         string
+		proxyAddress string
+		expectProxy  bool
+		expectError  bool
+	}{
+		{
+			name:         "no proxy",
+			proxyAddress: "",
+			expectProxy:  false,
+			expectError:  false,
+		},
+		{
+			name:         "http proxy",
+			proxyAddress: "http://proxy.example.com:8080",
+			expectProxy:  true,
+			expectError:  false,
+		},
+		{
+			name:         "https proxy",
+			proxyAddress: "https://proxy.example.com:8080",
+			expectProxy:  true,
+			expectError:  false,
+		},
+		{
+			name:         "proxy with auth",
+			proxyAddress: "http://user:password@proxy.example.com:8080",
+			expectProxy:  true,
+			expectError:  false,
+		},
+		{
+			name:         "invalid proxy url",
+			proxyAddress: "://invalid",
+			expectProxy:  false,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := map[string]string{
+				"serverAddress": "http://localhost:9090",
+				"threshold":     "100",
+				"query":         "up",
+			}
+			if tt.proxyAddress != "" {
+				metadata["proxyAddress"] = tt.proxyAddress
+			}
+
+			config := &scalersconfig.ScalerConfig{
+				TriggerMetadata: metadata,
+			}
+
+			scaler, err := NewPrometheusScaler(config)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			s, ok := scaler.(*prometheusScaler)
+			require.True(t, ok, "Scaler must be a Prometheus Scaler")
+
+			if tt.expectProxy {
+				assert.Equal(t, tt.proxyAddress, s.metadata.ProxyAddress)
+			} else {
+				assert.Empty(t, s.metadata.ProxyAddress)
+			}
 		})
 	}
 }

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -3409,6 +3409,12 @@
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "proxyAddress",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
                 }
             ]
         },

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -2221,6 +2221,10 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
+        - name: proxyAddress
+          type: string
+          optional: true
+          metadataVariableReadable: true
     - type: gcp-pubsub
       parameters:
         - name: subscriptionSize


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

In some cases, prometheus scaler needs to connect to remote prometheus endpoints via proxy. Currently you need to add HTTP_PROXY and NO_PROXY to keda controllers which is a bit hacky. Add this feature so that we can configure proxy as needed.

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
