### PR TITLE
Fix: azure-monitor scaler seems to ignore metricAggregationInterval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **Azure Monitor Scaler**: Pass aggregation interval to Azure Monitor API so `metricAggregationInterval` is respected ([#7524](https://github.com/kedacore/keda/issues/7524))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **Forgejo Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **GCP Scaler**: Validate Pub/Sub resource name in BuildMQLQuery ([#7468](https://github.com/kedacore/keda/pull/7468))

--- a/pkg/scalers/azure_monitor_scaler.go
+++ b/pkg/scalers/azure_monitor_scaler.go
@@ -259,7 +259,7 @@ func (s *azureMonitorScaler) GetMetricsAndActivity(ctx context.Context, metricNa
 	return []external_metrics.ExternalMetricValue{metric}, val > s.metadata.ActivationTargetValue, nil
 }
 func (s *azureMonitorScaler) requestMetric(ctx context.Context) (float64, error) {
-	timespan, err := formatTimeSpan(s.metadata.AggregationInterval)
+	timespan, interval, err := formatTimeSpan(s.metadata.AggregationInterval)
 	if err != nil {
 		return -1, err
 	}
@@ -267,7 +267,7 @@ func (s *azureMonitorScaler) requestMetric(ctx context.Context) (float64, error)
 		MetricNames:     &s.metadata.Name,
 		MetricNamespace: s.metadata.NamespaceRef,
 		Filter:          s.metadata.FilterRef,
-		Interval:        nil,
+		Interval:        interval,
 		Top:             nil,
 		ResultType:      nil,
 		OrderBy:         nil,
@@ -305,10 +305,12 @@ func (s *azureMonitorScaler) requestMetric(ctx context.Context) (float64, error)
 	return val, nil
 }
 
-// formatTimeSpan defaults to a 5 minute timespan if the user does not provide one
-func formatTimeSpan(timeSpan string) (*azquery.TimeInterval, error) {
+// formatTimeSpan defaults to a 5 minute timespan if the user does not provide one.
+// It returns the timespan and an optional ISO 8601 duration interval for the Azure Monitor API.
+func formatTimeSpan(timeSpan string) (*azquery.TimeInterval, *string, error) {
 	endtime := time.Now().UTC()
 	starttime := time.Now().Add(-(5 * time.Minute)).UTC()
+	var interval *string
 	if timeSpan != "" {
 		aggregationInterval := strings.Split(timeSpan, ":")
 		hours, herr := strconv.Atoi(aggregationInterval[0])
@@ -316,13 +318,34 @@ func formatTimeSpan(timeSpan string) (*azquery.TimeInterval, error) {
 		seconds, serr := strconv.Atoi(aggregationInterval[2])
 
 		if herr != nil || merr != nil || serr != nil {
-			return nil, fmt.Errorf("errors parsing metricAggregationInterval: %v, %v, %w", herr, merr, serr)
+			return nil, nil, fmt.Errorf("errors parsing metricAggregationInterval: %v, %v, %w", herr, merr, serr)
 		}
 
 		starttime = time.Now().Add(-(time.Duration(hours)*time.Hour + time.Duration(minutes)*time.Minute + time.Duration(seconds)*time.Second)).UTC()
+
+		iso8601 := formatISO8601Duration(hours, minutes, seconds)
+		interval = &iso8601
 	}
-	interval := azquery.NewTimeInterval(starttime, endtime)
-	return &interval, nil
+	timeInterval := azquery.NewTimeInterval(starttime, endtime)
+	return &timeInterval, interval, nil
+}
+
+// formatISO8601Duration converts hours, minutes, and seconds into an ISO 8601 duration string.
+func formatISO8601Duration(hours, minutes, seconds int) string {
+	d := "PT"
+	if hours > 0 {
+		d += fmt.Sprintf("%dH", hours)
+	}
+	if minutes > 0 {
+		d += fmt.Sprintf("%dM", minutes)
+	}
+	if seconds > 0 {
+		d += fmt.Sprintf("%dS", seconds)
+	}
+	if d == "PT" {
+		d = "PT0S"
+	}
+	return d
 }
 
 func verifyAggregationTypeIsSupported(aggregationType azquery.AggregationType, data []*azquery.MetricValue) (float64, error) {

--- a/pkg/scalers/azure_monitor_scaler_test.go
+++ b/pkg/scalers/azure_monitor_scaler_test.go
@@ -115,6 +115,112 @@ func TestAzMonitorParseMetadata(t *testing.T) {
 	}
 }
 
+func TestFormatTimeSpan(t *testing.T) {
+	tests := []struct {
+		name             string
+		timeSpan         string
+		expectErr        bool
+		expectedInterval *string
+	}{
+		{
+			name:             "empty timespan defaults to 5 minutes with nil interval",
+			timeSpan:         "",
+			expectErr:        false,
+			expectedInterval: nil,
+		},
+		{
+			name:             "15 minute interval",
+			timeSpan:         "0:15:0",
+			expectErr:        false,
+			expectedInterval: strPtr("PT15M"),
+		},
+		{
+			name:             "1 hour interval",
+			timeSpan:         "1:0:0",
+			expectErr:        false,
+			expectedInterval: strPtr("PT1H"),
+		},
+		{
+			name:             "1 hour 30 minutes interval",
+			timeSpan:         "1:30:0",
+			expectErr:        false,
+			expectedInterval: strPtr("PT1H30M"),
+		},
+		{
+			name:             "30 seconds interval",
+			timeSpan:         "0:0:30",
+			expectErr:        false,
+			expectedInterval: strPtr("PT30S"),
+		},
+		{
+			name:             "all components",
+			timeSpan:         "1:15:30",
+			expectErr:        false,
+			expectedInterval: strPtr("PT1H15M30S"),
+		},
+		{
+			name:      "invalid format",
+			timeSpan:  "abc:def:ghi",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timespan, interval, err := formatTimeSpan(tt.timeSpan)
+			if tt.expectErr {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if timespan == nil {
+				t.Error("Expected non-nil timespan")
+			}
+			if tt.expectedInterval == nil {
+				if interval != nil {
+					t.Errorf("Expected nil interval, got %s", *interval)
+				}
+			} else {
+				if interval == nil {
+					t.Errorf("Expected interval %s, got nil", *tt.expectedInterval)
+				} else if *interval != *tt.expectedInterval {
+					t.Errorf("Expected interval %s, got %s", *tt.expectedInterval, *interval)
+				}
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestFormatISO8601Duration(t *testing.T) {
+	tests := []struct {
+		hours, minutes, seconds int
+		expected                string
+	}{
+		{0, 15, 0, "PT15M"},
+		{1, 0, 0, "PT1H"},
+		{1, 30, 0, "PT1H30M"},
+		{0, 0, 30, "PT30S"},
+		{1, 15, 30, "PT1H15M30S"},
+		{0, 0, 0, "PT0S"},
+	}
+
+	for _, tt := range tests {
+		result := formatISO8601Duration(tt.hours, tt.minutes, tt.seconds)
+		if result != tt.expected {
+			t.Errorf("formatISO8601Duration(%d, %d, %d) = %s, want %s", tt.hours, tt.minutes, tt.seconds, result, tt.expected)
+		}
+	}
+}
+
 func TestAzMonitorGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azMonitorMetricIdentifiers {
 		meta, err := parseAzureMonitorMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata,


### PR DESCRIPTION
## What changed

The `formatTimeSpan` function in the Azure Monitor scaler now converts the user-provided `metricAggregationInterval` into an ISO 8601 duration string (e.g., `"0:15:0"` → `"PT15M"`) and passes it as the `Interval` parameter in the Azure Monitor metrics query. Previously, the `Interval` was always set to `nil`, causing Azure Monitor to use its default granularity regardless of the user's configuration.

## Why

When `metricAggregationInterval` was set (e.g., to `"0:15:0"` for 15 minutes), the scaler correctly expanded the query time window but never told the Azure Monitor API to aggregate data at that interval. Azure Monitor would return data points at its default granularity (typically 1 or 5 minutes), and since the code reads only the last data point, it effectively ignored the user's aggregation interval setting.

Fixes #7524

## Testing

- Added `TestFormatTimeSpan` to verify that the function returns correct ISO 8601 interval strings for various inputs (empty, minutes-only, hours-only, mixed, all components) and nil when no interval is specified.
- Added `TestFormatISO8601Duration` to verify the ISO 8601 duration formatting helper.
- All existing azure monitor scaler tests continue to pass.
