### PR TITLE
CRDs: allow patch merge for ScaledObject's and ScaledJob's triggers

### DIFF
--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -9056,6 +9056,8 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-patch-merge-key: name
+                x-kubernetes-patch-strategy: merge
             required:
             - jobTargetRef
             - triggers

--- a/config/crd/bases/keda.sh_scaledobjects.yaml
+++ b/config/crd/bases/keda.sh_scaledobjects.yaml
@@ -367,6 +367,8 @@ spec:
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-patch-merge-key: name
+                x-kubernetes-patch-strategy: merge
             required:
             - scaleTargetRef
             - triggers


### PR DESCRIPTION
This patch makes it possible to use Kustomize to define triggers across Kustomize overlays.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))