### PR TITLE
fix: handle NaN values in Prometheus scaler

### DIFF
--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -283,7 +283,7 @@ func (s *prometheusScaler) ExecutePromQuery(ctx context.Context) (float64, error
 		}
 	}
 
-	if math.IsInf(v, 0) {
+	if math.IsInf(v, 0) || math.IsNaN(v) {
 		if s.metadata.IgnoreNullValues {
 			return 0, nil
 		}


### PR DESCRIPTION
## What

Add `math.IsNaN()` check alongside the existing `math.IsInf()` check in the Prometheus scaler's `getPrometheusResult` function.

## Why

When Prometheus returns NaN (e.g., from a query over an empty time range), `strconv.ParseFloat` produces a valid NaN float64 that bypasses the Inf check. This results in a large negative metric value being returned, causing incorrect scaling decisions.

## How

Added `math.IsNaN(v)` to the existing `math.IsInf(v, 0)` condition in `prometheus_scaler.go`. NaN values are now handled the same way as Inf: return 0 when `ignoreNullValues` is true, or return an error otherwise.

Fixes https://github.com/kedacore/keda/issues/7475

Signed-off-by: Snigdha Aryakumar <snigdha.sambit.ak@gmail.com>