### PR TITLE
fix: lower log level for ScaledObject paused replicas transitioning state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
+- **General**: Fix `ScaledObject paused replicas are being scaled` being logged at error level and marking ScaledObject as not ready during the normal pausing transition ([#6604](https://github.com/kedacore/keda/issues/6604))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **Forgejo Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))
+- **General**: Fix `ScaledObject paused replicas are being scaled` being logged at error level and marking ScaledObject as not ready during the normal pausing transition ([#6604](https://github.com/kedacore/keda/issues/6604))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **Forgejo Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -349,7 +349,8 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(ctx context.Context, logg
 		logger.Info("Initializing Scaling logic according to ScaledObject Specification")
 	}
 	if scaledObject.NeedToBePausedByAnnotation() && conditions.GetPausedCondition().Status != metav1.ConditionTrue {
-		return "ScaledObject paused replicas are being scaled", fmt.Errorf("ScaledObject paused replicas are being scaled")
+		logger.Info("Warning: ScaledObject paused replicas are being scaled")
+		return "ScaledObject paused replicas are being scaled", nil
 	}
 	return kedav1alpha1.ScaledObjectConditionReadySuccessMessage, nil
 }

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -349,7 +349,7 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(ctx context.Context, logg
 		logger.Info("Initializing Scaling logic according to ScaledObject Specification")
 	}
 	if scaledObject.NeedToBePausedByAnnotation() && conditions.GetPausedCondition().Status != metav1.ConditionTrue {
-		logger.Info("Warning: ScaledObject paused replicas are being scaled")
+		logger.Info("ScaledObject paused replicas are being scaled")
 		return "ScaledObject paused replicas are being scaled", nil
 	}
 	return kedav1alpha1.ScaledObjectConditionReadySuccessMessage, nil

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -320,6 +320,7 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(ctx context.Context, logg
 		}
 		logger.Info("Initializing Scaling logic according to ScaledObject Specification")
 	}
+
 	return kedav1alpha1.ScaledObjectConditionReadySuccessMessage, nil
 }
 


### PR DESCRIPTION
When introducing the `autoscaling.keda.sh/paused-replicas` annotation on a ScaledObject, there is a brief window during the first reconciliation where the annotation is set but the `PausedCondition` status hasn't been committed yet. During this window, the controller was returning a non-nil error, causing:

1. `logger.Error(...)` — error-level log spam on every reconciliation during a normal, expected pausing transition
2. `ReadyCondition=False` with reason `ScaledObjectCheckFailed` — incorrectly marking the ScaledObject as unhealthy
3. A `Warning` Kubernetes event — unnecessary noise in the event stream

Fix: log at info level and return `nil` so this expected transitional state is not treated as a failure.

### Checklist

- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

### Wait for:
- https://github.com/kedacore/keda/pull/7664

Fixes #6604