### PR TITLE
fix: skip redundant lastActiveTime updates to prevent cascading cooldown reset

### DIFF
--- a/apis/keda/v1alpha1/withtriggers_types.go
+++ b/apis/keda/v1alpha1/withtriggers_types.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	// Default polling interval for a ScaledObject triggers if no pollingInterval is defined.
-	defaultPollingInterval = 30
+	// DefaultPollingInterval is the default polling interval (in seconds)
+	// for a ScaledObject's triggers when no pollingInterval is defined.
+	DefaultPollingInterval = 30
 )
 
 // +kubebuilder:object:root=true
@@ -86,7 +87,7 @@ func (t *WithTriggers) GetPollingInterval() time.Duration {
 		return time.Second * time.Duration(*t.Spec.PollingInterval)
 	}
 
-	return time.Second * time.Duration(defaultPollingInterval)
+	return time.Second * time.Duration(DefaultPollingInterval)
 }
 
 // GenerateIdentifier returns identifier for the object in for "kind.namespace.name"

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -76,6 +76,27 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 			logger.V(1).Info("Some triggers defined in ScaledObject are not working correctly")
 		default:
 			// triggers are active, but we didn't need to scale (replica count > 0)
+
+			// Guard: skip redundant lastActiveTime writes when the timestamp was
+			// already updated within the current polling interval. Under API
+			// throttling, the operator may re-evaluate objects whose previous
+			// status PATCH hasn't been applied yet, causing lastActiveTime to be
+			// refreshed even though the trigger went inactive. This resets the
+			// cooldown timer and delays scale-to-zero indefinitely.
+			// See https://github.com/kedacore/keda/issues/7613
+			if scaledObject.Status.LastActiveTime != nil {
+				pollingInterval := time.Duration(kedav1alpha1.DefaultPollingInterval) * time.Second
+				if scaledObject.Spec.PollingInterval != nil {
+					pollingInterval = time.Duration(*scaledObject.Spec.PollingInterval) * time.Second
+				}
+				if time.Since(scaledObject.Status.LastActiveTime.Time) < pollingInterval {
+					logger.V(1).Info("Skipping redundant lastActiveTime update",
+						"LastActiveTime", scaledObject.Status.LastActiveTime,
+						"PollingInterval", pollingInterval)
+					break
+				}
+			}
+
 			result.LastActiveTime = &metav1.Time{Time: time.Now()}
 		}
 	} else {

--- a/pkg/scaling/executor/scale_scaledobjects_test.go
+++ b/pkg/scaling/executor/scale_scaledobjects_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -679,6 +680,161 @@ func TestNoScaleFromMinReplicasWhenActiveAndPausedScaleOutAnnotationSet(t *testi
 	result := scaleExecutor.RequestScale(context.TODO(), &scaledObject, true, false, ScaleExecutorOptions{})
 
 	assert.Equal(t, int32(0), scale.Spec.Replicas)
+	condition := result.Conditions.GetActiveCondition()
+	assert.Equal(t, true, condition.IsTrue())
+}
+
+func TestSkipRedundantLastActiveTimeUpdate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	mockScaleInterface := mock_scale.NewMockScaleInterface(ctrl)
+
+	scaleExecutor := NewScaleExecutor(client, mockScaleClient, nil, recorder)
+
+	minReplicas := int32(1)
+	recentTime := v1.NewTime(time.Now().Add(-5 * time.Second))
+
+	scaledObject := v1alpha1.ScaledObject{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: v1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &v1alpha1.ScaleTarget{
+				Name: "name",
+			},
+			MinReplicaCount: &minReplicas,
+		},
+		Status: v1alpha1.ScaledObjectStatus{
+			ScaleTargetGVKR: &v1alpha1.GroupVersionKindResource{
+				Group: "apps",
+				Kind:  "Deployment",
+			},
+			LastActiveTime: &recentTime,
+		},
+	}
+
+	numberOfReplicas := int32(3)
+
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &numberOfReplicas,
+		},
+	})
+
+	mockScaleClient.EXPECT().Scales(gomock.Any()).Return(mockScaleInterface).Times(0)
+
+	// LastActiveTime update is skipped because lastActiveTime (5s ago) is
+	// within the default polling interval (30s), so result.LastActiveTime is nil.
+	result := scaleExecutor.RequestScale(context.Background(), &scaledObject, true, false, ScaleExecutorOptions{})
+
+	assert.Nil(t, result.LastActiveTime)
+	condition := result.Conditions.GetActiveCondition()
+	assert.Equal(t, true, condition.IsTrue())
+}
+
+func TestSkipRedundantLastActiveTimeUpdateWithCustomPollingInterval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	mockScaleInterface := mock_scale.NewMockScaleInterface(ctrl)
+
+	scaleExecutor := NewScaleExecutor(client, mockScaleClient, nil, recorder)
+
+	minReplicas := int32(1)
+	pollingInterval := int32(10)
+	recentTime := v1.NewTime(time.Now().Add(-5 * time.Second))
+
+	scaledObject := v1alpha1.ScaledObject{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: v1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &v1alpha1.ScaleTarget{
+				Name: "name",
+			},
+			MinReplicaCount: &minReplicas,
+			PollingInterval: &pollingInterval,
+		},
+		Status: v1alpha1.ScaledObjectStatus{
+			ScaleTargetGVKR: &v1alpha1.GroupVersionKindResource{
+				Group: "apps",
+				Kind:  "Deployment",
+			},
+			LastActiveTime: &recentTime,
+		},
+	}
+
+	numberOfReplicas := int32(3)
+
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &numberOfReplicas,
+		},
+	})
+
+	mockScaleClient.EXPECT().Scales(gomock.Any()).Return(mockScaleInterface).Times(0)
+
+	// LastActiveTime update is skipped because lastActiveTime (5s ago) is
+	// within the custom polling interval (10s), so result.LastActiveTime is nil.
+	result := scaleExecutor.RequestScale(context.Background(), &scaledObject, true, false, ScaleExecutorOptions{})
+
+	assert.Nil(t, result.LastActiveTime)
+	condition := result.Conditions.GetActiveCondition()
+	assert.Equal(t, true, condition.IsTrue())
+}
+
+func TestUpdateLastActiveTimeWhenExpired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	mockScaleInterface := mock_scale.NewMockScaleInterface(ctrl)
+
+	scaleExecutor := NewScaleExecutor(client, mockScaleClient, nil, recorder)
+
+	minReplicas := int32(1)
+	oldTime := v1.NewTime(time.Now().Add(-60 * time.Second))
+
+	scaledObject := v1alpha1.ScaledObject{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+		Spec: v1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &v1alpha1.ScaleTarget{
+				Name: "name",
+			},
+			MinReplicaCount: &minReplicas,
+		},
+		Status: v1alpha1.ScaledObjectStatus{
+			ScaleTargetGVKR: &v1alpha1.GroupVersionKindResource{
+				Group: "apps",
+				Kind:  "Deployment",
+			},
+			LastActiveTime: &oldTime,
+		},
+	}
+
+	numberOfReplicas := int32(3)
+
+	client.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).SetArg(2, appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &numberOfReplicas,
+		},
+	})
+
+	mockScaleClient.EXPECT().Scales(gomock.Any()).Return(mockScaleInterface).Times(0)
+
+	// lastActiveTime (60s ago) exceeds the default polling interval (30s),
+	// so result.LastActiveTime should be set.
+	result := scaleExecutor.RequestScale(context.Background(), &scaledObject, true, false, ScaleExecutorOptions{})
+
+	assert.NotNil(t, result.LastActiveTime)
 	condition := result.Conditions.GetActiveCondition()
 	assert.Equal(t, true, condition.IsTrue())
 }


### PR DESCRIPTION
## Summary

* Add a guard in `RequestScale` that skips redundant `lastActiveTime` writes when the existing timestamp is still within the current polling interval
* Under client-side API throttling, the operator re-evaluates ScaledObjects before their previous status PATCH has been applied. The stale `Active=True` status causes `updateLastActiveTime` to refresh the timestamp even though the trigger is already inactive, resetting the cooldown timer and delaying scale-to-zero indefinitely
* The guard prevents this cascading cooldown reset by recognizing that a write within the polling interval cannot meaningfully advance the cooldown window

See also: #7610
Fixes: #7613

## Test plan

* New unit test `TestSkipRedundantLastActiveTimeUpdate` verifies that `lastActiveTime` is not updated when it was already set within the polling interval (5s < 30s default)
* New unit test `TestUpdateLastActiveTimeWhenExpired` verifies that `lastActiveTime` IS updated when enough time has elapsed (60s > 30s default)
* All existing executor tests pass unchanged