### PR TITLE
feat: add MAINTAINERS file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# KEDA Maintainers
+
+This document lists the maintainers of the `kedacore/keda` project.
+
+## Maintainers
+
+| Maintainer            | GitHub ID                                     | Affiliation                       |
+| --------------------- | --------------------------------------------- | --------------------------------- |
+| Jan Wozniak           | [wozniakjan](https://github.com/wozniakjan)   | Kedify                            |
+| Jeff Hollan           | [jeffhollan](https://github.com/jeffhollan)   | Snowflake                         |
+| Jorge Turrado Ferrero | [jorturfer](https://github.com/jorturfer)     | SCRM Lidl International Hub       |
+| Rick Brouwer          | [rickbrouwer](https://github.com/rickbrouwer) | Dienst Uitvoering Onderwijs       |
+| Zbynek Roubalik       | [zroubalik](https://github.com/zroubalik)     | Kedify                            |


### PR DESCRIPTION
With our [MEMBERS.md](https://github.com/kedacore/governance/blob/main/MEMBERS.md), we deviate from the Linux Foundation’s standard. As a result, information about KEDA is not represented correctly because the data collection process cannot find the correct files.
That's why I want to add this file at project level to ensure [data collection processes](https://insights.linuxfoundation.org/docs/introduction/maintainers/#data-collection-process) are correct again.

The content is purely for `kedacore/keda` only, not for other repos under `kedacore`.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))