### PR TITLE
fix(docs): correct typo in admission webhooks filename

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -268,7 +268,7 @@ Follow these instructions if you want to debug the KEDA webhook using VS Code.
    Refer to [this](https://code.visualstudio.com/docs/editor/debugging) for more information about debugging with VS Code.
 2. Expose your local instance to the internet. If you can't expose it directly, you can use something like [localtunnel](https://theboroer.github.io/localtunnel-www/) using the command `lt --port 9443 --local-https --allow-invalid-cert` after installing the tool.
 
-3. Update the `admissing_webhooks.yaml` in `config/webhooks`, replacing the section (but not committing this change)
+3. Update the `admission_webhooks.yaml` in `config/webhooks`, replacing the section (but not committing this change)
    ```yaml
    webhooks:
    - admissionReviewVersions:


### PR DESCRIPTION
## Description
This PR corrects a typo in the documentation regarding the admission webhooks configuration file.  
The file name `admissing_webhooks.yaml` has been changed to `admission_webhooks.yaml` in the **Admission Webhooks** section to match the actual file name.

## Why is this change needed?
The incorrect file name may cause confusion for developers following the debugging instructions. Using the correct name ensures the documentation is accurate and easier to follow.