### PR TITLE
fix: typo in 'KEDAScaleTargetActivationFailed' event message

### DIFF
--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -352,7 +352,7 @@ func (e *scaleExecutor) scaleFromZeroOrIdle(ctx context.Context, logger logr.Log
 			return
 		}
 	} else {
-		e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.KEDAScaleTargetActivationFailed, "Failed to scaled %s %s/%s from %d to %d", scaledObject.Status.ScaleTargetKind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
+		e.recorder.Eventf(scaledObject, corev1.EventTypeWarning, eventreason.KEDAScaleTargetActivationFailed, "Failed to scale %s %s/%s from %d to %d", scaledObject.Status.ScaleTargetKind, scaledObject.Namespace, scaledObject.Spec.ScaleTargetRef.Name, currentReplicas, replicas)
 	}
 }
 


### PR DESCRIPTION
I just noticed a minor typo in the event message. Here's what it says currently:
```
Events:
  Type     Reason                           Age                   From           Message
  ----     ------                           ----                  ----           -------
  Warning  KEDAScaleTargetActivationFailed  18m (x2 over 5d15h)   keda-operator  Failed to scaled apps/v1.Deployment etl-engine/scheduler from 0 to 1
```
I believe it should be "Failed to scale ..." instead of "Failed to scaled ...". This PR corrects it.
This doesn't really change any logic, and I don't feel like this change is breaking or impacts end users, so I haven't updated the changelog, but I'm happy to do that if needed.

### Checklist

(https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
