### PR TITLE
feat(mssql): add driverName support for azuresql driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
+- **MSSQL Scaler**: Add support for `driverName` parameter to allow selecting between `sqlserver` and `azuresql` drivers ([#7567](https://github.com/kedacore/keda/pull/7567))
 
 ### Fixes
 

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -26,7 +26,7 @@ type mssqlScaler struct {
 }
 
 type mssqlMetadata struct {
-	DriverName            string  `keda:"name=driverName,			 order=authParams;triggerMetadata, default=sqlserver"`
+	DriverName            string  `keda:"name=driverName,			 order=authParams;triggerMetadata, enum=sqlserver;azuresql, default=sqlserver"`
 	ConnectionString      string  `keda:"name=connectionString,      order=authParams;resolvedEnv, optional"`
 	Username              string  `keda:"name=username,              order=authParams;triggerMetadata, optional"`
 	Password              string  `keda:"name=password,              order=authParams;resolvedEnv, optional"`
@@ -43,9 +43,6 @@ type mssqlMetadata struct {
 func (m *mssqlMetadata) Validate() error {
 	if m.ConnectionString == "" && m.Host == "" {
 		return fmt.Errorf("must provide either connectionstring or host")
-	}
-	if m.DriverName != "sqlserver" && m.DriverName != "azuresql" {
-		return fmt.Errorf("driver name must be 'sqlserver' or 'azuresql'")
 	}
 	return nil
 }

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -119,7 +119,7 @@ func getMSSQLConnectionString(s *mssqlScaler) string {
 		query.Add("database", meta.Database)
 	}
 
-	connectionURL := &url.URL{Scheme: s.metadata.DriverName, RawQuery: query.Encode()}
+	connectionURL := &url.URL{Scheme: "sqlserver", RawQuery: query.Encode()}
 	if meta.Username != "" {
 		if meta.Password != "" {
 			connectionURL.User = url.UserPassword(meta.Username, meta.Password)

--- a/pkg/scalers/mssql_scaler.go
+++ b/pkg/scalers/mssql_scaler.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-logr/logr"
 	// Import the MS SQL driver so it can register itself with database/sql
 	_ "github.com/microsoft/go-mssqldb"
+	// Import the Azure SQL driver so it can register itself with database/sql
+	_ "github.com/microsoft/go-mssqldb/azuread"
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -24,6 +26,7 @@ type mssqlScaler struct {
 }
 
 type mssqlMetadata struct {
+	DriverName            string  `keda:"name=driverName,			 order=authParams;triggerMetadata, default=sqlserver"`
 	ConnectionString      string  `keda:"name=connectionString,      order=authParams;resolvedEnv, optional"`
 	Username              string  `keda:"name=username,              order=authParams;triggerMetadata, optional"`
 	Password              string  `keda:"name=password,              order=authParams;resolvedEnv, optional"`
@@ -40,6 +43,9 @@ type mssqlMetadata struct {
 func (m *mssqlMetadata) Validate() error {
 	if m.ConnectionString == "" && m.Host == "" {
 		return fmt.Errorf("must provide either connectionstring or host")
+	}
+	if m.DriverName != "sqlserver" && m.DriverName != "azuresql" {
+		return fmt.Errorf("driver name must be 'sqlserver' or 'azuresql'")
 	}
 	return nil
 }
@@ -90,7 +96,7 @@ func parseMSSQLMetadata(config *scalersconfig.ScalerConfig) (*mssqlMetadata, err
 func newMSSQLConnection(s *mssqlScaler) (*sql.DB, error) {
 	connStr := getMSSQLConnectionString(s)
 
-	db, err := sql.Open("sqlserver", connStr)
+	db, err := sql.Open(s.metadata.DriverName, connStr)
 	if err != nil {
 		s.logger.Error(err, "Found error opening mssql")
 		return nil, err
@@ -116,7 +122,7 @@ func getMSSQLConnectionString(s *mssqlScaler) string {
 		query.Add("database", meta.Database)
 	}
 
-	connectionURL := &url.URL{Scheme: "sqlserver", RawQuery: query.Encode()}
+	connectionURL := &url.URL{Scheme: s.metadata.DriverName, RawQuery: query.Encode()}
 	if meta.Username != "" {
 		if meta.Password != "" {
 			connectionURL.User = url.UserPassword(meta.Username, meta.Password)

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -134,7 +134,7 @@ var testMSSQLMetadata = []parseMSSQLMetadataTestData{
 		metadata:      map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user7"},
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{"password": "Password#7", "driverName": "fake"},
-		expectedError: "driver name must be 'sqlserver' or 'azuresql'",
+		expectedError: "parameter \"driverName\" value \"fake\" must be one of [sqlserver azuresql]",
 	},
 }
 

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -88,6 +88,27 @@ var testMSSQLMetadata = []parseMSSQLMetadataTestData{
 		expectedConnectionString: "sqlserver://user3:Password%233@example.database.windows.net",
 	},
 	{
+		name:                     "no driver selected; default to sqlserver",
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user4"},
+		resolvedEnv:              map[string]string{},
+		authParams:               map[string]string{"password": "Password#4"},
+		expectedConnectionString: "sqlserver://user4:Password%233@example.database.windows.net",
+	},
+	{
+		name:                     "sqlserver driver selected",
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user5"},
+		resolvedEnv:              map[string]string{},
+		authParams:               map[string]string{"password": "Password#5", "driverName": "sqlserver"},
+		expectedConnectionString: "sqlserver://user5:Password%233@example.database.windows.net",
+	},
+	{
+		name:                     "azuresql driver selected",
+		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user6"},
+		resolvedEnv:              map[string]string{},
+		authParams:               map[string]string{"password": "Password#6", "driverName": "azuresql"},
+		expectedConnectionString: "sqlserver://user6:Password%233@example.database.windows.net",
+	},
+	{
 		name:          "Error: missing query",
 		metadata:      map[string]string{"targetValue": "1"},
 		resolvedEnv:   map[string]string{},
@@ -107,6 +128,13 @@ var testMSSQLMetadata = []parseMSSQLMetadataTestData{
 		resolvedEnv:   map[string]string{},
 		authParams:    map[string]string{},
 		expectedError: "must provide either connectionstring or host",
+	},
+	{
+		name:          "Error:  invalid driver",
+		metadata:      map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user7"},
+		resolvedEnv:   map[string]string{},
+		authParams:    map[string]string{"password": "Password#7", "driverName": "fake"},
+		expectedError: "driver name must be 'sqlserver' or 'azuresql'",
 	},
 }
 

--- a/pkg/scalers/mssql_scaler_test.go
+++ b/pkg/scalers/mssql_scaler_test.go
@@ -16,6 +16,7 @@ type parseMSSQLMetadataTestData struct {
 	authParams               map[string]string
 	expectedError            string
 	expectedConnectionString string
+	expectedDriverName       string
 	expectedMetricName       string
 }
 
@@ -92,21 +93,24 @@ var testMSSQLMetadata = []parseMSSQLMetadataTestData{
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user4"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#4"},
-		expectedConnectionString: "sqlserver://user4:Password%233@example.database.windows.net",
+		expectedDriverName:       "sqlserver",
+		expectedConnectionString: "sqlserver://user4:Password%234@example.database.windows.net",
 	},
 	{
 		name:                     "sqlserver driver selected",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user5"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#5", "driverName": "sqlserver"},
-		expectedConnectionString: "sqlserver://user5:Password%233@example.database.windows.net",
+		expectedDriverName:       "sqlserver",
+		expectedConnectionString: "sqlserver://user5:Password%235@example.database.windows.net",
 	},
 	{
 		name:                     "azuresql driver selected",
 		metadata:                 map[string]string{"query": "SELECT 1", "targetValue": "1", "host": "example.database.windows.net", "username": "user6"},
 		resolvedEnv:              map[string]string{},
 		authParams:               map[string]string{"password": "Password#6", "driverName": "azuresql"},
-		expectedConnectionString: "sqlserver://user6:Password%233@example.database.windows.net",
+		expectedDriverName:       "azuresql",
+		expectedConnectionString: "sqlserver://user6:Password%236@example.database.windows.net",
 	},
 	{
 		name:          "Error: missing query",
@@ -154,7 +158,37 @@ func TestParseMSSQLMetadata(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, meta)
+
+				if testData.expectedDriverName != "" {
+					assert.Equal(t, testData.expectedDriverName, meta.DriverName)
+				}
 			}
+		})
+	}
+}
+
+func TestMSSQLConnectionStringGeneration(t *testing.T) {
+	for _, testData := range testMSSQLMetadata {
+		t.Run(testData.name, func(t *testing.T) {
+			if testData.expectedError != "" {
+				return
+			}
+
+			meta, err := parseMSSQLMetadata(&scalersconfig.ScalerConfig{
+				TriggerMetadata: testData.metadata,
+				ResolvedEnv:     testData.resolvedEnv,
+				AuthParams:      testData.authParams,
+			})
+
+			assert.NoError(t, err)
+
+			mockMSSQLScaler := mssqlScaler{
+				metadata: meta,
+			}
+
+			connStr := getMSSQLConnectionString(&mockMSSQLScaler)
+
+			assert.Equal(t, testData.expectedConnectionString, connStr)
 		})
 	}
 }

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2836,6 +2836,10 @@
                     "name": "driverName",
                     "type": "string",
                     "default": "sqlserver",
+                    "allowedValue": [
+                        "sqlserver",
+                        "azuresql"
+                    ],
                     "metadataVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
                 },

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2833,6 +2833,13 @@
             "type": "mssql",
             "parameters": [
                 {
+                    "name": "driverName",
+                    "type": "string",
+                    "default": "sqlserver",
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
                     "name": "connectionString",
                     "type": "string",
                     "optional": true,

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1851,6 +1851,9 @@ scalers:
         - name: driverName
           type: string
           default: sqlserver
+          allowedValue:
+            - sqlserver
+            - azuresql
           metadataVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: connectionString

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1848,6 +1848,11 @@ scalers:
           metadataVariableReadable: true
     - type: mssql
       parameters:
+        - name: driverName
+          type: string
+          default: sqlserver
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
         - name: connectionString
           type: string
           optional: true

--- a/tests/scalers/mssql/azure_mssql_flex_server_aad_wi_test/azure_mssql_flex_server_aad_wi_test.go
+++ b/tests/scalers/mssql/azure_mssql_flex_server_aad_wi_test/azure_mssql_flex_server_aad_wi_test.go
@@ -1,0 +1,327 @@
+//go:build e2e
+// +build e2e
+
+package azure_mssql_flex_server_aad_wi_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
+	mssql "github.com/kedacore/keda/v2/tests/scalers/mssql/helper"
+)
+
+// Load environment variables from .env file
+var _ = godotenv.Load("../../.env")
+
+const (
+	testName = "azure-mssql-aad-test"
+)
+
+type authTestCase struct {
+	Name                        string
+	TriggerAuthenticationName   string
+	TriggerAuthenticationConfig string
+}
+
+var authTestCases = []authTestCase{
+	{
+		Name:                        "workload-identity",
+		TriggerAuthenticationName:   "azureTriggerAuthenticationTemplate",
+		TriggerAuthenticationConfig: azureTriggerAuthTemplate,
+	},
+	// Future extension point:
+	// {
+	// 	Name:                        "managed-identity",
+	// 	TriggerAuthenticationName:   "azureManagedIdentityTriggerAuthenticationTemplate",
+	// 	TriggerAuthenticationConfig: azureManagedIdentityTriggerAuthTemplate,
+	// },
+}
+
+var (
+	testNamespace              = fmt.Sprintf("%s-ns", testName)
+	mssqlHelperStatefulSetName = "azure-mssql-helper"
+	mssqlHelperPodName         = fmt.Sprintf("%s-0", mssqlHelperStatefulSetName)
+
+	azureMssqlAdminUsername = os.Getenv("TF_AZURE_MSSQL_ADMIN_USERNAME")
+	azureMssqlAdminPassword = os.Getenv("TF_AZURE_MSSQL_ADMIN_PASSWORD")
+	azureMssqlFQDN          = os.Getenv("TF_AZURE_MSSQL_FQDN")
+	azureMssqlDatabase      = os.Getenv("TF_AZURE_MSSQL_DB_NAME")
+	azureMssqlUamiName      = os.Getenv("TF_AZURE_IDENTITY_1_NAME")
+
+	azureMssqlConnectionString = GetAzureConnectionString(
+		azureMssqlAdminUsername,
+		azureMssqlAdminPassword,
+		azureMssqlFQDN,
+		azureMssqlDatabase,
+	)
+
+	localMssqlPassword = "Pass@word1"
+	minReplicaCount    = 0
+	maxReplicaCount    = 5
+)
+
+type templateData struct {
+	TestNamespace             string
+	DeploymentName            string
+	ScaledObjectName          string
+	TriggerAuthenticationName string
+	SecretName                string
+
+	MssqlServerName string
+	MssqlPassword   string
+
+	AzureMssqlAdminUsername    string
+	AzureMssqlAdminPassword    string
+	AzureMssqlFQDN             string
+	AzureMssqlDatabase         string
+	AzureMssqlUamiName         string
+	AzureMssqlConnectionString string
+
+	DriverName      string
+	MinReplicaCount int
+	MaxReplicaCount int
+}
+
+const (
+	azureSecretTemplate = `apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretName}}
+  namespace: {{.TestNamespace}}
+type: Opaque
+stringData:
+  mssql-connection-string: {{.AzureMssqlConnectionString}}
+`
+
+	azureTriggerAuthTemplate = `apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{.TriggerAuthenticationName}}
+  namespace: {{.TestNamespace}}
+spec:
+  podIdentity:
+    provider: azure-workload
+`
+
+	azureScaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  cooldownPeriod:  10
+  minReplicaCount: {{.MinReplicaCount}}
+  maxReplicaCount: {{.MaxReplicaCount}}
+  triggers:
+  - type: mssql
+    metadata:
+      host: {{.AzureMssqlFQDN}}
+      port: "1433"
+      database: {{.AzureMssqlDatabase}}
+      username: {{.AzureMssqlUamiName}}
+      driverName: {{.DriverName}}
+      query: "SELECT COUNT(*) FROM tasks WHERE [status]='running' OR [status]='queued'"
+      targetValue: "1"
+      activationTargetValue: "15"
+    authenticationRef:
+      name: {{.TriggerAuthenticationName}}
+`
+)
+
+func TestMssqlScaler(t *testing.T) {
+	requireEnv(t,
+		"TF_AZURE_MSSQL_ADMIN_USERNAME",
+		"TF_AZURE_MSSQL_ADMIN_PASSWORD",
+		"TF_AZURE_MSSQL_FQDN",
+		"TF_AZURE_MSSQL_DB_NAME",
+		"TF_AZURE_IDENTITY_1_NAME",
+	)
+
+	for _, authCase := range authTestCases {
+		t.Run(authCase.Name, func(t *testing.T) {
+			testMssqlScalerAuthPath(t, authCase)
+		})
+	}
+}
+
+func testMssqlScalerAuthPath(t *testing.T, authCase authTestCase) {
+	data := newTemplateData(authCase)
+
+	kc := GetKubernetesClient(t)
+	_, mssqlTemplates := getMssqlTemplateData(data)
+	_, templates := getTemplateData(data, authCase)
+
+	t.Cleanup(func() {
+		deleteTableCommand := fmt.Sprintf(
+			"/opt/mssql-tools18/bin/sqlcmd -S %s -C -U %s -P %q -d %s -Q %q",
+			data.AzureMssqlFQDN,
+			data.AzureMssqlAdminUsername,
+			data.AzureMssqlAdminPassword,
+			data.AzureMssqlDatabase,
+			"IF OBJECT_ID('dbo.tasks', 'U') IS NOT NULL DROP TABLE dbo.tasks;",
+		)
+		_, _, _, _ = WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlHelperPodName, data.TestNamespace, deleteTableCommand, 60, 3)
+
+		KubectlDeleteMultipleWithTemplate(t, data, templates)
+		DeleteKubernetesResources(t, data.TestNamespace, data, mssqlTemplates)
+	})
+
+	// Create kubernetes resources for local MSSQL helper server.
+	CreateKubernetesResources(t, kc, data.TestNamespace, data, mssqlTemplates)
+
+	require.True(t, WaitForStatefulsetReplicaReadyCount(t, kc, data.MssqlServerName, data.TestNamespace, 1, 60, 3),
+		"replica count should be %d after 3 minutes", 1)
+
+	// Delete table on remote Azure MSSQL server.
+	deleteTableCommand := fmt.Sprintf(
+		"/opt/mssql-tools18/bin/sqlcmd -S %s -C -U %s -P %q -d %s -Q %q",
+		data.AzureMssqlFQDN,
+		data.AzureMssqlAdminUsername,
+		data.AzureMssqlAdminPassword,
+		data.AzureMssqlDatabase,
+		"IF OBJECT_ID('dbo.tasks', 'U') IS NOT NULL DROP TABLE dbo.tasks;",
+	)
+	ok, out, errOut, err := WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlHelperPodName, data.TestNamespace, deleteTableCommand, 60, 3)
+	require.True(t, ok, "executing a command on MSSQL helper pod should work; Output: %s, ErrorOutput: %s, Error: %s", out, errOut, err)
+
+	// Create table on remote Azure MSSQL server.
+	createTableCommand := fmt.Sprintf(
+		"/opt/mssql-tools18/bin/sqlcmd -S %s -C -U %s -P %q -d %s -Q %q",
+		data.AzureMssqlFQDN,
+		data.AzureMssqlAdminUsername,
+		data.AzureMssqlAdminPassword,
+		data.AzureMssqlDatabase,
+		"CREATE TABLE tasks ([id] int identity primary key, [status] varchar(10));",
+	)
+	ok, out, errOut, err = WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlHelperPodName, data.TestNamespace, createTableCommand, 60, 3)
+	require.True(t, ok, "executing a command on MSSQL helper pod should work; Output: %s, ErrorOutput: %s, Error: %s", out, errOut, err)
+
+	// This may need adjustment depending on how the Azure identity is provisioned.
+	grantAccessCommand := fmt.Sprintf(
+		"/opt/mssql-tools18/bin/sqlcmd -S %s -C -U %s -P %q -d %s -Q %q",
+		data.AzureMssqlFQDN,
+		data.AzureMssqlAdminUsername,
+		data.AzureMssqlAdminPassword,
+		data.AzureMssqlDatabase,
+		fmt.Sprintf(
+			"IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = N'%s') BEGIN CREATE USER [%s] FROM EXTERNAL PROVIDER; END; ALTER ROLE db_datareader ADD MEMBER [%s]; ALTER ROLE db_datawriter ADD MEMBER [%s];",
+			data.AzureMssqlUamiName,
+			data.AzureMssqlUamiName,
+			data.AzureMssqlUamiName,
+			data.AzureMssqlUamiName,
+		),
+	)
+	ok, out, errOut, err = WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlHelperPodName, data.TestNamespace, grantAccessCommand, 60, 3)
+	require.True(t, ok, "executing a command on MSSQL helper pod should work; Output: %s, ErrorOutput: %s, Error: %s", out, errOut, err)
+
+	// Create kubernetes resources for testing.
+	KubectlApplyMultipleWithTemplate(t, data, templates)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, data.MinReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", data.MinReplicaCount)
+
+	testActivation(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc, data)
+}
+
+func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing activation ---")
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate1", mssql.InsertRecordsJobTemplate1)
+
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, data.DeploymentName, data.TestNamespace, data.MinReplicaCount, 60)
+}
+
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate2", mssql.InsertRecordsJobTemplate2)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, data.MaxReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", data.MaxReplicaCount)
+}
+
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale in ---")
+
+	updateRecordsCommand := fmt.Sprintf(
+		"/opt/mssql-tools18/bin/sqlcmd -S %s -C -U %s -P %q -d %s -Q %q",
+		data.AzureMssqlFQDN,
+		data.AzureMssqlAdminUsername,
+		data.AzureMssqlAdminPassword,
+		data.AzureMssqlDatabase,
+		"UPDATE tasks SET [status] = 'processed';",
+	)
+	ok, out, errOut, err := WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlHelperPodName, data.TestNamespace, updateRecordsCommand, 60, 3)
+	require.True(t, ok, "executing a command on MSSQL helper pod should work; Output: %s, ErrorOutput: %s, Error: %s", out, errOut, err)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, data.MinReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", data.MinReplicaCount)
+}
+
+func newTemplateData(authCase authTestCase) templateData {
+	testCaseName := fmt.Sprintf("%s-%s", testName, authCase.Name)
+
+	deploymentName := fmt.Sprintf("%s-deployment", testCaseName)
+	scaledObjectName := fmt.Sprintf("%s-so", testCaseName)
+	triggerAuthenticationName := fmt.Sprintf("%s-ta", testCaseName)
+	secretName := fmt.Sprintf("%s-secret", testCaseName)
+
+	return templateData{
+		TestNamespace:              testNamespace,
+		DeploymentName:             deploymentName,
+		ScaledObjectName:           scaledObjectName,
+		TriggerAuthenticationName:  triggerAuthenticationName,
+		SecretName:                 secretName,
+		MssqlServerName:            mssqlHelperStatefulSetName,
+		MssqlPassword:              localMssqlPassword,
+		AzureMssqlAdminUsername:    azureMssqlAdminUsername,
+		AzureMssqlAdminPassword:    azureMssqlAdminPassword,
+		AzureMssqlFQDN:             azureMssqlFQDN,
+		AzureMssqlDatabase:         azureMssqlDatabase,
+		AzureMssqlUamiName:         azureMssqlUamiName,
+		AzureMssqlConnectionString: azureMssqlConnectionString,
+		DriverName:                 "azuresql",
+		MinReplicaCount:            minReplicaCount,
+		MaxReplicaCount:            maxReplicaCount,
+	}
+}
+
+func getMssqlTemplateData(data templateData) (templateData, []Template) {
+	return data, []Template{
+		{Name: "mssqlStatefulSetTemplate", Config: mssql.MssqlStatefulSetTemplate},
+		{Name: "mssqlServiceTemplate", Config: mssql.MssqlServiceTemplate},
+	}
+}
+
+func getTemplateData(data templateData, authCase authTestCase) (templateData, []Template) {
+	return data, []Template{
+		{Name: "azureSecretTemplate", Config: azureSecretTemplate},
+		{Name: "deploymentTemplate", Config: mssql.DeploymentTemplate},
+		{Name: authCase.TriggerAuthenticationName, Config: authCase.TriggerAuthenticationConfig},
+		{Name: "azureScaledObjectTemplate", Config: azureScaledObjectTemplate},
+	}
+}
+
+func GetAzureConnectionString(username string, password string, fqdn string, database string) string {
+	return fmt.Sprintf(
+		"Server=%s;Database=%s;User ID=%s;Password=%s;Encrypt=true;TrustServerCertificate=false;",
+		fqdn, database, username, password,
+	)
+}
+
+func requireEnv(t *testing.T, keys ...string) {
+	t.Helper()
+
+	for _, key := range keys {
+		require.NotEmpty(t, os.Getenv(key), "environment variable %s must be set", key)
+	}
+}

--- a/tests/scalers/mssql/helper/mssql_helper.go
+++ b/tests/scalers/mssql/helper/mssql_helper.go
@@ -1,0 +1,201 @@
+//go:build e2e
+// +build e2e
+
+package helper
+
+const (
+	DeploymentTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mssql-consumer-worker
+  name: {{.DeploymentName}}
+  namespace: {{.TestNamespace}}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: mssql-consumer-worker
+  template:
+    metadata:
+      labels:
+        app: mssql-consumer-worker
+    spec:
+      containers:
+      - image: ghcr.io/kedacore/tests-mssql:latest
+        imagePullPolicy: Always
+        name: mssql-consumer-worker
+        command: ["/app"]
+        args: ["-mode", "consumer"]
+        env:
+          - name: SQL_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: {{.SecretName}}
+                key: mssql-connection-string
+`
+
+	SecretTemplate = `apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretName}}
+  namespace: {{.TestNamespace}}
+type: Opaque
+stringData:
+  mssql-sa-password: {{.MssqlPassword}}
+  mssql-connection-string: {{.MssqlConnectionString}}
+`
+
+	TriggerAuthenticationTemplate = `apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{.TriggerAuthenticationName}}
+  namespace: {{.TestNamespace}}
+spec:
+    secretTargetRef:
+    - parameter: password
+      name: {{.SecretName}}
+      key: mssql-sa-password
+`
+
+	ScaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 5
+  cooldownPeriod:  10
+  minReplicaCount: {{.MinReplicaCount}}
+  maxReplicaCount: {{.MaxReplicaCount}}
+  triggers:
+  - type: mssql
+    metadata:
+      host: {{.MssqlHostname}}
+      port: "1433"
+      database: {{.MssqlDatabase}}
+      username: sa
+      driverName: {{.DriverName}}
+      query: "SELECT COUNT(*) FROM tasks WHERE [status]='running' OR [status]='queued'"
+      targetValue: "1" # one replica per row
+      activationTargetValue: "15"
+    authenticationRef:
+      name: {{.TriggerAuthenticationName}}
+`
+
+	MssqlStatefulSetTemplate = `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{.MssqlServerName}}
+  namespace: {{.TestNamespace}}
+  labels:
+    app: mssql
+spec:
+  replicas: 1
+  serviceName: {{.MssqlServerName}}
+  selector:
+     matchLabels:
+       app: mssql
+  template:
+    metadata:
+      labels:
+        app: mssql
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: mssql
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        ports:
+        - containerPort: 1433
+        env:
+        - name: MSSQL_PID
+          value: "Developer"
+        - name: ACCEPT_EULA
+          value: "Y"
+        - name: SA_PASSWORD
+          value: {{.MssqlPassword}}
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "/opt/mssql-tools18/bin/sqlcmd -S . -C -U sa -P '{{.MssqlPassword}}' -Q 'SELECT @@Version'"
+`
+
+	MssqlServiceTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  name: {{.MssqlServerName}}
+  namespace: {{.TestNamespace}}
+spec:
+  selector:
+    app: mssql
+  ports:
+    - protocol: TCP
+      port: 1433
+      targetPort: 1433
+  type: ClusterIP
+`
+
+	// inserts 10 records in the table
+	InsertRecordsJobTemplate1 = `apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: mssql-producer-job
+  name: mssql-producer-job1
+  namespace: {{.TestNamespace}}
+spec:
+  template:
+    metadata:
+      labels:
+        app: mssql-producer-job
+    spec:
+      containers:
+      - image: ghcr.io/kedacore/tests-mssql:latest
+        imagePullPolicy: Always
+        name: mssql-test-producer
+        command: ["/app"]
+        args: ["-mode", "producer"]
+        env:
+          - name: SQL_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: {{.SecretName}}
+                key: mssql-connection-string
+      restartPolicy: Never
+  backoffLimit: 4
+`
+
+	// inserts 10 records in the table
+	InsertRecordsJobTemplate2 = `apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: mssql-producer-job
+  name: mssql-producer-job2
+  namespace: {{.TestNamespace}}
+spec:
+  template:
+    metadata:
+      labels:
+        app: mssql-producer-job
+    spec:
+      containers:
+      - image: ghcr.io/kedacore/tests-mssql:latest
+        imagePullPolicy: Always
+        name: mssql-test-producer
+        command: ["/app"]
+        args: ["-mode", "producer"]
+        env:
+          - name: SQL_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                name: {{.SecretName}}
+                key: mssql-connection-string
+      restartPolicy: Never
+  backoffLimit: 4
+  `
+)

--- a/tests/scalers/mssql/mssql_standalone/mssql_test.go
+++ b/tests/scalers/mssql/mssql_standalone/mssql_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package mssql_test
+package mssql_standalone_test
 
 import (
 	"fmt"
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
+	mssql "github.com/kedacore/keda/v2/tests/scalers/mssql/helper"
 )
 
 // Load environment variables from .env file
@@ -35,203 +36,6 @@ type templateData struct {
 	MinReplicaCount           int
 	MaxReplicaCount           int
 }
-
-const (
-	deploymentTemplate = `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: mssql-consumer-worker
-  name: {{.DeploymentName}}
-  namespace: {{.TestNamespace}}
-spec:
-  replicas: 0
-  selector:
-    matchLabels:
-      app: mssql-consumer-worker
-  template:
-    metadata:
-      labels:
-        app: mssql-consumer-worker
-    spec:
-      containers:
-      - image: ghcr.io/kedacore/tests-mssql:latest
-        imagePullPolicy: Always
-        name: mssql-consumer-worker
-        command: ["/app"]
-        args: ["-mode", "consumer"]
-        env:
-          - name: SQL_CONNECTION_STRING
-            valueFrom:
-              secretKeyRef:
-                name: {{.SecretName}}
-                key: mssql-connection-string
-`
-
-	secretTemplate = `apiVersion: v1
-kind: Secret
-metadata:
-  name: {{.SecretName}}
-  namespace: {{.TestNamespace}}
-type: Opaque
-stringData:
-  mssql-sa-password: {{.MssqlPassword}}
-  mssql-connection-string: {{.MssqlConnectionString}}
-`
-
-	triggerAuthenticationTemplate = `apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-  name: {{.TriggerAuthenticationName}}
-  namespace: {{.TestNamespace}}
-spec:
-    secretTargetRef:
-    - parameter: password
-      name: {{.SecretName}}
-      key: mssql-sa-password
-`
-
-	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: {{.ScaledObjectName}}
-  namespace: {{.TestNamespace}}
-spec:
-  scaleTargetRef:
-    name: {{.DeploymentName}}
-  pollingInterval: 5
-  cooldownPeriod:  10
-  minReplicaCount: {{.MinReplicaCount}}
-  maxReplicaCount: {{.MaxReplicaCount}}
-  triggers:
-  - type: mssql
-    metadata:
-      host: {{.MssqlHostname}}
-      port: "1433"
-      database: {{.MssqlDatabase}}
-      username: sa
-      driverName: {{.DriverName}}
-      query: "SELECT COUNT(*) FROM tasks WHERE [status]='running' OR [status]='queued'"
-      targetValue: "1" # one replica per row
-      activationTargetValue: "15"
-    authenticationRef:
-      name: {{.TriggerAuthenticationName}}
-`
-
-	mssqlStatefulSetTemplate = `apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: {{.MssqlServerName}}
-  namespace: {{.TestNamespace}}
-  labels:
-    app: mssql
-spec:
-  replicas: 1
-  serviceName: {{.MssqlServerName}}
-  selector:
-     matchLabels:
-       app: mssql
-  template:
-    metadata:
-      labels:
-        app: mssql
-    spec:
-      terminationGracePeriodSeconds: 30
-      containers:
-      - name: mssql
-        image: mcr.microsoft.com/mssql/server:2019-latest
-        ports:
-        - containerPort: 1433
-        env:
-        - name: MSSQL_PID
-          value: "Developer"
-        - name: ACCEPT_EULA
-          value: "Y"
-        - name: SA_PASSWORD
-          value: {{.MssqlPassword}}
-        readinessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - "/opt/mssql-tools18/bin/sqlcmd -S . -C -U sa -P '{{.MssqlPassword}}' -Q 'SELECT @@Version'"
-`
-
-	mssqlServiceTemplate = `apiVersion: v1
-kind: Service
-metadata:
-  name: {{.MssqlServerName}}
-  namespace: {{.TestNamespace}}
-spec:
-  selector:
-    app: mssql
-  ports:
-    - protocol: TCP
-      port: 1433
-      targetPort: 1433
-  type: ClusterIP
-`
-
-	// inserts 10 records in the table
-	insertRecordsJobTemplate1 = `apiVersion: batch/v1
-kind: Job
-metadata:
-  labels:
-    app: mssql-producer-job
-  name: mssql-producer-job1
-  namespace: {{.TestNamespace}}
-spec:
-  template:
-    metadata:
-      labels:
-        app: mssql-producer-job
-    spec:
-      containers:
-      - image: ghcr.io/kedacore/tests-mssql:latest
-        imagePullPolicy: Always
-        name: mssql-test-producer
-        command: ["/app"]
-        args: ["-mode", "producer"]
-        env:
-          - name: SQL_CONNECTION_STRING
-            valueFrom:
-              secretKeyRef:
-                name: {{.SecretName}}
-                key: mssql-connection-string
-      restartPolicy: Never
-  backoffLimit: 4
-`
-
-	// inserts 10 records in the table
-	insertRecordsJobTemplate2 = `apiVersion: batch/v1
-kind: Job
-metadata:
-  labels:
-    app: mssql-producer-job
-  name: mssql-producer-job2
-  namespace: {{.TestNamespace}}
-spec:
-  template:
-    metadata:
-      labels:
-        app: mssql-producer-job
-    spec:
-      containers:
-      - image: ghcr.io/kedacore/tests-mssql:latest
-        imagePullPolicy: Always
-        name: mssql-test-producer
-        command: ["/app"]
-        args: ["-mode", "producer"]
-        env:
-          - name: SQL_CONNECTION_STRING
-            valueFrom:
-              secretKeyRef:
-                name: {{.SecretName}}
-                key: mssql-connection-string
-      restartPolicy: Never
-  backoffLimit: 4
-  `
-)
 
 func TestMssqlScaler(t *testing.T) {
 	for _, driver := range mssqlDrivers {
@@ -286,7 +90,7 @@ func testMssqlScalerDriver(t *testing.T, driverName string) {
 // insert 10 records in the table -> activation should not happen (activationTargetValue = 15)
 func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
-	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate1", insertRecordsJobTemplate1)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate1", mssql.InsertRecordsJobTemplate1)
 
 	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, data.DeploymentName, data.TestNamespace, data.MinReplicaCount, 60)
 }
@@ -294,7 +98,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 // insert another 10 records in the table, which in total is 20 -> should be scaled up
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
-	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate2", insertRecordsJobTemplate2)
+	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate2", mssql.InsertRecordsJobTemplate2)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, data.MaxReplicaCount, 60, 3),
 		"replica count should be %d after 3 minutes", data.MaxReplicaCount)
@@ -343,16 +147,16 @@ func newTemplateData(driverName string) templateData {
 
 func getMssqlTemplateData(data templateData) (templateData, []Template) {
 	return data, []Template{
-		{Name: "mssqlStatefulSetTemplate", Config: mssqlStatefulSetTemplate},
-		{Name: "mssqlServiceTemplate", Config: mssqlServiceTemplate},
+		{Name: "mssqlStatefulSetTemplate", Config: mssql.MssqlStatefulSetTemplate},
+		{Name: "mssqlServiceTemplate", Config: mssql.MssqlServiceTemplate},
 	}
 }
 
 func getTemplateData(data templateData) (templateData, []Template) {
 	return data, []Template{
-		{Name: "secretTemplate", Config: secretTemplate},
-		{Name: "deploymentTemplate", Config: deploymentTemplate},
-		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
-		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+		{Name: "secretTemplate", Config: mssql.SecretTemplate},
+		{Name: "deploymentTemplate", Config: mssql.DeploymentTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: mssql.TriggerAuthenticationTemplate},
+		{Name: "scaledObjectTemplate", Config: mssql.ScaledObjectTemplate},
 	}
 }

--- a/tests/scalers/mssql/mssql_test.go
+++ b/tests/scalers/mssql/mssql_test.go
@@ -32,6 +32,7 @@ var (
 	mssqlServerPodName        = fmt.Sprintf("%s-0", mssqlServerName)
 	mssqlPassword             = "Pass@word1"
 	mssqlDatabase             = "TestDB"
+	mssqlDriverName           = "sqlserver"
 	mssqlHostname             = fmt.Sprintf("%s.%s.svc.cluster.local", mssqlServerName, testNamespace)
 	mssqlConnectionString     = fmt.Sprintf("Server=%s;Database=%s;User ID=sa;Password=%s;",
 		mssqlHostname, mssqlDatabase, mssqlPassword)
@@ -50,6 +51,7 @@ type templateData struct {
 	MssqlPassword             string
 	MssqlDatabase             string
 	MssqlConnectionString     string
+	DriverName                string
 	MinReplicaCount           int
 	MaxReplicaCount           int
 }
@@ -128,6 +130,7 @@ spec:
       port: "1433"
       database: {{.MssqlDatabase}}
       username: sa
+      driverName: {{.DriverName}}
       query: "SELECT COUNT(*) FROM tasks WHERE [status]='running' OR [status]='queued'"
       targetValue: "1" # one replica per row
       activationTargetValue: "15"
@@ -321,6 +324,7 @@ var data = templateData{
 	MssqlPassword:             mssqlPassword,
 	MssqlDatabase:             mssqlDatabase,
 	MssqlConnectionString:     mssqlConnectionString,
+	DriverName:                mssqlDriverName,
 }
 
 func getMssqlTemplateData() (templateData, []Template) {

--- a/tests/scalers/mssql/mssql_test.go
+++ b/tests/scalers/mssql/mssql_test.go
@@ -18,27 +18,7 @@ import (
 // Load environment variables from .env file
 var _ = godotenv.Load("../../.env")
 
-const (
-	testName = "mssql-test"
-)
-
-var (
-	testNamespace             = fmt.Sprintf("%s-ns", testName)
-	deploymentName            = fmt.Sprintf("%s-deployment", testName)
-	scaledObjectName          = fmt.Sprintf("%s-so", testName)
-	triggerAuthenticationName = fmt.Sprintf("%s-ta", testName)
-	secretName                = fmt.Sprintf("%s-secret", testName)
-	mssqlServerName           = fmt.Sprintf("%s-server", testName)
-	mssqlServerPodName        = fmt.Sprintf("%s-0", mssqlServerName)
-	mssqlPassword             = "Pass@word1"
-	mssqlDatabase             = "TestDB"
-	mssqlDriverName           = "sqlserver"
-	mssqlHostname             = fmt.Sprintf("%s.%s.svc.cluster.local", mssqlServerName, testNamespace)
-	mssqlConnectionString     = fmt.Sprintf("Server=%s;Database=%s;User ID=sa;Password=%s;",
-		mssqlHostname, mssqlDatabase, mssqlPassword)
-	minReplicaCount = 0
-	maxReplicaCount = 5
-)
+var mssqlDrivers = []string{"sqlserver", "azuresql"}
 
 type templateData struct {
 	TestNamespace             string
@@ -254,37 +234,51 @@ spec:
 )
 
 func TestMssqlScaler(t *testing.T) {
+	for _, driver := range mssqlDrivers {
+		t.Run(driver, func(t *testing.T) {
+			testMssqlScalerDriver(t, driver)
+		})
+	}
+}
+
+func testMssqlScalerDriver(t *testing.T, driverName string) {
+	data := newTemplateData(driverName)
+
 	// Create kubernetes resources for MS SQL server
 	kc := GetKubernetesClient(t)
-	_, mssqlTemplates := getMssqlTemplateData()
-	_, templates := getTemplateData()
+	_, mssqlTemplates := getMssqlTemplateData(data)
+	_, templates := getTemplateData(data)
+
 	t.Cleanup(func() {
-		DeleteKubernetesResources(t, testNamespace, data, templates)
+		DeleteKubernetesResources(t, data.TestNamespace, data, mssqlTemplates)
+		DeleteKubernetesResources(t, data.TestNamespace, data, templates)
 	})
 
-	CreateKubernetesResources(t, kc, testNamespace, data, mssqlTemplates)
+	CreateKubernetesResources(t, kc, data.TestNamespace, data, mssqlTemplates)
 
-	require.True(t, WaitForStatefulsetReplicaReadyCount(t, kc, mssqlServerName, testNamespace, 1, 60, 3),
+	require.True(t, WaitForStatefulsetReplicaReadyCount(t, kc, data.MssqlServerName, data.TestNamespace, 1, 60, 3),
 		"replica count should be %d after 3 minutes", 1)
 
-	createDatabaseCommand := fmt.Sprintf("/opt/mssql-tools18/bin/sqlcmd -S . -C -U sa -P \"%s\" -Q \"CREATE DATABASE [%s]\"", mssqlPassword, mssqlDatabase)
+	createDatabaseCommand := fmt.Sprintf("/opt/mssql-tools18/bin/sqlcmd -S . -C -U sa -P \"%s\" -Q \"CREATE DATABASE [%s]\"", data.MssqlPassword, data.MssqlDatabase)
 
-	ok, out, errOut, err := WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlServerPodName, testNamespace, createDatabaseCommand, 60, 3)
+	mssqlServerPodName := fmt.Sprintf("%s-0", data.MssqlServerName)
+
+	ok, out, errOut, err := WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlServerPodName, data.TestNamespace, createDatabaseCommand, 60, 3)
 	require.True(t, ok, "executing a command on MS SQL Pod should work; Output: %s, ErrorOutput: %s, Error: %s", out, errOut, err)
 
 	createTableCommand := fmt.Sprintf("/opt/mssql-tools18/bin/sqlcmd -S . -C -U sa -P \"%s\" -d %s -Q \"CREATE TABLE tasks ([id] int identity primary key, [status] varchar(10))\"",
-		mssqlPassword, mssqlDatabase)
-	ok, out, errOut, err = WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlServerPodName, testNamespace, createTableCommand, 60, 3)
+		data.MssqlPassword, data.MssqlDatabase)
+	ok, out, errOut, err = WaitForSuccessfulExecCommandOnSpecificPod(t, mssqlServerPodName, data.TestNamespace, createTableCommand, 60, 3)
 	require.True(t, ok, "executing a command on MS SQL Pod should work; Output: %s, ErrorOutput: %s, Error: %s", out, errOut, err)
 
 	// Create kubernetes resources for testing
 	KubectlApplyMultipleWithTemplate(t, data, templates)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, data.MinReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", data.MinReplicaCount)
 
 	testActivation(t, kc, data)
 	testScaleOut(t, kc, data)
-	testScaleIn(t, kc)
+	testScaleIn(t, kc, data)
 }
 
 // insert 10 records in the table -> activation should not happen (activationTargetValue = 15)
@@ -292,7 +286,7 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing activation ---")
 	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate1", insertRecordsJobTemplate1)
 
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, data.DeploymentName, data.TestNamespace, data.MinReplicaCount, 60)
 }
 
 // insert another 10 records in the table, which in total is 20 -> should be scaled up
@@ -300,41 +294,59 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 	KubectlReplaceWithTemplate(t, data, "insertRecordsJobTemplate2", insertRecordsJobTemplate2)
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
-		"replica count should be %d after 3 minutes", maxReplicaCount)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, data.MaxReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", data.MaxReplicaCount)
 }
 
-func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale in ---")
 
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
-		"replica count should be %d after 3 minutes", minReplicaCount)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, data.DeploymentName, data.TestNamespace, data.MinReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", data.MinReplicaCount)
 }
 
-var data = templateData{
-	TestNamespace:             testNamespace,
-	DeploymentName:            deploymentName,
-	ScaledObjectName:          scaledObjectName,
-	MinReplicaCount:           minReplicaCount,
-	MaxReplicaCount:           maxReplicaCount,
-	TriggerAuthenticationName: triggerAuthenticationName,
-	SecretName:                secretName,
-	MssqlServerName:           mssqlServerName,
-	MssqlHostname:             mssqlHostname,
-	MssqlPassword:             mssqlPassword,
-	MssqlDatabase:             mssqlDatabase,
-	MssqlConnectionString:     mssqlConnectionString,
-	DriverName:                mssqlDriverName,
+func newTemplateData(driverName string) templateData {
+	testName := fmt.Sprintf("mssql-%s-test", driverName)
+
+	testNamespace := fmt.Sprintf("%s-ns", testName)
+	deploymentName := fmt.Sprintf("%s-deployment", testName)
+	scaledObjectName := fmt.Sprintf("%s-so", testName)
+	triggerAuthenticationName := fmt.Sprintf("%s-ta", testName)
+	secretName := fmt.Sprintf("%s-secret", testName)
+	mssqlServerName := fmt.Sprintf("%s-server", testName)
+	mssqlPassword := "Pass@word1"
+	mssqlDatabase := "TestDB"
+	mssqlHostname := fmt.Sprintf("%s.%s.svc.cluster.local", mssqlServerName, testNamespace)
+	mssqlConnectionString := fmt.Sprintf(
+		"Server=%s;Database=%s;User ID=sa;Password=%s;",
+		mssqlHostname, mssqlDatabase, mssqlPassword,
+	)
+
+	return templateData{
+		TestNamespace:             testNamespace,
+		DeploymentName:            deploymentName,
+		ScaledObjectName:          scaledObjectName,
+		TriggerAuthenticationName: triggerAuthenticationName,
+		SecretName:                secretName,
+		MssqlServerName:           mssqlServerName,
+		MssqlHostname:             mssqlHostname,
+		MssqlPassword:             mssqlPassword,
+		MssqlDatabase:             mssqlDatabase,
+		MssqlConnectionString:     mssqlConnectionString,
+		DriverName:                driverName,
+		MinReplicaCount:           0,
+		MaxReplicaCount:           5,
+	}
 }
 
-func getMssqlTemplateData() (templateData, []Template) {
+func getMssqlTemplateData(data templateData) (templateData, []Template) {
 	return data, []Template{
 		{Name: "mssqlStatefulSetTemplate", Config: mssqlStatefulSetTemplate},
 		{Name: "mssqlServiceTemplate", Config: mssqlServiceTemplate},
 	}
 }
 
-func getTemplateData() (templateData, []Template) {
+func getTemplateData(data templateData) (templateData, []Template) {
 	return data, []Template{
 		{Name: "secretTemplate", Config: secretTemplate},
 		{Name: "deploymentTemplate", Config: deploymentTemplate},

--- a/tests/scalers/mssql/mssql_test.go
+++ b/tests/scalers/mssql/mssql_test.go
@@ -249,9 +249,11 @@ func testMssqlScalerDriver(t *testing.T, driverName string) {
 	_, mssqlTemplates := getMssqlTemplateData(data)
 	_, templates := getTemplateData(data)
 
+	allTemplates := append([]Template{}, mssqlTemplates...)
+	allTemplates = append(allTemplates, templates...)
+
 	t.Cleanup(func() {
-		DeleteKubernetesResources(t, data.TestNamespace, data, mssqlTemplates)
-		DeleteKubernetesResources(t, data.TestNamespace, data, templates)
+		DeleteKubernetesResources(t, data.TestNamespace, data, allTemplates)
 	})
 
 	CreateKubernetesResources(t, kc, data.TestNamespace, data, mssqlTemplates)

--- a/vendor/github.com/microsoft/go-mssqldb/azuread/configuration.go
+++ b/vendor/github.com/microsoft/go-mssqldb/azuread/configuration.go
@@ -1,0 +1,483 @@
+//go:build go1.18
+// +build go1.18
+
+package azuread
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+const (
+	ActiveDirectoryDefault     = "ActiveDirectoryDefault"
+	ActiveDirectoryIntegrated  = "ActiveDirectoryIntegrated"
+	ActiveDirectoryPassword    = "ActiveDirectoryPassword"
+	ActiveDirectoryInteractive = "ActiveDirectoryInteractive"
+	// ActiveDirectoryMSI is a synonym for ActiveDirectoryManagedIdentity
+	ActiveDirectoryMSI             = "ActiveDirectoryMSI"
+	ActiveDirectoryManagedIdentity = "ActiveDirectoryManagedIdentity"
+	// ActiveDirectoryApplication is a synonym for ActiveDirectoryServicePrincipal
+	ActiveDirectoryApplication                 = "ActiveDirectoryApplication"
+	ActiveDirectoryServicePrincipal            = "ActiveDirectoryServicePrincipal"
+	ActiveDirectoryServicePrincipalAccessToken = "ActiveDirectoryServicePrincipalAccessToken"
+	ActiveDirectoryDeviceCode                  = "ActiveDirectoryDeviceCode"
+	ActiveDirectoryAzCli                       = "ActiveDirectoryAzCli"
+	// New credential types added in azidentity v1.7+
+	ActiveDirectoryAzureDeveloperCli = "ActiveDirectoryAzureDeveloperCli"
+	ActiveDirectoryAzurePipelines    = "ActiveDirectoryAzurePipelines"
+	ActiveDirectoryEnvironment       = "ActiveDirectoryEnvironment"
+	ActiveDirectoryWorkloadIdentity  = "ActiveDirectoryWorkloadIdentity"
+	ActiveDirectoryClientAssertion   = "ActiveDirectoryClientAssertion"
+	ActiveDirectoryOnBehalfOf        = "ActiveDirectoryOnBehalfOf"
+	scopeDefaultSuffix               = "/.default"
+)
+
+type azureFedAuthConfig struct {
+	adalWorkflow byte
+	mssqlConfig  msdsn.Config
+	// The detected federated authentication library
+	fedAuthLibrary  int
+	fedAuthWorkflow string
+	// Service principal logins
+	clientID        string
+	tenantID        string
+	clientSecret    string
+	certificatePath string
+	resourceID      string
+
+	// AD password/managed identity/interactive
+	user                string
+	password            string
+	applicationClientID string
+
+	// New fields for additional credential types
+	serviceConnectionID string // For Azure Pipelines
+	systemAccessToken   string // For Azure Pipelines
+	userAssertion       string // For On-Behalf-Of flow
+	clientAssertion     string // For Client Assertion
+
+	// Common credential options
+	additionallyAllowedTenants []string // For most credential types
+	disableInstanceDiscovery   bool     // For most credential types
+	tokenFilePath              string   // For WorkloadIdentity
+	sendCertificateChain       bool     // For ClientCertificate
+}
+
+// parse returns a config based on an msdsn-style connection string
+func parse(dsn string) (*azureFedAuthConfig, error) {
+	mssqlConfig, err := msdsn.Parse(dsn)
+	if err != nil {
+		return nil, err
+	}
+	config := &azureFedAuthConfig{
+		fedAuthLibrary: mssql.FedAuthLibraryReserved,
+		mssqlConfig:    mssqlConfig,
+	}
+
+	err = config.validateParameters(mssqlConfig.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func (p *azureFedAuthConfig) validateParameters(params map[string]string) error {
+
+	fedAuthWorkflow := params["fedauth"]
+	if fedAuthWorkflow == "" {
+		return nil
+	}
+
+	p.fedAuthLibrary = mssql.FedAuthLibraryADAL
+
+	p.applicationClientID = params["applicationclientid"]
+
+	switch {
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryPassword):
+		if p.applicationClientID == "" {
+			return errors.New("applicationclientid parameter is required for " + ActiveDirectoryPassword)
+		}
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+		p.user = params["user id"]
+		p.password = params["password"]
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryIntegrated):
+		// Active Directory Integrated authentication is not fully supported:
+		// you can only use this by also implementing an a token provider
+		// and supplying it via ActiveDirectoryTokenProvider in the Connection.
+		p.adalWorkflow = mssql.FedAuthADALWorkflowIntegrated
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryManagedIdentity) || strings.EqualFold(fedAuthWorkflow, ActiveDirectoryMSI):
+		// When using MSI, to request a specific client ID or user-assigned identity,
+		// provide the ID in the "user id" parameter
+		p.adalWorkflow = mssql.FedAuthADALWorkflowMSI
+		p.resourceID = params["resource id"]
+		p.clientID, _ = splitTenantAndClientID(params["user id"])
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryApplication) || strings.EqualFold(fedAuthWorkflow, ActiveDirectoryServicePrincipal):
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+		// Split the clientID@tenantID format
+		// If no tenant is provided we'll use the one from the server
+		p.clientID, p.tenantID = splitTenantAndClientID(params["user id"])
+		if p.clientID == "" {
+			return errors.New("Must provide 'client id[@tenant id]' as username parameter when using ActiveDirectoryApplication authentication")
+		}
+
+		p.clientSecret = params["password"]
+
+		p.certificatePath = params["clientcertpath"]
+
+		if p.certificatePath == "" && p.clientSecret == "" {
+			return errors.New("Must provide 'password' parameter when using ActiveDirectoryApplication authentication without cert/key credentials")
+		}
+	case isPasswordWorkflowAuth(fedAuthWorkflow):
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryInteractive):
+		if p.applicationClientID == "" {
+			return errors.New("applicationclientid parameter is required for " + ActiveDirectoryInteractive)
+		}
+		// user is an optional login hint
+		p.user = params["user id"]
+		// we don't really have a password but we need to use some value.
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryServicePrincipalAccessToken):
+		p.fedAuthLibrary = mssql.FedAuthLibrarySecurityToken
+		p.adalWorkflow = mssql.FedAuthADALWorkflowNone
+		p.password = params["password"]
+
+		if p.password == "" {
+			return errors.New("Must provide 'password' parameter when using ActiveDirectoryServicePrincipalAccessToken authentication")
+		}
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryAzurePipelines):
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+		// Split the clientID@tenantID format from connection string
+		p.clientID, p.tenantID = splitTenantAndClientID(params["user id"])
+
+		// If not provided in connection string, check environment variables
+		if p.clientID == "" {
+			p.clientID = os.Getenv("AZURESUBSCRIPTION_CLIENT_ID")
+		}
+		if p.tenantID == "" {
+			p.tenantID = os.Getenv("AZURESUBSCRIPTION_TENANT_ID")
+		}
+
+		if p.clientID == "" {
+			return errors.New("Must provide 'client id[@tenant id]' as username parameter or set AZURESUBSCRIPTION_CLIENT_ID environment variable when using ActiveDirectoryAzurePipelines authentication")
+		}
+
+		p.serviceConnectionID = params["serviceconnectionid"]
+		if p.serviceConnectionID == "" {
+			p.serviceConnectionID = os.Getenv("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID")
+		}
+		if p.serviceConnectionID == "" {
+			return errors.New("Must provide 'serviceconnectionid' parameter or set AZURESUBSCRIPTION_SERVICE_CONNECTION_ID environment variable when using ActiveDirectoryAzurePipelines authentication")
+		}
+
+		p.systemAccessToken = params["systemtoken"]
+		if p.systemAccessToken == "" {
+			p.systemAccessToken = os.Getenv("SYSTEM_ACCESSTOKEN")
+		}
+		if p.systemAccessToken == "" {
+			return errors.New("Must provide 'systemtoken' parameter or set SYSTEM_ACCESSTOKEN environment variable when using ActiveDirectoryAzurePipelines authentication")
+		}
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryClientAssertion):
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+		// Split the clientID@tenantID format
+		p.clientID, p.tenantID = splitTenantAndClientID(params["user id"])
+		if p.clientID == "" {
+			return errors.New("Must provide 'client id[@tenant id]' as username parameter when using ActiveDirectoryClientAssertion authentication")
+		}
+		p.clientAssertion = params["clientassertion"]
+		if p.clientAssertion == "" {
+			return errors.New("Must provide 'clientassertion' parameter when using ActiveDirectoryClientAssertion authentication")
+		}
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryWorkloadIdentity):
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+		// Split the clientID@tenantID format if provided
+		// If no user id is provided, the credential will use environment variables
+		if userID := params["user id"]; userID != "" {
+			p.clientID, p.tenantID = splitTenantAndClientID(userID)
+		}
+	case strings.EqualFold(fedAuthWorkflow, ActiveDirectoryOnBehalfOf):
+		p.adalWorkflow = mssql.FedAuthADALWorkflowPassword
+		// Split the clientID@tenantID format
+		p.clientID, p.tenantID = splitTenantAndClientID(params["user id"])
+		if p.clientID == "" {
+			return errors.New("Must provide 'client id[@tenant id]' as username parameter when using ActiveDirectoryOnBehalfOf authentication")
+		}
+		p.userAssertion = params["userassertion"]
+		if p.userAssertion == "" {
+			return errors.New("Must provide 'userassertion' parameter when using ActiveDirectoryOnBehalfOf authentication")
+		}
+		// On-behalf-of can use client secret, certificate, or client assertion
+		p.clientSecret = params["password"]
+		p.certificatePath = params["clientcertpath"]
+		p.clientAssertion = params["clientassertion"]
+		if p.clientSecret == "" && p.certificatePath == "" && p.clientAssertion == "" {
+			return errors.New("Must provide one of 'password', 'clientcertpath', or 'clientassertion' parameter when using ActiveDirectoryOnBehalfOf authentication")
+		}
+	default:
+		return fmt.Errorf("Invalid federated authentication type '%s': expected one of %+v",
+			fedAuthWorkflow,
+			[]string{ActiveDirectoryApplication, ActiveDirectoryServicePrincipal, ActiveDirectoryDefault, ActiveDirectoryIntegrated, ActiveDirectoryInteractive, ActiveDirectoryManagedIdentity, ActiveDirectoryMSI, ActiveDirectoryPassword, ActiveDirectoryAzCli, ActiveDirectoryDeviceCode, ActiveDirectoryAzureDeveloperCli, ActiveDirectoryAzurePipelines, ActiveDirectoryEnvironment, ActiveDirectoryWorkloadIdentity, ActiveDirectoryClientAssertion, ActiveDirectoryOnBehalfOf})
+	}
+
+	// Parse common credential options that apply to multiple auth types
+	p.parseCommonCredentialOptions(params)
+
+	p.fedAuthWorkflow = fedAuthWorkflow
+	return nil
+}
+
+// parseCommonCredentialOptions parses connection string parameters that are common across multiple credential types
+func (p *azureFedAuthConfig) parseCommonCredentialOptions(params map[string]string) {
+	// AdditionallyAllowedTenants - comma or semicolon separated list of tenant IDs
+	if allowedTenants := params["additionallyallowedtenants"]; allowedTenants != "" {
+		// Support both comma and semicolon as separators (following Azure SDK convention)
+		separators := []string{",", ";"}
+		for _, sep := range separators {
+			if strings.Contains(allowedTenants, sep) {
+				p.additionallyAllowedTenants = strings.Split(allowedTenants, sep)
+				// Trim whitespace from each tenant
+				for i, tenant := range p.additionallyAllowedTenants {
+					p.additionallyAllowedTenants[i] = strings.TrimSpace(tenant)
+				}
+				break
+			}
+		}
+		// If no separators found, treat as single tenant
+		if len(p.additionallyAllowedTenants) == 0 {
+			p.additionallyAllowedTenants = []string{strings.TrimSpace(allowedTenants)}
+		}
+	}
+
+	// DisableInstanceDiscovery - boolean flag for disconnected/private clouds
+	if disableDiscovery := params["disableinstancediscovery"]; disableDiscovery != "" {
+		p.disableInstanceDiscovery = strings.EqualFold(disableDiscovery, "true") || disableDiscovery == "1"
+	}
+
+	// TokenFilePath - for WorkloadIdentity specifically
+	if tokenFilePath := params["tokenfilepath"]; tokenFilePath != "" {
+		p.tokenFilePath = tokenFilePath
+	}
+
+	// SendCertificateChain - for ClientCertificate specifically
+	if sendCertChain := params["sendcertificatechain"]; sendCertChain != "" {
+		p.sendCertificateChain = strings.EqualFold(sendCertChain, "true") || sendCertChain == "1"
+	}
+}
+
+// isPasswordWorkflowAuth checks if the federated auth workflow uses the password workflow
+func isPasswordWorkflowAuth(workflow string) bool {
+	passwordWorkflows := []string{
+		ActiveDirectoryDefault,
+		ActiveDirectoryAzCli,
+		ActiveDirectoryDeviceCode,
+		ActiveDirectoryAzureDeveloperCli,
+		ActiveDirectoryEnvironment,
+	}
+
+	for _, w := range passwordWorkflows {
+		if strings.EqualFold(workflow, w) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitTenantAndClientID(user string) (string, string) {
+	// Split the user name into client id and tenant id at the @ symbol
+	at := strings.IndexRune(user, '@')
+	if at < 1 || at >= (len(user)-1) {
+		return user, ""
+	}
+
+	return user[0:at], user[at+1:]
+}
+
+func splitAuthorityAndTenant(authorityURL string) (string, string) {
+	separatorIndex := strings.LastIndex(authorityURL, "/")
+	tenant := authorityURL[separatorIndex+1:]
+	authority := authorityURL[:separatorIndex]
+	return authority, tenant
+}
+
+func (p *azureFedAuthConfig) provideActiveDirectoryToken(ctx context.Context, serverSPN, stsURL string) (string, error) {
+	var cred azcore.TokenCredential
+	var err error
+	authority, tenant := splitAuthorityAndTenant(stsURL)
+	// client secret connection strings may override the server tenant
+	if p.tenantID != "" {
+		tenant = p.tenantID
+	}
+	scope := serverSPN
+	if !strings.HasSuffix(serverSPN, scopeDefaultSuffix) {
+		scope = serverSPN + scopeDefaultSuffix
+	}
+
+	switch p.fedAuthWorkflow {
+	case ActiveDirectoryServicePrincipal, ActiveDirectoryApplication:
+		switch {
+		case p.certificatePath != "":
+			var certData []byte
+			certData, err = os.ReadFile(p.certificatePath)
+			if err == nil {
+				var certs []*x509.Certificate
+				var key crypto.PrivateKey
+				certs, key, err = azidentity.ParseCertificates(certData, []byte(p.clientSecret))
+				if err == nil {
+					options := &azidentity.ClientCertificateCredentialOptions{
+						AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+						DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+						SendCertificateChain:       p.sendCertificateChain,
+					}
+					cred, err = azidentity.NewClientCertificateCredential(tenant, p.clientID, certs, key, options)
+				}
+			}
+		default:
+			options := &azidentity.ClientSecretCredentialOptions{
+				AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+				DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+			}
+			cred, err = azidentity.NewClientSecretCredential(tenant, p.clientID, p.clientSecret, options)
+		}
+	case ActiveDirectoryServicePrincipalAccessToken:
+		return p.password, nil
+	case ActiveDirectoryPassword:
+		options := &azidentity.UsernamePasswordCredentialOptions{
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+			DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+		}
+		cred, err = azidentity.NewUsernamePasswordCredential(tenant, p.applicationClientID, p.user, p.password, options)
+	case ActiveDirectoryMSI, ActiveDirectoryManagedIdentity:
+		if p.resourceID != "" {
+			cred, err = azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ResourceID(p.resourceID)})
+		} else if p.clientID != "" {
+			cred, err = azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(p.clientID)})
+		} else {
+			cred, err = azidentity.NewManagedIdentityCredential(nil)
+		}
+	case ActiveDirectoryInteractive:
+		c := cloud.Configuration{ActiveDirectoryAuthorityHost: authority}
+		config := azcore.ClientOptions{Cloud: c}
+		options := &azidentity.InteractiveBrowserCredentialOptions{
+			ClientOptions:              config,
+			ClientID:                   p.applicationClientID,
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+			DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+		}
+		cred, err = azidentity.NewInteractiveBrowserCredential(options)
+
+	case ActiveDirectoryDeviceCode:
+		options := &azidentity.DeviceCodeCredentialOptions{
+			ClientID:                   p.applicationClientID,
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+			DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+		}
+		cred, err = azidentity.NewDeviceCodeCredential(options)
+	case ActiveDirectoryAzCli:
+		options := &azidentity.AzureCLICredentialOptions{
+			TenantID:                   p.tenantID,
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+		}
+		cred, err = azidentity.NewAzureCLICredential(options)
+	case ActiveDirectoryAzureDeveloperCli:
+		options := &azidentity.AzureDeveloperCLICredentialOptions{
+			TenantID:                   p.tenantID,
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+		}
+		cred, err = azidentity.NewAzureDeveloperCLICredential(options)
+	case ActiveDirectoryAzurePipelines:
+		cred, err = azidentity.NewAzurePipelinesCredential(tenant, p.clientID, p.serviceConnectionID, p.systemAccessToken, nil)
+	case ActiveDirectoryEnvironment:
+		options := &azidentity.EnvironmentCredentialOptions{
+			DisableInstanceDiscovery: p.disableInstanceDiscovery,
+		}
+		cred, err = azidentity.NewEnvironmentCredential(options)
+	case ActiveDirectoryWorkloadIdentity:
+		options := &azidentity.WorkloadIdentityCredentialOptions{
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+			DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+		}
+		if p.clientID != "" {
+			options.ClientID = p.clientID
+		}
+		if p.tenantID != "" {
+			options.TenantID = p.tenantID
+		}
+		if p.tokenFilePath != "" {
+			options.TokenFilePath = p.tokenFilePath
+		}
+		cred, err = azidentity.NewWorkloadIdentityCredential(options)
+	case ActiveDirectoryClientAssertion:
+		assertionProvider := func(ctx context.Context) (string, error) {
+			return p.clientAssertion, nil
+		}
+		options := &azidentity.ClientAssertionCredentialOptions{
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+			DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+		}
+		cred, err = azidentity.NewClientAssertionCredential(tenant, p.clientID, assertionProvider, options)
+	case ActiveDirectoryOnBehalfOf:
+		switch {
+		case p.certificatePath != "":
+			var certData []byte
+			certData, err = os.ReadFile(p.certificatePath)
+			if err == nil {
+				var certs []*x509.Certificate
+				var key crypto.PrivateKey
+				certs, key, err = azidentity.ParseCertificates(certData, []byte(p.clientSecret))
+				if err == nil {
+					options := &azidentity.OnBehalfOfCredentialOptions{
+						AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+						DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+						SendCertificateChain:       p.sendCertificateChain,
+					}
+					cred, err = azidentity.NewOnBehalfOfCredentialWithCertificate(tenant, p.clientID, p.userAssertion, certs, key, options)
+				}
+			}
+		case p.clientAssertion != "":
+			assertionProvider := func(ctx context.Context) (string, error) {
+				return p.clientAssertion, nil
+			}
+			options := &azidentity.OnBehalfOfCredentialOptions{
+				AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+				DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+			}
+			cred, err = azidentity.NewOnBehalfOfCredentialWithClientAssertions(tenant, p.clientID, p.userAssertion, assertionProvider, options)
+		default:
+			options := &azidentity.OnBehalfOfCredentialOptions{
+				AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+				DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+			}
+			cred, err = azidentity.NewOnBehalfOfCredentialWithSecret(tenant, p.clientID, p.userAssertion, p.clientSecret, options)
+		}
+	default:
+		// Integrated just uses Default until azidentity adds Windows-specific authentication
+		options := &azidentity.DefaultAzureCredentialOptions{
+			AdditionallyAllowedTenants: p.additionallyAllowedTenants,
+			DisableInstanceDiscovery:   p.disableInstanceDiscovery,
+		}
+		cred, err = azidentity.NewDefaultAzureCredential(options)
+	}
+
+	if err != nil {
+		return "", err
+	}
+	opts := policy.TokenRequestOptions{Scopes: []string{scope}}
+	tk, err := cred.GetToken(ctx, opts)
+	if err != nil {
+		return "", err
+	}
+	return tk.Token, err
+}

--- a/vendor/github.com/microsoft/go-mssqldb/azuread/driver.go
+++ b/vendor/github.com/microsoft/go-mssqldb/azuread/driver.go
@@ -1,0 +1,66 @@
+//go:build go1.18
+// +build go1.18
+
+package azuread
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+
+	mssql "github.com/microsoft/go-mssqldb"
+)
+
+// DriverName is the name used to register the driver
+const DriverName = "azuresql"
+
+func init() {
+	sql.Register(DriverName, &Driver{})
+}
+
+// Driver wraps the underlying MSSQL driver, but configures the Azure AD token provider
+type Driver struct {
+}
+
+// Open returns a new connection to the database.
+func (d *Driver) Open(dsn string) (driver.Conn, error) {
+	c, err := NewConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Connect(context.Background())
+}
+
+// NewConnector creates a new connector from a DSN.
+// The returned connector may be used with sql.OpenDB.
+func NewConnector(dsn string) (*mssql.Connector, error) {
+
+	config, err := parse(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return newConnectorConfig(config)
+}
+
+// newConnectorConfig creates a Connector from config.
+func newConnectorConfig(config *azureFedAuthConfig) (*mssql.Connector, error) {
+	switch config.fedAuthLibrary {
+	case mssql.FedAuthLibraryADAL:
+		return mssql.NewActiveDirectoryTokenConnector(
+			config.mssqlConfig, config.adalWorkflow,
+			func(ctx context.Context, serverSPN, stsURL string) (string, error) {
+				return config.provideActiveDirectoryToken(ctx, serverSPN, stsURL)
+			},
+		)
+	case mssql.FedAuthLibrarySecurityToken:
+		return mssql.NewSecurityTokenConnector(
+			config.mssqlConfig,
+			func(ctx context.Context) (string, error) {
+				return config.password, nil
+			},
+		)
+	default:
+		return mssql.NewConnectorConfig(config.mssqlConfig), nil
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1221,6 +1221,7 @@ github.com/microsoft/azure-devops-go-api/azuredevops/webapi
 ## explicit; go 1.24.0
 github.com/microsoft/go-mssqldb
 github.com/microsoft/go-mssqldb/aecmk
+github.com/microsoft/go-mssqldb/azuread
 github.com/microsoft/go-mssqldb/integratedauth
 github.com/microsoft/go-mssqldb/integratedauth/ntlm
 github.com/microsoft/go-mssqldb/integratedauth/winsspi


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This PR adds optional `driverName` support to the MSSQL scaler, allowing users to use the `azuresql` driver for Azure AD–based authentication.

If not specified, it defaults to `sqlserver`, so existing configurations remain unchanged.

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7412
Related Docs: kedacore/keda-docs#1722