### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/pr-e2e-checker.yml
+++ b/.github/workflows/pr-e2e-checker.yml
@@ -5,6 +5,9 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  contents: read
+
 env:
   SKIP_E2E_TAG: skip-e2e
   E2E_CHECK_NAME: e2e tests

--- a/.github/workflows/pr-e2e-creator.yml
+++ b/.github/workflows/pr-e2e-creator.yml
@@ -5,6 +5,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 env:
   SKIP_E2E_TAG: skip-e2e
   E2E_CHECK_NAME: e2e tests

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -3,6 +3,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 env:
   E2E_CHECK_NAME: e2e tests
   ARM_SMOKE_CHECK_NAME: ARM smoke tests

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -2,6 +2,9 @@ name: Auto Assign
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   assign_reviewer:
     runs-on: ubuntu-slim

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,6 +2,9 @@ name: CI
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,14 +5,15 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
-permissions:
-  actions: write
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
     runs-on: ubuntu-slim
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:

--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -5,9 +5,7 @@ on:
     branches: ["main"]
   pull_request: {}
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -19,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/kedacore/keda-tools:1.26.2
     if: (github.actor != 'dependabot[bot]')
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -3,6 +3,9 @@ name: Reusable workflow to run e2e tests on main branch
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: Run e2e test

--- a/.github/workflows/template-s390x-smoke-tests.yml
+++ b/.github/workflows/template-s390x-smoke-tests.yml
@@ -3,6 +3,9 @@ name: Reusable workflow to run smoke tests on s390x
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   smoke-tests-s390x:
     name: Validate k8s

--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -13,6 +13,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   smoke-tests:
     name: Validate k8s-${{ inputs.kubernetesVersion }}

--- a/.github/workflows/template-trivy-scan.yml
+++ b/.github/workflows/template-trivy-scan.yml
@@ -31,6 +31,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   trivy-scan:
     name: Trivy - ${{ inputs.runs-on }} - ${{ inputs.scan-type }} ${{ inputs.image-ref }}

--- a/.github/workflows/template-versions-smoke-tests.yml
+++ b/.github/workflows/template-versions-smoke-tests.yml
@@ -3,6 +3,9 @@ name: Reusable workflow to run smoke tests on different k8s versions
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   smoke-tests:
     name: ${{ matrix.arch }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] ~When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)~
- [x] ~I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)~
- [x] ~Tests have been added *(if applicable)*~
- [x] ~Ensure `make generate-scalers-schema` has been run to update any outdated generated files~
- [x] ~Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users~
- [x] ~A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~
- [x] ~A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*~
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7666

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
