### PR TITLE
fix(azure-data-explorer): remove clientSecretFromEnv support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
-- **Azure Data Explorer Scaler**: Resolve clientSecret from env instead of using env var name ([#7554](https://github.com/kedacore/keda/issues/7554))
+- **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **External Scaler**: Fix context cancellation handling in `waitForState` of external scaler ([#7542](https://github.com/kedacore/keda/issues/7542))
 - **Forgejo Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))

--- a/pkg/scalers/azure_data_explorer_scaler.go
+++ b/pkg/scalers/azure_data_explorer_scaler.go
@@ -49,7 +49,7 @@ type azureDataExplorerMetadata struct {
 
 	TenantID     string `keda:"name=tenantId,order=triggerMetadata;authParams;resolvedEnv,optional"`
 	ClientID     string `keda:"name=clientId,order=triggerMetadata;authParams;resolvedEnv,optional"`
-	ClientSecret string `keda:"name=clientSecret,order=authParams;resolvedEnv,optional"`
+	ClientSecret string `keda:"name=clientSecret,order=authParams,optional"`
 
 	triggerIndex int
 }

--- a/pkg/scalers/azure_data_explorer_scaler_test.go
+++ b/pkg/scalers/azure_data_explorer_scaler_test.go
@@ -29,14 +29,16 @@ import (
 )
 
 type parseDataExplorerMetadataTestData struct {
-	metadata map[string]string
-	isError  bool
+	metadata   map[string]string
+	authParams map[string]string
+	isError    bool
 }
 
 type dataExplorerMetricIdentifier struct {
 	metadataTestData *parseDataExplorerMetadataTestData
 	triggerIndex     int
 	name             string
+	podIdentity      kedav1alpha1.AuthPodIdentity
 }
 
 var (
@@ -48,63 +50,72 @@ var (
 	dataExplorerQuery       = "print 3"
 	dataExplorerThreshold   = "1"
 	dataExplorerEndpoint    = "https://test-keda-e2e.eastus.kusto.windows.net"
-	clientSecretEnvVarName  = "ADX_CLIENT_SECRET"
 )
 
-var dataExplorerResolvedEnv = map[string]string{
-	clientSecretEnvVarName: aadAppSecret,
+var validAuthParams = map[string]string{
+	"clientSecret": aadAppSecret,
 }
 
 var testDataExplorerMetadataWithClientAndSecret = []parseDataExplorerMetadataTestData{
 	// Empty metadata - fail
-	{map[string]string{}, true},
+	{map[string]string{}, validAuthParams, true},
 	// Missing tenantId - fail
-	{map[string]string{"tenantId": "", "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": "", "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, validAuthParams, true},
 	// Missing clientId - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": "", "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": "", "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, validAuthParams, true},
 	// Missing clientSecret - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": "", "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, map[string]string{}, true},
 	// Missing endpoint - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, validAuthParams, true},
 	// Missing databaseName - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": "", "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": "", "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, validAuthParams, true},
 	// Missing query - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, validAuthParams, true},
 	// Missing threshold - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, validAuthParams, true},
 	// Invalid activationThreshold - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": "1", "activationThreshold": "A"}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": "1", "activationThreshold": "A"}, validAuthParams, true},
 	// known cloud
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold,
-		"cloud": "azureChinaCloud"}, false},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold,
+		"cloud": "azureChinaCloud"}, validAuthParams, false},
 	// private cloud
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold,
-		"cloud": "private", "activeDirectoryEndpoint": activeDirectoryEndpoint}, false},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold,
+		"cloud": "private", "activeDirectoryEndpoint": activeDirectoryEndpoint}, validAuthParams, false},
 	// private cloud - missing active directory endpoint - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold,
-		"cloud": "private"}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold,
+		"cloud": "private"}, validAuthParams, true},
 	// All parameters set - pass
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, false},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, validAuthParams, false},
 	// clientSecret in TriggerMetadata should not be accepted - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecret": aadAppSecret, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, map[string]string{}, true},
 }
 
 var testDataExplorerMetadataWithPodIdentity = []parseDataExplorerMetadataTestData{
 	// Empty metadata - fail
-	{map[string]string{}, true},
+	{map[string]string{}, map[string]string{}, true},
 	// Missing endpoint - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": "", "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, map[string]string{}, true},
 	// Missing query - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": "", "threshold": dataExplorerThreshold}, map[string]string{}, true},
 	// Missing threshold - fail
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, true},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": ""}, map[string]string{}, true},
 	// All parameters set - pass
-	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "clientSecretFromEnv": clientSecretEnvVarName, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, false},
+	{map[string]string{"tenantId": azureTenantID, "clientId": aadAppClientID, "endpoint": dataExplorerEndpoint, "databaseName": databaseName, "query": dataExplorerQuery, "threshold": dataExplorerThreshold}, map[string]string{}, false},
 }
 
 var testDataExplorerMetricIdentifiers = []dataExplorerMetricIdentifier{
-	{&testDataExplorerMetadataWithClientAndSecret[len(testDataExplorerMetadataWithClientAndSecret)-2], 0, GenerateMetricNameWithIndex(0, kedautil.NormalizeString(fmt.Sprintf("%s-%s", adxName, databaseName)))},
-	{&testDataExplorerMetadataWithPodIdentity[len(testDataExplorerMetadataWithPodIdentity)-1], 1, GenerateMetricNameWithIndex(1, kedautil.NormalizeString(fmt.Sprintf("%s-%s", adxName, databaseName)))},
+	{
+		metadataTestData: &testDataExplorerMetadataWithClientAndSecret[len(testDataExplorerMetadataWithClientAndSecret)-2],
+		triggerIndex:     0,
+		name:             GenerateMetricNameWithIndex(0, kedautil.NormalizeString(fmt.Sprintf("%s-%s", adxName, databaseName))),
+		podIdentity:      kedav1alpha1.AuthPodIdentity{},
+	},
+	{
+		metadataTestData: &testDataExplorerMetadataWithPodIdentity[len(testDataExplorerMetadataWithPodIdentity)-1],
+		triggerIndex:     1,
+		name:             GenerateMetricNameWithIndex(1, kedautil.NormalizeString(fmt.Sprintf("%s-%s", adxName, databaseName))),
+		podIdentity:      kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload},
+	},
 }
 
 func TestDataExplorerParseMetadata(t *testing.T) {
@@ -112,9 +123,8 @@ func TestDataExplorerParseMetadata(t *testing.T) {
 	for id, testData := range testDataExplorerMetadataWithClientAndSecret {
 		_, err := parseAzureDataExplorerMetadata(
 			&scalersconfig.ScalerConfig{
-				ResolvedEnv:     dataExplorerResolvedEnv,
 				TriggerMetadata: testData.metadata,
-				AuthParams:      map[string]string{},
+				AuthParams:      testData.authParams,
 				PodIdentity:     kedav1alpha1.AuthPodIdentity{}},
 			logr.Discard())
 
@@ -130,10 +140,10 @@ func TestDataExplorerParseMetadata(t *testing.T) {
 	for _, testData := range testDataExplorerMetadataWithPodIdentity {
 		_, err := parseAzureDataExplorerMetadata(
 			&scalersconfig.ScalerConfig{
-				ResolvedEnv:     dataExplorerResolvedEnv,
 				TriggerMetadata: testData.metadata,
-				AuthParams:      map[string]string{},
-				PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload}}, logr.Discard())
+				AuthParams:      testData.authParams,
+				PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload}},
+			logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -147,10 +157,10 @@ func TestDataExplorerParseMetadata(t *testing.T) {
 	for _, testData := range testDataExplorerMetadataWithPodIdentity {
 		_, err := parseAzureDataExplorerMetadata(
 			&scalersconfig.ScalerConfig{
-				ResolvedEnv:     dataExplorerResolvedEnv,
 				TriggerMetadata: testData.metadata,
-				AuthParams:      map[string]string{},
-				PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload}}, logr.Discard())
+				AuthParams:      testData.authParams,
+				PodIdentity:     kedav1alpha1.AuthPodIdentity{Provider: kedav1alpha1.PodIdentityProviderAzureWorkload}},
+			logr.Discard())
 
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
@@ -165,10 +175,9 @@ func TestDataExplorerGetMetricSpecForScaling(t *testing.T) {
 	for id, testData := range testDataExplorerMetricIdentifiers {
 		meta, err := parseAzureDataExplorerMetadata(
 			&scalersconfig.ScalerConfig{
-				ResolvedEnv:     dataExplorerResolvedEnv,
 				TriggerMetadata: testData.metadataTestData.metadata,
-				AuthParams:      map[string]string{},
-				PodIdentity:     kedav1alpha1.AuthPodIdentity{},
+				AuthParams:      testData.metadataTestData.authParams,
+				PodIdentity:     testData.podIdentity,
 				TriggerIndex:    testData.triggerIndex},
 			logr.Discard())
 		if err != nil {

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -805,7 +805,6 @@
                     "name": "clientSecret",
                     "type": "string",
                     "optional": true,
-                    "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
                 }
             ]

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -527,7 +527,6 @@ scalers:
         - name: clientSecret
           type: string
           optional: true
-          envVariableReadable: true
           triggerAuthenticationVariableReadable: true
     - type: azure-eventhub
       parameters:


### PR DESCRIPTION
Refactor the Azure Data Explorer, the last one.

Further, the `clientSecretFromEnv` was storing the environment variable name as the secret value instead of resolving it via `ResolvedEnv`. This went unnoticed because the existing tests used the actual secret value as the env var name.

What is worth considering now, since `clientSecretFromEnv` has effectively never worked in production, this raises the question of whether we should keep it at all. Given the general preference to move away from FromEnv parameters, we could remove it entirely as part of this change. If there is a reason to keep it, please indicate so.
If we want to remove this, then in that case the documentation will likely need to be updated as well.

### Checklist

- [X] Tests have been added *(if applicable)*
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #5797