### PR TITLE
perf(webhooks): remove eager json.MarshalIndent from admission validation hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Allow more control of TLS versions & ciphers via `KEDA_HTTP_TLS_CIPHER_LIST`, `KEDA_SERVICE_TLS_CIPHER_LIST` and `KEDA_SERVICE_MIN_TLS_VERSION` env vars ([#7617](https://github.com/kedacore/keda/pull/7617))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
+- **General**: Remove unconditional `json.MarshalIndent` calls from admission webhook validation hot paths; replace spec-comparison `MarshalIndent`-and-string-compare in `isRemovingFinalizer` variants with `reflect.DeepEqual`. Prevents webhook OOM under sustained admission load at large scale (observed at ~60k ScaledObjects) ([#7670](https://github.com/kedacore/keda/pull/7670))
 - **AWS Scalers**: Add support for AWS External ID in TriggerAuthentication podIdentity for all AWS scalers (SQS, Kinesis, DynamoDB, CloudWatch, etc.) to enable cross-account access scenarios ([#6921](https://github.com/kedacore/keda/issues/6921))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
 - **Github Runner Scaler**: Handle rate limit errors by respecting X-RateLimit-Reset and Retry-After headers and returning cached queue length ([#7683](https://github.com/kedacore/keda/issues/7683))

--- a/apis/eventing/v1alpha1/cloudeventsource_webhook.go
+++ b/apis/eventing/v1alpha1/cloudeventsource_webhook.go
@@ -18,8 +18,8 @@ package v1alpha1
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"reflect"
 	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,18 +83,16 @@ var _ webhook.CustomValidator = &CloudEventSourceCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (ces *CloudEventSource) ValidateCreate(_ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(ces, "", "  ")
-	cloudeventsourcelog.Info(fmt.Sprintf("validating cloudeventsource creation for %s", string(val)))
+	cloudeventsourcelog.Info("validating cloudeventsource creation", "namespace", ces.Namespace, "name", ces.Name, "cloudeventsource", ces)
 	return validateSpec(&ces.Spec)
 }
 
 func (ces *CloudEventSource) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(ces, "", "  ")
-	cloudeventsourcelog.V(1).Info(fmt.Sprintf("validating cloudeventsource update for %s", string(val)))
+	cloudeventsourcelog.V(1).Info("validating cloudeventsource update", "namespace", ces.Namespace, "name", ces.Name, "cloudeventsource", ces)
 
 	oldCes := old.(*CloudEventSource)
 	if isCloudEventSourceRemovingFinalizer(ces.ObjectMeta, oldCes.ObjectMeta, ces.Spec, oldCes.Spec) {
-		cloudeventsourcelog.V(1).Info("finalizer removal, skipping validation")
+		cloudeventsourcelog.V(1).Info("finalizer removal, skipping validation", "namespace", ces.Namespace, "name", ces.Name)
 		return nil, nil
 	}
 	return validateSpec(&ces.Spec)
@@ -141,18 +139,16 @@ var _ webhook.CustomValidator = &ClusterCloudEventSourceCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (cces *ClusterCloudEventSource) ValidateCreate(_ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(cces, "", "  ")
-	cloudeventsourcelog.Info(fmt.Sprintf("validating clustercloudeventsource creation for %s", string(val)))
+	cloudeventsourcelog.Info("validating clustercloudeventsource creation", "name", cces.Name, "clustercloudeventsource", cces)
 	return validateSpec(&cces.Spec)
 }
 
 func (cces *ClusterCloudEventSource) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(cces, "", "  ")
-	cloudeventsourcelog.V(1).Info(fmt.Sprintf("validating clustercloudeventsource update for %s", string(val)))
+	cloudeventsourcelog.V(1).Info("validating clustercloudeventsource update", "name", cces.Name, "clustercloudeventsource", cces)
 
 	oldCes := old.(*ClusterCloudEventSource)
 	if isCloudEventSourceRemovingFinalizer(cces.ObjectMeta, oldCes.ObjectMeta, cces.Spec, oldCes.Spec) {
-		cloudeventsourcelog.V(1).Info("finalizer removal, skipping validation")
+		cloudeventsourcelog.V(1).Info("finalizer removal, skipping validation", "name", cces.Name)
 		return nil, nil
 	}
 	return validateSpec(&cces.Spec)
@@ -163,12 +159,7 @@ func (cces *ClusterCloudEventSource) ValidateDelete(_ *bool) (admission.Warnings
 }
 
 func isCloudEventSourceRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1.ObjectMeta, spec CloudEventSourceSpec, oldSpec CloudEventSourceSpec) bool {
-	cesSpec, _ := json.MarshalIndent(spec, "", "  ")
-	oldCesSpec, _ := json.MarshalIndent(oldSpec, "", "  ")
-	cesSpecString := string(cesSpec)
-	oldCesSpecString := string(oldCesSpec)
-
-	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && cesSpecString == oldCesSpecString
+	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && reflect.DeepEqual(spec, oldSpec)
 }
 
 func validateSpec(spec *CloudEventSourceSpec) (admission.Warnings, error) {

--- a/apis/eventing/v1alpha1/cloudeventsource_webhook.go
+++ b/apis/eventing/v1alpha1/cloudeventsource_webhook.go
@@ -19,9 +19,9 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"slices"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -159,7 +159,7 @@ func (cces *ClusterCloudEventSource) ValidateDelete(_ *bool) (admission.Warnings
 }
 
 func isCloudEventSourceRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1.ObjectMeta, spec CloudEventSourceSpec, oldSpec CloudEventSourceSpec) bool {
-	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && reflect.DeepEqual(spec, oldSpec)
+	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && equality.Semantic.DeepEqual(spec, oldSpec)
 }
 
 func validateSpec(spec *CloudEventSourceSpec) (admission.Warnings, error) {

--- a/apis/keda/v1alpha1/scaledjob_webhook.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook.go
@@ -18,8 +18,7 @@ package v1alpha1
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
+	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,18 +74,16 @@ var _ webhook.CustomValidator = &ScaledJobCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (s *ScaledJob) ValidateCreate(dryRun *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(s, "", "  ")
-	scaledjoblog.Info(fmt.Sprintf("validating scaledjob creation for %s", string(val)))
+	scaledjoblog.Info("validating scaledjob creation", "namespace", s.Namespace, "name", s.Name, "scaledjob", s)
 	return nil, verifyTriggers(s, "create", *dryRun)
 }
 
 func (s *ScaledJob) ValidateUpdate(old runtime.Object, dryRun *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(s, "", "  ")
-	scaledobjectlog.V(1).Info(fmt.Sprintf("validating scaledjob update for %s", string(val)))
+	scaledjoblog.V(1).Info("validating scaledjob update", "namespace", s.Namespace, "name", s.Name, "scaledjob", s)
 
 	oldTa := old.(*ScaledJob)
 	if isScaledJobRemovingFinalizer(s.ObjectMeta, oldTa.ObjectMeta, s.Spec, oldTa.Spec) {
-		scaledjoblog.V(1).Info("finalizer removal, skipping validation")
+		scaledjoblog.V(1).Info("finalizer removal, skipping validation", "namespace", s.Namespace, "name", s.Name)
 		return nil, nil
 	}
 	return nil, verifyTriggers(s, "update", *dryRun)
@@ -97,10 +94,5 @@ func (s *ScaledJob) ValidateDelete(_ *bool) (admission.Warnings, error) {
 }
 
 func isScaledJobRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1.ObjectMeta, spec ScaledJobSpec, oldSpec ScaledJobSpec) bool {
-	taSpec, _ := json.MarshalIndent(spec, "", "  ")
-	oldTaSpec, _ := json.MarshalIndent(oldSpec, "", "  ")
-	taSpecString := string(taSpec)
-	oldTaSpecString := string(oldTaSpec)
-
-	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && taSpecString == oldTaSpecString
+	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && reflect.DeepEqual(spec, oldSpec)
 }

--- a/apis/keda/v1alpha1/scaledjob_webhook.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook.go
@@ -18,8 +18,8 @@ package v1alpha1
 
 import (
 	"context"
-	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,8 +81,8 @@ func (s *ScaledJob) ValidateCreate(dryRun *bool) (admission.Warnings, error) {
 func (s *ScaledJob) ValidateUpdate(old runtime.Object, dryRun *bool) (admission.Warnings, error) {
 	scaledjoblog.V(1).Info("validating scaledjob update", "namespace", s.Namespace, "name", s.Name, "scaledjob", s)
 
-	oldTa := old.(*ScaledJob)
-	if isScaledJobRemovingFinalizer(s.ObjectMeta, oldTa.ObjectMeta, s.Spec, oldTa.Spec) {
+	oldSj := old.(*ScaledJob)
+	if isScaledJobRemovingFinalizer(s.ObjectMeta, oldSj.ObjectMeta, s.Spec, oldSj.Spec) {
 		scaledjoblog.V(1).Info("finalizer removal, skipping validation", "namespace", s.Namespace, "name", s.Name)
 		return nil, nil
 	}
@@ -94,5 +94,5 @@ func (s *ScaledJob) ValidateDelete(_ *bool) (admission.Warnings, error) {
 }
 
 func isScaledJobRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1.ObjectMeta, spec ScaledJobSpec, oldSpec ScaledJobSpec) bool {
-	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && reflect.DeepEqual(spec, oldSpec)
+	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && equality.Semantic.DeepEqual(spec, oldSpec)
 }

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -18,9 +18,9 @@ package v1alpha1
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -123,17 +123,15 @@ var _ webhook.CustomValidator = &ScaledObjectCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (so *ScaledObject) ValidateCreate(dryRun *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(so, "", "  ")
-	scaledobjectlog.V(1).Info(fmt.Sprintf("validating scaledobject creation for %s", string(val)))
+	scaledobjectlog.V(1).Info("validating scaledobject creation", "namespace", so.Namespace, "name", so.Name, "scaledobject", so)
 	return validateWorkload(so, "create", *dryRun)
 }
 
 func (so *ScaledObject) ValidateUpdate(old runtime.Object, dryRun *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(so, "", "  ")
-	scaledobjectlog.V(1).Info(fmt.Sprintf("validating scaledobject update for %s", string(val)))
+	scaledobjectlog.V(1).Info("validating scaledobject update", "namespace", so.Namespace, "name", so.Name, "scaledobject", so)
 
 	if isRemovingFinalizer(so, old) {
-		scaledobjectlog.V(1).Info("finalizer removal, skipping validation")
+		scaledobjectlog.V(1).Info("finalizer removal, skipping validation", "namespace", so.Namespace, "name", so.Name)
 		return nil, nil
 	}
 
@@ -146,13 +144,7 @@ func (so *ScaledObject) ValidateDelete(_ *bool) (admission.Warnings, error) {
 
 func isRemovingFinalizer(so *ScaledObject, old runtime.Object) bool {
 	oldSo := old.(*ScaledObject)
-
-	soSpec, _ := json.MarshalIndent(so.Spec, "", "  ")
-	oldSoSpec, _ := json.MarshalIndent(oldSo.Spec, "", "  ")
-	soSpecString := string(soSpec)
-	oldSoSpecString := string(oldSoSpec)
-
-	return len(so.Finalizers) < len(oldSo.Finalizers) && soSpecString == oldSoSpecString
+	return len(so.Finalizers) < len(oldSo.Finalizers) && reflect.DeepEqual(so.Spec, oldSo.Spec)
 }
 
 func validateWorkload(so *ScaledObject, action string, dryRun bool) (admission.Warnings, error) {
@@ -167,7 +159,7 @@ func validateWorkload(so *ScaledObject, action string, dryRun bool) (admission.W
 	}
 
 	for functionName, function := range verifyFunctions {
-		scaledobjectlog.V(1).Info(fmt.Sprintf("calling %s to validate %s", functionName, so.Name))
+		scaledobjectlog.V(1).Info("validating scaledobject", "function", functionName, "name", so.Name)
 		err := function(so, action, dryRun)
 		if err != nil {
 			return nil, err
@@ -179,14 +171,14 @@ func validateWorkload(so *ScaledObject, action string, dryRun bool) (admission.W
 	}
 
 	for functionName, function := range verifyCommonFunctions {
-		scaledobjectlog.V(1).Info(fmt.Sprintf("calling %s to validate %s", functionName, so.Name))
+		scaledobjectlog.V(1).Info("validating scaledobject", "function", functionName, "name", so.Name)
 		err := function(so, action, dryRun)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	scaledobjectlog.V(1).Info(fmt.Sprintf("scaledobject %s is valid", so.Name))
+	scaledobjectlog.V(1).Info("scaledobject is valid", "namespace", so.Namespace, "name", so.Name)
 	return nil, nil
 }
 
@@ -254,8 +246,7 @@ func verifyHpas(incomingSo *ScaledObject, action string, _ bool) error {
 		if hpa.Annotations[ValidationsHpaOwnershipAnnotation] == "false" {
 			continue
 		}
-		val, _ := json.MarshalIndent(hpa, "", "  ")
-		scaledobjectlog.V(1).Info(fmt.Sprintf("checking hpa %s: %v", hpa.Name, string(val)))
+		scaledobjectlog.V(1).Info("checking hpa", "name", hpa.Name, "namespace", hpa.Namespace, "hpa", hpa)
 
 		hpaGvkr, err := ParseGVKR(restMapper, hpa.Spec.ScaleTargetRef.APIVersion, hpa.Spec.ScaleTargetRef.Kind)
 		if err != nil {
@@ -318,8 +309,7 @@ func verifyScaledObjects(incomingSo *ScaledObject, action string, _ bool) error 
 		if so.Name == incomingSo.Name {
 			continue
 		}
-		val, _ := json.MarshalIndent(so, "", "  ")
-		scaledobjectlog.V(1).Info(fmt.Sprintf("checking scaledobject %s: %v", so.Name, string(val)))
+		scaledobjectlog.V(1).Info("checking scaledobject", "name", so.Name, "namespace", so.Namespace, "scaledobject", so)
 
 		soGckr, err := ParseGVKR(restMapper, so.Spec.ScaleTargetRef.APIVersion, so.Spec.ScaleTargetRef.Kind)
 		if err != nil {

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -29,6 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -144,7 +144,7 @@ func (so *ScaledObject) ValidateDelete(_ *bool) (admission.Warnings, error) {
 
 func isRemovingFinalizer(so *ScaledObject, old runtime.Object) bool {
 	oldSo := old.(*ScaledObject)
-	return len(so.Finalizers) < len(oldSo.Finalizers) && reflect.DeepEqual(so.Spec, oldSo.Spec)
+	return len(so.Finalizers) < len(oldSo.Finalizers) && equality.Semantic.DeepEqual(so.Spec, oldSo.Spec)
 }
 
 func validateWorkload(so *ScaledObject, action string, dryRun bool) (admission.Warnings, error) {

--- a/apis/keda/v1alpha1/triggerauthentication_webhook.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook.go
@@ -18,8 +18,8 @@ package v1alpha1
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -87,18 +87,16 @@ var _ webhook.CustomValidator = &TriggerAuthenticationCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (ta *TriggerAuthentication) ValidateCreate(_ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(ta, "", "  ")
-	triggerauthenticationlog.Info(fmt.Sprintf("validating triggerauthentication creation for %s", string(val)))
+	triggerauthenticationlog.Info("validating triggerauthentication creation", "namespace", ta.Namespace, "name", ta.Name, "triggerauthentication", ta)
 	return validateSpec(&ta.Spec)
 }
 
 func (ta *TriggerAuthentication) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(ta, "", "  ")
-	scaledobjectlog.V(1).Info(fmt.Sprintf("validating triggerauthentication update for %s", string(val)))
+	triggerauthenticationlog.V(1).Info("validating triggerauthentication update", "namespace", ta.Namespace, "name", ta.Name, "triggerauthentication", ta)
 
 	oldTa := old.(*TriggerAuthentication)
 	if isTriggerAuthenticationRemovingFinalizer(ta.ObjectMeta, oldTa.ObjectMeta, ta.Spec, oldTa.Spec) {
-		triggerauthenticationlog.V(1).Info("finalizer removal, skipping validation")
+		triggerauthenticationlog.V(1).Info("finalizer removal, skipping validation", "namespace", ta.Namespace, "name", ta.Name)
 		return nil, nil
 	}
 	return validateSpec(&ta.Spec)
@@ -145,18 +143,16 @@ var _ webhook.CustomValidator = &ClusterTriggerAuthenticationCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (cta *ClusterTriggerAuthentication) ValidateCreate(_ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(cta, "", "  ")
-	triggerauthenticationlog.Info(fmt.Sprintf("validating clustertriggerauthentication creation for %s", string(val)))
+	triggerauthenticationlog.Info("validating clustertriggerauthentication creation", "name", cta.Name, "clustertriggerauthentication", cta)
 	return validateSpec(&cta.Spec)
 }
 
 func (cta *ClusterTriggerAuthentication) ValidateUpdate(old runtime.Object, _ *bool) (admission.Warnings, error) {
-	val, _ := json.MarshalIndent(cta, "", "  ")
-	scaledobjectlog.V(1).Info(fmt.Sprintf("validating clustertriggerauthentication update for %s", string(val)))
+	triggerauthenticationlog.V(1).Info("validating clustertriggerauthentication update", "name", cta.Name, "clustertriggerauthentication", cta)
 
 	oldCta := old.(*ClusterTriggerAuthentication)
 	if isTriggerAuthenticationRemovingFinalizer(cta.ObjectMeta, oldCta.ObjectMeta, cta.Spec, oldCta.Spec) {
-		triggerauthenticationlog.V(1).Info("finalizer removal, skipping validation")
+		triggerauthenticationlog.V(1).Info("finalizer removal, skipping validation", "name", cta.Name)
 		return nil, nil
 	}
 
@@ -168,12 +164,7 @@ func (cta *ClusterTriggerAuthentication) ValidateDelete(_ *bool) (admission.Warn
 }
 
 func isTriggerAuthenticationRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1.ObjectMeta, spec TriggerAuthenticationSpec, oldSpec TriggerAuthenticationSpec) bool {
-	taSpec, _ := json.MarshalIndent(spec, "", "  ")
-	oldTaSpec, _ := json.MarshalIndent(oldSpec, "", "  ")
-	taSpecString := string(taSpec)
-	oldTaSpecString := string(oldTaSpec)
-
-	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && taSpecString == oldTaSpecString
+	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && reflect.DeepEqual(spec, oldSpec)
 }
 
 func validateSpec(spec *TriggerAuthenticationSpec) (admission.Warnings, error) {

--- a/apis/keda/v1alpha1/triggerauthentication_webhook.go
+++ b/apis/keda/v1alpha1/triggerauthentication_webhook.go
@@ -19,8 +19,8 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
-	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -164,7 +164,7 @@ func (cta *ClusterTriggerAuthentication) ValidateDelete(_ *bool) (admission.Warn
 }
 
 func isTriggerAuthenticationRemovingFinalizer(om metav1.ObjectMeta, oldOm metav1.ObjectMeta, spec TriggerAuthenticationSpec, oldSpec TriggerAuthenticationSpec) bool {
-	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && reflect.DeepEqual(spec, oldSpec)
+	return len(om.Finalizers) == 0 && len(oldOm.Finalizers) == 1 && equality.Semantic.DeepEqual(spec, oldSpec)
 }
 
 func validateSpec(spec *TriggerAuthenticationSpec) (admission.Warnings, error) {


### PR DESCRIPTION
 ## Problem                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  Every admission request on ScaledObject, ScaledJob, TriggerAuthentication,                                                                                                                                                                                                                
  ClusterTriggerAuthentication, CloudEventSource, and ClusterCloudEventSource                                                                                                                                                                                                               
  unconditionally calls `json.MarshalIndent` on the full object for a                                                                                                                                                                                                                       
  `.V(1).Info` debug log, e.g.:                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
      func (so *ScaledObject) ValidateCreate(dryRun *bool) (admission.Warnings, error) {                                                                                                                                                                                                    
          val, _ := json.MarshalIndent(so, "", "  ")   // always runs                                                                                                                                                                                                                       
          scaledobjectlog.V(1).Info(fmt.Sprintf("...%s", string(val)))  // dropped at default level                                                                                                                                                                                         
          return validateWorkload(so, "create", *dryRun)                                                                                                                                                                                                                                    
      }                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
  The marshaled bytes are discarded at the default log level. Under sustained                                                                                                                                                                                                               
  admission throughput this generates large amounts of transient garbage;                                                                                                                                                                                                                   
  Go's runtime lazily returns memory to the kernel (MADV_FREE) so the                                                                                                                                                                                                                       
  container's RSS grows faster than it shrinks and the webhook OOMs.                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                            
  Four `isRemovingFinalizer`-style helpers do additional damage — each call                                                                                                                                                                                                                 
  marshals both specs to indented JSON, converts to strings, and compares                                                                                                                                                                                                                   
  the strings, where `reflect.DeepEqual` is correct and cheap.                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                            
  ## Observed impact at Netflix                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                            
  During a KWOK+Karpenter scale test with 60k ScaledObjects created at                                                                                                                                                                                                                      
  30/sec, the admission webhook was OOMKilled in a crash loop at a 4 GiB                                                                                                                                                                                                                    
  memory limit (~10 restarts during a single run, kube-burner completed                                                                                                                                                                                                                     
  via `failurePolicy: Ignore`). A heap profile captured between restarts                                                                                                                                                                                                                    
  showed only a few MiB of `inuse_space` — the Go heap was fine; the                                                                                                                                                                                                                        
  pressure was RSS from the MarshalIndent-generated garbage that hadn't                                                                                                                                                                                                                     
  been returned to the kernel yet. Sustained rate was ~2000 admissions/sec.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                            
  After mitigating on the operations side by raising the limit to 10 GiB,                                                                                                                                                                                                                   
  we pursued this fix to reduce the underlying cost.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                            
  - Replace `json.MarshalIndent(...) + fmt.Sprintf(...) + V(1).Info(...)`                                                                                                                                                                                                                   
    pattern with structured logr kv-args across all four webhook files.                                                                                                                                                                                                                     
    Values are passed as `interface{}`; only serialized by the sink if the                                                                                                                                                                                                                  
    verbosity level is actually enabled.                                                                                                                                                                                                                                                    
  - Replace four `isRemovingFinalizer`-style `json.MarshalIndent` string                                                                                                                                                                                                                    
    comparisons with `reflect.DeepEqual(spec, oldSpec)`. Both approaches                                                                                                                                                                                                                    
    agree on nil-vs-empty-slice (both treat them as different), so behavior                                                                                                                                                                                                                 
    is preserved.                                                                                                                                                                                                                                                                           
  - Incidentally fixed two pre-existing copy-paste bugs where the wrong                                                                                                                                                                                                                     
    logger (`scaledobjectlog`) was used in `scaledjob_webhook.go` and                                                                                                                                                                                                                       
    `triggerauthentication_webhook.go`.                     
  - Remove `encoding/json` import from files that no longer need it.                                                                                                                                                                                                                        
                                                            
  Net: +32 / -67 lines across 5 files.                                                                                                                                                                                                                                                      
                                                            
  ## Tests                                                                                                                                                                                                                                                                                  
                                                            
  `go test ./apis/...` passes on my branch. The kv-args refactor is a                                                                                                                                                                                                                       
  drop-in replacement; the `reflect.DeepEqual` substitution preserves
  semantics for the `isRemovingFinalizer` call site.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                            
  Happy to add benchmarks if helpful, but the production 60k evidence is                                                                                                                                                                                                                    
  already quite strong.                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                            
  ## Related                                                

  - Pairs with #7661 (GetCurrentReplicas nil guard) as a second finding from                                                                                                                                                                                                                
    the same large-scale KEDA load test.