### PR TITLE
fix(maxprocs): treat ConfigureMaxProcs error as non-fatal

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -288,10 +288,8 @@ func main() {
 		return
 	}
 
-	err = kedautil.ConfigureMaxProcs(setupLog)
-	if err != nil {
-		setupLog.Error(err, "failed to set max procs")
-		return
+	if err := kedautil.ConfigureMaxProcs(setupLog); err != nil {
+		setupLog.Info("failed to set max procs, using default GOMAXPROCS", "error", err)
 	}
 
 	kedaProvider, err := cmd.makeProvider(ctx)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -124,10 +124,8 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	ctx := ctrl.SetupSignalHandler()
 
-	err := kedautil.ConfigureMaxProcs(setupLog)
-	if err != nil {
-		setupLog.Error(err, "failed to set max procs")
-		os.Exit(1)
+	if err := kedautil.ConfigureMaxProcs(setupLog); err != nil {
+		setupLog.Info("failed to set max procs, using default GOMAXPROCS", "error", err)
 	}
 
 	namespaces, err := kedautil.GetWatchNamespaces()

--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -78,12 +78,9 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	err := kedautil.ConfigureMaxProcs(setupLog)
-	if err != nil {
-		setupLog.Error(err, "failed to set max procs")
-		os.Exit(1)
+	if err := kedautil.ConfigureMaxProcs(setupLog); err != nil {
+		setupLog.Info("failed to set max procs, using default GOMAXPROCS", "error", err)
 	}
-
 	ctx := ctrl.SetupSignalHandler()
 
 	cfg := ctrl.GetConfigOrDie()


### PR DESCRIPTION
## Summary
KEDA pods crash on startup with `failed to set max procs: open /sys/fs/cgroup/cpu.max: permission denied` in environments where the operator cannot read cgroup files (e.g. EKS auto-mode, restricted SecurityContexts).

## Root Cause
`maxprocs.Set()` from `go.uber.org/automaxprocs` returns an error when it can't read `/sys/fs/cgroup/cpu.max`, and all three KEDA entry points (operator, webhooks, adapter) treat this as fatal.

## Fix
Log the error as a warning and continue startup. The Go runtime will use a sensible default `GOMAXPROCS` value, so this is not actually a fatal condition.

Applied the same fix to all three entry points:
- `cmd/operator/main.go`
- `cmd/webhooks/main.go`
- `cmd/adapter/main.go`

## Validation
- `go build ./cmd/operator/ ./cmd/webhooks/ ./cmd/adapter/` succeeds

Fixes #7653