### PR TITLE
fix(nats-jetstream): return error when configured consumer is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Github Runner Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **Loki Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **Metrics API Scaler**: Fix `aggregateFromKubeServiceEndpoints` using empty label selector that matched all EndpointSlices in the namespace instead of only the target service's ([#7641](https://github.com/kedacore/keda/issues/7641))
+- **NATS JetStream Scaler**: Return an error from `getMaxMsgLag` when the configured consumer is missing instead of falling back to the stream's last sequence, preventing incorrect scale-up to `maxReplicaCount` ([#7657](https://github.com/kedacore/keda/issues/7657))
 - **NATS JetStream Scaler**: URL-encode user input in monitoring URL construction ([#7483](https://github.com/kedacore/keda/pull/7483))
 - **Prometheus Scaler**: Handle NaN results in the same manner as Inf ([#7475](https://github.com/kedacore/keda/issues/7475))
 - **Prometheus Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -419,15 +419,15 @@ func (s *natsJetStreamScaler) getNATSJetStreamMonitoringNodeURLByNode(node strin
 	return nodeURL.String(), nil
 }
 
-func (s *natsJetStreamScaler) getMaxMsgLag() int64 {
+func (s *natsJetStreamScaler) getMaxMsgLag() (int64, error) {
 	consumerName := s.metadata.Consumer
 
 	for _, consumer := range s.stream.Consumers {
 		if consumer.Name == consumerName {
-			return int64(consumer.NumPending + consumer.NumAckPending)
+			return int64(consumer.NumPending + consumer.NumAckPending), nil
 		}
 	}
-	return s.stream.State.LastSequence
+	return 0, fmt.Errorf("consumer %q not found in stream %q", consumerName, s.metadata.Stream)
 }
 
 func (s *natsJetStreamScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
@@ -455,7 +455,10 @@ func (s *natsJetStreamScaler) GetMetricsAndActivity(ctx context.Context, metricN
 		return []external_metrics.ExternalMetricValue{}, false, errors.New("stream not found")
 	}
 
-	totalLag := s.getMaxMsgLag()
+	totalLag, err := s.getMaxMsgLag()
+	if err != nil {
+		return []external_metrics.ExternalMetricValue{}, false, err
+	}
 	s.logger.V(1).Info("NATS JetStream Scaler: Providing metrics based on totalLag, threshold", "totalLag", totalLag, "lagThreshold", s.metadata.LagThreshold)
 
 	metric := GenerateMetricInMili(metricName, float64(totalLag))

--- a/pkg/scalers/nats_jetstream_scaler_test.go
+++ b/pkg/scalers/nats_jetstream_scaler_test.go
@@ -163,7 +163,7 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 		}, true, false,
 	},
 	{
-		"Not Active - Bad consumer name uses stream last sequence",
+		"Fail - stream exists but configured consumer missing",
 		&natsJetStreamMetricIdentifier{
 			&parseNATSJetStreamMetadataTestData{
 				testNATSJetStreamGoodMetadata, map[string]string{}, false,
@@ -174,11 +174,11 @@ var testNATSJetStreamMockResponses = []parseNATSJetStreamMockResponsesTestData{
 			Accounts: []accountDetail{{
 				Name: "$G",
 				Streams: []*streamDetail{{
-					Name: "mystream", State: streamState{LastSequence: 1},
+					Name: "mystream", State: streamState{LastSequence: 1000},
 					Consumers: []consumerDetail{{Name: "pull_consumer_bad", NumPending: 100}},
 				}},
 			}},
-		}, false, false,
+		}, false, true,
 	},
 	{
 		"Fail - Non-matching stream name",
@@ -468,6 +468,52 @@ func TestNATSJetStreamGetNATSJetstreamServerURL(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for parsing monitoring server URL but got success")
 	}
+}
+
+func TestNATSJetStreamGetMaxMsgLag(t *testing.T) {
+	meta, err := parseNATSJetStreamMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testNATSJetStreamGoodMetadata, TriggerIndex: 0})
+	if err != nil {
+		t.Fatal("Could not parse metadata:", err)
+	}
+
+	t.Run("consumer present returns pending+ackPending", func(t *testing.T) {
+		scaler := natsJetStreamScaler{
+			metadata: meta,
+			stream: &streamDetail{
+				Name:  "mystream",
+				State: streamState{LastSequence: 9999},
+				Consumers: []consumerDetail{{
+					Name:          "pull_consumer",
+					NumPending:    7,
+					NumAckPending: 3,
+				}},
+			},
+		}
+
+		lag, err := scaler.getMaxMsgLag()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(10), lag)
+	})
+
+	t.Run("stream exists but consumer missing returns error and zero lag", func(t *testing.T) {
+		scaler := natsJetStreamScaler{
+			metadata: meta,
+			stream: &streamDetail{
+				Name:  "mystream",
+				State: streamState{LastSequence: 9999},
+				Consumers: []consumerDetail{{
+					Name:       "some_other_consumer",
+					NumPending: 100,
+				}},
+			},
+		}
+
+		lag, err := scaler.getMaxMsgLag()
+		assert.Error(t, err)
+		assert.Equal(t, int64(0), lag, "must not fall back to stream LastSequence")
+		assert.Contains(t, err.Error(), "pull_consumer")
+		assert.Contains(t, err.Error(), "mystream")
+	})
 }
 
 func TestNATSJetStreamClose(t *testing.T) {


### PR DESCRIPTION
## Description                                                                                                                                                                                                         
                  
  Fixes a bug in the NATS JetStream scaler where a ScaledObject referencing a consumer that does not exist in the target stream would cause the workload to scale up to `maxReplicaCount`. 
  
### Root cause

  `getMaxMsgLag()` iterates the stream's consumers looking for the configured one. If it isn't found, the function previously fell back to returning `s.stream.State.LastSequence` - the stream's last published sequence
   number. On any non-trivial stream this value is very large, exceeds any reasonable `lagThreshold`, and the HPA scales the workload out to its maximum.
   
### Fix

  - `getMaxMsgLag()` now returns `(int64, error)` and surfaces an error when the configured consumer is missing, instead of returning the stream's last sequence.                                                        
  - `GetMetricsAndActivity` propagates that error so user-configured `fallback` behaviour can take over.
  - Updated an existing test that was asserting the previous (bugged) behaviour, and added a dedicated unit test covering both the consumer-present and stream-exists-but-consumer-missing cases.
                       
### Behaviour change
                            
Before: scaler silently reported a large metric and scaled to max replicas.
After: scaler returns an error; the ScaledObject's `fallback` can engage, or the metric becomes unavailable until the consumer is created.

  ### Checklist

  - [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
  - [x] Tests have been added *(if applicable)*
  - [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users                                                                       
  - [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))                       
                                                                                                                                                                                                                   
  Fixes #7657