### PR TITLE
fix: use %w verb for proper error wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
+- **General**: Use `%w` verb for error wrapping in AWS DynamoDB, Azure App Insights, and Azure Monitor scalers to enable proper error unwrapping ([#7515](https://github.com/kedacore/keda/pull/7515))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **External Scaler**: Fix context cancellation handling in `waitForState` of external scaler ([#7542](https://github.com/kedacore/keda/issues/7542))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
-- **General**: Use `%w` verb for error wrapping in AWS DynamoDB, Azure App Insights, and Azure Monitor scalers to enable proper error unwrapping ([#7515](https://github.com/kedacore/keda/pull/7515))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **External Scaler**: Fix context cancellation handling in `waitForState` of external scaler ([#7542](https://github.com/kedacore/keda/issues/7542))

--- a/pkg/scalers/aws_dynamodb_scaler.go
+++ b/pkg/scalers/aws_dynamodb_scaler.go
@@ -203,7 +203,7 @@ func (s *awsDynamoDBScaler) GetQueryMetrics(ctx context.Context) (float64, error
 func json2Map(js string) (m map[string]string, err error) {
 	err = bson.UnmarshalExtJSON([]byte(js), true, &m)
 	if err != nil {
-		return nil, fmt.Errorf("%v: %w", ErrAwsDynamoInvalidExpressionAttributeNames, err)
+		return nil, fmt.Errorf("%w: %w", ErrAwsDynamoInvalidExpressionAttributeNames, err)
 	}
 
 	if len(m) == 0 {

--- a/pkg/scalers/aws_dynamodb_scaler.go
+++ b/pkg/scalers/aws_dynamodb_scaler.go
@@ -203,7 +203,7 @@ func (s *awsDynamoDBScaler) GetQueryMetrics(ctx context.Context) (float64, error
 func json2Map(js string) (m map[string]string, err error) {
 	err = bson.UnmarshalExtJSON([]byte(js), true, &m)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrAwsDynamoInvalidExpressionAttributeNames, err)
+		return nil, errors.Join(ErrAwsDynamoInvalidExpressionAttributeNames, err)
 	}
 
 	if len(m) == 0 {

--- a/pkg/scalers/azure/azure_app_insights.go
+++ b/pkg/scalers/azure/azure_app_insights.go
@@ -55,7 +55,7 @@ func toISO8601(time string) (string, error) {
 	minutes, merr := strconv.Atoi(timeSegments[1])
 
 	if herr != nil || merr != nil {
-		return "", fmt.Errorf("errors parsing time: %v, %w", herr, merr)
+		return "", fmt.Errorf("errors parsing time: %w, %w", herr, merr)
 	}
 
 	return fmt.Sprintf("PT%02dH%02dM", hours, minutes), nil

--- a/pkg/scalers/azure/azure_app_insights.go
+++ b/pkg/scalers/azure/azure_app_insights.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,7 +56,7 @@ func toISO8601(time string) (string, error) {
 	minutes, merr := strconv.Atoi(timeSegments[1])
 
 	if herr != nil || merr != nil {
-		return "", fmt.Errorf("errors parsing time: %w, %w", herr, merr)
+		return "", fmt.Errorf("errors parsing time: %w", errors.Join(herr, merr))
 	}
 
 	return fmt.Sprintf("PT%02dH%02dM", hours, minutes), nil

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -316,7 +316,7 @@ func formatTimeSpan(timeSpan string) (*azquery.TimeInterval, error) {
 		seconds, serr := strconv.Atoi(aggregationInterval[2])
 
 		if herr != nil || merr != nil || serr != nil {
-			return nil, fmt.Errorf("errors parsing metricAggregationInterval: %v, %v, %w", herr, merr, serr)
+			return nil, fmt.Errorf("errors parsing metricAggregationInterval: %w, %w, %w", herr, merr, serr)
 		}
 
 		starttime = time.Now().Add(-(time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute + time.Duration(seconds)*time.Second)).UTC()

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -18,6 +18,7 @@ package scalers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -316,7 +317,7 @@ func formatTimeSpan(timeSpan string) (*azquery.TimeInterval, error) {
 		seconds, serr := strconv.Atoi(aggregationInterval[2])
 
 		if herr != nil || merr != nil || serr != nil {
-			return nil, fmt.Errorf("errors parsing metricAggregationInterval: %w, %w, %w", herr, merr, serr)
+			return nil, fmt.Errorf("errors parsing metricAggregationInterval: %w", errors.Join(herr, merr, serr))
 		}
 
 		starttime = time.Now().Add(-(time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute + time.Duration(seconds)*time.Second)).UTC()


### PR DESCRIPTION
Use `%w` instead of `%v` in `fmt.Errorf` calls to enable `errors.Is` and `errors.As`.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))