### PR TITLE
fix(maxprocs): gracefully handle cgroup permission errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
+- **General**: Gracefully handle cgroup permission errors in `ConfigureMaxProcs` so KEDA components start instead of crash-looping when `/sys/fs/cgroup/cpu.max` is not readable ([#7653](https://github.com/kedacore/keda/issues/7653))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))

--- a/pkg/util/maxprocs.go
+++ b/pkg/util/maxprocs.go
@@ -17,7 +17,9 @@ limitations under the License.
 package util
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 
 	"go.uber.org/automaxprocs/maxprocs"
 	"k8s.io/klog/v2"
@@ -26,9 +28,24 @@ import (
 // ConfigureMaxProcs sets up automaxprocs with proper logging configuration.
 // It wraps the automaxprocs logger to handle structured logging with string keys
 // to prevent panics when automaxprocs tries to pass numeric keys.
+//
+// When the cgroup filesystem is not readable (for example, when the container
+// runs under a restricted SecurityContext that denies access to
+// /sys/fs/cgroup/cpu.max), maxprocs.Set returns a permission error. In that
+// case GOMAXPROCS is already left at the Go runtime default (NumCPU), which is
+// a safe fallback, so we log a warning and return nil instead of propagating
+// the error to callers that would otherwise os.Exit(1) and cause a
+// CrashLoopBackOff. See kedacore/keda#7653.
 func ConfigureMaxProcs(logger klog.Logger) error {
 	_, err := maxprocs.Set(maxprocs.Logger(func(format string, args ...interface{}) {
 		logger.Info(fmt.Sprintf(format, args...))
 	}))
-	return err
+	if err != nil {
+		if errors.Is(err, fs.ErrPermission) {
+			logger.Info(fmt.Sprintf("automaxprocs: unable to read cgroup CPU quota, falling back to runtime default GOMAXPROCS: %v", err))
+			return nil
+		}
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Fixes #7653.

When KEDA pods run in an environment where the cgroup CPU files are not readable (for example, under a restricted `SecurityContext` that denies access to `/sys/fs/cgroup/cpu.max`, or on certain managed Kubernetes offerings that mount cgroups read-only), `go.uber.org/automaxprocs`'s `maxprocs.Set` returns a permission error:

```
failed to set max procs
 {"error": "open /sys/fs/cgroup/cpu.max: permission denied"}
```

Today all three callers — `cmd/operator/main.go`, `cmd/webhooks/main.go`, and `cmd/adapter/main.go` — treat that error as fatal and call `os.Exit(1)`. The result is a `CrashLoopBackOff` with no way to bring KEDA up at all, even though the *only* consequence of the failure is that `GOMAXPROCS` cannot be derived from cgroup quota. Go's runtime default (`runtime.NumCPU()`) is already a safe fallback.

### Fix

`pkg/util/maxprocs.go` now:

1. Inspects the error returned by `maxprocs.Set`.
2. If it is an `fs.ErrPermission`, logs a warning via the same `klog.Logger` (so it is still visible in pod logs) and returns `nil`.
3. Otherwise propagates the error unchanged, preserving today's behavior for genuinely unexpected failures.

This lets KEDA start in locked-down environments while still surfacing the misconfiguration in logs. Non-permission errors (malformed cgroup data, I/O errors, etc.) remain fatal as before.

### Which issue(s) this PR fixes

Fixes #7653

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A [changelog](https://github.com/kedacore/keda/blob/main/CHANGELOG.md) entry was added under **Unreleased → Fixes**
- [x] Change is trivial enough to not require unit tests (single call-site, behavior change is "convert permission error → warning")
