### PR TITLE
feat: add jobCreationCooldownPeriod to ScaledJob to prevent duplicate job creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### New
 
-- **General:** Add `cooldownPeriod` to ScaledJob to prevent duplicate job creation from stale metrics ([#7330](https://github.com/kedacore/keda/issues/7330))
+- **General**: Add `cooldownPeriod` to ScaledJob to prevent duplicate job creation from stale metrics ([#7330](https://github.com/kedacore/keda/issues/7330))
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### New
 
-- **General**: Add `cooldownPeriod` to ScaledJob to prevent duplicate job creation from stale metrics ([#7330](https://github.com/kedacore/keda/issues/7330))
+- **General**: Add `jobCreationCooldownPeriod` to ScaledJob to prevent duplicate job creation from stale metrics ([#7330](https://github.com/kedacore/keda/issues/7330))
 
 #### Experimental
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### New
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **General:** Add `cooldownPeriod` to ScaledJob to prevent duplicate job creation from stale metrics ([#7330](https://github.com/kedacore/keda/issues/7330))
 
 #### Experimental
 

--- a/apis/keda/v1alpha1/scaledjob_types.go
+++ b/apis/keda/v1alpha1/scaledjob_types.go
@@ -69,8 +69,12 @@ type ScaledJobSpec struct {
 	MinReplicaCount *int32 `json:"minReplicaCount,omitempty"`
 	// +optional
 	MaxReplicaCount *int32 `json:"maxReplicaCount,omitempty"`
+	// JobCreationCooldownPeriod defines the minimum time (in seconds) to wait after the last active
+	// time before creating new jobs on re-activation. This prevents duplicate job creation caused by
+	// eventually consistent metrics. Defaults to 0 (disabled).
 	// +optional
-	CooldownPeriod *int32 `json:"cooldownPeriod,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	JobCreationCooldownPeriod *int32 `json:"jobCreationCooldownPeriod,omitempty"`
 	// +optional
 	ScalingStrategy ScalingStrategy `json:"scalingStrategy,omitempty"`
 	Triggers        []ScaleTriggers `json:"triggers"`
@@ -155,10 +159,10 @@ func (s ScaledJob) MinReplicaCount() int64 {
 	return defaultScaledJobMinReplicaCount
 }
 
-// CooldownPeriod returns the cooldown period duration, or 0 if not set
-func (s ScaledJob) CooldownPeriod() int32 {
-	if s.Spec.CooldownPeriod != nil {
-		return *s.Spec.CooldownPeriod
+// JobCreationCooldownPeriod returns the job creation cooldown period duration, or 0 if not set
+func (s ScaledJob) JobCreationCooldownPeriod() int32 {
+	if s.Spec.JobCreationCooldownPeriod != nil {
+		return *s.Spec.JobCreationCooldownPeriod
 	}
 	return 0
 }

--- a/apis/keda/v1alpha1/scaledjob_types.go
+++ b/apis/keda/v1alpha1/scaledjob_types.go
@@ -70,6 +70,8 @@ type ScaledJobSpec struct {
 	// +optional
 	MaxReplicaCount *int32 `json:"maxReplicaCount,omitempty"`
 	// +optional
+	CooldownPeriod *int32 `json:"cooldownPeriod,omitempty"`
+	// +optional
 	ScalingStrategy ScalingStrategy `json:"scalingStrategy,omitempty"`
 	Triggers        []ScaleTriggers `json:"triggers"`
 }
@@ -151,6 +153,14 @@ func (s ScaledJob) MinReplicaCount() int64 {
 		return int64(*s.Spec.MinReplicaCount)
 	}
 	return defaultScaledJobMinReplicaCount
+}
+
+// CooldownPeriod returns the cooldown period duration, or 0 if not set
+func (s ScaledJob) CooldownPeriod() int32 {
+	if s.Spec.CooldownPeriod != nil {
+		return *s.Spec.CooldownPeriod
+	}
+	return 0
 }
 
 func (s *ScaledJob) GenerateIdentifier() string {

--- a/apis/keda/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/keda/v1alpha1/zz_generated.deepcopy.go
@@ -829,8 +829,8 @@ func (in *ScaledJobSpec) DeepCopyInto(out *ScaledJobSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.CooldownPeriod != nil {
-		in, out := &in.CooldownPeriod, &out.CooldownPeriod
+	if in.JobCreationCooldownPeriod != nil {
+		in, out := &in.JobCreationCooldownPeriod, &out.JobCreationCooldownPeriod
 		*out = new(int32)
 		**out = **in
 	}

--- a/apis/keda/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/keda/v1alpha1/zz_generated.deepcopy.go
@@ -829,6 +829,11 @@ func (in *ScaledJobSpec) DeepCopyInto(out *ScaledJobSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.CooldownPeriod != nil {
+		in, out := &in.CooldownPeriod, &out.CooldownPeriod
+		*out = new(int32)
+		**out = **in
+	}
 	in.ScalingStrategy.DeepCopyInto(&out.ScalingStrategy)
 	if in.Triggers != nil {
 		in, out := &in.Triggers, &out.Triggers

--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -66,13 +66,18 @@ spec:
           spec:
             description: ScaledJobSpec defines the desired state of ScaledJob
             properties:
-              cooldownPeriod:
-                format: int32
-                type: integer
               envSourceContainerName:
                 type: string
               failedJobsHistoryLimit:
                 format: int32
+                type: integer
+              jobCreationCooldownPeriod:
+                description: |-
+                  JobCreationCooldownPeriod defines the minimum time (in seconds) to wait after the last active
+                  time before creating new jobs on re-activation. This prevents duplicate job creation caused by
+                  eventually consistent metrics. Defaults to 0 (disabled).
+                format: int32
+                minimum: 0
                 type: integer
               jobTargetRef:
                 description: JobSpec describes how the job execution will look like.

--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -66,6 +66,9 @@ spec:
           spec:
             description: ScaledJobSpec defines the desired state of ScaledJob
             properties:
+              cooldownPeriod:
+                format: int32
+                type: integer
               envSourceContainerName:
                 type: string
               failedJobsHistoryLimit:

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
@@ -58,15 +59,26 @@ func (e *scaleExecutor) RequestJobScale(ctx context.Context, scaledJob *kedav1al
 		effectiveMaxScale = 0
 	}
 
+	inCooldown := false
 	if isActive {
 		logger.V(1).Info("At least one scaler is active")
-		now := metav1.Now()
-		scaledJob.Status.LastActiveTime = &now
-		err := e.updateLastActiveTime(ctx, logger, scaledJob)
-		if err != nil {
-			logger.Error(err, "Failed to update last active time")
+
+		inCooldown = isScaledJobInCooldownPeriod(scaledJob)
+		if inCooldown {
+			logger.Info("ScaledJob is in cooldown period, skipping job creation",
+				"LastActiveTime", scaledJob.Status.LastActiveTime,
+				"CooldownPeriod", time.Second*time.Duration(scaledJob.CooldownPeriod()))
 		}
-		e.createJobs(ctx, logger, scaledJob, scaleTo, effectiveMaxScale)
+
+		if !inCooldown {
+			now := metav1.Now()
+			scaledJob.Status.LastActiveTime = &now
+			err := e.updateLastActiveTime(ctx, logger, scaledJob)
+			if err != nil {
+				logger.Error(err, "Failed to update last active time")
+			}
+			e.createJobs(ctx, logger, scaledJob, scaleTo, effectiveMaxScale)
+		}
 	} else {
 		logger.V(1).Info("No change in activity")
 	}
@@ -106,7 +118,14 @@ func (e *scaleExecutor) RequestJobScale(ctx context.Context, scaledJob *kedav1al
 	}
 
 	condition := scaledJob.Status.Conditions.GetActiveCondition()
-	if condition.IsUnknown() || condition.IsTrue() != isActive {
+	if inCooldown {
+		if !condition.IsFalse() || condition.Reason != "ScalerCooldown" {
+			if err := e.setActiveCondition(ctx, logger, scaledJob, metav1.ConditionFalse, "ScalerCooldown", "Scaling is paused due to cooldown period"); err != nil {
+				logger.Error(err, "Error setting active condition during cooldown")
+				return
+			}
+		}
+	} else if condition.IsUnknown() || condition.IsTrue() != isActive {
 		if isActive {
 			if !condition.IsTrue() {
 				e.recorder.Event(scaledJob, corev1.EventTypeNormal, eventreason.ScaledJobActive, "Scaling is performed because triggers are active")
@@ -451,6 +470,28 @@ func (e *scaleExecutor) getFinishedJobConditionType(j *batchv1.Job) batchv1.JobC
 		}
 	}
 	return ""
+}
+
+// isScaledJobInCooldownPeriod checks if a ScaledJob is within its cooldown period.
+// Cooldown applies when re-activating (condition is not True) and the time since
+// LastActiveTime is less than the configured cooldown period.
+func isScaledJobInCooldownPeriod(scaledJob *kedav1alpha1.ScaledJob) bool {
+	cooldownSeconds := scaledJob.CooldownPeriod()
+	if cooldownSeconds <= 0 {
+		return false
+	}
+
+	condition := scaledJob.Status.Conditions.GetActiveCondition()
+	if condition.IsTrue() {
+		return false
+	}
+
+	if scaledJob.Status.LastActiveTime == nil {
+		return false
+	}
+
+	cooldownPeriod := time.Second * time.Duration(cooldownSeconds)
+	return time.Since(scaledJob.Status.LastActiveTime.Time) < cooldownPeriod
 }
 
 // NewScalingStrategy returns ScalingStrategy instance

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -65,9 +65,9 @@ func (e *scaleExecutor) RequestJobScale(ctx context.Context, scaledJob *kedav1al
 
 		inCooldown = isScaledJobInCooldownPeriod(scaledJob)
 		if inCooldown {
-			logger.Info("ScaledJob is in cooldown period, skipping job creation",
+			logger.Info("ScaledJob is in job creation cooldown period, skipping job creation",
 				"LastActiveTime", scaledJob.Status.LastActiveTime,
-				"CooldownPeriod", time.Second*time.Duration(scaledJob.CooldownPeriod()))
+				"JobCreationCooldownPeriod", time.Second*time.Duration(scaledJob.JobCreationCooldownPeriod()))
 		}
 
 		if !inCooldown {
@@ -472,11 +472,11 @@ func (e *scaleExecutor) getFinishedJobConditionType(j *batchv1.Job) batchv1.JobC
 	return ""
 }
 
-// isScaledJobInCooldownPeriod checks if a ScaledJob is within its cooldown period.
+// isScaledJobInCooldownPeriod checks if a ScaledJob is within its job creation cooldown period.
 // Cooldown applies when re-activating (condition is not True) and the time since
-// LastActiveTime is less than the configured cooldown period.
+// LastActiveTime is less than the configured job creation cooldown period.
 func isScaledJobInCooldownPeriod(scaledJob *kedav1alpha1.ScaledJob) bool {
-	cooldownSeconds := scaledJob.CooldownPeriod()
+	cooldownSeconds := scaledJob.JobCreationCooldownPeriod()
 	if cooldownSeconds <= 0 {
 		return false
 	}

--- a/pkg/scaling/executor/scale_jobs_test.go
+++ b/pkg/scaling/executor/scale_jobs_test.go
@@ -494,6 +494,10 @@ type pendingJobTestData struct {
 }
 
 func getMockScaleExecutor(client *mock_client.MockClient) *scaleExecutor {
+	return getMockScaleExecutorWithBuffer(client, 1)
+}
+
+func getMockScaleExecutorWithBuffer(client *mock_client.MockClient, eventBufferSize int) *scaleExecutor {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(kedav1alpha1.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -502,7 +506,7 @@ func getMockScaleExecutor(client *mock_client.MockClient) *scaleExecutor {
 		scaleClient:      nil,
 		reconcilerScheme: scheme,
 		logger:           logf.Log.WithName("scaleexecutor"),
-		recorder:         record.NewFakeRecorder(1),
+		recorder:         record.NewFakeRecorder(eventBufferSize),
 	}
 }
 
@@ -728,6 +732,209 @@ func getPodCondition(podConditionType v1.PodConditionType) v1.PodCondition {
 	}
 }
 
+func TestRequestJobScale_CooldownSkipsJobCreation(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_client.NewMockClient(ctrl)
+	statusWriter := mock_client.NewMockStatusWriter(ctrl)
+
+	// Mock List calls: getRunningJobCount, getPendingJobCount, and cleanUp
+	client.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
+
+	// Mock Status().Patch() for setActiveCondition, setReadyCondition, updateTriggersActivity
+	client.EXPECT().Status().Return(statusWriter).AnyTimes()
+	statusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	// We should NOT see any Create calls (no jobs created during cooldown)
+	// gomock will fail if Create is called unexpectedly
+
+	scaleExecutor := getMockScaleExecutorWithBuffer(client, 10)
+
+	cooldown := int32(60)
+	scaledJob := &kedav1alpha1.ScaledJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: kedav1alpha1.ScaledJobSpec{
+			JobCreationCooldownPeriod: &cooldown,
+			JobTargetRef:              &batchv1.JobSpec{},
+		},
+		Status: kedav1alpha1.ScaledJobStatus{
+			// Last active 10s ago, well within cooldown
+			LastActiveTime: ptr.To(metav1.NewTime(time.Now().Add(-10 * time.Second))),
+			Conditions: kedav1alpha1.Conditions{
+				{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionFalse},
+			},
+		},
+	}
+
+	scaleExecutor.RequestJobScale(ctx, scaledJob, true, false, 1, 1, nil)
+
+	// Verify LastActiveTime was NOT updated (should still be ~10s ago)
+	assert.True(t, time.Since(scaledJob.Status.LastActiveTime.Time) >= 9*time.Second,
+		"LastActiveTime should not be updated during cooldown")
+}
+
+func TestRequestJobScale_CooldownSetsScalerCooldownCondition(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_client.NewMockClient(ctrl)
+	statusWriter := mock_client.NewMockStatusWriter(ctrl)
+
+	client.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
+
+	client.EXPECT().Status().Return(statusWriter).AnyTimes()
+
+	// Capture the patched object to verify the condition
+	var patchedObj runtimeclient.Object
+	statusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, obj runtimeclient.Object, _ runtimeclient.Patch, _ ...runtimeclient.SubResourcePatchOption) error {
+			patchedObj = obj
+			return nil
+		}).AnyTimes()
+
+	scaleExecutor := getMockScaleExecutorWithBuffer(client, 10)
+
+	cooldown := int32(60)
+	scaledJob := &kedav1alpha1.ScaledJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: kedav1alpha1.ScaledJobSpec{
+			JobCreationCooldownPeriod: &cooldown,
+			JobTargetRef:              &batchv1.JobSpec{},
+		},
+		Status: kedav1alpha1.ScaledJobStatus{
+			LastActiveTime: ptr.To(metav1.NewTime(time.Now().Add(-10 * time.Second))),
+			Conditions: kedav1alpha1.Conditions{
+				{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionFalse},
+				{Type: kedav1alpha1.ConditionReady, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	scaleExecutor.RequestJobScale(ctx, scaledJob, true, false, 1, 1, nil)
+
+	// Verify the active condition was set to ScalerCooldown
+	assert.NotNil(t, patchedObj)
+	sj, ok := patchedObj.(*kedav1alpha1.ScaledJob)
+	if ok {
+		activeCondition := sj.Status.Conditions.GetActiveCondition()
+		assert.True(t, activeCondition.IsFalse())
+		assert.Equal(t, "ScalerCooldown", activeCondition.Reason)
+	}
+}
+
+func TestRequestJobScale_CooldownExpiredCreatesJobs(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_client.NewMockClient(ctrl)
+	statusWriter := mock_client.NewMockStatusWriter(ctrl)
+
+	client.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
+
+	client.EXPECT().Status().Return(statusWriter).AnyTimes()
+	statusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	// Expect job creation since cooldown has expired
+	jobCreated := false
+	client.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...runtimeclient.CreateOption) error {
+			jobCreated = true
+			return nil
+		}).Times(1)
+
+	scaleExecutor := getMockScaleExecutorWithBuffer(client, 10)
+
+	cooldown := int32(60)
+	scaledJob := &kedav1alpha1.ScaledJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: kedav1alpha1.ScaledJobSpec{
+			JobCreationCooldownPeriod: &cooldown,
+			JobTargetRef:              &batchv1.JobSpec{},
+		},
+		Status: kedav1alpha1.ScaledJobStatus{
+			// Last active 120s ago — cooldown (60s) has expired
+			LastActiveTime: ptr.To(metav1.NewTime(time.Now().Add(-120 * time.Second))),
+			Conditions: kedav1alpha1.Conditions{
+				{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionFalse},
+			},
+		},
+	}
+
+	scaleExecutor.RequestJobScale(ctx, scaledJob, true, false, 1, 1, nil)
+
+	assert.True(t, jobCreated, "Job should be created when cooldown has expired")
+	// LastActiveTime should be updated to now
+	assert.True(t, time.Since(scaledJob.Status.LastActiveTime.Time) < 2*time.Second,
+		"LastActiveTime should be updated after cooldown expires")
+}
+
+func TestRequestJobScale_NoCooldownCreatesJobsNormally(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_client.NewMockClient(ctrl)
+	statusWriter := mock_client.NewMockStatusWriter(ctrl)
+
+	client.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
+
+	client.EXPECT().Status().Return(statusWriter).AnyTimes()
+	statusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	jobCreated := false
+	client.EXPECT().
+		Create(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...runtimeclient.CreateOption) error {
+			jobCreated = true
+			return nil
+		}).Times(1)
+
+	scaleExecutor := getMockScaleExecutorWithBuffer(client, 10)
+
+	// No cooldown configured (nil)
+	scaledJob := &kedav1alpha1.ScaledJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: "default",
+		},
+		Spec: kedav1alpha1.ScaledJobSpec{
+			JobTargetRef: &batchv1.JobSpec{},
+		},
+		Status: kedav1alpha1.ScaledJobStatus{
+			LastActiveTime: ptr.To(metav1.NewTime(time.Now().Add(-5 * time.Second))),
+			Conditions: kedav1alpha1.Conditions{
+				{Type: kedav1alpha1.ConditionActive, Status: metav1.ConditionFalse},
+			},
+		},
+	}
+
+	scaleExecutor.RequestJobScale(ctx, scaledJob, true, false, 1, 1, nil)
+
+	assert.True(t, jobCreated, "Job should be created when no cooldown is configured")
+}
+
 func TestIsScaledJobInCooldownPeriod(t *testing.T) {
 	cooldownPeriod := int32(60)
 
@@ -793,7 +1000,7 @@ func TestIsScaledJobInCooldownPeriod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scaledJob := &kedav1alpha1.ScaledJob{
 				Spec: kedav1alpha1.ScaledJobSpec{
-					CooldownPeriod: tt.cooldownPeriod,
+					JobCreationCooldownPeriod: tt.cooldownPeriod,
 				},
 				Status: kedav1alpha1.ScaledJobStatus{
 					LastActiveTime: tt.lastActiveTime,

--- a/pkg/scaling/executor/scale_jobs_test.go
+++ b/pkg/scaling/executor/scale_jobs_test.go
@@ -31,12 +31,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
-	"k8s.io/utils/ptr"
 )
 
 func TestCleanUpNormalCase(t *testing.T) {

--- a/pkg/scaling/executor/scale_jobs_test.go
+++ b/pkg/scaling/executor/scale_jobs_test.go
@@ -36,6 +36,7 @@ import (
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
+	"k8s.io/utils/ptr"
 )
 
 func TestCleanUpNormalCase(t *testing.T) {
@@ -724,5 +725,85 @@ func getPodCondition(podConditionType v1.PodConditionType) v1.PodCondition {
 	return v1.PodCondition{
 		Type:   podConditionType,
 		Status: v1.ConditionTrue,
+	}
+}
+
+func TestIsScaledJobInCooldownPeriod(t *testing.T) {
+	cooldownPeriod := int32(60)
+
+	tests := []struct {
+		name            string
+		cooldownPeriod  *int32
+		lastActiveTime  *metav1.Time
+		activeCondition metav1.ConditionStatus
+		expected        bool
+	}{
+		{
+			name:            "no cooldown configured",
+			cooldownPeriod:  nil,
+			lastActiveTime:  ptr.To(metav1.NewTime(time.Now().Add(-10 * time.Second))),
+			activeCondition: metav1.ConditionFalse,
+			expected:        false,
+		},
+		{
+			name:            "cooldown zero",
+			cooldownPeriod:  ptr.To(int32(0)),
+			lastActiveTime:  ptr.To(metav1.NewTime(time.Now().Add(-10 * time.Second))),
+			activeCondition: metav1.ConditionFalse,
+			expected:        false,
+		},
+		{
+			name:            "in cooldown - recently active, now re-activating",
+			cooldownPeriod:  &cooldownPeriod,
+			lastActiveTime:  ptr.To(metav1.NewTime(time.Now().Add(-10 * time.Second))),
+			activeCondition: metav1.ConditionFalse,
+			expected:        true,
+		},
+		{
+			name:            "cooldown expired - last active long ago",
+			cooldownPeriod:  &cooldownPeriod,
+			lastActiveTime:  ptr.To(metav1.NewTime(time.Now().Add(-120 * time.Second))),
+			activeCondition: metav1.ConditionFalse,
+			expected:        false,
+		},
+		{
+			name:            "already active - no cooldown check",
+			cooldownPeriod:  &cooldownPeriod,
+			lastActiveTime:  ptr.To(metav1.NewTime(time.Now().Add(-5 * time.Second))),
+			activeCondition: metav1.ConditionTrue,
+			expected:        false,
+		},
+		{
+			name:            "condition unknown - first activation, no LastActiveTime",
+			cooldownPeriod:  &cooldownPeriod,
+			lastActiveTime:  nil,
+			activeCondition: metav1.ConditionUnknown,
+			expected:        false,
+		},
+		{
+			name:            "condition unknown - re-activation within cooldown",
+			cooldownPeriod:  &cooldownPeriod,
+			lastActiveTime:  ptr.To(metav1.NewTime(time.Now().Add(-10 * time.Second))),
+			activeCondition: metav1.ConditionUnknown,
+			expected:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaledJob := &kedav1alpha1.ScaledJob{
+				Spec: kedav1alpha1.ScaledJobSpec{
+					CooldownPeriod: tt.cooldownPeriod,
+				},
+				Status: kedav1alpha1.ScaledJobStatus{
+					LastActiveTime: tt.lastActiveTime,
+					Conditions: kedav1alpha1.Conditions{
+						{Type: kedav1alpha1.ConditionActive, Status: tt.activeCondition},
+					},
+				},
+			}
+			result := isScaledJobInCooldownPeriod(scaledJob)
+			assert.Equal(t, tt.expected, result, "Test case: %s", tt.name)
+		})
 	}
 }


### PR DESCRIPTION
Add a configurable `jobCreationCooldownPeriod` field to `ScaledJobSpec` that prevents new job creation when a scaler re-activates shortly after going inactive. This addresses duplicate job creation caused by eventually consistent metrics (e.g., AWS SQS `ApproximateNumberOfMessages`) that can temporarily report stale values after message deletion.

The field is intentionally named `jobCreationCooldownPeriod` (not `cooldownPeriod`) to avoid semantic clash with ScaledObject's `cooldownPeriod`, which controls scale-down delay. This field controls scale-up suppression — a distinct behavior.

**How it works:**

When `jobCreationCooldownPeriod` is set and the scaler transitions from inactive to active, job creation is skipped if the time since `LastActiveTime` is less than the configured cooldown duration. During cooldown, the Active condition is set to `False` with reason `ScalerCooldown`, ensuring the cooldown persists across polling cycles. Once the cooldown expires, normal job creation resumes.

The default value is `0` (disabled), ensuring full backward compatibility. CRD-level validation enforces `minimum: 0`.

**Example usage:**
```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledJob
metadata:
  name: sqs-consumer
spec:
  jobCreationCooldownPeriod: 60  # Wait 60s after last active time before creating new jobs on re-activation
  jobTargetRef:
    # ...
  triggers:
    - type: aws-sqs-queue
      metadata:
        queueURL: https://sqs.region.amazonaws.com/account/queue
        queueLength: "1"
```

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #7330