### PR TITLE
fix(e2e): fix stale trigger metrics and flaky events test

### DIFF
--- a/controllers/keda/scaledjob_controller.go
+++ b/controllers/keda/scaledjob_controller.go
@@ -106,9 +106,7 @@ func (r *ScaledJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err := r.Get(ctx, req.NamespacedName, scaledJob)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
+			r.updatePromMetricsOnDelete(req.String())
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -123,12 +121,13 @@ func (r *ScaledJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if scaledJob.GetDeletionTimestamp() != nil {
 		return ctrl.Result{}, r.finalizeScaledJob(ctx, reqLogger, scaledJob, req.String())
 	}
-	r.updatePromMetrics(scaledJob, req.String())
 
 	// ensure finalizer is set on this CR
 	if err := r.ensureFinalizer(ctx, reqLogger, scaledJob); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	r.updatePromMetrics(scaledJob, req.String())
 
 	// ensure Status Conditions are initialized
 	if !scaledJob.Status.Conditions.AreInitialized() {

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -159,9 +159,7 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	err := r.Client.Get(ctx, req.NamespacedName, scaledObject)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
+			r.updatePromMetricsOnDelete(req.String())
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -176,12 +174,13 @@ func (r *ScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if scaledObject.GetDeletionTimestamp() != nil {
 		return ctrl.Result{}, r.finalizeScaledObject(ctx, reqLogger, scaledObject, req.String())
 	}
-	r.updatePromMetrics(scaledObject, req.String())
 
 	// ensure finalizer is set on this CR
 	if err := r.ensureFinalizer(ctx, reqLogger, scaledObject); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	r.updatePromMetrics(scaledObject, req.String())
 
 	// ensure Status Conditions are initialized
 	if !scaledObject.Status.Conditions.AreInitialized() {

--- a/tests/internals/events/events_test.go
+++ b/tests/internals/events/events_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes"
@@ -324,12 +325,15 @@ func getTemplateData() (templateData, []Template) {
 	}, []Template{}
 }
 
-func checkingEvent(t *testing.T, namespace string, scaledObject string, index int, eventReason string, message string) {
-	result, err := ExecuteCommand(fmt.Sprintf("kubectl get events -n %s --field-selector involvedObject.name=%s --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[%d].reason}:{.items[%d].message}\"", namespace, scaledObject, index, index))
-
-	assert.NoError(t, err)
-	lastEventMessage := strings.Trim(string(result), "\"")
-	assert.Contains(t, lastEventMessage, eventReason+":"+message)
+func checkingEvent(t *testing.T, namespace string, scaledObject string, index int, eventReason string, msg string) {
+	assert.Eventually(t, func() bool {
+		result, err := ExecuteCommand(fmt.Sprintf("kubectl get events -n %s --field-selector involvedObject.name=%s --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[%d].reason}:{.items[%d].message}\"", namespace, scaledObject, index, index))
+		if err != nil {
+			return false
+		}
+		lastEventMessage := strings.Trim(string(result), "\"")
+		return strings.Contains(lastEventMessage, eventReason+":"+msg)
+	}, 60*time.Second, 2*time.Second, "expected event %s:%s for %s/%s[%d]", eventReason, msg, namespace, scaledObject, index)
 }
 
 func testNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {


### PR DESCRIPTION
When a ScaledObject/ScaledJob is deleted before the reconciler has added its finalizer (e.g. during namespace teardown),  the object is garbage-collected immediately without the finalization path running.. If this happens, prometheus metrics will never get cleaned up to decrement the number of scaledobjects/jobs active. We fix this by putting the metrics cleanup logic when the scaledObject is not found. Even if a scaledObject never existed in the first place, the function should simply do a no-op since it will not exist in the in-memory `scaledObjectPromMetricsMap` map.

Also adds a fix for the events test which retries event queries in case the API server has not emitted the event yet.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Related to None