### PR TITLE
feat(aws): add support for externalId in AssumeRole for TriggerAuthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
+- **AWS Scalers**: Add support for `externalId` in AssumeRole via TriggerAuthentication spec field ([#7388](https://github.com/kedacore/keda/pull/7388))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
 - **Kubernetes Workload Scaler**: Add `groupByNode` parameter ([#7628](https://github.com/kedacore/keda/issues/7628))
 

--- a/apis/keda/v1alpha1/triggerauthentication_types.go
+++ b/apis/keda/v1alpha1/triggerauthentication_types.go
@@ -162,6 +162,10 @@ type AuthPodIdentity struct {
 	// RoleArn sets the AWS RoleArn to be used. Mutually exclusive with IdentityOwner
 	RoleArn *string `json:"roleArn,omitempty"`
 
+	// +kubebuilder:validation:Optional
+	// ExternalID sets the AWS ExternalID to use when assuming the role specified by RoleArn
+	ExternalID *string `json:"externalId,omitempty"`
+
 	// +kubebuilder:validation:Enum=keda;workload
 	// +optional
 	// IdentityOwner configures which identity has to be used during auto discovery, keda or the scaled workload. Mutually exclusive with roleArn

--- a/apis/keda/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/keda/v1alpha1/zz_generated.deepcopy.go
@@ -100,6 +100,11 @@ func (in *AuthPodIdentity) DeepCopyInto(out *AuthPodIdentity) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ExternalID != nil {
+		in, out := &in.ExternalID, &out.ExternalID
+		*out = new(string)
+		**out = **in
+	}
 	if in.IdentityOwner != nil {
 		in, out := &in.IdentityOwner, &out.IdentityOwner
 		*out = new(string)

--- a/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_clustertriggerauthentications.yaml
@@ -141,6 +141,10 @@ spec:
                       AuthPodIdentity allows users to select the platform native identity
                       mechanism
                     properties:
+                      externalId:
+                        description: ExternalID sets the AWS ExternalID to use when
+                          assuming the role specified by RoleArn
+                        type: string
                       identityAuthorityHost:
                         description: Set identityAuthorityHost to override the default
                           Azure authority host. If this is set, then the IdentityTenantID
@@ -252,6 +256,10 @@ spec:
                       AuthPodIdentity allows users to select the platform native identity
                       mechanism
                     properties:
+                      externalId:
+                        description: ExternalID sets the AWS ExternalID to use when
+                          assuming the role specified by RoleArn
+                        type: string
                       identityAuthorityHost:
                         description: Set identityAuthorityHost to override the default
                           Azure authority host. If this is set, then the IdentityTenantID
@@ -392,6 +400,10 @@ spec:
                       AuthPodIdentity allows users to select the platform native identity
                       mechanism
                     properties:
+                      externalId:
+                        description: ExternalID sets the AWS ExternalID to use when
+                          assuming the role specified by RoleArn
+                        type: string
                       identityAuthorityHost:
                         description: Set identityAuthorityHost to override the default
                           Azure authority host. If this is set, then the IdentityTenantID
@@ -529,6 +541,10 @@ spec:
                   AuthPodIdentity allows users to select the platform native identity
                   mechanism
                 properties:
+                  externalId:
+                    description: ExternalID sets the AWS ExternalID to use when assuming
+                      the role specified by RoleArn
+                    type: string
                   identityAuthorityHost:
                     description: Set identityAuthorityHost to override the default
                       Azure authority host. If this is set, then the IdentityTenantID

--- a/config/crd/bases/keda.sh_triggerauthentications.yaml
+++ b/config/crd/bases/keda.sh_triggerauthentications.yaml
@@ -137,6 +137,10 @@ spec:
                       AuthPodIdentity allows users to select the platform native identity
                       mechanism
                     properties:
+                      externalId:
+                        description: ExternalID sets the AWS ExternalID to use when
+                          assuming the role specified by RoleArn
+                        type: string
                       identityAuthorityHost:
                         description: Set identityAuthorityHost to override the default
                           Azure authority host. If this is set, then the IdentityTenantID
@@ -248,6 +252,10 @@ spec:
                       AuthPodIdentity allows users to select the platform native identity
                       mechanism
                     properties:
+                      externalId:
+                        description: ExternalID sets the AWS ExternalID to use when
+                          assuming the role specified by RoleArn
+                        type: string
                       identityAuthorityHost:
                         description: Set identityAuthorityHost to override the default
                           Azure authority host. If this is set, then the IdentityTenantID
@@ -388,6 +396,10 @@ spec:
                       AuthPodIdentity allows users to select the platform native identity
                       mechanism
                     properties:
+                      externalId:
+                        description: ExternalID sets the AWS ExternalID to use when
+                          assuming the role specified by RoleArn
+                        type: string
                       identityAuthorityHost:
                         description: Set identityAuthorityHost to override the default
                           Azure authority host. If this is set, then the IdentityTenantID
@@ -525,6 +537,10 @@ spec:
                   AuthPodIdentity allows users to select the platform native identity
                   mechanism
                 properties:
+                  externalId:
+                    description: ExternalID sets the AWS ExternalID to use when assuming
+                      the role specified by RoleArn
+                    type: string
                   identityAuthorityHost:
                     description: Set identityAuthorityHost to override the default
                       Azure authority host. If this is set, then the IdentityTenantID

--- a/pkg/scalers/aws/aws_authorization.go
+++ b/pkg/scalers/aws/aws_authorization.go
@@ -17,7 +17,8 @@ limitations under the License.
 package aws
 
 type AuthorizationMetadata struct {
-	AwsRoleArn string
+	AwsRoleArn        string
+	AwsRoleExternalID string
 
 	AwsAccessKeyID     string
 	AwsSecretAccessKey string

--- a/pkg/scalers/aws/aws_common.go
+++ b/pkg/scalers/aws/aws_common.go
@@ -67,7 +67,11 @@ func GetAwsConfig(ctx context.Context, awsAuthorization AuthorizationMetadata) (
 
 	if awsAuthorization.AwsRoleArn != "" {
 		stsSvc := sts.NewFromConfig(cfg)
-		stsCredentialProvider := stscreds.NewAssumeRoleProvider(stsSvc, awsAuthorization.AwsRoleArn, func(_ *stscreds.AssumeRoleOptions) {})
+		stsCredentialProvider := stscreds.NewAssumeRoleProvider(stsSvc, awsAuthorization.AwsRoleArn, func(options *stscreds.AssumeRoleOptions) {
+			if awsAuthorization.AwsRoleExternalID != "" {
+				options.ExternalID = &awsAuthorization.AwsRoleExternalID
+			}
+		})
 		cfg.Credentials = aws.NewCredentialsCache(stsCredentialProvider)
 	}
 	return &cfg, err
@@ -85,6 +89,9 @@ func GetAwsAuthorization(uniqueKey, awsRegion string, podIdentity kedav1alpha1.A
 		meta.UsingPodIdentity = true
 		if val, ok := authParams["awsRoleArn"]; ok && val != "" {
 			meta.AwsRoleArn = val
+		}
+		if val, ok := authParams["awsRoleExternalId"]; ok && val != "" {
+			meta.AwsRoleExternalID = val
 		}
 		return meta, nil
 	}

--- a/pkg/scalers/aws/aws_common_test.go
+++ b/pkg/scalers/aws/aws_common_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+)
+
+func TestGetAwsAuthorizationParsesExternalID(t *testing.T) {
+	authParams := map[string]string{
+		"awsRoleArn":        "arn:aws:iam::123456789012:role/TestRole",
+		"awsRoleExternalId": "my-external-id",
+	}
+	podIdentity := kedav1alpha1.AuthPodIdentity{
+		Provider: kedav1alpha1.PodIdentityProviderAws,
+	}
+
+	meta, err := GetAwsAuthorization("test-key", "us-east-1", podIdentity, map[string]string{}, authParams, map[string]string{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/TestRole", meta.AwsRoleArn)
+	assert.Equal(t, "my-external-id", meta.AwsRoleExternalID)
+}
+
+func TestGetAwsAuthorizationWithEmptyExternalID(t *testing.T) {
+	authParams := map[string]string{
+		"awsRoleArn": "arn:aws:iam::123456789012:role/TestRole",
+	}
+	podIdentity := kedav1alpha1.AuthPodIdentity{
+		Provider: kedav1alpha1.PodIdentityProviderAws,
+	}
+
+	meta, err := GetAwsAuthorization("test-key", "us-east-1", podIdentity, map[string]string{}, authParams, map[string]string{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/TestRole", meta.AwsRoleArn)
+	assert.Empty(t, meta.AwsRoleExternalID)
+}
+
+func TestGetAwsAuthorizationWithOnlyExternalID(t *testing.T) {
+	authParams := map[string]string{
+		"awsRoleExternalId": "my-external-id",
+	}
+	podIdentity := kedav1alpha1.AuthPodIdentity{
+		Provider: kedav1alpha1.PodIdentityProviderAws,
+	}
+
+	meta, err := GetAwsAuthorization("test-key", "us-east-1", podIdentity, map[string]string{}, authParams, map[string]string{})
+
+	assert.NoError(t, err)
+	assert.Empty(t, meta.AwsRoleArn)
+	assert.Equal(t, "my-external-id", meta.AwsRoleExternalID)
+}

--- a/pkg/scalers/aws/aws_config_cache.go
+++ b/pkg/scalers/aws/aws_config_cache.go
@@ -73,7 +73,7 @@ func (a *sharedConfigCache) getCacheKey(awsAuthorization AuthorizationMetadata) 
 	if awsAuthorization.AwsAccessKeyID != "" {
 		key = fmt.Sprintf("%s-%s-%s-%s", awsAuthorization.AwsAccessKeyID, awsAuthorization.AwsSecretAccessKey, awsAuthorization.AwsSessionToken, awsAuthorization.AwsRegion)
 	} else if awsAuthorization.AwsRoleArn != "" {
-		key = fmt.Sprintf("%s-%s", awsAuthorization.AwsRoleArn, awsAuthorization.AwsRegion)
+		key = fmt.Sprintf("%s-%s-%s", awsAuthorization.AwsRoleArn, awsAuthorization.AwsRoleExternalID, awsAuthorization.AwsRegion)
 	}
 	// to avoid sensitive data as key and to use a constant key size,
 	// we hash the key with sha3
@@ -105,7 +105,7 @@ func (a *sharedConfigCache) GetCredentials(ctx context.Context, awsAuthorization
 
 	if awsAuthorization.UsingPodIdentity {
 		if awsAuthorization.AwsRoleArn != "" {
-			cfg.Credentials = a.retrievePodIdentityCredentials(ctx, cfg, awsAuthorization.AwsRoleArn)
+			cfg.Credentials = a.retrievePodIdentityCredentials(ctx, cfg, awsAuthorization.AwsRoleArn, awsAuthorization.AwsRoleExternalID)
 		}
 	} else {
 		cfg.Credentials = a.retrieveStaticCredentials(awsAuthorization)
@@ -145,7 +145,7 @@ func (a *sharedConfigCache) RemoveCachedEntry(awsAuthorization AuthorizationMeta
 // retrievePodIdentityCredentials returns an *aws.CredentialsCache to assume given roleArn.
 // It tries first to assume the role using WebIdentity (OIDC federation) and if this method fails,
 // it tries to assume the role using KEDA's role (AssumeRole)
-func (a *sharedConfigCache) retrievePodIdentityCredentials(ctx context.Context, cfg aws.Config, roleArn string) *aws.CredentialsCache {
+func (a *sharedConfigCache) retrievePodIdentityCredentials(ctx context.Context, cfg aws.Config, roleArn, roleExternalID string) *aws.CredentialsCache {
 	stsSvc := sts.NewFromConfig(cfg)
 
 	if webIdentityTokenFile != "" {
@@ -167,6 +167,9 @@ func (a *sharedConfigCache) retrievePodIdentityCredentials(ctx context.Context, 
 	a.logger.V(1).Info(fmt.Sprintf("using assume role to retrieve token for arnRole %s", roleArn))
 	assumeRoleCredentialProvider := stscreds.NewAssumeRoleProvider(stsSvc, roleArn, func(options *stscreds.AssumeRoleOptions) {
 		options.RoleSessionName = "KEDA"
+		if roleExternalID != "" {
+			options.ExternalID = &roleExternalID
+		}
 	})
 	return aws.NewCredentialsCache(assumeRoleCredentialProvider)
 }

--- a/pkg/scalers/aws/aws_config_cache_test.go
+++ b/pkg/scalers/aws/aws_config_cache_test.go
@@ -120,3 +120,46 @@ func TestCredentialsShouldBeCachedPerRegion(t *testing.T) {
 	assert.NoError(t, err2)
 	assert.NotEqual(t, cred1, cred2, "Credentials should be stored per region")
 }
+
+func TestCredentialsShouldBeCachedPerExternalID(t *testing.T) {
+	cache := newSharedConfigsCache()
+	cache.logger = logr.Discard()
+	awsAuthorization1 := AuthorizationMetadata{
+		TriggerUniqueKey:  "test5-key",
+		AwsRegion:         "test5-region",
+		AwsRoleArn:        "arn:aws:iam::123456789012:role/TestRole",
+		AwsRoleExternalID: "external-id-1",
+	}
+	awsAuthorization2 := AuthorizationMetadata{
+		TriggerUniqueKey:  "test5-key",
+		AwsRegion:         "test5-region",
+		AwsRoleArn:        "arn:aws:iam::123456789012:role/TestRole",
+		AwsRoleExternalID: "external-id-2",
+	}
+	cacheKey1 := cache.getCacheKey(awsAuthorization1)
+	cacheKey2 := cache.getCacheKey(awsAuthorization2)
+
+	assert.NotEqual(t, cacheKey1, cacheKey2, "Cache keys should be different for different external IDs")
+}
+
+func TestCacheKeyIncludesExternalID(t *testing.T) {
+	cache := newSharedConfigsCache()
+	cache.logger = logr.Discard()
+
+	authWithExternalID := AuthorizationMetadata{
+		TriggerUniqueKey:  "test6-key",
+		AwsRegion:         "us-east-1",
+		AwsRoleArn:        "arn:aws:iam::123456789012:role/TestRole",
+		AwsRoleExternalID: "my-external-id",
+	}
+	authWithoutExternalID := AuthorizationMetadata{
+		TriggerUniqueKey: "test6-key",
+		AwsRegion:        "us-east-1",
+		AwsRoleArn:       "arn:aws:iam::123456789012:role/TestRole",
+	}
+
+	keyWithExternalID := cache.getCacheKey(authWithExternalID)
+	keyWithoutExternalID := cache.getCacheKey(authWithoutExternalID)
+
+	assert.NotEqual(t, keyWithExternalID, keyWithoutExternalID, "Cache key should include external ID")
+}

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -218,6 +218,9 @@ func ResolveAuthRefAndPodIdentity(ctx context.Context, client client.Client, log
 						fmt.Errorf("roleArn can't be set if KEDA isn't identity owner, current value: '%s'", *podIdentity.IdentityOwner)
 				}
 				authParams["awsRoleArn"] = *podIdentity.RoleArn
+				if podIdentity.ExternalID != nil {
+					authParams["awsRoleExternalId"] = *podIdentity.ExternalID
+				}
 			}
 			if podIdentity.IsWorkloadIdentityOwner() {
 				value, err := resolveServiceAccountAnnotation(ctx, client, podTemplateSpec.Spec.ServiceAccountName, namespace, kedav1alpha1.PodIdentityAnnotationEKS, true)


### PR DESCRIPTION
This PR adds support for passing an `externalId` when KEDA assumes an AWS IAM role via the `TriggerAuthentication` resource. The external ID is a security best practice for cross-account role assumption that prevents the "confused deputy" problem.

The `externalId` is specified as a field in `spec.podIdentity`, consistent with how `roleArn` is already modeled on `AuthPodIdentity`:

```yaml
apiVersion: keda.sh/v1alpha1
kind: TriggerAuthentication
metadata:
  name: aws-trigger-auth
spec:
  podIdentity:
    provider: aws
    roleArn: "arn:aws:iam::123456789012:role/your-cross-account-role"
    externalId: "your-external-id-here"
```

The external ID is passed to AWS STS during the `AssumeRole` API call, which is required when assuming roles that have an `sts:ExternalId` condition in their trust policy.

> **Note:** This PR supersedes #7388, which implemented the same feature using a metadata annotation (`keda.sh/aws-role-external-id`). Both PR authors are from the same organization. Based on the review feedback in #7388 — specifically [@JorTurFer's request](https://github.com/kedacore/keda/pull/7388#issuecomment-2641682855) to use a spec field instead of an annotation for better alignment with existing configurations — this PR reimplements the feature as a first-class spec field. PR #7388 will not be continued and can be closed in favour of this one.

### Changes

- Add `ExternalID *string` field (`json:"externalId,omitempty"`) to `AuthPodIdentity` spec
- Add `AwsRoleExternalID` field to `AuthorizationMetadata`
- Map `podIdentity.ExternalID` to `authParams["awsRoleExternalId"]` in `ResolveAuthRefAndPodIdentity`
- Parse `awsRoleExternalId` from `authParams` in `GetAwsAuthorization`
- Include `ExternalID` in cache key generation to ensure separate cache entries per external ID
- Pass `ExternalID` to `AssumeRoleOptions` in `retrievePodIdentityCredentials` (pod identity path)
- Pass `ExternalID` to `AssumeRoleOptions` in `GetAwsConfig` (deprecated aws-eks path)
- Regenerate CRD manifests and deepcopy code
- Add unit tests for external ID parsing and cache key differentiation

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #

Relates to #7388