### PR TITLE
feat(metrics-api): add zeroOnMissingEndpoints option for aggregated endpoint scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
 - **Kubernetes Workload Scaler**: Add `groupByNode` parameter ([#7628](https://github.com/kedacore/keda/issues/7628))
+- **Metrics API Scaler**: Add `zeroOnMissingEndpoints` option for aggregated endpoint scaling ([#7651](https://github.com/kedacore/keda/issues/7651))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **Metrics API Scaler**: Add `zeroOnMissingEndpoints` option for aggregated endpoint scaling ([#7651](https://github.com/kedacore/keda/issues/7651))
 
 ### Fixes
 

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -48,6 +48,7 @@ type metricsAPIScalerMetadata struct {
 	UnsafeSsl                         bool            `keda:"name=unsafeSsl,order=triggerMetadata,default=false"`
 	AggregateFromKubeServiceEndpoints bool            `keda:"name=aggregateFromKubeServiceEndpoints,order=triggerMetadata,default=false"`
 	AggregationType                   AggregationType `keda:"name=aggregationType,order=triggerMetadata,default=average,enum=average;sum;max;min"`
+	ZeroOnMissingEndpoints            bool            `keda:"name=zeroOnMissingEndpoints,order=triggerMetadata,default=false"`
 	// Authentication parameters for connecting to the metrics API
 	MetricsAPIAuth *authentication.Config `keda:"optional"`
 
@@ -124,6 +125,10 @@ func parseMetricsAPIMetadata(config *scalersconfig.ScalerConfig) (*metricsAPISca
 	// Special validation for targetValue when not used as metric source
 	if meta.TargetValue == 0 && !config.AsMetricSource {
 		return nil, fmt.Errorf("no targetValue given in metadata")
+	}
+
+	if meta.ZeroOnMissingEndpoints && !meta.AggregateFromKubeServiceEndpoints {
+		return nil, fmt.Errorf("zeroOnMissingEndpoints requires aggregateFromKubeServiceEndpoints to be true")
 	}
 
 	return meta, nil
@@ -377,6 +382,10 @@ func (s *metricsAPIScaler) getMetricValue(ctx context.Context) (float64, error) 
 			return 0, fmt.Errorf("failed to get kubernetes endpoints urls from configured service URL")
 		}
 		if len(endpointsUrls) == 0 {
+			if s.metadata.ZeroOnMissingEndpoints {
+				s.logger.V(1).Info("no endpoints URLs were given for the service name but returning metric value 0 because of zeroOnMissingEndpoints")
+				return 0, nil
+			}
 			return 0, fmt.Errorf("no endpoints URLs were given for the service name")
 		}
 		return s.aggregateMetricsFromMultipleEndpoints(ctx, endpointsUrls)

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -51,6 +51,7 @@ type metricsAPIScalerMetadata struct {
 	AggregateFromKubeServiceEndpoints bool            `keda:"name=aggregateFromKubeServiceEndpoints,order=triggerMetadata,default=false"`
 	AggregationType                   AggregationType `keda:"name=aggregationType,order=triggerMetadata,default=average,enum=average;sum;max;min"`
 	Timeout                           time.Duration   `keda:"name=timeout, order=triggerMetadata, optional"`
+	ZeroOnMissingEndpoints            bool            `keda:"name=zeroOnMissingEndpoints,order=triggerMetadata,default=false"`
 	// Authentication parameters for connecting to the metrics API
 	MetricsAPIAuth *authentication.Config `keda:"optional"`
 
@@ -133,6 +134,10 @@ func parseMetricsAPIMetadata(config *scalersconfig.ScalerConfig) (*metricsAPISca
 	// Special validation for targetValue when not used as metric source
 	if meta.TargetValue == 0 && !config.AsMetricSource {
 		return nil, fmt.Errorf("no targetValue given in metadata")
+	}
+
+	if meta.ZeroOnMissingEndpoints && !meta.AggregateFromKubeServiceEndpoints {
+		return nil, fmt.Errorf("zeroOnMissingEndpoints requires aggregateFromKubeServiceEndpoints to be true")
 	}
 
 	return meta, nil
@@ -386,6 +391,10 @@ func (s *metricsAPIScaler) getMetricValue(ctx context.Context) (float64, error) 
 			return 0, fmt.Errorf("failed to get kubernetes endpoints urls from configured service URL")
 		}
 		if len(endpointsUrls) == 0 {
+			if s.metadata.ZeroOnMissingEndpoints {
+				s.logger.V(1).Info("no endpoints URLs were given for the service name but returning metric value 0 because of zeroOnMissingEndpoints")
+				return 0, nil
+			}
 			return 0, fmt.Errorf("no endpoints URLs were given for the service name")
 		}
 		return s.aggregateMetricsFromMultipleEndpoints(ctx, endpointsUrls)

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -3,8 +3,10 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	discoveryV1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -38,6 +41,15 @@ var testMetricsAPIMetadata = []metricsAPIMetadataTestData{
 	{metadata: map[string]string{"valueLocation": "metric", "targetValue": "aa"}, raisesError: true},
 	// Missing targetValue
 	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric"}, raisesError: true},
+	// OK with just aggregateFromKubeServiceEndpoints
+	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric.test", "targetValue": "42",
+		"aggregateFromKubeServiceEndpoints": "true"}, raisesError: false},
+	// OK with aggregateFromKubeServiceEndpoints AND zeroOnMissingEndpoints
+	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric.test", "targetValue": "42",
+		"aggregateFromKubeServiceEndpoints": "true", "zeroOnMissingEndpoints": "true"}, raisesError: false},
+	// Invalid configuration: zeroOnMissingEndpoints requires aggregateFromKubeServiceEndpoints
+	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric.test", "targetValue": "42",
+		"aggregateFromKubeServiceEndpoints": "false", "zeroOnMissingEndpoints": "true"}, raisesError: true},
 }
 
 type metricAPIAuthMetadataTestData struct {
@@ -242,6 +254,151 @@ func (m *MockHTTPRoundTripper) RoundTrip(request *http.Request) (*http.Response,
 	resp := args.Get(0).(*http.Response)
 	resp.Request = request
 	return resp, args.Error(1)
+}
+
+func newMockTransport() *MockHTTPRoundTripper {
+	m := &MockHTTPRoundTripper{}
+	m.On("RoundTrip", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"metric": 42}`)),
+	}, nil)
+	return m
+}
+
+func TestGetMetricValueZeroOnMissingEndpoints(t *testing.T) {
+	readyTrue := true
+	readyFalse := false
+	port80 := int32(80)
+
+	tests := []struct {
+		name           string
+		zeroOnMissing  bool
+		endpointSlices []discoveryV1.EndpointSlice
+		wantValue      float64
+		wantErr        bool
+		wantErrMsg     string
+	}{
+		{
+			name:           "no endpoints, zeroOnMissingEndpoints=true returns 0",
+			zeroOnMissing:  true,
+			endpointSlices: nil,
+			wantValue:      0,
+			wantErr:        false,
+		},
+		{
+			name:           "no endpoints, zeroOnMissingEndpoints=false returns error",
+			zeroOnMissing:  false,
+			endpointSlices: nil,
+			wantValue:      0,
+			wantErr:        true,
+			wantErrMsg:     "no endpoints URLs were given for the service name",
+		},
+		{
+			name:          "only not-ready endpoints, zeroOnMissingEndpoints=true returns 0",
+			zeroOnMissing: true,
+			endpointSlices: []discoveryV1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc",
+						Namespace: "ns",
+						Labels:    map[string]string{discoveryV1.LabelServiceName: "svc"},
+					},
+					Endpoints: []discoveryV1.Endpoint{
+						{
+							Addresses:  []string{"10.0.0.1"},
+							Conditions: discoveryV1.EndpointConditions{Ready: &readyFalse},
+						},
+					},
+					Ports: []discoveryV1.EndpointPort{
+						{Port: &port80},
+					},
+				},
+			},
+			wantValue: 0,
+			wantErr:   false,
+		},
+		{
+			name:          "only not-ready endpoints, zeroOnMissingEndpoints=false returns error",
+			zeroOnMissing: false,
+			endpointSlices: []discoveryV1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc",
+						Namespace: "ns",
+						Labels:    map[string]string{discoveryV1.LabelServiceName: "svc"},
+					},
+					Endpoints: []discoveryV1.Endpoint{
+						{
+							Addresses:  []string{"10.0.0.1"},
+							Conditions: discoveryV1.EndpointConditions{Ready: &readyFalse},
+						},
+					},
+					Ports: []discoveryV1.EndpointPort{
+						{Port: &port80},
+					},
+				},
+			},
+			wantValue:  0,
+			wantErr:    true,
+			wantErrMsg: "no endpoints URLs were given for the service name",
+		},
+		{
+			name:          "endpoints present, zeroOnMissingEndpoints=true fetches metrics normally",
+			zeroOnMissing: true,
+			endpointSlices: []discoveryV1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc",
+						Namespace: "ns",
+						Labels:    map[string]string{discoveryV1.LabelServiceName: "svc"},
+					},
+					Endpoints: []discoveryV1.Endpoint{
+						{
+							Addresses:  []string{"10.0.0.1"},
+							Conditions: discoveryV1.EndpointConditions{Ready: &readyTrue},
+						},
+					},
+					Ports: []discoveryV1.EndpointPort{
+						{Port: &port80},
+					},
+				},
+			},
+			wantValue: 42,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var runtimeObjects []client.Object
+			for i := range tt.endpointSlices {
+				runtimeObjects = append(runtimeObjects, &tt.endpointSlices[i])
+			}
+			kubeClient := fake.NewClientBuilder().WithObjects(runtimeObjects...).Build()
+
+			s := metricsAPIScaler{
+				metadata: &metricsAPIScalerMetadata{
+					URL:                               "http://svc.ns.svc.cluster.local:80/metrics",
+					ValueLocation:                     "metric",
+					Format:                            JSONFormat,
+					AggregateFromKubeServiceEndpoints: true,
+					ZeroOnMissingEndpoints:            tt.zeroOnMissing,
+				},
+				httpClient: &http.Client{Transport: newMockTransport()},
+				logger:     InitializeLogger(&scalersconfig.ScalerConfig{}, "metrics_api_scaler"),
+				kubeClient: kubeClient,
+			}
+
+			val, err := s.getMetricValue(t.Context())
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
 }
 
 func TestGetMetricValueErrorMessage(t *testing.T) {

--- a/pkg/scalers/metrics_api_scaler_test.go
+++ b/pkg/scalers/metrics_api_scaler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	discoveryV1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -47,6 +48,15 @@ var testMetricsAPIMetadata = []metricsAPIMetadataTestData{
 	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "timeout": "-1"}, raisesError: true},
 	// Invalid - not a number - HTTP timeout
 	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric", "targetValue": "42", "timeout": "a"}, raisesError: true},
+	// OK with just aggregateFromKubeServiceEndpoints
+	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric.test", "targetValue": "42",
+		"aggregateFromKubeServiceEndpoints": "true"}, raisesError: false},
+	// OK with aggregateFromKubeServiceEndpoints AND zeroOnMissingEndpoints
+	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric.test", "targetValue": "42",
+		"aggregateFromKubeServiceEndpoints": "true", "zeroOnMissingEndpoints": "true"}, raisesError: false},
+	// Invalid configuration: zeroOnMissingEndpoints requires aggregateFromKubeServiceEndpoints
+	{metadata: map[string]string{"url": "http://dummy:1230/api/v1/", "valueLocation": "metric.test", "targetValue": "42",
+		"aggregateFromKubeServiceEndpoints": "false", "zeroOnMissingEndpoints": "true"}, raisesError: true},
 }
 
 type metricAPIAuthMetadataTestData struct {
@@ -337,6 +347,151 @@ func TestAggregateMetricsFromMultipleEndpoints_NoEndpoints(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no endpoints provided")
 	assert.Equal(t, 0.0, aggregation)
+}
+
+func newMockTransport() *MockHTTPRoundTripper {
+	m := &MockHTTPRoundTripper{}
+	m.On("RoundTrip", mock.Anything).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"metric": 42}`)),
+	}, nil)
+	return m
+}
+
+func TestGetMetricValueZeroOnMissingEndpoints(t *testing.T) {
+	readyTrue := true
+	readyFalse := false
+	port80 := int32(80)
+
+	tests := []struct {
+		name           string
+		zeroOnMissing  bool
+		endpointSlices []discoveryV1.EndpointSlice
+		wantValue      float64
+		wantErr        bool
+		wantErrMsg     string
+	}{
+		{
+			name:           "no endpoints, zeroOnMissingEndpoints=true returns 0",
+			zeroOnMissing:  true,
+			endpointSlices: nil,
+			wantValue:      0,
+			wantErr:        false,
+		},
+		{
+			name:           "no endpoints, zeroOnMissingEndpoints=false returns error",
+			zeroOnMissing:  false,
+			endpointSlices: nil,
+			wantValue:      0,
+			wantErr:        true,
+			wantErrMsg:     "no endpoints URLs were given for the service name",
+		},
+		{
+			name:          "only not-ready endpoints, zeroOnMissingEndpoints=true returns 0",
+			zeroOnMissing: true,
+			endpointSlices: []discoveryV1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc",
+						Namespace: "ns",
+						Labels:    map[string]string{discoveryV1.LabelServiceName: "svc"},
+					},
+					Endpoints: []discoveryV1.Endpoint{
+						{
+							Addresses:  []string{"10.0.0.1"},
+							Conditions: discoveryV1.EndpointConditions{Ready: &readyFalse},
+						},
+					},
+					Ports: []discoveryV1.EndpointPort{
+						{Port: &port80},
+					},
+				},
+			},
+			wantValue: 0,
+			wantErr:   false,
+		},
+		{
+			name:          "only not-ready endpoints, zeroOnMissingEndpoints=false returns error",
+			zeroOnMissing: false,
+			endpointSlices: []discoveryV1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc",
+						Namespace: "ns",
+						Labels:    map[string]string{discoveryV1.LabelServiceName: "svc"},
+					},
+					Endpoints: []discoveryV1.Endpoint{
+						{
+							Addresses:  []string{"10.0.0.1"},
+							Conditions: discoveryV1.EndpointConditions{Ready: &readyFalse},
+						},
+					},
+					Ports: []discoveryV1.EndpointPort{
+						{Port: &port80},
+					},
+				},
+			},
+			wantValue:  0,
+			wantErr:    true,
+			wantErrMsg: "no endpoints URLs were given for the service name",
+		},
+		{
+			name:          "endpoints present, zeroOnMissingEndpoints=true fetches metrics normally",
+			zeroOnMissing: true,
+			endpointSlices: []discoveryV1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc",
+						Namespace: "ns",
+						Labels:    map[string]string{discoveryV1.LabelServiceName: "svc"},
+					},
+					Endpoints: []discoveryV1.Endpoint{
+						{
+							Addresses:  []string{"10.0.0.1"},
+							Conditions: discoveryV1.EndpointConditions{Ready: &readyTrue},
+						},
+					},
+					Ports: []discoveryV1.EndpointPort{
+						{Port: &port80},
+					},
+				},
+			},
+			wantValue: 42,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var runtimeObjects []client.Object
+			for i := range tt.endpointSlices {
+				runtimeObjects = append(runtimeObjects, &tt.endpointSlices[i])
+			}
+			kubeClient := fake.NewClientBuilder().WithObjects(runtimeObjects...).Build()
+
+			s := metricsAPIScaler{
+				metadata: &metricsAPIScalerMetadata{
+					URL:                               "http://svc.ns.svc.cluster.local:80/metrics",
+					ValueLocation:                     "metric",
+					Format:                            JSONFormat,
+					AggregateFromKubeServiceEndpoints: true,
+					ZeroOnMissingEndpoints:            tt.zeroOnMissing,
+				},
+				httpClient: &http.Client{Transport: newMockTransport()},
+				logger:     InitializeLogger(&scalersconfig.ScalerConfig{}, "metrics_api_scaler"),
+				kubeClient: kubeClient,
+			}
+
+			val, err := s.getMetricValue(t.Context())
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
 }
 
 func TestGetMetricValueErrorMessage(t *testing.T) {

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -3096,6 +3096,12 @@
                         "min"
                     ],
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "zeroOnMissingEndpoints",
+                    "type": "string",
+                    "default": "false",
+                    "metadataVariableReadable": true
                 }
             ]
         },

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -3177,6 +3177,12 @@
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "zeroOnMissingEndpoints",
+                    "type": "string",
+                    "default": "false",
+                    "metadataVariableReadable": true
                 }
             ]
         },

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -2024,6 +2024,10 @@ scalers:
             - max
             - min
           metadataVariableReadable: true
+        - name: zeroOnMissingEndpoints
+          type: string
+          default: "false"
+          metadataVariableReadable: true
     - type: mongodb
       parameters:
         - name: connectionString

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -2078,6 +2078,10 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
+        - name: zeroOnMissingEndpoints
+          type: string
+          default: "false"
+          metadataVariableReadable: true
     - type: mongodb
       parameters:
         - name: connectionString


### PR DESCRIPTION
When `aggregateFromKubeServiceEndpoints` is `true` and the target Service has no ready endpoints, the scaler currently returns an error. With `zeroOnMissingEndpoints: "true"`, the scaler returns a metric value of `0` instead, allowing the ScaledObject to evaluate normally. This option is only valid when `aggregateFromKubeServiceEndpoints` is `true`;  setting it without that flag is rejected at parse time. 

See issue https://github.com/kedacore/keda/issues/7651 for details.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/7651
Docs: https://github.com/kedacore/keda-docs/pull/1737
