### PR TITLE
fix: surface HPA errors on ScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
+- **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))

--- a/apis/keda/v1alpha1/condition_types.go
+++ b/apis/keda/v1alpha1/condition_types.go
@@ -45,6 +45,11 @@ const (
 	ScaledObjectConditionPausedReason = "ScaledObjectPaused"
 	// ScaledObjectConditionPausedMessage defines the default Message for paused ScaledObject
 	ScaledObjectConditionPausedMessage = "ScaledObject is paused"
+
+	// ScaledObjectConditionHPAMetricsUnavailableReason is the Ready condition reason when the HPA cannot fetch metrics
+	ScaledObjectConditionHPAMetricsUnavailableReason = "HPAMetricsUnavailable"
+	// ScaledObjectConditionScalingDegradedReason is the Ready condition reason when both scalers and HPA are unhealthy
+	ScaledObjectConditionScalingDegradedReason = "ScalingDegraded"
 )
 
 const (

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -162,8 +162,10 @@ func (e *scaleExecutor) getHPAHealth(ctx context.Context, logger logr.Logger, sc
 	// Check HPA's ScalingActive condition
 	for _, cond := range hpa.Status.Conditions {
 		if cond.Type == autoscalingv2.ScalingActive {
-			hpaHealthy := cond.Status == corev1.ConditionTrue || cond.Reason == "ScalingDisabled"
-			return hpaHealthy, cond.Reason
+			if cond.Status == corev1.ConditionTrue || cond.Reason == "ScalingDisabled" {
+				return true, ""
+			}
+			return false, cond.Reason
 		}
 	}
 

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -24,13 +24,18 @@ import (
 
 	"github.com/go-logr/logr"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/eventreason"
 	"github.com/kedacore/keda/v2/pkg/scaling/resolver"
 )
+
+// hpaHealthGracePeriod is the amount of time after HPA creation during which we skip health checks to allow the HPA to initialize and report metrics, avoiding condition flapping.
+const hpaHealthGracePeriod = time.Minute
 
 func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1alpha1.ScaledObject, isActive bool, isError bool, options ScaleExecutorOptions) ScaleResult {
 	logger := e.logger.WithValues("scaledobject.Name", scaledObject.Name, "scaledObject.Namespace", scaledObject.Namespace, "scaleTarget.Name", scaledObject.Spec.ScaleTargetRef.Name)
@@ -110,7 +115,59 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 			logger.V(1).Info("ScaleTarget no change")
 		}
 	}
+	e.checkHPAHealth(ctx, logger, scaledObject, &result)
+
 	return result
+}
+
+// checkHPAHealth checks HPA health and adjusts the Ready condition. If the HPA is healthy, the existing Ready condition is left as-is.
+// If the HPA is unhealthy, the Ready condition is set to False with an appropriate reason.
+func (e *scaleExecutor) checkHPAHealth(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, result *ScaleResult) {
+	hpaHealthy, hpaMessage := e.getHPAHealth(ctx, logger, scaledObject)
+	if hpaHealthy {
+		return
+	}
+
+	readyCondition := result.Conditions.GetReadyCondition()
+	if readyCondition.IsTrue() {
+		msg := fmt.Sprintf("ScaledObject is configured correctly but HPA is not healthy: %v", hpaMessage)
+		result.Conditions.SetReadyCondition(metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, msg)
+	} else {
+		msg := fmt.Sprintf("Not ready because HPA is not healthy: %v and SO is not healthy: %v - %v", hpaMessage, readyCondition.Reason, readyCondition.Message)
+		result.Conditions.SetReadyCondition(metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionScalingDegradedReason, msg)
+	}
+}
+
+// getHPAHealth gets the HPA ScalingActive condition to determine if the HPA is operationally healthy.
+func (e *scaleExecutor) getHPAHealth(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) (healthy bool, message string) {
+	hpaName := scaledObject.Status.HpaName
+	if hpaName == "" {
+		logger.V(1).Info("HPA name not found in ScaledObject status, skipping health check")
+		return true, ""
+	}
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+	err := e.client.Get(ctx, types.NamespacedName{Name: hpaName, Namespace: scaledObject.Namespace}, hpa)
+	if err != nil {
+		logger.Error(err, "Could not read HPA status, skipping health check")
+		return true, ""
+	}
+
+	// Grace period after HPA creation where we skip health checks to allow HPA to initialize and report metrics and avoid condition flapping.
+	if hpa.CreationTimestamp.Add(hpaHealthGracePeriod).After(time.Now()) {
+		logger.V(1).Info("HPA is still initializing, skipping health check")
+		return true, ""
+	}
+
+	// Check HPA's ScalingActive condition
+	for _, cond := range hpa.Status.Conditions {
+		if cond.Type == autoscalingv2.ScalingActive {
+			hpaHealthy := cond.Status == corev1.ConditionTrue || cond.Reason == "ScalingDisabled"
+			return hpaHealthy, cond.Reason
+		}
+	}
+
+	return true, ""
 }
 
 // An object will be scaled down to 0 only if it's passed its cooldown period

--- a/pkg/scaling/executor/scale_scaledobjects_test.go
+++ b/pkg/scaling/executor/scale_scaledobjects_test.go
@@ -18,14 +18,19 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
@@ -734,4 +739,336 @@ func TestNoScaleFromIdleReplicasToMinReplicasWhenActiveAndPausedScaleOutAnnotati
 	assert.Equal(t, int32(0), scale.Spec.Replicas)
 	condition := result.Conditions.GetActiveCondition()
 	assert.Equal(t, true, condition.IsTrue())
+}
+
+// --------------------------------------------------------------------------- //
+// ----------         getHPAHealth tests                             --------- //
+// --------------------------------------------------------------------------- //
+
+func newTestExecutor(client *mock_client.MockClient) *scaleExecutor {
+	return &scaleExecutor{
+		client:   client,
+		logger:   logf.Log.WithName("test"),
+		recorder: record.NewFakeRecorder(1),
+	}
+}
+
+func TestGetHPAHealth_NoHPAName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Status.HpaName = ""
+
+	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.True(t, healthy)
+	assert.Empty(t, msg)
+}
+
+func TestGetHPAHealth_HPAReadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		Return(errors.New("api unavailable"))
+
+	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.True(t, healthy, "should treat HPA read error as healthy to avoid flapping")
+	assert.Empty(t, msg)
+}
+
+func TestGetHPAHealth_ScalingActiveTrue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue},
+			}
+			return nil
+		})
+
+	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.True(t, healthy)
+	assert.Empty(t, msg)
+}
+
+func TestGetHPAHealth_ScalingActiveFalse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetExternalMetric", Message: "unable to get metrics"},
+			}
+			return nil
+		})
+
+	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.False(t, healthy)
+	assert.Equal(t, "FailedGetExternalMetric", msg)
+}
+
+func TestGetHPAHealth_ScalingDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				// ScalingDisabled is set by the HPA controller when the target has 0 replicas
+				// (scale-to-zero managed by KEDA). This should NOT be treated as unhealthy.
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "ScalingDisabled", Message: "scaling is disabled since the replica count of the target is zero"},
+			}
+			return nil
+		})
+
+	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.True(t, healthy, "ScalingDisabled should be treated as healthy since KEDA manages scale-to-zero")
+	assert.Equal(t, "ScalingDisabled", msg)
+}
+
+func TestGetHPAHealth_WithinGracePeriod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.CreationTimestamp = v1.Now() // just created
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetExternalMetric"},
+			}
+			return nil
+		})
+
+	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.True(t, healthy, "should be healthy within grace period even if ScalingActive=False")
+	assert.Empty(t, msg)
+}
+
+// --------------------------------------------------------------------------- //
+// ----------    HPA health aggregation in RequestScale tests        --------- //
+// --------------------------------------------------------------------------- //
+
+// newSOWithHPA creates a minimal ScaledObject with an HPA name for testing.
+func newSOWithHPA() v1alpha1.ScaledObject {
+	minReplicas := int32(1)
+	return v1alpha1.ScaledObject{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-so",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.ScaledObjectSpec{
+			ScaleTargetRef:  &v1alpha1.ScaleTarget{Name: "test-deploy"},
+			MinReplicaCount: &minReplicas,
+		},
+		Status: v1alpha1.ScaledObjectStatus{
+			HpaName: "my-hpa",
+			ScaleTargetGVKR: &v1alpha1.GroupVersionKindResource{
+				Group: "apps",
+				Kind:  "Deployment",
+			},
+		},
+	}
+}
+
+// mockHealthyHPA sets up the mock to return an HPA with ScalingActive=True.
+func mockHealthyHPA(mockClient *mock_client.MockClient) {
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.AssignableToTypeOf(&autoscalingv2.HorizontalPodAutoscaler{})).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionTrue},
+			}
+			obj.Status.CurrentMetrics = []autoscalingv2.MetricStatus{{}}
+			return nil
+		})
+}
+
+// mockUnhealthyHPA sets up the mock to return an HPA with ScalingActive=False.
+func mockUnhealthyHPA(mockClient *mock_client.MockClient) {
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.AssignableToTypeOf(&autoscalingv2.HorizontalPodAutoscaler{})).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "FailedGetExternalMetric", Message: "metrics not available"},
+			}
+			return nil
+		})
+}
+
+// mockDeploymentGet sets up the mock for the deployment Get that resolver.GetCurrentReplicas calls.
+func mockDeploymentGet(mockClient *mock_client.MockClient) {
+	replicas := int32(1)
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&appsv1.Deployment{})).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *appsv1.Deployment, _ ...interface{}) error {
+			obj.Spec.Replicas = &replicas
+			return nil
+		})
+}
+
+func TestRequestScale_AllHealthy_HPAHealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+
+	// GetCurrentReplicas: return 1 replica (at minReplicas, so no scaling needed)
+	mockDeploymentGet(mockClient)
+	// HPA health check
+	mockHealthyHPA(mockClient)
+
+	result := exec.RequestScale(context.TODO(), &so, true, false, ScaleExecutorOptions{})
+
+	readyCond := result.Conditions.GetReadyCondition()
+	assert.True(t, readyCond.IsTrue())
+	assert.Equal(t, v1alpha1.ScaledObjectConditionReadySuccessReason, readyCond.Reason)
+}
+
+func TestRequestScale_ScalerError_HPAHealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+
+	mockDeploymentGet(mockClient)
+	mockHealthyHPA(mockClient)
+
+	// isActive=false, isError=true, no fallback → TriggerError
+	result := exec.RequestScale(context.TODO(), &so, false, true, ScaleExecutorOptions{})
+
+	readyCond := result.Conditions.GetReadyCondition()
+	assert.True(t, readyCond.IsFalse())
+	assert.Equal(t, "TriggerError", readyCond.Reason)
+}
+
+func TestRequestScale_PartialError_HPAHealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+
+	mockDeploymentGet(mockClient)
+	mockHealthyHPA(mockClient)
+
+	// isActive=true, isError=true → PartialTriggerError
+	result := exec.RequestScale(context.TODO(), &so, true, true, ScaleExecutorOptions{})
+
+	readyCond := result.Conditions.GetReadyCondition()
+	assert.True(t, readyCond.IsUnknown())
+	assert.Equal(t, "PartialTriggerError", readyCond.Reason)
+}
+
+func TestRequestScale_NoError_HPAUnhealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+
+	mockDeploymentGet(mockClient)
+	mockUnhealthyHPA(mockClient)
+
+	result := exec.RequestScale(context.TODO(), &so, true, false, ScaleExecutorOptions{})
+
+	readyCond := result.Conditions.GetReadyCondition()
+	assert.True(t, readyCond.IsFalse())
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, readyCond.Reason)
+	assert.Contains(t, readyCond.Message, "FailedGetExternalMetric")
+}
+
+func TestRequestScale_ScalerError_HPAUnhealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+
+	mockDeploymentGet(mockClient)
+	mockUnhealthyHPA(mockClient)
+
+	// isActive=false, isError=true, no fallback → ScalingDegraded (both broken)
+	result := exec.RequestScale(context.TODO(), &so, false, true, ScaleExecutorOptions{})
+
+	readyCond := result.Conditions.GetReadyCondition()
+	assert.True(t, readyCond.IsFalse())
+	assert.Equal(t, v1alpha1.ScaledObjectConditionScalingDegradedReason, readyCond.Reason)
+	assert.Contains(t, readyCond.Message, "FailedGetExternalMetric")
+}
+
+func TestRequestScale_ScalerErrorWithFallback_HPAHealthy(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := record.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+	fallbackReplicas := int32(5)
+	so.Spec.Fallback = &v1alpha1.Fallback{Replicas: fallbackReplicas}
+
+	mockDeploymentGet(mockClient)
+	mockHealthyHPA(mockClient)
+
+	// isActive=false, isError=true, fallback configured → Ready stays True
+	result := exec.RequestScale(context.TODO(), &so, false, true, ScaleExecutorOptions{})
+
+	readyCond := result.Conditions.GetReadyCondition()
+	assert.Truef(t, readyCond.IsTrue(), "with fallback configured and HPA healthy, Ready should be True, got %s/%s", readyCond.Status, readyCond.Reason)
 }

--- a/pkg/scaling/executor/scale_scaledobjects_test.go
+++ b/pkg/scaling/executor/scale_scaledobjects_test.go
@@ -857,7 +857,7 @@ func TestGetHPAHealth_ScalingDisabled(t *testing.T) {
 
 	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
 	assert.True(t, healthy, "ScalingDisabled should be treated as healthy since KEDA manages scale-to-zero")
-	assert.Equal(t, "ScalingDisabled", msg)
+	assert.Empty(t, msg)
 }
 
 func TestGetHPAHealth_WithinGracePeriod(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->
KEDA's ScaledObject currently reports `Ready=True` even when its managed HPA cannot fetch metrics (HPA shows `<unknown>` targets with `ScalingActive=False`). Users see a healthy-looking `ScaledObject` while scaling is silently broken, the only way to discover the problem is to manually inspect the HPA. Examples of this might be broken metrics adapter, broken APIService.apiregistration, or invalid certs for the gRPC connection between operator and metrics adapter.

</details>

<details>

<summary>HPA broken with adapter not running</summary>

```yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: keda-hpa-nginx
  namespace: keda
spec:
  maxReplicas: 10
  metrics:
  - external:
      metric:
        name: s0-configmap-mock-metric-metric-value
        selector:
          matchLabels:
            scaledobject.keda.sh/name: nginx
      target:
        averageValue: "5"
        type: AverageValue
    type: External
  minReplicas: 1
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: nginx
status:
  conditions:
  - lastTransitionTime: "2026-04-20T08:49:50Z"
    message: the HPA controller was able to get the target's current scale
    reason: SucceededGetScale
    status: "True"
    type: AbleToScale
  - lastTransitionTime: "2026-04-20T10:26:40Z"
    message: 'the HPA was unable to compute the replica count: unable to get external
      metric keda/s0-configmap-mock-metric-metric-value/&LabelSelector{MatchLabels:map[string]string{scaledobject.keda.sh/name:
      nginx,},MatchExpressions:[]LabelSelectorRequirement{},}: unable to fetch metrics
      from external metrics API: the server is currently unable to handle the request
      (get s0-configmap-mock-metric-metric-value.external.metrics.k8s.io)'
    reason: FailedGetExternalMetric
    status: "False"
    type: ScalingActive
  - lastTransitionTime: "2026-04-20T08:49:50Z"
    message: the desired count is within the acceptable range
    reason: DesiredWithinRange
    status: "False"
    type: ScalingLimited
  currentMetrics:
  - type: ""
  currentReplicas: 4
  desiredReplicas: 4
  lastScaleTime: "2026-04-20T08:49:50Z"
```

</details>

<details>

<summary>Former SO status reporting when HPA is broken</summary>

```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: nginx
  namespace: keda
spec:
  maxReplicaCount: 10
  minReplicaCount: 1
  scaleTargetRef:
    kind: Deployment
    name: nginx
  triggers:
  - metadata:
      key: metric-value
      resourceKind: ConfigMap
      resourceName: mock-metric
      targetValue: "5"
    type: kubernetes-resource
status:
  authenticationsTypes: ""
  conditions:
  - message: ScaledObject is defined correctly and is ready for scaling
    reason: ScaledObjectReady                                       # <-- imho this is incorrect
    status: "True"
    type: Ready
  - message: Scaling is performed because triggers are active
    reason: ScalerActive                                            # <- debatable whether active should be true?
    status: "True"
    type: Active
  - message: No fallbacks are active on this scaled object
    reason: NoFallbackFound
    status: "False"
    type: Fallback
  - status: "False"
    type: Paused
  externalMetricNames:
  - s0-configmap-mock-metric-metric-value
  hpaName: keda-hpa-nginx
  lastActiveTime: "2026-04-20T10:25:31Z"
  originalReplicaCount: 1
  scaleTargetGVKR:
    group: apps
    kind: Deployment
    resource: deployments
    version: v1
  scaleTargetKind: apps/v1.Deployment
  triggersActivity:
    s0-configmap-mock-metric-metric-value:
      isActive: true
  triggersTypes: kubernetes-resource
```

</details>

<details>

<summary>Proposed SO status reporting when HPA is broken</summary>

```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: nginx
  namespace: keda
spec:
  maxReplicaCount: 10
  minReplicaCount: 1
  scaleTargetRef:
    kind: Deployment
    name: nginx
  triggers:
  - metadata:
      key: metric-value
      resourceKind: ConfigMap
      resourceName: mock-metric
      targetValue: "5"
    type: kubernetes-resource
status:
  authenticationsTypes: ""
  conditions:
  - message: 'ScaledObject is configured correctly but HPA is not healthy: FailedGetExternalMetric'
    reason: HPAMetricsUnavailable                                    # <- no longer reported as ready
    status: "False"
    type: Ready
  - message: Scaling is performed because triggers are active
    reason: ScalerActive                                             # <- still reports as active
    status: "True"
    type: Active
  - message: No fallbacks are active on this scaled object
    reason: NoFallbackFound
    status: "False"
    type: Fallback
  - status: "False"
    type: Paused
  externalMetricNames:
  - s0-configmap-mock-metric-metric-value
  hpaName: keda-hpa-nginx
  lastActiveTime: "2026-04-20T10:27:01Z"
  originalReplicaCount: 1
  scaleTargetGVKR:
    group: apps
    kind: Deployment
    resource: deployments
    version: v1
  scaleTargetKind: apps/v1.Deployment
  triggersActivity:
    s0-configmap-mock-metric-metric-value:
      isActive: true
  triggersTypes: kubernetes-resource
```

</details>

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes https://github.com/kedacore/keda/issues/7649
