### PR TITLE
operator cert auto-management: make APIService cert injections optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
+- **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
 
 ### Fixes

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -87,6 +87,7 @@ func main() {
 	var validatingWebhookName string
 	var caDirs []string
 	var enableWebhookPatching bool
+	var enableAPIServicePatching bool
 	var filePathAuthRootPath string
 	pflag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", true, "Enable the prometheus metric of keda-operator.")
 	pflag.BoolVar(&enableOpenTelemetryMetrics, "enable-opentelemetry-metrics", false, "Enable the opentelemetry metric of keda-operator.")
@@ -111,6 +112,7 @@ func main() {
 	pflag.StringVar(&validatingWebhookName, "validating-webhook-name", "keda-admission", "ValidatingWebhookConfiguration name. Defaults to keda-admission")
 	pflag.StringArrayVar(&caDirs, "ca-dir", []string{"/custom/ca"}, "Directory with CA certificates for scalers to authenticate TLS connections. Can be specified multiple times. Defaults to /custom/ca")
 	pflag.BoolVar(&enableWebhookPatching, "enable-webhook-patching", true, "Enable patching of webhook resources. Defaults to true.")
+	pflag.BoolVar(&enableAPIServicePatching, "enable-apiservice-patching", true, "Enable patching of APIService resources. Defaults to true.")
 	pflag.StringVar(&filePathAuthRootPath, "filepath-auth-root-path", "", "Allowed filesystem path for KEDA to read auth from.")
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
@@ -312,19 +314,20 @@ func main() {
 	certReady := make(chan struct{})
 	if enableCertRotation {
 		certManager := certificates.CertManager{
-			SecretName:            certSecretName,
-			CertDir:               certDir,
-			OperatorService:       operatorServiceName,
-			MetricsServerService:  metricsServerServiceName,
-			WebhookService:        webhooksServiceName,
-			K8sClusterDomain:      k8sClusterDomain,
-			CAName:                "KEDA",
-			CAOrganization:        "KEDAORG",
-			ValidatingWebhookName: validatingWebhookName,
-			APIServiceName:        "v1beta1.external.metrics.k8s.io",
-			Logger:                setupLog,
-			Ready:                 certReady,
-			EnableWebhookPatching: enableWebhookPatching,
+			SecretName:               certSecretName,
+			CertDir:                  certDir,
+			OperatorService:          operatorServiceName,
+			MetricsServerService:     metricsServerServiceName,
+			WebhookService:           webhooksServiceName,
+			K8sClusterDomain:         k8sClusterDomain,
+			CAName:                   "KEDA",
+			CAOrganization:           "KEDAORG",
+			ValidatingWebhookName:    validatingWebhookName,
+			APIServiceName:           "v1beta1.external.metrics.k8s.io",
+			Logger:                   setupLog,
+			Ready:                    certReady,
+			EnableWebhookPatching:    enableWebhookPatching,
+			EnableAPIServicePatching: enableAPIServicePatching,
 		}
 		if err := certManager.AddCertificateRotation(ctx, mgr); err != nil {
 			setupLog.Error(err, "unable to set up cert rotation")

--- a/pkg/certificates/certificate_manager.go
+++ b/pkg/certificates/certificate_manager.go
@@ -38,28 +38,35 @@ import (
 // +kubebuilder:rbac:groups="",namespace=keda,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 type CertManager struct {
-	SecretName            string
-	CertDir               string
-	OperatorService       string
-	MetricsServerService  string
-	WebhookService        string
-	K8sClusterDomain      string
-	CAName                string
-	CAOrganization        string
-	ValidatingWebhookName string
-	APIServiceName        string
-	Logger                logr.Logger
-	Ready                 chan struct{}
-	EnableWebhookPatching bool
+	SecretName               string
+	CertDir                  string
+	OperatorService          string
+	MetricsServerService     string
+	WebhookService           string
+	K8sClusterDomain         string
+	CAName                   string
+	CAOrganization           string
+	ValidatingWebhookName    string
+	APIServiceName           string
+	Logger                   logr.Logger
+	Ready                    chan struct{}
+	EnableWebhookPatching    bool
+	EnableAPIServicePatching bool
 }
 
 // AddCertificateRotation registers all needed services to generate the certificates and patches needed resources with the caBundle
 func (cm CertManager) AddCertificateRotation(ctx context.Context, mgr manager.Manager) error {
-	rotatorHooks := []rotator.WebhookInfo{
-		{
-			Name: cm.APIServiceName,
-			Type: rotator.APIService,
-		},
+	rotatorHooks := []rotator.WebhookInfo{}
+
+	if cm.EnableAPIServicePatching {
+		rotatorHooks = append(rotatorHooks,
+			rotator.WebhookInfo{
+				Name: cm.APIServiceName,
+				Type: rotator.APIService,
+			},
+		)
+	} else {
+		cm.Logger.V(1).Info("APIService patching is disabled, skipping APIService certificates")
 	}
 
 	if cm.EnableWebhookPatching {


### PR DESCRIPTION
When deploying multiple independent keda-operators, they all generate their TLS certs and then try to inject them to APIService.apiregistration for external metrics. They clash and keep constantly overwriting each other.

This PR allows each keda-operator to generate and rotate their own TLS certs in `kedaorg-cert` secret, with custom logic what to inject to APIService.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
  - https://github.com/kedacore/charts/pull/832 
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))