### PR TITLE
fix: resolve *FromEnv trigger metadata for custom resources with workloadRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
+- **General**: Resolve `*FromEnv` trigger metadata when ScaledObject targets a custom resource (e.g. Argo Rollout) that uses `workloadRef` by following the reference to the underlying workload ([#7486](https://github.com/kedacore/keda/issues/7486))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **External Scaler**: Fix context cancellation handling in `waitForState` of external scaler ([#7542](https://github.com/kedacore/keda/issues/7542))
 - **Forgejo Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/scale"
@@ -157,6 +158,17 @@ func ResolveScaleTargetPodSpec(ctx context.Context, kubeClient client.Client, sc
 			}
 			podTemplateSpec.ObjectMeta = withPods.ObjectMeta
 			podTemplateSpec.Spec = withPods.Spec.Template.Spec
+
+			// If there are no containers, the custom resource (e.g. Argo Rollout) may use
+			// a workloadRef to point to another resource that holds the pod template.
+			// Follow the reference to resolve the pod spec from the underlying workload.
+			if len(podTemplateSpec.Spec.Containers) == 0 {
+				if refPodTemplateSpec, err := resolveWorkloadRef(ctx, kubeClient, unstruct, obj.Namespace, logger); err != nil {
+					logger.V(1).Info("failed to resolve workloadRef from custom resource", "error", err)
+				} else if refPodTemplateSpec != nil {
+					podTemplateSpec = *refPodTemplateSpec
+				}
+			}
 		}
 
 		if len(podTemplateSpec.Spec.Containers) == 0 {
@@ -170,6 +182,78 @@ func ResolveScaleTargetPodSpec(ctx context.Context, kubeClient client.Client, sc
 	default:
 		return nil, "", fmt.Errorf("unknown scalable object type %v", scalableObject)
 	}
+}
+
+// resolveWorkloadRef checks if an unstructured object contains a spec.workloadRef field
+// (as used by Argo Rollouts) and fetches the referenced resource to extract its pod template.
+// This enables KEDA to resolve *FromEnv trigger metadata when the ScaledObject targets a
+// custom resource that delegates its pod spec to another workload via workloadRef.
+func resolveWorkloadRef(ctx context.Context, kubeClient client.Client, unstruct *unstructured.Unstructured, namespace string, logger logr.Logger) (*corev1.PodTemplateSpec, error) {
+	spec, ok := unstruct.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("cannot extract spec from unstructured object")
+	}
+
+	workloadRef, ok := spec["workloadRef"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("no workloadRef found in spec")
+	}
+
+	refAPIVersion, _ := workloadRef["apiVersion"].(string)
+	refKind, _ := workloadRef["kind"].(string)
+	refName, _ := workloadRef["name"].(string)
+
+	if refAPIVersion == "" || refKind == "" || refName == "" {
+		return nil, fmt.Errorf("workloadRef is incomplete: apiVersion=%q, kind=%q, name=%q", refAPIVersion, refKind, refName)
+	}
+
+	logger.V(1).Info("following workloadRef to resolve pod spec", "apiVersion", refAPIVersion, "kind", refKind, "name", refName)
+
+	podTemplateSpec := corev1.PodTemplateSpec{}
+	refObjKey := client.ObjectKey{Namespace: namespace, Name: refName}
+
+	// Use typed clients for known core types to benefit from informer caching
+	switch {
+	case refAPIVersion == "apps/v1" && refKind == "Deployment":
+		deployment := &appsv1.Deployment{}
+		if err := kubeClient.Get(ctx, refObjKey, deployment); err != nil {
+			return nil, fmt.Errorf("cannot get referenced Deployment %q: %w", refName, err)
+		}
+		podTemplateSpec.ObjectMeta = deployment.ObjectMeta
+		podTemplateSpec.Spec = deployment.Spec.Template.Spec
+	case refAPIVersion == "apps/v1" && refKind == "StatefulSet":
+		statefulSet := &appsv1.StatefulSet{}
+		if err := kubeClient.Get(ctx, refObjKey, statefulSet); err != nil {
+			return nil, fmt.Errorf("cannot get referenced StatefulSet %q: %w", refName, err)
+		}
+		podTemplateSpec.ObjectMeta = statefulSet.ObjectMeta
+		podTemplateSpec.Spec = statefulSet.Spec.Template.Spec
+	default:
+		// For other workload types, use unstructured + duck typing
+		refUnstruct := &unstructured.Unstructured{}
+		refUnstruct.SetGroupVersionKind(parseGVK(refAPIVersion, refKind))
+		if err := kubeClient.Get(ctx, refObjKey, refUnstruct); err != nil {
+			return nil, fmt.Errorf("cannot get referenced resource %s/%s %q: %w", refAPIVersion, refKind, refName, err)
+		}
+		withPods := &duckv1.WithPod{}
+		if err := duck.FromUnstructured(refUnstruct, withPods); err != nil {
+			return nil, fmt.Errorf("cannot convert referenced resource into PodSpecable Duck-type: %w", err)
+		}
+		podTemplateSpec.ObjectMeta = withPods.ObjectMeta
+		podTemplateSpec.Spec = withPods.Spec.Template.Spec
+	}
+
+	return &podTemplateSpec, nil
+}
+
+// parseGVK splits an apiVersion string (e.g. "apps/v1") into group and version,
+// and returns a schema.GroupVersionKind.
+func parseGVK(apiVersion, kind string) schema.GroupVersionKind {
+	parts := strings.SplitN(apiVersion, "/", 2)
+	if len(parts) == 2 {
+		return schema.GroupVersionKind{Group: parts[0], Version: parts[1], Kind: kind}
+	}
+	return schema.GroupVersionKind{Version: apiVersion, Kind: kind}
 }
 
 // ResolveContainerEnv resolves all environment variables in a container.

--- a/pkg/scaling/resolver/scale_resolvers_test.go
+++ b/pkg/scaling/resolver/scale_resolvers_test.go
@@ -26,9 +26,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -1123,4 +1125,271 @@ func TestReadAuthParamsFromFile_Errors(t *testing.T) {
 	_, err = readAuthParamsFromFile("../test.json")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "filePath must be relative")
+}
+
+func TestResolveWorkloadRef(t *testing.T) {
+	if err := appsv1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("failed to add appsv1 to scheme: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		unstruct       *unstructured.Unstructured
+		existing       []runtime.Object
+		expectedEnvVar string
+		expectedEnvVal string
+		expectErr      bool
+		expectNil      bool
+	}{
+		{
+			name: "workloadRef points to Deployment with env vars",
+			unstruct: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Rollout",
+					"metadata": map[string]interface{}{
+						"name":      "my-rollout",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"workloadRef": map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"name":       "my-deployment",
+						},
+					},
+				},
+			},
+			existing: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-deployment",
+						Namespace: namespace,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "app",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "MY_QUEUE_URL",
+												Value: "https://sqs.us-east-1.amazonaws.com/123/my-queue",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEnvVar: "MY_QUEUE_URL",
+			expectedEnvVal: "https://sqs.us-east-1.amazonaws.com/123/my-queue",
+		},
+		{
+			name: "workloadRef points to StatefulSet",
+			unstruct: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Rollout",
+					"metadata": map[string]interface{}{
+						"name":      "my-rollout",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"workloadRef": map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "StatefulSet",
+							"name":       "my-statefulset",
+						},
+					},
+				},
+			},
+			existing: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-statefulset",
+						Namespace: namespace,
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "app",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "DB_HOST",
+												Value: "postgres.default.svc",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedEnvVar: "DB_HOST",
+			expectedEnvVal: "postgres.default.svc",
+		},
+		{
+			name: "no workloadRef in spec",
+			unstruct: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Rollout",
+					"metadata": map[string]interface{}{
+						"name":      "my-rollout",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "workloadRef with incomplete fields",
+			unstruct: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Rollout",
+					"metadata": map[string]interface{}{
+						"name":      "my-rollout",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"workloadRef": map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							// missing "name"
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "workloadRef points to non-existent Deployment",
+			unstruct: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Rollout",
+					"metadata": map[string]interface{}{
+						"name":      "my-rollout",
+						"namespace": namespace,
+					},
+					"spec": map[string]interface{}{
+						"workloadRef": map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"name":       "does-not-exist",
+						},
+					},
+				},
+			},
+			existing:  []runtime.Object{},
+			expectErr: true,
+		},
+		{
+			name: "no spec in unstructured object",
+			unstruct: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "argoproj.io/v1alpha1",
+					"kind":       "Rollout",
+					"metadata": map[string]interface{}{
+						"name":      "my-rollout",
+						"namespace": namespace,
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			clientBuilder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+			if test.existing != nil {
+				clientBuilder = clientBuilder.WithRuntimeObjects(test.existing...)
+			}
+			kubeClient := clientBuilder.Build()
+
+			result, err := resolveWorkloadRef(ctx, kubeClient, test.unstruct, namespace, logf.Log.WithName("test"))
+
+			if test.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			if test.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Greater(t, len(result.Spec.Containers), 0)
+
+			if test.expectedEnvVar != "" {
+				container := result.Spec.Containers[0]
+				found := false
+				for _, env := range container.Env {
+					if env.Name == test.expectedEnvVar {
+						assert.Equal(t, test.expectedEnvVal, env.Value)
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected env var %s not found", test.expectedEnvVar)
+			}
+		})
+	}
+}
+
+func TestParseGVK(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		kind       string
+		wantGroup  string
+		wantVer    string
+		wantKind   string
+	}{
+		{
+			name:       "apps/v1 Deployment",
+			apiVersion: "apps/v1",
+			kind:       "Deployment",
+			wantGroup:  "apps",
+			wantVer:    "v1",
+			wantKind:   "Deployment",
+		},
+		{
+			name:       "core v1 (no group)",
+			apiVersion: "v1",
+			kind:       "Pod",
+			wantGroup:  "",
+			wantVer:    "v1",
+			wantKind:   "Pod",
+		},
+		{
+			name:       "argoproj.io/v1alpha1 Rollout",
+			apiVersion: "argoproj.io/v1alpha1",
+			kind:       "Rollout",
+			wantGroup:  "argoproj.io",
+			wantVer:    "v1alpha1",
+			wantKind:   "Rollout",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gvk := parseGVK(test.apiVersion, test.kind)
+			assert.Equal(t, test.wantGroup, gvk.Group)
+			assert.Equal(t, test.wantVer, gvk.Version)
+			assert.Equal(t, test.wantKind, gvk.Kind)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #7486

### Checklist
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

When the ScaledObject targets an Argo Rollout with `workloadRef`, KEDA can't find the pod spec because it's not inline in the CR. The duck typing extraction returns zero containers and `*FromEnv` params silently fail.

Added `resolveWorkloadRef()` that follows `spec.workloadRef` one level to fetch the referenced Deployment/StatefulSet and extract the pod template from there. Only kicks in when the initial extraction finds nothing, so existing behavior is preserved.