### PR TITLE
e2e: replace gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0 with quay.io/brancz/kube-rbac-proxy:v0.18.2

### DIFF
--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -160,7 +160,7 @@ func TestSetupGcpIdentityComponents(t *testing.T) {
 	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, GcpIdentityNamespace)
 
-	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install gcp-identity-webhook gcp-workload-identity-federation-webhook/gcp-workload-identity-federation-webhook --namespace %s --set fullnameOverride=gcp-identity-webhook --set controllerManager.manager.args[0]=--token-default-mode=0444",
+	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install gcp-identity-webhook gcp-workload-identity-federation-webhook/gcp-workload-identity-federation-webhook --namespace %s --set fullnameOverride=gcp-identity-webhook --set controllerManager.manager.args[0]=--token-default-mode=0444 --set controllerManager.kubeRbacProxy.image.repository=quay.io/brancz/kube-rbac-proxy --set controllerManager.kubeRbacProxy.image.tag=v0.18.2",
 		GcpIdentityNamespace))
 	require.NoErrorf(t, err, "cannot install workload identity webhook - %s", err)
 }


### PR DESCRIPTION
The e2e test `TestVerifyPodsIdentity` has started to fail this weekend
- https://github.com/kedacore/keda/actions/runs/22787706034
- https://github.com/kedacore/keda/actions/runs/22810449987
- https://github.com/kedacore/keda/actions/runs/22833492471

the reason seems to be that `gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0` no longer exists after being marked for deprecation for a longer period of time - https://github.com/kubernetes-sigs/kubebuilder/discussions/3907. The gcp-workload-identity-federation-webhook/gcp-workload-identity-federation-webhook chart installed in the e2e setup expects to become ready but it can't
```
$ k describe po gcp-identity-webhook-controller-manager-7c6bb5687b-jsdzg
...
Events:
  Warning  Failed     7s (x4 over 94s)   kubelet            spec.containers{kube-rbac-proxy}: Failed to pull image "gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0": rpc error: code = NotFound desc = failed to pull and unpack image "gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0": failed to resolve reference "gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0": gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0: not found
```
https://github.com/kedacore/keda/blob/73a639f6e1b4126df9c01d11e3965ce5a8ca5b7f/tests/utils/setup_test.go#L179-L182

Replacing the kubebuilder repository with brancz hosted version.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to _#broken-e2e-tests_ :)
