### PR TITLE
fix(influxdb): make authToken optional for unauthenticated instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **GCP Scaler**: Validate Pub/Sub resource name in BuildMQLQuery ([#7468](https://github.com/kedacore/keda/pull/7468))
 - **Github Runner Scaler**: Improve URL construction and error handling ([#7495](https://github.com/kedacore/keda/pull/7495))
 - **Github Runner Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
+- **InfluxDB Scaler**: Make `authToken` optional to support unauthenticated InfluxDB instances ([#7616](https://github.com/kedacore/keda/issues/7616))
 - **Loki Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **Loki Scaler**: `serverAddress` now appends `/loki/api/v1/query` to the end of existing path instead of overriding ([#7648](https://github.com/kedacore/keda/pull/7648))
 - **Metrics API Scaler**: Fix `aggregateFromKubeServiceEndpoints` using empty label selector that matched all EndpointSlices in the namespace instead of only the target service's ([#7641](https://github.com/kedacore/keda/issues/7641))

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -56,10 +56,6 @@ func (i *influxDBMetadata) Validate() error {
 		i.AuthToken = i.AuthTokenOld
 	}
 
-	if i.AuthToken == "" {
-		return fmt.Errorf("authToken is required")
-	}
-
 	if i.InfluxVersion == "3" {
 		if i.Database == "" {
 			return fmt.Errorf("database is required if influxVersion is 3")

--- a/pkg/scalers/influxdb_scaler_test.go
+++ b/pkg/scalers/influxdb_scaler_test.go
@@ -43,8 +43,8 @@ var testInfluxDBMetadata = []parseInfluxDBMetadataTestData{
 	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
 	// 7 no threshold value passed
 	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "query": "from(bucket: hello)", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
-	// 8 no auth token passed
-	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, true, map[string]string{}},
+	// 8 no auth token passed (optional, for unauthenticated instances)
+	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{}},
 	// 9 authToken, organizationName, and serverURL are defined in authParams
 	{map[string]string{"query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "authToken": "myToken"}},
 	// 10 no unsafeSsl value passed


### PR DESCRIPTION
The InfluxDB scaler's `Validate()` rejects an empty `authToken` even though the [documentation](https://keda.sh/docs/2.19/scalers/influxdb/) marks it as optional, and the struct already tags it as `optional`. This breaks use against InfluxDB 3 Core (OSS), which runs without auth by default.

Drop the unconditional `authToken is required` check and update the matching test case (#8) so empty tokens are accepted for unauthenticated instances.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7616