### PR TITLE
fix(metrics-api): use correct label selector in getEndpointsUrlsFromServiceURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Github Runner Scaler**: Improve URL construction and error handling ([#7495](https://github.com/kedacore/keda/pull/7495))
 - **Github Runner Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **Loki Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
+- **Metrics API Scaler**: Fix `aggregateFromKubeServiceEndpoints` using empty label selector that matched all EndpointSlices in the namespace instead of only the target service's ([#7641](https://github.com/kedacore/keda/issues/7641))
 - **NATS JetStream Scaler**: URL-encode user input in monitoring URL construction ([#7483](https://github.com/kedacore/keda/pull/7483))
 - **Prometheus Scaler**: Handle NaN results in the same manner as Inf ([#7475](https://github.com/kedacore/keda/issues/7475))
 - **Prometheus Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -325,10 +325,9 @@ func (s *metricsAPIScaler) getEndpointsUrlsFromServiceURL(ctx context.Context, s
 	}
 	// get service serviceEndpointsSlices
 	serviceEndpointsSlices := &discoveryV1.EndpointSliceList{}
-	serviceNameSelector := labels.NewSelector()
-	serviceNameSelector.Matches(labels.Set(map[string]string{
+	serviceNameSelector := labels.SelectorFromSet(labels.Set{
 		discoveryV1.LabelServiceName: serviceName,
-	}))
+	})
 	err = s.kubeClient.List(ctx, serviceEndpointsSlices, &client.ListOptions{
 		LabelSelector: serviceNameSelector,
 		Namespace:     namespace,

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -8,8 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	discoveryV1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
@@ -254,4 +258,53 @@ func TestGetMetricValueErrorMessage(t *testing.T) {
 	_, err := s.getMetricValue(context.TODO())
 
 	assert.Equal(t, err.Error(), "/api/v1/: api returned 418")
+}
+
+func TestGetEndpointsUrlsFromServiceURL_SelectorFiltersCorrectly(t *testing.T) {
+	ready := true
+	port8080 := int32(8080)
+
+	targetSlice := &discoveryV1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-service-abc",
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				discoveryV1.LabelServiceName: "my-service",
+			},
+		},
+		Ports: []discoveryV1.EndpointPort{{Port: &port8080}},
+		Endpoints: []discoveryV1.Endpoint{{
+			Addresses:  []string{"10.0.0.1"},
+			Conditions: discoveryV1.EndpointConditions{Ready: &ready},
+		}},
+	}
+
+	unrelatedSlice := &discoveryV1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-service-xyz",
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				discoveryV1.LabelServiceName: "other-service",
+			},
+		},
+		Ports: []discoveryV1.EndpointPort{{Port: &port8080}},
+		Endpoints: []discoveryV1.Endpoint{{
+			Addresses:  []string{"10.0.0.99"},
+			Conditions: discoveryV1.EndpointConditions{Ready: &ready},
+		}},
+	}
+
+	kubeClient := fake.NewClientBuilder().
+		WithLists(&discoveryV1.EndpointSliceList{Items: []discoveryV1.EndpointSlice{*targetSlice, *unrelatedSlice}}).
+		Build()
+
+	s := metricsAPIScaler{
+		kubeClient: kubeClient,
+		logger:     logr.Discard(),
+	}
+
+	urls, err := s.getEndpointsUrlsFromServiceURL(t.Context(), "http://my-service.my-namespace.svc:8080/metrics")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"http://10.0.0.1:8080/metrics"}, urls,
+		"should only return endpoints from my-service, not other-service")
 }


### PR DESCRIPTION
Fix the issue described in https://github.com/kedacore/keda/issues/7641

### Root cause of the issue
`labels.NewSelector()` creates an empty selector matching everything, and `Matches()` is read-only — its return value was discarded. This caused KEDA to list all `EndpointSlices` in the namespace instead of filtering by `kubernetes.io/service-name`.

### Content of this PR
- Add a unit test that seeds a fake client with two services' `EndpointSlices` and asserts only the target service's endpoints are returned.
- Replace with `labels.SelectorFromSet()` which correctly constrains the selector. 

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes https://github.com/kedacore/keda/issues/7641

