### PR TITLE
operator: configurable leader election lease resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
+- **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -73,6 +73,7 @@ func main() {
 	var metricsServiceAddr string
 	var profilingAddr string
 	var enableLeaderElection bool
+	var leaderElectionID string
 	var adapterClientRequestQPS float32
 	var adapterClientRequestBurst int
 	var disableCompression bool
@@ -98,6 +99,7 @@ func main() {
 	pflag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	pflag.StringVar(&leaderElectionID, "leader-election-id", "operator.keda.sh", "Leader election ID for the controller manager. Defaults to operator.keda.sh")
 	pflag.Float32Var(&adapterClientRequestQPS, "kube-api-qps", 20.0, "Set the QPS rate for throttling requests sent to the apiserver")
 	pflag.IntVar(&adapterClientRequestBurst, "kube-api-burst", 30, "Set the burst for throttling requests sent to the apiserver")
 	pflag.BoolVar(&disableCompression, "disable-compression", true, "Disable response compression for k8s restAPI in client-go. ")
@@ -180,7 +182,7 @@ func main() {
 		HealthProbeBindAddress:  probeAddr,
 		PprofBindAddress:        profilingAddr,
 		LeaderElection:          enableLeaderElection,
-		LeaderElectionID:        "operator.keda.sh",
+		LeaderElectionID:        leaderElectionID,
 		LeaderElectionNamespace: kedautil.GetPodNamespace(),
 		LeaseDuration:           leaseDuration,
 		RenewDeadline:           renewDeadline,


### PR DESCRIPTION
When deploying multiple keda-operators (multiple Deployments) in the same namespace, they all clash for the same leader election lease resource, making only one Pod effectively run. This is desired when running multiple replicas of the same operator, but if users want to try any sharding of the cluster (e.g. each operator Deployment gets configured their own subset of watchNamespaces), this is currently not possible with leader election enabled.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
  - https://github.com/kedacore/charts/pull/836
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))