### PR TITLE
refactor: use promhttp and otelhttp for scaler HTTP metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
-- **General**: Add scaler HTTP request metrics (`keda_scaler_http_requests_total`, `keda_scaler_http_request_duration_seconds`) for outbound HTTP requests made during scaler metric fetches ([#6600](https://github.com/kedacore/keda/issues/6600))
+- **General**: Add scaler HTTP request metrics (`keda_scaler_http_requests_total`, `keda_scaler_http_request_duration_seconds`) for outbound HTTP requests made during scaler metric collection ([#6600](https://github.com/kedacore/keda/issues/6600))
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Add scaler HTTP request metrics (`keda_scaler_http_requests_total`, `keda_scaler_http_request_duration_seconds`) for outbound HTTP requests made during scaler metric collection ([#6600](https://github.com/kedacore/keda/issues/6600))
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
+- **General**: Add scaler HTTP request metrics for outbound HTTP requests made during scaler metric collection, using `promhttp` for Prometheus (`keda_scaler_http_requests_total`, `keda_scaler_http_request_duration_seconds`) and `otelhttp` for OpenTelemetry HTTP client duration metrics ([#6600](https://github.com/kedacore/keda/issues/6600))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
 - **Kubernetes Workload Scaler**: Add `groupByNode` parameter ([#7628](https://github.com/kedacore/keda/issues/7628))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
-- **General**: Add HTTP client request metrics for all outbound HTTP requests made by KEDA scalers ([#6600](https://github.com/kedacore/keda/issues/6600))
+- **General**: Add scaler HTTP request metrics (`keda_scaler_http_requests_total`, `keda_scaler_http_request_duration_seconds`) for outbound HTTP requests made during scaler metric fetches ([#6600](https://github.com/kedacore/keda/issues/6600))
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
+- **General**: Add HTTP client request metrics for all outbound HTTP requests made by KEDA scalers ([#6600](https://github.com/kedacore/keda/issues/6600))
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))

--- a/pkg/metricscollector/http_roundtripper.go
+++ b/pkg/metricscollector/http_roundtripper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package metricscollector
 
 import (
 	"context"
@@ -22,8 +22,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-
-	"github.com/kedacore/keda/v2/pkg/metricscollector"
 )
 
 // contextKey is an unexported type for context keys defined in this package,
@@ -63,8 +61,8 @@ func NewInstrumentedRoundTripper(next http.RoundTripper) http.RoundTripper {
 		next = http.DefaultTransport
 	}
 
-	enablePrometheusMetrics := metricscollector.HTTPClientPrometheusMetricsEnabled()
-	enableOpenTelemetryMetrics := metricscollector.HTTPClientOpenTelemetryMetricsEnabled()
+	enablePrometheusMetrics := HTTPClientPrometheusMetricsEnabled()
+	enableOpenTelemetryMetrics := HTTPClientOpenTelemetryMetricsEnabled()
 
 	var instrumented http.RoundTripper = next
 
@@ -82,12 +80,12 @@ func NewInstrumentedRoundTripper(next http.RoundTripper) http.RoundTripper {
 		}
 
 		instrumented = promhttp.InstrumentRoundTripperCounter(
-			metricscollector.HTTPClientRequestsCollector(),
+			HTTPClientRequestsCollector(),
 			instrumented,
 			counterOpts...,
 		)
 		instrumented = promhttp.InstrumentRoundTripperDuration(
-			metricscollector.HTTPClientRequestDurationCollector(),
+			HTTPClientRequestDurationCollector(),
 			instrumented,
 			durationOpts...,
 		)

--- a/pkg/metricscollector/http_roundtripper_test.go
+++ b/pkg/metricscollector/http_roundtripper_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package metricscollector_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -29,14 +30,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
-type mockRoundTripper struct {
+type collectorMockRoundTripper struct {
 	resp *http.Response
 	err  error
 }
 
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (m *collectorMockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if m.resp != nil && m.resp.Request == nil {
 		m.resp.Request = req
 	}
@@ -94,7 +96,7 @@ func TestInstrumentedRoundTripper_ResponseReturnedUnmodified(t *testing.T) {
 	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
 
 	expected := fakeResponse(http.StatusAccepted)
-	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: expected})
+	rt := metricscollector.NewInstrumentedRoundTripper(&collectorMockRoundTripper{resp: expected})
 
 	got, err := rt.RoundTrip(newRequest(context.Background()))
 
@@ -106,22 +108,21 @@ func TestInstrumentedRoundTripper_ResponseReturnedUnmodified(t *testing.T) {
 func TestInstrumentedRoundTripper_NilNextUsesDefault(t *testing.T) {
 	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
 
-	rt := NewInstrumentedRoundTripper(nil)
-	_, ok := rt.(*scalerMetricsRoundTripper)
-	require.True(t, ok)
+	rt := metricscollector.NewInstrumentedRoundTripper(nil)
+	assert.Equal(t, "*metricscollector.scalerMetricsRoundTripper", fmt.Sprintf("%T", rt))
 }
 
 func TestInstrumentedRoundTripper_WithScalerContextRecordsPrometheusMetrics(t *testing.T) {
 	metricscollector.ConfigureHTTPClientMetricsInstrumentation(true, false)
 
-	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(http.StatusOK)})
+	rt := metricscollector.NewInstrumentedRoundTripper(&collectorMockRoundTripper{resp: fakeResponse(http.StatusOK)})
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, ScalerContextKey, "prometheus")
-	ctx = context.WithValue(ctx, TriggerNameContextKey, "my-trigger")
-	ctx = context.WithValue(ctx, MetricNameContextKey, "my-metric")
-	ctx = context.WithValue(ctx, NamespaceContextKey, "default")
-	ctx = context.WithValue(ctx, ScaledResourceContextKey, "my-so")
+	ctx = context.WithValue(ctx, metricscollector.ScalerContextKey, "prometheus")
+	ctx = context.WithValue(ctx, metricscollector.TriggerNameContextKey, "my-trigger")
+	ctx = context.WithValue(ctx, metricscollector.MetricNameContextKey, "my-metric")
+	ctx = context.WithValue(ctx, metricscollector.NamespaceContextKey, "default")
+	ctx = context.WithValue(ctx, metricscollector.ScaledResourceContextKey, "my-so")
 
 	resp, err := rt.RoundTrip(newRequest(ctx))
 	require.NoError(t, err)
@@ -153,15 +154,13 @@ func TestInstrumentedRoundTripper_WithScalerContextRecordsPrometheusMetrics(t *t
 func TestCreateHTTPClient_TransportIsInstrumented(t *testing.T) {
 	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
 
-	client := CreateHTTPClient(0, false)
-	_, ok := client.Transport.(*scalerMetricsRoundTripper)
-	assert.True(t, ok, "expected CreateHTTPClient to wrap transport with scalerMetricsRoundTripper")
+	client := kedautil.CreateHTTPClient(0, false)
+	assert.Equal(t, "*metricscollector.scalerMetricsRoundTripper", fmt.Sprintf("%T", client.Transport))
 }
 
 func TestCreateRTWithTLSConfig_IsInstrumented(t *testing.T) {
 	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
 
-	rt := CreateRTWithTLSConfig(nil)
-	_, ok := rt.(*scalerMetricsRoundTripper)
-	assert.True(t, ok, "expected CreateRTWithTLSConfig to return scalerMetricsRoundTripper")
+	rt := kedautil.CreateRTWithTLSConfig(nil)
+	assert.Equal(t, "*metricscollector.scalerMetricsRoundTripper", fmt.Sprintf("%T", rt))
 }

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -17,7 +17,7 @@ limitations under the License.
 package metricscollector
 
 import (
-	"strconv"
+	"sync/atomic"
 	"time"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
@@ -34,8 +34,10 @@ const (
 )
 
 var (
-	collectors        []MetricsCollector
-	promServerMetrics *grpcprom.ServerMetrics
+	collectors                            []MetricsCollector
+	promServerMetrics                     *grpcprom.ServerMetrics
+	httpClientPrometheusMetricsEnabled    atomic.Bool
+	httpClientOpenTelemetryMetricsEnabled atomic.Bool
 )
 
 type MetricsCollector interface {
@@ -80,15 +82,11 @@ type MetricsCollector interface {
 
 	// RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting
 	RecordCloudEventQueueStatus(namespace string, value int)
-
-	// RecordHTTPClientRequest records the duration and outcome of an outbound HTTP request
-	// made by one of KEDA's internal HTTP clients. scaler, triggerName, metricName,
-	// namespace, and scaledResource are provided explicitly by the caller; upstream
-	// instrumentation may derive them from context before invoking the collector.
-	RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string)
 }
 
 func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool) {
+	ConfigureHTTPClientMetricsInstrumentation(enablePrometheusMetrics, enableOpenTelemetryMetrics)
+
 	if enablePrometheusMetrics {
 		promometrics := NewPromMetrics()
 		collectors = append(collectors, promometrics)
@@ -102,6 +100,19 @@ func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetri
 		otelmetrics := NewOtelMetrics()
 		collectors = append(collectors, otelmetrics)
 	}
+}
+
+func ConfigureHTTPClientMetricsInstrumentation(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool) {
+	httpClientPrometheusMetricsEnabled.Store(enablePrometheusMetrics)
+	httpClientOpenTelemetryMetricsEnabled.Store(enableOpenTelemetryMetrics)
+}
+
+func HTTPClientPrometheusMetricsEnabled() bool {
+	return httpClientPrometheusMetricsEnabled.Load()
+}
+
+func HTTPClientOpenTelemetryMetricsEnabled() bool {
+	return httpClientOpenTelemetryMetricsEnabled.Load()
 }
 
 // RecordScalerMetric create a measurement of the external metric used by the HPA
@@ -210,22 +221,6 @@ func RecordCloudEventQueueStatus(namespace string, value int) {
 	for _, element := range collectors {
 		element.RecordCloudEventQueueStatus(namespace, value)
 	}
-}
-
-// RecordHTTPClientRequest records the duration and outcome of an outbound HTTP request
-// made by one of KEDA's internal HTTP clients. Called by InstrumentedRoundTripper in
-// the util package after extracting label values from the request context.
-func RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
-	for _, element := range collectors {
-		element.RecordHTTPClientRequest(durationSeconds, statusCode, isError, scaler, triggerName, metricName, namespace, scaledResource)
-	}
-}
-
-func httpStatusCodeLabel(code int, isError bool) string {
-	if isError {
-		return "error"
-	}
-	return strconv.Itoa(code)
 }
 
 // Returns the ServerMetrics object for GRPC Server metrics. Used to initialize the GRPC server with the proper intercepts

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -79,6 +79,11 @@ type MetricsCollector interface {
 
 	// RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting
 	RecordCloudEventQueueStatus(namespace string, value int)
+
+	// RecordHTTPClientRequest records the duration and outcome of an outbound HTTP request
+	// made by one of KEDA's internal HTTP clients. scaler, triggerName, and metricName
+	// are read from context keys set in util package; empty string if unset.
+	RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string)
 }
 
 func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool) {
@@ -202,6 +207,15 @@ func RecordCloudEventEmittedError(namespace string, cloudeventsource string, eve
 func RecordCloudEventQueueStatus(namespace string, value int) {
 	for _, element := range collectors {
 		element.RecordCloudEventQueueStatus(namespace, value)
+	}
+}
+
+// RecordHTTPClientRequest records the duration and outcome of an outbound HTTP request
+// made by one of KEDA's internal HTTP clients. scaler, triggerName, and metricName
+// are read from context keys set in util package; empty string if unset.
+func RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
+	for _, element := range collectors {
+		element.RecordHTTPClientRequest(durationSeconds, statusCode, isError, scaler, triggerName, metricName, namespace, scaledResource)
 	}
 }
 

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -82,8 +82,9 @@ type MetricsCollector interface {
 	RecordCloudEventQueueStatus(namespace string, value int)
 
 	// RecordHTTPClientRequest records the duration and outcome of an outbound HTTP request
-	// made by one of KEDA's internal HTTP clients. scaler, triggerName, and metricName
-	// are read from context keys set in util package; empty string if unset.
+	// made by one of KEDA's internal HTTP clients. The scaler, triggerName, metricName,
+	// namespace, and scaledResource values are extracted from context keys by
+	// InstrumentedRoundTripper in the util package before this method is called.
 	RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string)
 }
 
@@ -212,8 +213,8 @@ func RecordCloudEventQueueStatus(namespace string, value int) {
 }
 
 // RecordHTTPClientRequest records the duration and outcome of an outbound HTTP request
-// made by one of KEDA's internal HTTP clients. scaler, triggerName, and metricName
-// are read from context keys set in util package; empty string if unset.
+// made by one of KEDA's internal HTTP clients. Called by InstrumentedRoundTripper in
+// the util package after extracting label values from the request context.
 func RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
 	for _, element := range collectors {
 		element.RecordHTTPClientRequest(durationSeconds, statusCode, isError, scaler, triggerName, metricName, namespace, scaledResource)

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -82,9 +82,9 @@ type MetricsCollector interface {
 	RecordCloudEventQueueStatus(namespace string, value int)
 
 	// RecordHTTPClientRequest records the duration and outcome of an outbound HTTP request
-	// made by one of KEDA's internal HTTP clients. The scaler, triggerName, metricName,
-	// namespace, and scaledResource values are extracted from context keys by
-	// InstrumentedRoundTripper in the util package before this method is called.
+	// made by one of KEDA's internal HTTP clients. scaler, triggerName, metricName,
+	// namespace, and scaledResource are provided explicitly by the caller; upstream
+	// instrumentation may derive them from context before invoking the collector.
 	RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string)
 }
 

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metricscollector
 
 import (
+	"strconv"
 	"time"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
@@ -217,6 +218,13 @@ func RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bo
 	for _, element := range collectors {
 		element.RecordHTTPClientRequest(durationSeconds, statusCode, isError, scaler, triggerName, metricName, namespace, scaledResource)
 	}
+}
+
+func httpStatusCodeLabel(code int, isError bool) string {
+	if isError {
+		return "error"
+	}
+	return strconv.Itoa(code)
 }
 
 // Returns the ServerMetrics object for GRPC Server metrics. Used to initialize the GRPC server with the proper intercepts

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -226,7 +226,7 @@ func initMeters() {
 
 	otHTTPClientRequestsCounter, err = meter.Int64Counter(
 		"keda.scaler.http.requests.count",
-		api.WithDescription("Total number of outbound HTTP requests issued during scaler metric fetches, labeled by status class."),
+		api.WithDescription("Total number of outbound HTTP requests issued during scaler metric collection, labeled by status class."),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
@@ -234,7 +234,7 @@ func initMeters() {
 
 	otHTTPClientRequestDuration, err = meter.Float64Histogram(
 		"keda.scaler.http.request.duration.seconds",
-		api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric fetches."),
+		api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric collection."),
 		api.WithUnit("s"),
 	)
 	if err != nil {

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -518,7 +518,7 @@ func CloudeventQueueStatusCallback(_ context.Context, obsrv api.Float64Observer)
 // RecordHTTPClientRequest records the duration and outcome of a single outbound HTTP request.
 func (o *OtelMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
 	code := httpStatusCodeLabel(statusCode, isError)
-	opt := api.WithAttributes(
+	counterOpt := api.WithAttributes(
 		attribute.Key("namespace").String(namespace),
 		attribute.Key("scaled_resource").String(scaledResource),
 		attribute.Key("scaler").String(scaler),
@@ -526,8 +526,12 @@ func (o *OtelMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCod
 		attribute.Key("metric_name").String(metricName),
 		attribute.Key("status_code").String(code),
 	)
-	otHTTPClientRequestsCounter.Add(context.Background(), 1, opt)
-	otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, opt)
+	histOpt := api.WithAttributes(
+		attribute.Key("scaler").String(scaler),
+		attribute.Key("status_code").String(code),
+	)
+	otHTTPClientRequestsCounter.Add(context.Background(), 1, counterOpt)
+	otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, histOpt)
 }
 
 // RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -47,9 +47,6 @@ var (
 
 	otelScalerActiveVals []OtelMetricFloat64Val
 	otelScalerPauseVals  []OtelMetricFloat64Val
-
-	otHTTPClientRequestsCounter api.Int64Counter
-	otHTTPClientRequestDuration api.Float64Histogram
 )
 
 type OtelMetrics struct {
@@ -219,23 +216,6 @@ func initMeters() {
 		"keda.scaled.object.paused",
 		api.WithDescription("Indicates whether a ScaledObject is paused"),
 		api.WithFloat64Callback(PausedStatusCallback),
-	)
-	if err != nil {
-		otLog.Error(err, msg)
-	}
-
-	otHTTPClientRequestsCounter, err = meter.Int64Counter(
-		"keda.scaler.http.requests.count",
-		api.WithDescription("Total number of outbound HTTP requests issued during scaler metric collection, labeled by HTTP status code."),
-	)
-	if err != nil {
-		otLog.Error(err, msg)
-	}
-
-	otHTTPClientRequestDuration, err = meter.Float64Histogram(
-		"keda.scaler.http.request.duration.seconds",
-		api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric collection."),
-		api.WithUnit("s"),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
@@ -513,25 +493,6 @@ func CloudeventQueueStatusCallback(_ context.Context, obsrv api.Float64Observer)
 	}
 	otCloudEventQueueStatusVals = []OtelMetricFloat64Val{}
 	return nil
-}
-
-// RecordHTTPClientRequest records the duration and outcome of a single outbound HTTP request.
-func (o *OtelMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
-	code := httpStatusCodeLabel(statusCode, isError)
-	counterOpt := api.WithAttributes(
-		attribute.Key("namespace").String(namespace),
-		attribute.Key("scaled_resource").String(scaledResource),
-		attribute.Key("scaler").String(scaler),
-		attribute.Key("trigger_name").String(triggerName),
-		attribute.Key("metric_name").String(metricName),
-		attribute.Key("status_code").String(code),
-	)
-	histOpt := api.WithAttributes(
-		attribute.Key("scaler").String(scaler),
-		attribute.Key("status_code").String(code),
-	)
-	otHTTPClientRequestsCounter.Add(context.Background(), 1, counterOpt)
-	otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, histOpt)
 }
 
 // RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -47,6 +47,9 @@ var (
 
 	otelScalerActiveVals []OtelMetricFloat64Val
 	otelScalerPauseVals  []OtelMetricFloat64Val
+
+	otHTTPClientRequestsCounter api.Int64Counter
+	otHTTPClientRequestDuration api.Float64Histogram
 )
 
 type OtelMetrics struct {
@@ -216,6 +219,23 @@ func initMeters() {
 		"keda.scaled.object.paused",
 		api.WithDescription("Indicates whether a ScaledObject is paused"),
 		api.WithFloat64Callback(PausedStatusCallback),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
+	otHTTPClientRequestsCounter, err = meter.Int64Counter(
+		"keda.http.client.requests.count",
+		api.WithDescription("Total number of outbound HTTP requests issued by KEDA's HTTP clients, labeled by status class."),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
+	otHTTPClientRequestDuration, err = meter.Float64Histogram(
+		"keda.http.client.request.duration.seconds",
+		api.WithDescription("Duration in seconds of outbound HTTP requests issued by KEDA's HTTP clients."),
+		api.WithUnit("s"),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
@@ -493,6 +513,21 @@ func CloudeventQueueStatusCallback(_ context.Context, obsrv api.Float64Observer)
 	}
 	otCloudEventQueueStatusVals = []OtelMetricFloat64Val{}
 	return nil
+}
+
+// RecordHTTPClientRequest records the duration and outcome of a single outbound HTTP request.
+func (o *OtelMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
+	code := httpStatusCodeLabel(statusCode, isError)
+	opt := api.WithAttributes(
+		attribute.Key("namespace").String(namespace),
+		attribute.Key("scaled_resource").String(scaledResource),
+		attribute.Key("scaler").String(scaler),
+		attribute.Key("trigger_name").String(triggerName),
+		attribute.Key("metric_name").String(metricName),
+		attribute.Key("status_code").String(code),
+	)
+	otHTTPClientRequestsCounter.Add(context.Background(), 1, opt)
+	otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, opt)
 }
 
 // RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -226,7 +226,7 @@ func initMeters() {
 
 	otHTTPClientRequestsCounter, err = meter.Int64Counter(
 		"keda.scaler.http.requests.count",
-		api.WithDescription("Total number of outbound HTTP requests issued during scaler metric collection, labeled by status class."),
+		api.WithDescription("Total number of outbound HTTP requests issued during scaler metric collection, labeled by HTTP status code."),
 	)
 	if err != nil {
 		otLog.Error(err, msg)

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -225,16 +225,16 @@ func initMeters() {
 	}
 
 	otHTTPClientRequestsCounter, err = meter.Int64Counter(
-		"keda.http.client.requests.count",
-		api.WithDescription("Total number of outbound HTTP requests issued by KEDA's HTTP clients, labeled by status class."),
+		"keda.scaler.http.requests.count",
+		api.WithDescription("Total number of outbound HTTP requests issued during scaler metric fetches, labeled by status class."),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
 	}
 
 	otHTTPClientRequestDuration, err = meter.Float64Histogram(
-		"keda.http.client.request.duration.seconds",
-		api.WithDescription("Duration in seconds of outbound HTTP requests issued by KEDA's HTTP clients."),
+		"keda.scaler.http.request.duration.seconds",
+		api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric fetches."),
 		api.WithUnit("s"),
 	)
 	if err != nil {

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -101,7 +101,7 @@ func NewOtelMetrics(options ...metric.Option) *OtelMetrics {
 
 func initMeters() {
 	var err error
-	msg := "create opentelemetry counter failed"
+	msg := "failed to create OpenTelemetry instrument"
 
 	otScalerErrorsCounter, err = meter.Int64Counter("keda.scaler.errors", api.WithDescription("Number of scaler errors"))
 	if err != nil {

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 var (
@@ -143,11 +142,11 @@ func TestHTTPClientDurationMetric(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, kedautil.ScalerContextKey, "prometheus")
-	ctx = context.WithValue(ctx, kedautil.TriggerNameContextKey, "my-trigger")
-	ctx = context.WithValue(ctx, kedautil.MetricNameContextKey, "my-metric")
-	ctx = context.WithValue(ctx, kedautil.NamespaceContextKey, "default")
-	ctx = context.WithValue(ctx, kedautil.ScaledResourceContextKey, "my-so")
+	ctx = context.WithValue(ctx, metricscollector.ScalerContextKey, "prometheus")
+	ctx = context.WithValue(ctx, metricscollector.TriggerNameContextKey, "my-trigger")
+	ctx = context.WithValue(ctx, metricscollector.MetricNameContextKey, "my-metric")
+	ctx = context.WithValue(ctx, metricscollector.NamespaceContextKey, "default")
+	ctx = context.WithValue(ctx, metricscollector.ScaledResourceContextKey, "my-so")
 
 	labeler := &otelhttp.Labeler{}
 	labeler.Add(
@@ -162,7 +161,7 @@ func TestHTTPClientDurationMetric(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
 	assert.NoError(t, err)
 
-	rt := kedautil.NewInstrumentedRoundTripper(mockRoundTripper{statusCode: http.StatusOK})
+	rt := metricscollector.NewInstrumentedRoundTripper(mockRoundTripper{statusCode: http.StatusOK})
 	resp, err := rt.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())
@@ -212,11 +211,11 @@ func TestHTTPClientDurationMetricDisabled(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, kedautil.ScalerContextKey, "prometheus")
-	ctx = context.WithValue(ctx, kedautil.TriggerNameContextKey, "my-trigger")
-	ctx = context.WithValue(ctx, kedautil.MetricNameContextKey, "my-metric")
-	ctx = context.WithValue(ctx, kedautil.NamespaceContextKey, "default")
-	ctx = context.WithValue(ctx, kedautil.ScaledResourceContextKey, "my-so")
+	ctx = context.WithValue(ctx, metricscollector.ScalerContextKey, "prometheus")
+	ctx = context.WithValue(ctx, metricscollector.TriggerNameContextKey, "my-trigger")
+	ctx = context.WithValue(ctx, metricscollector.MetricNameContextKey, "my-metric")
+	ctx = context.WithValue(ctx, metricscollector.NamespaceContextKey, "default")
+	ctx = context.WithValue(ctx, metricscollector.ScaledResourceContextKey, "my-so")
 
 	labeler := &otelhttp.Labeler{}
 	labeler.Add(
@@ -231,7 +230,7 @@ func TestHTTPClientDurationMetricDisabled(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
 	assert.NoError(t, err)
 
-	rt := kedautil.NewInstrumentedRoundTripper(mockRoundTripper{statusCode: http.StatusOK})
+	rt := metricscollector.NewInstrumentedRoundTripper(mockRoundTripper{statusCode: http.StatusOK})
 	resp, err := rt.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.NoError(t, resp.Body.Close())

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -185,11 +185,14 @@ func TestHTTPClientDurationMetric(t *testing.T) {
 		metricName, _ := dp.Attributes.Value("metric_name")
 		namespace, _ := dp.Attributes.Value("namespace")
 		scaledResource, _ := dp.Attributes.Value("scaled_resource")
+		statusCode, ok := dp.Attributes.Value("http.response.status_code")
+		assert.True(t, ok)
 
 		assert.Equal(t, "my-trigger", triggerName.AsString())
 		assert.Equal(t, "my-metric", metricName.AsString())
 		assert.Equal(t, "default", namespace.AsString())
 		assert.Equal(t, "my-so", scaledResource.AsString())
+		assert.Equal(t, int64(http.StatusOK), statusCode.AsInt64())
 		assert.Greater(t, dp.Count, uint64(0))
 		found = true
 		break

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -103,6 +103,59 @@ func TestLoopLatency(t *testing.T) {
 	assert.Equal(t, data.Value, float64(0.5))
 }
 
+func TestRecordHTTPClientRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		isError        bool
+		wantStatusCode string
+	}{
+		{"200 success", 200, false, "200"},
+		{"301 redirect", 301, false, "301"},
+		{"404 client error", 404, false, "404"},
+		{"503 server error", 503, false, "503"},
+		{"transport error", 0, true, "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testOtel.RecordHTTPClientRequest(0.1, tt.statusCode, tt.isError, "prometheus", "my-trigger", "my-metric", "default", "my-so")
+			got := metricdata.ResourceMetrics{}
+			err := testReader.Collect(context.Background(), &got)
+			assert.Nil(t, err)
+
+			scopeMetrics := got.ScopeMetrics[0]
+			requestCount := retrieveMetric(scopeMetrics.Metrics, "keda.http.client.requests.count")
+			assert.NotNil(t, requestCount)
+
+			var found bool
+			for _, dp := range requestCount.Data.(metricdata.Sum[int64]).DataPoints {
+				code, ok := dp.Attributes.Value("status_code")
+				if !ok || code.AsString() != tt.wantStatusCode {
+					continue
+				}
+				scaler, _ := dp.Attributes.Value("scaler")
+				assert.Equal(t, "prometheus", scaler.AsString())
+				triggerName, _ := dp.Attributes.Value("trigger_name")
+				assert.Equal(t, "my-trigger", triggerName.AsString())
+				metricName, _ := dp.Attributes.Value("metric_name")
+				assert.Equal(t, "my-metric", metricName.AsString())
+				ns, _ := dp.Attributes.Value("namespace")
+				assert.Equal(t, "default", ns.AsString())
+				sr, _ := dp.Attributes.Value("scaled_resource")
+				assert.Equal(t, "my-so", sr.AsString())
+				found = true
+				break
+			}
+			assert.True(t, found, "expected data point with status_code=%q", tt.wantStatusCode)
+
+			requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.http.client.request.duration.seconds")
+			assert.NotNil(t, requestDuration)
+			assert.Equal(t, "s", requestDuration.Unit)
+		})
+	}
+}
+
 func TestContinuousMetrics(t *testing.T) {
 	testOtel.RecordScalerActive("testnamespace", "testresource", "testscaler", 0, "testmetric", true, true)
 	testOtel.RecordScalerActive("testnamespace2", "testresource2", "testscaler2", 0, "testmetric", false, false)

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -125,7 +125,7 @@ func TestRecordHTTPClientRequest(t *testing.T) {
 			assert.Nil(t, err)
 
 			scopeMetrics := got.ScopeMetrics[0]
-			requestCount := retrieveMetric(scopeMetrics.Metrics, "keda.http.client.requests.count")
+			requestCount := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.requests.count")
 			assert.NotNil(t, requestCount)
 
 			var found bool
@@ -149,7 +149,7 @@ func TestRecordHTTPClientRequest(t *testing.T) {
 			}
 			assert.True(t, found, "expected data point with status_code=%q", tt.wantStatusCode)
 
-			requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.http.client.request.duration.seconds")
+			requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.request.duration.seconds")
 			assert.NotNil(t, requestDuration)
 			assert.Equal(t, "s", requestDuration.Unit)
 		})

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -1,24 +1,32 @@
-package metricscollector
+package metricscollector_test
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 var (
-	testOtel   *OtelMetrics
+	testOtel   *metricscollector.OtelMetrics
 	testReader metric.Reader
 )
 
 func init() {
 	testReader = metric.NewManualReader()
 	options := metric.WithReader(testReader)
-	testOtel = NewOtelMetrics(options)
+	testOtel = metricscollector.NewOtelMetrics(options)
 }
 
 func retrieveMetric(metrics []metricdata.Metrics, metricname string) *metricdata.Metrics {
@@ -27,6 +35,16 @@ func retrieveMetric(metrics []metricdata.Metrics, metricname string) *metricdata
 			return &m
 		}
 	}
+	return nil
+}
+
+func retrieveMetricFromScopes(scopeMetrics []metricdata.ScopeMetrics, metricname string) *metricdata.Metrics {
+	for _, scopeMetric := range scopeMetrics {
+		if metric := retrieveMetric(scopeMetric.Metrics, metricname); metric != nil {
+			return metric
+		}
+	}
+
 	return nil
 }
 
@@ -103,57 +121,124 @@ func TestLoopLatency(t *testing.T) {
 	assert.Equal(t, data.Value, float64(0.5))
 }
 
-func TestRecordHTTPClientRequest(t *testing.T) {
-	tests := []struct {
-		name           string
-		statusCode     int
-		isError        bool
-		wantStatusCode string
-	}{
-		{"200 success", 200, false, "200"},
-		{"301 redirect", 301, false, "301"},
-		{"404 client error", 404, false, "404"},
-		{"503 server error", 503, false, "503"},
-		{"transport error", 0, true, "error"},
+type mockRoundTripper struct {
+	statusCode int
+}
+
+func (m mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    req,
+	}, nil
+}
+
+func TestHTTPClientDurationMetric(t *testing.T) {
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, true)
+	reader := metric.NewManualReader()
+	metricscollector.NewOtelMetrics(metric.WithReader(reader))
+	defer func() {
+		testReader = metric.NewManualReader()
+		testOtel = metricscollector.NewOtelMetrics(metric.WithReader(testReader))
+	}()
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, kedautil.ScalerContextKey, "prometheus")
+	ctx = context.WithValue(ctx, kedautil.TriggerNameContextKey, "my-trigger")
+	ctx = context.WithValue(ctx, kedautil.MetricNameContextKey, "my-metric")
+	ctx = context.WithValue(ctx, kedautil.NamespaceContextKey, "default")
+	ctx = context.WithValue(ctx, kedautil.ScaledResourceContextKey, "my-so")
+
+	labeler := &otelhttp.Labeler{}
+	labeler.Add(
+		attribute.String("scaler", "prometheus"),
+		attribute.String("trigger_name", "my-trigger"),
+		attribute.String("metric_name", "my-metric"),
+		attribute.String("namespace", "default"),
+		attribute.String("scaled_resource", "my-so"),
+	)
+	ctx = otelhttp.ContextWithLabeler(ctx, labeler)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	assert.NoError(t, err)
+
+	rt := kedautil.NewInstrumentedRoundTripper(mockRoundTripper{statusCode: http.StatusOK})
+	resp, err := rt.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+
+	got := metricdata.ResourceMetrics{}
+	err = reader.Collect(context.Background(), &got)
+	assert.Nil(t, err)
+
+	requestDuration := retrieveMetricFromScopes(got.ScopeMetrics, "http.client.request.duration")
+	assert.NotNil(t, requestDuration)
+	assert.Equal(t, "s", requestDuration.Unit)
+
+	var found bool
+	for _, dp := range requestDuration.Data.(metricdata.Histogram[float64]).DataPoints {
+		scaler, ok := dp.Attributes.Value("scaler")
+		if !ok || scaler.AsString() != "prometheus" {
+			continue
+		}
+		triggerName, _ := dp.Attributes.Value("trigger_name")
+		metricName, _ := dp.Attributes.Value("metric_name")
+		namespace, _ := dp.Attributes.Value("namespace")
+		scaledResource, _ := dp.Attributes.Value("scaled_resource")
+
+		assert.Equal(t, "my-trigger", triggerName.AsString())
+		assert.Equal(t, "my-metric", metricName.AsString())
+		assert.Equal(t, "default", namespace.AsString())
+		assert.Equal(t, "my-so", scaledResource.AsString())
+		assert.Greater(t, dp.Count, uint64(0))
+		found = true
+		break
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testOtel.RecordHTTPClientRequest(0.1, tt.statusCode, tt.isError, "prometheus", "my-trigger", "my-metric", "default", "my-so")
-			got := metricdata.ResourceMetrics{}
-			err := testReader.Collect(context.Background(), &got)
-			assert.Nil(t, err)
+	assert.True(t, found, "expected http.client.request.duration datapoint with scaler labels")
+}
 
-			scopeMetrics := got.ScopeMetrics[0]
-			requestCount := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.requests.count")
-			assert.NotNil(t, requestCount)
+func TestHTTPClientDurationMetricDisabled(t *testing.T) {
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
 
-			var found bool
-			for _, dp := range requestCount.Data.(metricdata.Sum[int64]).DataPoints {
-				code, ok := dp.Attributes.Value("status_code")
-				if !ok || code.AsString() != tt.wantStatusCode {
-					continue
-				}
-				scaler, _ := dp.Attributes.Value("scaler")
-				assert.Equal(t, "prometheus", scaler.AsString())
-				triggerName, _ := dp.Attributes.Value("trigger_name")
-				assert.Equal(t, "my-trigger", triggerName.AsString())
-				metricName, _ := dp.Attributes.Value("metric_name")
-				assert.Equal(t, "my-metric", metricName.AsString())
-				ns, _ := dp.Attributes.Value("namespace")
-				assert.Equal(t, "default", ns.AsString())
-				sr, _ := dp.Attributes.Value("scaled_resource")
-				assert.Equal(t, "my-so", sr.AsString())
-				found = true
-				break
-			}
-			assert.True(t, found, "expected data point with status_code=%q", tt.wantStatusCode)
+	reader := metric.NewManualReader()
+	metricscollector.NewOtelMetrics(metric.WithReader(reader))
+	defer func() {
+		testReader = metric.NewManualReader()
+		testOtel = metricscollector.NewOtelMetrics(metric.WithReader(testReader))
+	}()
 
-			requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.request.duration.seconds")
-			assert.NotNil(t, requestDuration)
-			assert.Equal(t, "s", requestDuration.Unit)
-		})
-	}
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, kedautil.ScalerContextKey, "prometheus")
+	ctx = context.WithValue(ctx, kedautil.TriggerNameContextKey, "my-trigger")
+	ctx = context.WithValue(ctx, kedautil.MetricNameContextKey, "my-metric")
+	ctx = context.WithValue(ctx, kedautil.NamespaceContextKey, "default")
+	ctx = context.WithValue(ctx, kedautil.ScaledResourceContextKey, "my-so")
+
+	labeler := &otelhttp.Labeler{}
+	labeler.Add(
+		attribute.String("scaler", "prometheus"),
+		attribute.String("trigger_name", "my-trigger"),
+		attribute.String("metric_name", "my-metric"),
+		attribute.String("namespace", "default"),
+		attribute.String("scaled_resource", "my-so"),
+	)
+	ctx = otelhttp.ContextWithLabeler(ctx, labeler)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	assert.NoError(t, err)
+
+	rt := kedautil.NewInstrumentedRoundTripper(mockRoundTripper{statusCode: http.StatusOK})
+	resp, err := rt.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+
+	got := metricdata.ResourceMetrics{}
+	err = reader.Collect(context.Background(), &got)
+	assert.Nil(t, err)
+
+	requestDuration := retrieveMetricFromScopes(got.ScopeMetrics, "http.client.request.duration")
+	assert.Nil(t, requestDuration)
 }
 
 func TestContinuousMetrics(t *testing.T) {
@@ -167,7 +252,7 @@ func TestContinuousMetrics(t *testing.T) {
 	assert.NotEqual(t, len(scopeMetrics.Metrics), 0)
 	activeMetric := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.active")
 
-	assert.NotNil(t, buildInfo)
+	assert.NotNil(t, activeMetric)
 
 	dataPoints := activeMetric.Data.(metricdata.Gauge[float64]).DataPoints
 	assert.Len(t, dataPoints, 2)

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -152,6 +152,27 @@ var (
 		},
 		[]string{"namespace"},
 	)
+
+	httpClientRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "http_client",
+			Name:      "requests_total",
+			Help:      "Total number of outbound HTTP requests issued by KEDA's HTTP clients.",
+		},
+		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},
+	)
+
+	httpClientRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "http_client",
+			Name:      "request_duration_seconds",
+			Help:      "Duration in seconds of outbound HTTP requests issued by KEDA's HTTP clients.",
+			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},
+	)
 )
 
 type PromMetrics struct {
@@ -173,6 +194,9 @@ func NewPromMetrics() *PromMetrics {
 
 	metrics.Registry.MustRegister(cloudeventEmitted)
 	metrics.Registry.MustRegister(cloudeventQueueStatus)
+
+	metrics.Registry.MustRegister(httpClientRequestsTotal)
+	metrics.Registry.MustRegister(httpClientRequestDuration)
 
 	RecordBuildInfo()
 	return &PromMetrics{}
@@ -326,6 +350,20 @@ func (p *PromMetrics) RecordCloudEventEmittedError(namespace string, cloudevents
 // RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting
 func (p *PromMetrics) RecordCloudEventQueueStatus(namespace string, value int) {
 	cloudeventQueueStatus.With(prometheus.Labels{"namespace": namespace}).Set(float64(value))
+}
+
+// RecordHTTPClientRequest records the duration and outcome of a single outbound HTTP request.
+func (p *PromMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
+	code := httpStatusCodeLabel(statusCode, isError)
+	httpClientRequestsTotal.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Inc()
+	httpClientRequestDuration.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Observe(durationSeconds)
+}
+
+func httpStatusCodeLabel(code int, isError bool) string {
+	if isError {
+		return "error"
+	}
+	return strconv.Itoa(code)
 }
 
 // Returns a grpcprom server Metrics object and registers the metrics. The object contains

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -156,9 +156,9 @@ var (
 	httpClientRequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: DefaultPromMetricsNamespace,
-			Subsystem: "http_client",
+			Subsystem: "scaler_http",
 			Name:      "requests_total",
-			Help:      "Total number of outbound HTTP requests issued by KEDA's HTTP clients.",
+			Help:      "Total number of outbound HTTP requests issued during scaler metric fetches.",
 		},
 		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},
 	)
@@ -166,9 +166,9 @@ var (
 	httpClientRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: DefaultPromMetricsNamespace,
-			Subsystem: "http_client",
+			Subsystem: "scaler_http",
 			Name:      "request_duration_seconds",
-			Help:      "Duration in seconds of outbound HTTP requests issued by KEDA's HTTP clients.",
+			Help:      "Duration in seconds of outbound HTTP requests issued during scaler metric fetches.",
 			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
 		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -160,7 +160,7 @@ var (
 			Name:      "requests_total",
 			Help:      "Total number of outbound HTTP requests issued during scaler metric collection.",
 		},
-		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},
+		[]string{"code", "namespace", "scaled_resource", "scaler", "trigger_name", "metric_name"},
 	)
 
 	httpClientRequestDuration = prometheus.NewHistogramVec(
@@ -171,7 +171,7 @@ var (
 			Help:      "Duration in seconds of outbound HTTP requests issued during scaler metric collection.",
 			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
-		[]string{"scaler", "status_code"},
+		[]string{"code", "scaler"},
 	)
 )
 
@@ -352,12 +352,9 @@ func (p *PromMetrics) RecordCloudEventQueueStatus(namespace string, value int) {
 	cloudeventQueueStatus.With(prometheus.Labels{"namespace": namespace}).Set(float64(value))
 }
 
-// RecordHTTPClientRequest records the duration and outcome of a single outbound HTTP request.
-func (p *PromMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
-	code := httpStatusCodeLabel(statusCode, isError)
-	httpClientRequestsTotal.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Inc()
-	httpClientRequestDuration.WithLabelValues(scaler, code).Observe(durationSeconds)
-}
+func HTTPClientRequestsCollector() *prometheus.CounterVec { return httpClientRequestsTotal }
+
+func HTTPClientRequestDurationCollector() *prometheus.HistogramVec { return httpClientRequestDuration }
 
 
 // Returns a grpcprom server Metrics object and registers the metrics. The object contains

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -171,7 +171,7 @@ var (
 			Help:      "Duration in seconds of outbound HTTP requests issued during scaler metric collection.",
 			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
-		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},
+		[]string{"scaler", "status_code"},
 	)
 )
 
@@ -356,7 +356,7 @@ func (p *PromMetrics) RecordCloudEventQueueStatus(namespace string, value int) {
 func (p *PromMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
 	code := httpStatusCodeLabel(statusCode, isError)
 	httpClientRequestsTotal.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Inc()
-	httpClientRequestDuration.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Observe(durationSeconds)
+	httpClientRequestDuration.WithLabelValues(scaler, code).Observe(durationSeconds)
 }
 
 

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -158,7 +158,7 @@ var (
 			Namespace: DefaultPromMetricsNamespace,
 			Subsystem: "scaler_http",
 			Name:      "requests_total",
-			Help:      "Total number of outbound HTTP requests issued during scaler metric fetches.",
+			Help:      "Total number of outbound HTTP requests issued during scaler metric collection.",
 		},
 		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},
 	)
@@ -168,7 +168,7 @@ var (
 			Namespace: DefaultPromMetricsNamespace,
 			Subsystem: "scaler_http",
 			Name:      "request_duration_seconds",
-			Help:      "Duration in seconds of outbound HTTP requests issued during scaler metric fetches.",
+			Help:      "Duration in seconds of outbound HTTP requests issued during scaler metric collection.",
 			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
 		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -359,12 +359,6 @@ func (p *PromMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCod
 	httpClientRequestDuration.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Observe(durationSeconds)
 }
 
-func httpStatusCodeLabel(code int, isError bool) string {
-	if isError {
-		return "error"
-	}
-	return strconv.Itoa(code)
-}
 
 // Returns a grpcprom server Metrics object and registers the metrics. The object contains
 // interceptors to chain to the server so that all requests served are observed. Intended to be called

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -82,7 +82,7 @@ func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
 	require.NoError(t, counter.Write(m))
 	assert.EqualValues(t, 1, m.Counter.GetValue())
 
-	hist, err := httpClientRequestDuration.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
+	hist, err := httpClientRequestDuration.GetMetricWithLabelValues("prometheus", "200")
 	require.NoError(t, err)
 	require.NoError(t, hist.(prometheus.Metric).Write(m))
 	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricscollector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPStatusCodeLabel(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		isError    bool
+		want       string
+	}{
+		{"transport error", 0, true, "error"},
+		{"200 OK", 200, false, "200"},
+		{"201 Created", 201, false, "201"},
+		{"301 Moved", 301, false, "301"},
+		{"400 Bad Request", 400, false, "400"},
+		{"404 Not Found", 404, false, "404"},
+		{"500 Internal Server Error", 500, false, "500"},
+		{"503 Service Unavailable", 503, false, "503"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := httpStatusCodeLabel(tt.statusCode, tt.isError)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
+	p := &PromMetrics{}
+
+	// Verify no panic and label combinations are created without error.
+	p.RecordHTTPClientRequest(0.05, 200, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
+	p.RecordHTTPClientRequest(0.1, 404, false, "redis", "redis-trigger", "redis-metric", "default", "my-so")
+	p.RecordHTTPClientRequest(0.2, 500, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
+	p.RecordHTTPClientRequest(0.3, 0, true, "", "", "", "", "")
+
+	counter, err := httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
+	assert.NoError(t, err)
+	assert.NotNil(t, counter)
+
+	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "redis", "redis-trigger", "redis-metric", "404")
+	assert.NoError(t, err)
+	assert.NotNil(t, counter)
+
+	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "500")
+	assert.NoError(t, err)
+	assert.NotNil(t, counter)
+
+	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("", "", "", "", "", "error")
+	assert.NoError(t, err)
+	assert.NotNil(t, counter)
+}

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -17,74 +17,11 @@ limitations under the License.
 package metricscollector
 
 import (
-	"testing"
-
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"testing"
 )
 
-func TestHTTPStatusCodeLabel(t *testing.T) {
-	tests := []struct {
-		name       string
-		statusCode int
-		isError    bool
-		want       string
-	}{
-		{"transport error", 0, true, "error"},
-		{"isError flag takes precedence over non-zero code", 500, true, "error"},
-		{"200 OK", 200, false, "200"},
-		{"201 Created", 201, false, "201"},
-		{"301 Moved", 301, false, "301"},
-		{"400 Bad Request", 400, false, "400"},
-		{"404 Not Found", 404, false, "404"},
-		{"500 Internal Server Error", 500, false, "500"},
-		{"503 Service Unavailable", 503, false, "503"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := httpStatusCodeLabel(tt.statusCode, tt.isError)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
-	p := &PromMetrics{}
-
-	// Verify no panic and label combinations are created without error.
-	p.RecordHTTPClientRequest(0.05, 200, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
-	p.RecordHTTPClientRequest(0.1, 404, false, "redis", "redis-trigger", "redis-metric", "default", "my-so")
-	p.RecordHTTPClientRequest(0.2, 500, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
-	p.RecordHTTPClientRequest(0.3, 0, true, "", "", "", "", "")
-
-	m := &dto.Metric{}
-
-	counter, err := httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
-	require.NoError(t, err)
-	require.NoError(t, counter.Write(m))
-	assert.EqualValues(t, 1, m.Counter.GetValue())
-
-	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "redis", "redis-trigger", "redis-metric", "404")
-	require.NoError(t, err)
-	require.NoError(t, counter.Write(m))
-	assert.EqualValues(t, 1, m.Counter.GetValue())
-
-	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "500")
-	require.NoError(t, err)
-	require.NoError(t, counter.Write(m))
-	assert.EqualValues(t, 1, m.Counter.GetValue())
-
-	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("", "", "", "", "", "error")
-	require.NoError(t, err)
-	require.NoError(t, counter.Write(m))
-	assert.EqualValues(t, 1, m.Counter.GetValue())
-
-	hist, err := httpClientRequestDuration.GetMetricWithLabelValues("prometheus", "200")
-	require.NoError(t, err)
-	require.NoError(t, hist.(prometheus.Metric).Write(m))
-	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
-	assert.InDelta(t, 0.05, m.Histogram.GetSampleSum(), 0.001)
+func TestHTTPClientCollectorsAvailable(t *testing.T) {
+	assert.NotNil(t, HTTPClientRequestsCollector())
+	assert.NotNil(t, HTTPClientRequestDurationCollector())
 }

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -19,7 +19,10 @@ package metricscollector
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPStatusCodeLabel(t *testing.T) {
@@ -30,6 +33,7 @@ func TestHTTPStatusCodeLabel(t *testing.T) {
 		want       string
 	}{
 		{"transport error", 0, true, "error"},
+		{"isError flag takes precedence over non-zero code", 500, true, "error"},
 		{"200 OK", 200, false, "200"},
 		{"201 Created", 201, false, "201"},
 		{"301 Moved", 301, false, "301"},
@@ -56,19 +60,31 @@ func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
 	p.RecordHTTPClientRequest(0.2, 500, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
 	p.RecordHTTPClientRequest(0.3, 0, true, "", "", "", "", "")
 
+	m := &dto.Metric{}
+
 	counter, err := httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
-	assert.NoError(t, err)
-	assert.NotNil(t, counter)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
 
 	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "redis", "redis-trigger", "redis-metric", "404")
-	assert.NoError(t, err)
-	assert.NotNil(t, counter)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
 
 	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "500")
-	assert.NoError(t, err)
-	assert.NotNil(t, counter)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
 
 	counter, err = httpClientRequestsTotal.GetMetricWithLabelValues("", "", "", "", "", "error")
-	assert.NoError(t, err)
-	assert.NotNil(t, counter)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
+
+	hist, err := httpClientRequestDuration.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+	assert.InDelta(t, 0.05, m.Histogram.GetSampleSum(), 0.001)
 }

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KEDA Authors
+Copyright 2026 The KEDA Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/metricscollector/request_context.go
+++ b/pkg/metricscollector/request_context.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricscollector
+
+import (
+	"context"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+)
+
+// BuildScalerRequestCtx attaches scaler metadata used by HTTP client
+// instrumentation to the outbound request context.
+func BuildScalerRequestCtx(ctx context.Context, config scalersconfig.ScalerConfig, metricName string) context.Context {
+	requestCtx := context.WithValue(ctx, ScalerContextKey, config.TriggerType)
+	requestCtx = context.WithValue(requestCtx, TriggerNameContextKey, config.TriggerName)
+	requestCtx = context.WithValue(requestCtx, MetricNameContextKey, metricName)
+	requestCtx = context.WithValue(requestCtx, NamespaceContextKey, config.ScalableObjectNamespace)
+	requestCtx = context.WithValue(requestCtx, ScaledResourceContextKey, config.ScalableObjectName)
+
+	if !HTTPClientOpenTelemetryMetricsEnabled() {
+		return requestCtx
+	}
+
+	labeler := &otelhttp.Labeler{}
+	labeler.Add(
+		attribute.String("scaler", config.TriggerType),
+		attribute.String("trigger_name", config.TriggerName),
+		attribute.String("metric_name", metricName),
+		attribute.String("namespace", config.ScalableObjectNamespace),
+		attribute.String("scaled_resource", config.ScalableObjectName),
+	)
+
+	return otelhttp.ContextWithLabeler(requestCtx, labeler)
+}

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -109,7 +109,7 @@ func NewArtemisQueueScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error creating TLS config: %w", err)
 		}
-		httpClient.Transport = kedautil.CreateHTTPTransportWithTLSConfig(tlsConfig)
+		httpClient.Transport = kedautil.CreateRTWithTLSConfig(tlsConfig)
 	}
 
 	return &artemisScaler{

--- a/pkg/scalers/aws/aws_sigv4.go
+++ b/pkg/scalers/aws/aws_sigv4.go
@@ -101,7 +101,7 @@ func NewSigV4RoundTripper(config *scalersconfig.ScalerConfig, awsRegion string) 
 	client := amp.NewFromConfig(*awsCfg, func(_ *amp.Options) {})
 	rt := &roundTripper{
 		client: client,
-		next:   httputils.CreateHTTPTransport(false),
+		next:   httputils.CreateRT(false),
 	}
 
 	return rt, nil

--- a/pkg/scalers/aws/aws_sigv4.go
+++ b/pkg/scalers/aws/aws_sigv4.go
@@ -40,6 +40,7 @@ import (
 // roundTripper adds custom round tripper to sign requests
 type roundTripper struct {
 	client *amp.Client
+	next   http.RoundTripper
 }
 
 var (
@@ -63,11 +64,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Create default transport
-	transport := httputils.CreateHTTPTransport(false)
-
-	// Send signed request
-	return transport.RoundTrip(req)
+	return rt.next.RoundTrip(req)
 }
 
 // parseAwsAMPMetadata parses the data to get the AWS specific auth info and metadata
@@ -104,6 +101,7 @@ func NewSigV4RoundTripper(config *scalersconfig.ScalerConfig, awsRegion string) 
 	client := amp.NewFromConfig(*awsCfg, func(_ *amp.Options) {})
 	rt := &roundTripper{
 		client: client,
+		next:   httputils.CreateHTTPTransport(false),
 	}
 
 	return rt, nil

--- a/pkg/scalers/aws/aws_sigv4_test.go
+++ b/pkg/scalers/aws/aws_sigv4_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestSigV4RoundTripper(t *testing.T) {
-	transport := util.CreateHTTPTransport(false)
+	transport := util.CreateRT(false)
 
 	cli := &http.Client{Transport: transport}
 

--- a/pkg/scalers/azure/azure_managed_prometheus_http_round_tripper.go
+++ b/pkg/scalers/azure/azure_managed_prometheus_http_round_tripper.go
@@ -55,7 +55,7 @@ func TryAndGetAzureManagedPrometheusHTTPRoundTripper(logger logr.Logger, podIden
 			return nil, err
 		}
 
-		transport := util.CreateHTTPTransport(false)
+		transport := util.CreateRT(false)
 		rt := &azureManagedPrometheusHTTPRoundTripper{
 			next:              transport,
 			chainedCredential: chainedCred,

--- a/pkg/scalers/elasticsearch_scaler.go
+++ b/pkg/scalers/elasticsearch_scaler.go
@@ -130,7 +130,7 @@ func newElasticsearchClient(meta elasticsearchMetadata, logger logr.Logger) (*el
 		}
 	}
 
-	config.Transport = util.CreateHTTPTransport(meta.UnsafeSsl)
+	config.Transport = util.CreateRT(meta.UnsafeSsl)
 	esClient, err := elasticsearch.NewClient(config)
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Found error when creating client: %s", err))

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -347,7 +347,7 @@ func NewGitHubRunnerScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	}
 
 	if meta.ApplicationID != 0 && meta.InstallationID != 0 && meta.ApplicationKey != "" {
-		httpTrans := kedautil.CreateHTTPTransport(false)
+		httpTrans := kedautil.CreateRT(false)
 		hc, err := gha.New(httpTrans, meta.ApplicationID, meta.InstallationID, []byte(meta.ApplicationKey))
 		if err != nil {
 			return nil, fmt.Errorf("error creating GitHub App client: %w, \n appID: %d, instID: %d", err, meta.ApplicationID, meta.InstallationID)

--- a/pkg/scalers/ibmmq_scaler.go
+++ b/pkg/scalers/ibmmq_scaler.go
@@ -98,7 +98,7 @@ func NewIBMMQScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 		if err != nil {
 			return nil, err
 		}
-		httpClient.Transport = kedautil.CreateHTTPTransportWithTLSConfig(tlsConfig)
+		httpClient.Transport = kedautil.CreateRTWithTLSConfig(tlsConfig)
 	}
 
 	scaler := &ibmmqScaler{

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -101,7 +101,7 @@ func NewMetricsAPIScaler(config *scalersconfig.ScalerConfig, kubeClient client.C
 		if err != nil {
 			return nil, err
 		}
-		httpClient.Transport = kedautil.CreateHTTPTransportWithTLSConfig(tlsConfig)
+		httpClient.Transport = kedautil.CreateRTWithTLSConfig(tlsConfig)
 	}
 
 	return &metricsAPIScaler{

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -165,7 +165,7 @@ func NewPulsarScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 			if err != nil {
 				return nil, err
 			}
-			client.Transport = kedautil.CreateHTTPTransportWithTLSConfig(tlsConfig)
+			client.Transport = kedautil.CreateRTWithTLSConfig(tlsConfig)
 		}
 
 		if pulsarMetadata.PulsarAuth.EnabledBearerAuth() || pulsarMetadata.PulsarAuth.EnabledBasicAuth() {

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -298,7 +298,7 @@ func NewRabbitMQScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 		if tlsErr != nil {
 			return nil, tlsErr
 		}
-		s.httpClient.Transport = kedautil.CreateHTTPTransportWithTLSConfig(tlsConfig)
+		s.httpClient.Transport = kedautil.CreateRTWithTLSConfig(tlsConfig)
 	}
 
 	if meta.Protocol == amqpProtocol {

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -31,6 +31,7 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/scalers"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 var log = logf.Log.WithName("scalers_cache")
@@ -156,6 +157,11 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 	if err != nil {
 		return nil, false, -1, err
 	}
+	ctx = context.WithValue(ctx, kedautil.ScalerContextKey, sb.ScalerConfig.TriggerType)
+	ctx = context.WithValue(ctx, kedautil.TriggerNameContextKey, sb.ScalerConfig.TriggerName)
+	ctx = context.WithValue(ctx, kedautil.MetricNameContextKey, metricName)
+	ctx = context.WithValue(ctx, kedautil.NamespaceContextKey, sb.ScalerConfig.ScalableObjectNamespace)
+	ctx = context.WithValue(ctx, kedautil.ScaledResourceContextKey, sb.ScalerConfig.ScalableObjectName)
 	startTime := time.Now()
 	metric, activity, err := sb.Scaler.GetMetricsAndActivity(ctx, metricName)
 	if err == nil {

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -31,6 +31,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/scalers"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
@@ -158,6 +159,10 @@ func buildScalerRequestCtx(ctx context.Context, sb ScalerBuilder, metricName str
 	requestCtx = context.WithValue(requestCtx, kedautil.MetricNameContextKey, metricName)
 	requestCtx = context.WithValue(requestCtx, kedautil.NamespaceContextKey, sb.ScalerConfig.ScalableObjectNamespace)
 	requestCtx = context.WithValue(requestCtx, kedautil.ScaledResourceContextKey, sb.ScalerConfig.ScalableObjectName)
+
+	if !metricscollector.HTTPClientOpenTelemetryMetricsEnabled() {
+		return requestCtx
+	}
 
 	labeler := &otelhttp.Labeler{}
 	labeler.Add(

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -150,6 +150,15 @@ func (c *ScalersCache) GetMetricSpecForScalingForScaler(ctx context.Context, ind
 	return metricSpecs, err
 }
 
+func buildScalerRequestCtx(ctx context.Context, sb ScalerBuilder, metricName string) context.Context {
+	requestCtx := context.WithValue(ctx, kedautil.ScalerContextKey, sb.ScalerConfig.TriggerType)
+	requestCtx = context.WithValue(requestCtx, kedautil.TriggerNameContextKey, sb.ScalerConfig.TriggerName)
+	requestCtx = context.WithValue(requestCtx, kedautil.MetricNameContextKey, metricName)
+	requestCtx = context.WithValue(requestCtx, kedautil.NamespaceContextKey, sb.ScalerConfig.ScalableObjectNamespace)
+	requestCtx = context.WithValue(requestCtx, kedautil.ScaledResourceContextKey, sb.ScalerConfig.ScalableObjectName)
+	return requestCtx
+}
+
 // GetMetricsAndActivityForScaler returns metric value, activity and latency for a scaler identified by the metric name
 // and by the input index (from the list of scalers in this ScaledObject)
 func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index int, metricName string) ([]external_metrics.ExternalMetricValue, bool, time.Duration, error) {
@@ -157,13 +166,9 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 	if err != nil {
 		return nil, false, -1, err
 	}
-	ctx = context.WithValue(ctx, kedautil.ScalerContextKey, sb.ScalerConfig.TriggerType)
-	ctx = context.WithValue(ctx, kedautil.TriggerNameContextKey, sb.ScalerConfig.TriggerName)
-	ctx = context.WithValue(ctx, kedautil.MetricNameContextKey, metricName)
-	ctx = context.WithValue(ctx, kedautil.NamespaceContextKey, sb.ScalerConfig.ScalableObjectNamespace)
-	ctx = context.WithValue(ctx, kedautil.ScaledResourceContextKey, sb.ScalerConfig.ScalableObjectName)
+	requestCtx := buildScalerRequestCtx(ctx, sb, metricName)
 	startTime := time.Now()
-	metric, activity, err := sb.Scaler.GetMetricsAndActivity(ctx, metricName)
+	metric, activity, err := sb.Scaler.GetMetricsAndActivity(requestCtx, metricName)
 	if err == nil {
 		return metric, activity, time.Since(startTime), nil
 	}
@@ -172,8 +177,13 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 	if err != nil {
 		return nil, false, -1, err
 	}
+	newSb, err := c.getScalerBuilder(index)
+	if err != nil {
+		return nil, false, -1, err
+	}
+	requestCtx = buildScalerRequestCtx(ctx, newSb, metricName)
 	startTime = time.Now()
-	metric, activity, err = ns.GetMetricsAndActivity(ctx, metricName)
+	metric, activity, err = ns.GetMetricsAndActivity(requestCtx, metricName)
 	return metric, activity, time.Since(startTime), err
 }
 

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/expr-lang/expr/vm"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -156,6 +158,17 @@ func buildScalerRequestCtx(ctx context.Context, sb ScalerBuilder, metricName str
 	requestCtx = context.WithValue(requestCtx, kedautil.MetricNameContextKey, metricName)
 	requestCtx = context.WithValue(requestCtx, kedautil.NamespaceContextKey, sb.ScalerConfig.ScalableObjectNamespace)
 	requestCtx = context.WithValue(requestCtx, kedautil.ScaledResourceContextKey, sb.ScalerConfig.ScalableObjectName)
+
+	labeler := &otelhttp.Labeler{}
+	labeler.Add(
+		attribute.String("scaler", sb.ScalerConfig.TriggerType),
+		attribute.String("trigger_name", sb.ScalerConfig.TriggerName),
+		attribute.String("metric_name", metricName),
+		attribute.String("namespace", sb.ScalerConfig.ScalableObjectNamespace),
+		attribute.String("scaled_resource", sb.ScalerConfig.ScalableObjectName),
+	)
+
+	requestCtx = otelhttp.ContextWithLabeler(requestCtx, labeler)
 	return requestCtx
 }
 

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	"github.com/expr-lang/expr/vm"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/attribute"
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/metrics/pkg/apis/external_metrics"
@@ -34,7 +32,6 @@ import (
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/scalers"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 var log = logf.Log.WithName("scalers_cache")
@@ -153,30 +150,6 @@ func (c *ScalersCache) GetMetricSpecForScalingForScaler(ctx context.Context, ind
 	return metricSpecs, err
 }
 
-func buildScalerRequestCtx(ctx context.Context, sb ScalerBuilder, metricName string) context.Context {
-	requestCtx := context.WithValue(ctx, kedautil.ScalerContextKey, sb.ScalerConfig.TriggerType)
-	requestCtx = context.WithValue(requestCtx, kedautil.TriggerNameContextKey, sb.ScalerConfig.TriggerName)
-	requestCtx = context.WithValue(requestCtx, kedautil.MetricNameContextKey, metricName)
-	requestCtx = context.WithValue(requestCtx, kedautil.NamespaceContextKey, sb.ScalerConfig.ScalableObjectNamespace)
-	requestCtx = context.WithValue(requestCtx, kedautil.ScaledResourceContextKey, sb.ScalerConfig.ScalableObjectName)
-
-	if !metricscollector.HTTPClientOpenTelemetryMetricsEnabled() {
-		return requestCtx
-	}
-
-	labeler := &otelhttp.Labeler{}
-	labeler.Add(
-		attribute.String("scaler", sb.ScalerConfig.TriggerType),
-		attribute.String("trigger_name", sb.ScalerConfig.TriggerName),
-		attribute.String("metric_name", metricName),
-		attribute.String("namespace", sb.ScalerConfig.ScalableObjectNamespace),
-		attribute.String("scaled_resource", sb.ScalerConfig.ScalableObjectName),
-	)
-
-	requestCtx = otelhttp.ContextWithLabeler(requestCtx, labeler)
-	return requestCtx
-}
-
 // GetMetricsAndActivityForScaler returns metric value, activity and latency for a scaler identified by the metric name
 // and by the input index (from the list of scalers in this ScaledObject)
 func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index int, metricName string) ([]external_metrics.ExternalMetricValue, bool, time.Duration, error) {
@@ -184,7 +157,7 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 	if err != nil {
 		return nil, false, -1, err
 	}
-	requestCtx := buildScalerRequestCtx(ctx, sb, metricName)
+	requestCtx := metricscollector.BuildScalerRequestCtx(ctx, sb.ScalerConfig, metricName)
 	startTime := time.Now()
 	metric, activity, err := sb.Scaler.GetMetricsAndActivity(requestCtx, metricName)
 	if err == nil {
@@ -199,7 +172,7 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 	if err != nil {
 		return nil, false, -1, err
 	}
-	requestCtx = buildScalerRequestCtx(ctx, newSb, metricName)
+	requestCtx = metricscollector.BuildScalerRequestCtx(ctx, newSb.ScalerConfig, metricName)
 	startTime = time.Now()
 	metric, activity, err = ns.GetMetricsAndActivity(requestCtx, metricName)
 	return metric, activity, time.Since(startTime), err

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
 func TestBuildScalerRequestCtxWithOtelEnabled(t *testing.T) {
@@ -41,13 +40,13 @@ func TestBuildScalerRequestCtxWithOtelEnabled(t *testing.T) {
 		},
 	}
 
-	ctx := buildScalerRequestCtx(context.Background(), sb, "my-metric")
+	ctx := metricscollector.BuildScalerRequestCtx(context.Background(), sb.ScalerConfig, "my-metric")
 
-	Expect(ctx.Value(kedautil.ScalerContextKey)).To(Equal("prometheus"))
-	Expect(ctx.Value(kedautil.TriggerNameContextKey)).To(Equal("my-trigger"))
-	Expect(ctx.Value(kedautil.MetricNameContextKey)).To(Equal("my-metric"))
-	Expect(ctx.Value(kedautil.NamespaceContextKey)).To(Equal("my-namespace"))
-	Expect(ctx.Value(kedautil.ScaledResourceContextKey)).To(Equal("my-scaled-object"))
+	Expect(ctx.Value(metricscollector.ScalerContextKey)).To(Equal("prometheus"))
+	Expect(ctx.Value(metricscollector.TriggerNameContextKey)).To(Equal("my-trigger"))
+	Expect(ctx.Value(metricscollector.MetricNameContextKey)).To(Equal("my-metric"))
+	Expect(ctx.Value(metricscollector.NamespaceContextKey)).To(Equal("my-namespace"))
+	Expect(ctx.Value(metricscollector.ScaledResourceContextKey)).To(Equal("my-scaled-object"))
 
 	labeler, ok := otelhttp.LabelerFromContext(ctx)
 	Expect(ok).To(BeTrue())
@@ -67,13 +66,13 @@ func TestBuildScalerRequestCtxWithOtelDisabled(t *testing.T) {
 		},
 	}
 
-	ctx := buildScalerRequestCtx(context.Background(), sb, "my-metric")
+	ctx := metricscollector.BuildScalerRequestCtx(context.Background(), sb.ScalerConfig, "my-metric")
 
-	Expect(ctx.Value(kedautil.ScalerContextKey)).To(Equal("prometheus"))
-	Expect(ctx.Value(kedautil.TriggerNameContextKey)).To(Equal("my-trigger"))
-	Expect(ctx.Value(kedautil.MetricNameContextKey)).To(Equal("my-metric"))
-	Expect(ctx.Value(kedautil.NamespaceContextKey)).To(Equal("my-namespace"))
-	Expect(ctx.Value(kedautil.ScaledResourceContextKey)).To(Equal("my-scaled-object"))
+	Expect(ctx.Value(metricscollector.ScalerContextKey)).To(Equal("prometheus"))
+	Expect(ctx.Value(metricscollector.TriggerNameContextKey)).To(Equal("my-trigger"))
+	Expect(ctx.Value(metricscollector.MetricNameContextKey)).To(Equal("my-metric"))
+	Expect(ctx.Value(metricscollector.NamespaceContextKey)).To(Equal("my-namespace"))
+	Expect(ctx.Value(metricscollector.ScaledResourceContextKey)).To(Equal("my-scaled-object"))
 
 	_, ok := otelhttp.LabelerFromContext(ctx)
 	Expect(ok).To(BeFalse())

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -45,6 +46,10 @@ func TestBuildScalerRequestCtx(t *testing.T) {
 	Expect(ctx.Value(kedautil.MetricNameContextKey)).To(Equal("my-metric"))
 	Expect(ctx.Value(kedautil.NamespaceContextKey)).To(Equal("my-namespace"))
 	Expect(ctx.Value(kedautil.ScaledResourceContextKey)).To(Equal("my-scaled-object"))
+
+	labeler, ok := otelhttp.LabelerFromContext(ctx)
+	Expect(ok).To(BeTrue())
+	Expect(labeler.Get()).To(HaveLen(5))
 }
 
 func TestEmptyScalersCache(t *testing.T) {

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -21,7 +21,31 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
+
+func TestBuildScalerRequestCtx(t *testing.T) {
+	RegisterTestingT(t)
+
+	sb := ScalerBuilder{
+		ScalerConfig: scalersconfig.ScalerConfig{
+			TriggerType:             "prometheus",
+			TriggerName:             "my-trigger",
+			ScalableObjectNamespace: "my-namespace",
+			ScalableObjectName:      "my-scaled-object",
+		},
+	}
+
+	ctx := buildScalerRequestCtx(context.Background(), sb, "my-metric")
+
+	Expect(ctx.Value(kedautil.ScalerContextKey)).To(Equal("prometheus"))
+	Expect(ctx.Value(kedautil.TriggerNameContextKey)).To(Equal("my-trigger"))
+	Expect(ctx.Value(kedautil.MetricNameContextKey)).To(Equal("my-metric"))
+	Expect(ctx.Value(kedautil.NamespaceContextKey)).To(Equal("my-namespace"))
+	Expect(ctx.Value(kedautil.ScaledResourceContextKey)).To(Equal("my-scaled-object"))
+}
 
 func TestEmptyScalersCache(t *testing.T) {
 	RegisterTestingT(t)

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -23,12 +23,14 @@ import (
 	. "github.com/onsi/gomega"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
-	kedautil "github.com/kedacore/keda/v2/pkg/util"
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
 
-func TestBuildScalerRequestCtx(t *testing.T) {
+func TestBuildScalerRequestCtxWithOtelEnabled(t *testing.T) {
 	RegisterTestingT(t)
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, true)
 
 	sb := ScalerBuilder{
 		ScalerConfig: scalersconfig.ScalerConfig{
@@ -50,6 +52,31 @@ func TestBuildScalerRequestCtx(t *testing.T) {
 	labeler, ok := otelhttp.LabelerFromContext(ctx)
 	Expect(ok).To(BeTrue())
 	Expect(labeler.Get()).To(HaveLen(5))
+}
+
+func TestBuildScalerRequestCtxWithOtelDisabled(t *testing.T) {
+	RegisterTestingT(t)
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
+
+	sb := ScalerBuilder{
+		ScalerConfig: scalersconfig.ScalerConfig{
+			TriggerType:             "prometheus",
+			TriggerName:             "my-trigger",
+			ScalableObjectNamespace: "my-namespace",
+			ScalableObjectName:      "my-scaled-object",
+		},
+	}
+
+	ctx := buildScalerRequestCtx(context.Background(), sb, "my-metric")
+
+	Expect(ctx.Value(kedautil.ScalerContextKey)).To(Equal("prometheus"))
+	Expect(ctx.Value(kedautil.TriggerNameContextKey)).To(Equal("my-trigger"))
+	Expect(ctx.Value(kedautil.MetricNameContextKey)).To(Equal("my-metric"))
+	Expect(ctx.Value(kedautil.NamespaceContextKey)).To(Equal("my-namespace"))
+	Expect(ctx.Value(kedautil.ScaledResourceContextKey)).To(Equal("my-scaled-object"))
+
+	_, ok := otelhttp.LabelerFromContext(ctx)
+	Expect(ok).To(BeFalse())
 }
 
 func TestEmptyScalersCache(t *testing.T) {

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -64,8 +64,8 @@ func CreateRT(unsafeSsl bool) http.RoundTripper {
 	return CreateRTWithTLSConfig(CreateTLSClientConfig(unsafeSsl))
 }
 
-// CreateRTWithTLSConfig returns a new instrumented HTTP RoundTripper with Proxy and Keep-alive
-// settings using the given tls.Config.
+// CreateRTWithTLSConfig returns a new instrumented HTTP RoundTripper with Proxy and
+// Keep-alive settings using the given tls.Config.
 func CreateRTWithTLSConfig(config *tls.Config) http.RoundTripper {
 	transport := &http.Transport{
 		TLSClientConfig: config,

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -50,7 +50,7 @@ func CreateHTTPClient(timeout time.Duration, unsafeSsl bool) *http.Client {
 	if timeout <= 0 {
 		timeout = 300 * time.Millisecond
 	}
-	transport := CreateHTTPTransport(unsafeSsl)
+	transport := CreateRT(unsafeSsl)
 	httpClient := &http.Client{
 		Timeout:   timeout,
 		Transport: transport,
@@ -58,15 +58,15 @@ func CreateHTTPClient(timeout time.Duration, unsafeSsl bool) *http.Client {
 	return httpClient
 }
 
-// CreateHTTPTransport returns a new HTTP Transport with Proxy, Keep alives
-// unsafeSsl parameter allows to avoid tls cert validation if it's required
-func CreateHTTPTransport(unsafeSsl bool) http.RoundTripper {
-	return CreateHTTPTransportWithTLSConfig(CreateTLSClientConfig(unsafeSsl))
+// CreateRT returns a new instrumented HTTP RoundTripper with Proxy and Keep-alive settings.
+// unsafeSsl parameter allows to avoid tls cert validation if it's required.
+func CreateRT(unsafeSsl bool) http.RoundTripper {
+	return CreateRTWithTLSConfig(CreateTLSClientConfig(unsafeSsl))
 }
 
-// CreateHTTPTransportWithTLSConfig returns a new HTTP Transport with Proxy, Keep alives
-// using given tls.Config, wrapped with instrumentation for HTTP client metrics.
-func CreateHTTPTransportWithTLSConfig(config *tls.Config) http.RoundTripper {
+// CreateRTWithTLSConfig returns a new instrumented HTTP RoundTripper with Proxy and Keep-alive
+// settings using the given tls.Config.
+func CreateRTWithTLSConfig(config *tls.Config) http.RoundTripper {
 	transport := &http.Transport{
 		TLSClientConfig: config,
 		Proxy:           http.ProxyFromEnvironment,

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -60,13 +60,13 @@ func CreateHTTPClient(timeout time.Duration, unsafeSsl bool) *http.Client {
 
 // CreateHTTPTransport returns a new HTTP Transport with Proxy, Keep alives
 // unsafeSsl parameter allows to avoid tls cert validation if it's required
-func CreateHTTPTransport(unsafeSsl bool) *http.Transport {
+func CreateHTTPTransport(unsafeSsl bool) http.RoundTripper {
 	return CreateHTTPTransportWithTLSConfig(CreateTLSClientConfig(unsafeSsl))
 }
 
 // CreateHTTPTransportWithTLSConfig returns a new HTTP Transport with Proxy, Keep alives
-// using given tls.Config
-func CreateHTTPTransportWithTLSConfig(config *tls.Config) *http.Transport {
+// using given tls.Config, wrapped with instrumentation for HTTP client metrics.
+func CreateHTTPTransportWithTLSConfig(config *tls.Config) http.RoundTripper {
 	transport := &http.Transport{
 		TLSClientConfig: config,
 		Proxy:           http.ProxyFromEnvironment,
@@ -76,5 +76,5 @@ func CreateHTTPTransportWithTLSConfig(config *tls.Config) *http.Transport {
 		transport.DisableKeepAlives = true
 		transport.IdleConnTimeout = 100 * time.Second
 	}
-	return transport
+	return NewInstrumentedRoundTripper(transport)
 }

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -20,6 +20,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"time"
+
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
 )
 
 var disableKeepAlives bool
@@ -76,5 +78,5 @@ func CreateRTWithTLSConfig(config *tls.Config) http.RoundTripper {
 		transport.DisableKeepAlives = true
 		transport.IdleConnTimeout = 100 * time.Second
 	}
-	return NewInstrumentedRoundTripper(transport)
+	return metricscollector.NewInstrumentedRoundTripper(transport)
 }

--- a/pkg/util/http_roundtripper.go
+++ b/pkg/util/http_roundtripper.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
+)
+
+// contextKey is an unexported type for context keys defined in this package,
+// preventing collisions with keys from other packages.
+type contextKey string
+
+const (
+	// ScalerContextKey is the context key used to attach the scaler type name
+	// (e.g. "prometheus", "redis") to an outbound HTTP request so that metrics
+	// observers can include it as a dimension.
+	ScalerContextKey contextKey = "scaler"
+
+	// TriggerNameContextKey is the context key used to attach the user-defined
+	// trigger name to an outbound HTTP request.
+	TriggerNameContextKey contextKey = "trigger_name"
+
+	// MetricNameContextKey is the context key used to attach the metric name
+	// being queried to an outbound HTTP request.
+	MetricNameContextKey contextKey = "metric_name"
+
+	// NamespaceContextKey is the context key used to attach the namespace of the
+	// ScaledObject/ScaledJob that owns the scaler making the request.
+	NamespaceContextKey contextKey = "namespace"
+
+	// ScaledResourceContextKey is the context key used to attach the name of the
+	// ScaledObject/ScaledJob that owns the scaler making the request.
+	ScaledResourceContextKey contextKey = "scaled_resource"
+)
+
+// InstrumentedRoundTripper wraps an http.RoundTripper and records outbound
+// HTTP request metrics after every completed round-trip. It reads known
+// context keys from the request context to populate metric dimensions. It
+// does not buffer or inspect the response body.
+type InstrumentedRoundTripper struct {
+	next http.RoundTripper
+}
+
+// NewInstrumentedRoundTripper wraps next with a RoundTripper that records
+// HTTP request metrics after every request. If next is nil,
+// http.DefaultTransport is used.
+func NewInstrumentedRoundTripper(next http.RoundTripper) http.RoundTripper {
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	return &InstrumentedRoundTripper{next: next}
+}
+
+func (r *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := r.next.RoundTrip(req)
+	duration := time.Since(start).Seconds()
+
+	ctx := req.Context()
+	scaler, ok := ctx.Value(ScalerContextKey).(string)
+	if !ok || scaler == "" {
+		scaler = "unknown"
+	}
+	triggerName, _ := ctx.Value(TriggerNameContextKey).(string)
+	metricName, _ := ctx.Value(MetricNameContextKey).(string)
+	namespace, _ := ctx.Value(NamespaceContextKey).(string)
+	scaledResource, _ := ctx.Value(ScaledResourceContextKey).(string)
+
+	if err != nil {
+		metricscollector.RecordHTTPClientRequest(duration, 0, true, scaler, triggerName, metricName, namespace, scaledResource)
+		return nil, err
+	}
+	metricscollector.RecordHTTPClientRequest(duration, resp.StatusCode, false, scaler, triggerName, metricName, namespace, scaledResource)
+	return resp, nil
+}

--- a/pkg/util/http_roundtripper.go
+++ b/pkg/util/http_roundtripper.go
@@ -74,14 +74,18 @@ func (r *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	duration := time.Since(start).Seconds()
 
 	ctx := req.Context()
-	scaler, ok := ctx.Value(ScalerContextKey).(string)
-	if !ok || scaler == "" {
-		scaler = "unknown"
+	scaler, scalerOK := ctx.Value(ScalerContextKey).(string)
+	triggerName, triggerOK := ctx.Value(TriggerNameContextKey).(string)
+	metricName, metricOK := ctx.Value(MetricNameContextKey).(string)
+	namespace, nsOK := ctx.Value(NamespaceContextKey).(string)
+	scaledResource, srOK := ctx.Value(ScaledResourceContextKey).(string)
+
+	// Only record metrics for scaler metric-fetch requests, identified by the
+	// presence of all five context keys injected by buildScalerRequestCtx.
+	// Other HTTP calls (e.g. during scaler initialization) are not recorded.
+	if !scalerOK || !triggerOK || !metricOK || !nsOK || !srOK {
+		return resp, err
 	}
-	triggerName, _ := ctx.Value(TriggerNameContextKey).(string)
-	metricName, _ := ctx.Value(MetricNameContextKey).(string)
-	namespace, _ := ctx.Value(NamespaceContextKey).(string)
-	scaledResource, _ := ctx.Value(ScaledResourceContextKey).(string)
 
 	if err != nil {
 		metricscollector.RecordHTTPClientRequest(duration, 0, true, scaler, triggerName, metricName, namespace, scaledResource)

--- a/pkg/util/http_roundtripper.go
+++ b/pkg/util/http_roundtripper.go
@@ -17,8 +17,11 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"net/http"
-	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
 )
@@ -50,47 +53,80 @@ const (
 	ScaledResourceContextKey contextKey = "scaled_resource"
 )
 
-// InstrumentedRoundTripper wraps an http.RoundTripper and records outbound
-// HTTP request metrics after every completed round-trip. It reads known
-// context keys from the request context to populate metric dimensions. It
-// does not buffer or inspect the response body.
-type InstrumentedRoundTripper struct {
-	next http.RoundTripper
+type scalerMetricsRoundTripper struct {
+	next         http.RoundTripper
+	instrumented http.RoundTripper
 }
 
-// NewInstrumentedRoundTripper wraps next with a RoundTripper that records
-// HTTP request metrics after every request. If next is nil,
-// http.DefaultTransport is used.
 func NewInstrumentedRoundTripper(next http.RoundTripper) http.RoundTripper {
 	if next == nil {
 		next = http.DefaultTransport
 	}
-	return &InstrumentedRoundTripper{next: next}
+
+	enablePrometheusMetrics := metricscollector.HTTPClientPrometheusMetricsEnabled()
+	enableOpenTelemetryMetrics := metricscollector.HTTPClientOpenTelemetryMetricsEnabled()
+
+	var instrumented http.RoundTripper = next
+
+	if enablePrometheusMetrics {
+		counterOpts := []promhttp.Option{
+			promhttp.WithLabelFromCtx("namespace", labelFromCtx(NamespaceContextKey)),
+			promhttp.WithLabelFromCtx("scaled_resource", labelFromCtx(ScaledResourceContextKey)),
+			promhttp.WithLabelFromCtx("scaler", labelFromCtx(ScalerContextKey)),
+			promhttp.WithLabelFromCtx("trigger_name", labelFromCtx(TriggerNameContextKey)),
+			promhttp.WithLabelFromCtx("metric_name", labelFromCtx(MetricNameContextKey)),
+		}
+
+		durationOpts := []promhttp.Option{
+			promhttp.WithLabelFromCtx("scaler", labelFromCtx(ScalerContextKey)),
+		}
+
+		instrumented = promhttp.InstrumentRoundTripperCounter(
+			metricscollector.HTTPClientRequestsCollector(),
+			instrumented,
+			counterOpts...,
+		)
+		instrumented = promhttp.InstrumentRoundTripperDuration(
+			metricscollector.HTTPClientRequestDurationCollector(),
+			instrumented,
+			durationOpts...,
+		)
+	}
+
+	if enableOpenTelemetryMetrics {
+		instrumented = otelhttp.NewTransport(instrumented)
+	}
+
+	return &scalerMetricsRoundTripper{
+		next:         next,
+		instrumented: instrumented,
+	}
 }
 
-func (r *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	start := time.Now()
-	resp, err := r.next.RoundTrip(req)
-	duration := time.Since(start).Seconds()
-
-	ctx := req.Context()
-	scaler, scalerOK := ctx.Value(ScalerContextKey).(string)
-	triggerName, triggerOK := ctx.Value(TriggerNameContextKey).(string)
-	metricName, metricOK := ctx.Value(MetricNameContextKey).(string)
-	namespace, nsOK := ctx.Value(NamespaceContextKey).(string)
-	scaledResource, srOK := ctx.Value(ScaledResourceContextKey).(string)
-
-	// Only record metrics for scaler metric collection requests, identified by the
-	// presence of all five context keys injected by buildScalerRequestCtx.
-	// Other HTTP calls (e.g. during scaler initialization) are not recorded.
-	if !scalerOK || !triggerOK || !metricOK || !nsOK || !srOK {
-		return resp, err
+func (r *scalerMetricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !hasScalerMetricsContext(req.Context()) {
+		return r.next.RoundTrip(req)
 	}
 
-	if err != nil {
-		metricscollector.RecordHTTPClientRequest(duration, 0, true, scaler, triggerName, metricName, namespace, scaledResource)
-		return nil, err
+	return r.instrumented.RoundTrip(req)
+}
+
+func hasScalerMetricsContext(ctx context.Context) bool {
+	_, scalerOK := ctx.Value(ScalerContextKey).(string)
+	_, triggerOK := ctx.Value(TriggerNameContextKey).(string)
+	_, metricOK := ctx.Value(MetricNameContextKey).(string)
+	_, nsOK := ctx.Value(NamespaceContextKey).(string)
+	_, resourceOK := ctx.Value(ScaledResourceContextKey).(string)
+
+	return scalerOK && triggerOK && metricOK && nsOK && resourceOK
+}
+
+func labelFromCtx(key contextKey) promhttp.LabelValueFromCtx {
+	return func(ctx context.Context) string {
+		if value, ok := ctx.Value(key).(string); ok {
+			return value
+		}
+
+		return ""
 	}
-	metricscollector.RecordHTTPClientRequest(duration, resp.StatusCode, false, scaler, triggerName, metricName, namespace, scaledResource)
-	return resp, nil
 }

--- a/pkg/util/http_roundtripper.go
+++ b/pkg/util/http_roundtripper.go
@@ -80,7 +80,7 @@ func (r *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	namespace, nsOK := ctx.Value(NamespaceContextKey).(string)
 	scaledResource, srOK := ctx.Value(ScaledResourceContextKey).(string)
 
-	// Only record metrics for scaler metric-fetch requests, identified by the
+	// Only record metrics for scaler metric collection requests, identified by the
 	// presence of all five context keys injected by buildScalerRequestCtx.
 	// Other HTTP calls (e.g. during scaler initialization) are not recorded.
 	if !scalerOK || !triggerOK || !metricOK || !nsOK || !srOK {

--- a/pkg/util/http_roundtripper.go
+++ b/pkg/util/http_roundtripper.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KEDA Authors
+Copyright 2026 The KEDA Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/util/http_roundtripper_test.go
+++ b/pkg/util/http_roundtripper_test.go
@@ -18,14 +18,17 @@ package util
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
 )
 
 type mockRoundTripper struct {
@@ -33,7 +36,11 @@ type mockRoundTripper struct {
 	err  error
 }
 
-func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.resp != nil && m.resp.Request == nil {
+		m.resp.Request = req
+	}
+
 	return m.resp, m.err
 }
 
@@ -49,32 +56,44 @@ func newRequest(ctx context.Context) *http.Request {
 	return req
 }
 
-func TestInstrumentedRoundTripper_SuccessfulRequest(t *testing.T) {
-	for _, statusCode := range []int{200, 201, 301, 400, 500} {
-		t.Run(http.StatusText(statusCode), func(t *testing.T) {
-			rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(statusCode)})
+func collectMetrics(t *testing.T, collector prometheus.Collector) []*dto.Metric {
+	t.Helper()
 
-			resp, err := rt.RoundTrip(newRequest(context.Background()))
+	ch := make(chan prometheus.Metric, 32)
+	collector.Collect(ch)
+	close(ch)
 
-			require.NoError(t, err)
-			defer resp.Body.Close()
-			assert.Equal(t, statusCode, resp.StatusCode)
-		})
+	var metrics []*dto.Metric
+	for metric := range ch {
+		dtoMetric := &dto.Metric{}
+		require.NoError(t, metric.Write(dtoMetric))
+		metrics = append(metrics, dtoMetric)
 	}
+
+	return metrics
 }
 
-func TestInstrumentedRoundTripper_TransportError(t *testing.T) {
-	transportErr := errors.New("connection refused")
-	rt := NewInstrumentedRoundTripper(&mockRoundTripper{err: transportErr})
+func hasLabels(metric *dto.Metric, labels map[string]string) bool {
+	for key, value := range labels {
+		found := false
+		for _, label := range metric.GetLabel() {
+			if label.GetName() == key && label.GetValue() == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
 
-	resp, err := rt.RoundTrip(newRequest(context.Background())) //nolint:bodyclose // resp is nil on error
-
-	assert.ErrorIs(t, err, transportErr)
-	assert.Nil(t, resp)
+	return true
 }
 
 func TestInstrumentedRoundTripper_ResponseReturnedUnmodified(t *testing.T) {
-	expected := fakeResponse(202)
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
+
+	expected := fakeResponse(http.StatusAccepted)
 	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: expected})
 
 	got, err := rt.RoundTrip(newRequest(context.Background()))
@@ -85,28 +104,17 @@ func TestInstrumentedRoundTripper_ResponseReturnedUnmodified(t *testing.T) {
 }
 
 func TestInstrumentedRoundTripper_NilNextUsesDefault(t *testing.T) {
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
+
 	rt := NewInstrumentedRoundTripper(nil)
-	irt, ok := rt.(*InstrumentedRoundTripper)
+	_, ok := rt.(*scalerMetricsRoundTripper)
 	require.True(t, ok)
-	assert.Equal(t, http.DefaultTransport, irt.next)
 }
 
-func TestInstrumentedRoundTripper_ScalerContextKey_Missing(t *testing.T) {
-	// When one or more of the five required context keys are absent, the
-	// RoundTripper should not panic, complete normally, and skip metric recording.
-	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(200)})
+func TestInstrumentedRoundTripper_WithScalerContextRecordsPrometheusMetrics(t *testing.T) {
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(true, false)
 
-	resp, err := rt.RoundTrip(newRequest(context.Background()))
-
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.Equal(t, 200, resp.StatusCode)
-}
-
-func TestInstrumentedRoundTripper_AllContextKeys(t *testing.T) {
-	// When all five required context keys are present the RoundTripper should
-	// complete normally and forward the request to the underlying transport.
-	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(200)})
+	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(http.StatusOK)})
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, ScalerContextKey, "prometheus")
@@ -114,21 +122,46 @@ func TestInstrumentedRoundTripper_AllContextKeys(t *testing.T) {
 	ctx = context.WithValue(ctx, MetricNameContextKey, "my-metric")
 	ctx = context.WithValue(ctx, NamespaceContextKey, "default")
 	ctx = context.WithValue(ctx, ScaledResourceContextKey, "my-so")
-	resp, err := rt.RoundTrip(newRequest(ctx))
 
+	resp, err := rt.RoundTrip(newRequest(ctx))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, 200, resp.StatusCode)
+
+	counter, err := metricscollector.HTTPClientRequestsCollector().
+		GetMetricWithLabelValues("200", "default", "my-so", "prometheus", "my-trigger", "my-metric")
+	require.NoError(t, err)
+
+	m := &dto.Metric{}
+	require.NoError(t, counter.Write(m))
+	assert.GreaterOrEqual(t, m.Counter.GetValue(), float64(1))
+
+	var found bool
+	for _, metric := range collectMetrics(t, metricscollector.HTTPClientRequestDurationCollector()) {
+		if hasLabels(metric, map[string]string{
+			"code":   "200",
+			"scaler": "prometheus",
+		}) {
+			assert.GreaterOrEqual(t, metric.GetHistogram().GetSampleCount(), uint64(1))
+			found = true
+			break
+		}
+	}
+
+	assert.True(t, found, "expected histogram metric with scaler context labels")
 }
 
 func TestCreateHTTPClient_TransportIsInstrumented(t *testing.T) {
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
+
 	client := CreateHTTPClient(0, false)
-	_, ok := client.Transport.(*InstrumentedRoundTripper)
-	assert.True(t, ok, "expected CreateHTTPClient to wrap transport with InstrumentedRoundTripper")
+	_, ok := client.Transport.(*scalerMetricsRoundTripper)
+	assert.True(t, ok, "expected CreateHTTPClient to wrap transport with scalerMetricsRoundTripper")
 }
 
 func TestCreateRTWithTLSConfig_IsInstrumented(t *testing.T) {
+	metricscollector.ConfigureHTTPClientMetricsInstrumentation(false, false)
+
 	rt := CreateRTWithTLSConfig(nil)
-	_, ok := rt.(*InstrumentedRoundTripper)
-	assert.True(t, ok, "expected CreateRTWithTLSConfig to return an InstrumentedRoundTripper")
+	_, ok := rt.(*scalerMetricsRoundTripper)
+	assert.True(t, ok, "expected CreateRTWithTLSConfig to return scalerMetricsRoundTripper")
 }

--- a/pkg/util/http_roundtripper_test.go
+++ b/pkg/util/http_roundtripper_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2025 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRoundTripper struct {
+	resp *http.Response
+	err  error
+}
+
+func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return m.resp, m.err
+}
+
+func fakeResponse(statusCode int) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+}
+
+func newRequest(ctx context.Context) *http.Request {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	return req
+}
+
+func TestInstrumentedRoundTripper_SuccessfulRequest(t *testing.T) {
+	for _, statusCode := range []int{200, 201, 301, 400, 500} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(statusCode)})
+
+			resp, err := rt.RoundTrip(newRequest(context.Background()))
+
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, statusCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestInstrumentedRoundTripper_TransportError(t *testing.T) {
+	transportErr := errors.New("connection refused")
+	rt := NewInstrumentedRoundTripper(&mockRoundTripper{err: transportErr})
+
+	resp, err := rt.RoundTrip(newRequest(context.Background())) //nolint:bodyclose // resp is nil on error
+
+	assert.ErrorIs(t, err, transportErr)
+	assert.Nil(t, resp)
+}
+
+func TestInstrumentedRoundTripper_ResponseReturnedUnmodified(t *testing.T) {
+	expected := fakeResponse(202)
+	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: expected})
+
+	got, err := rt.RoundTrip(newRequest(context.Background()))
+
+	require.NoError(t, err)
+	defer got.Body.Close()
+	assert.Same(t, expected, got)
+}
+
+func TestInstrumentedRoundTripper_NilNextUsesDefault(t *testing.T) {
+	rt := NewInstrumentedRoundTripper(nil)
+	irt, ok := rt.(*InstrumentedRoundTripper)
+	require.True(t, ok)
+	assert.Equal(t, http.DefaultTransport, irt.next)
+}
+
+func TestInstrumentedRoundTripper_ScalerContextKey_Missing(t *testing.T) {
+	// When ScalerContextKey is absent the RoundTripper should not panic and
+	// should complete normally — "unknown" is used as the scaler label value.
+	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(200)})
+
+	resp, err := rt.RoundTrip(newRequest(context.Background()))
+
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestInstrumentedRoundTripper_ScalerContextKey(t *testing.T) {
+	// Requests with ScalerContextKey set should not panic or error — the key
+	// is read inside RoundTrip and forwarded to the metrics collector.
+	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(200)})
+
+	ctx := context.WithValue(context.Background(), ScalerContextKey, "prometheus")
+	resp, err := rt.RoundTrip(newRequest(ctx))
+
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestCreateHTTPClient_TransportIsInstrumented(t *testing.T) {
+	client := CreateHTTPClient(0, false)
+	_, ok := client.Transport.(*InstrumentedRoundTripper)
+	assert.True(t, ok, "expected CreateHTTPClient to wrap transport with InstrumentedRoundTripper")
+}

--- a/pkg/util/http_roundtripper_test.go
+++ b/pkg/util/http_roundtripper_test.go
@@ -121,3 +121,9 @@ func TestCreateHTTPClient_TransportIsInstrumented(t *testing.T) {
 	_, ok := client.Transport.(*InstrumentedRoundTripper)
 	assert.True(t, ok, "expected CreateHTTPClient to wrap transport with InstrumentedRoundTripper")
 }
+
+func TestCreateHTTPTransportWithTLSConfig_IsInstrumented(t *testing.T) {
+	rt := CreateHTTPTransportWithTLSConfig(nil)
+	_, ok := rt.(*InstrumentedRoundTripper)
+	assert.True(t, ok, "expected CreateHTTPTransportWithTLSConfig to return an InstrumentedRoundTripper")
+}

--- a/pkg/util/http_roundtripper_test.go
+++ b/pkg/util/http_roundtripper_test.go
@@ -92,8 +92,8 @@ func TestInstrumentedRoundTripper_NilNextUsesDefault(t *testing.T) {
 }
 
 func TestInstrumentedRoundTripper_ScalerContextKey_Missing(t *testing.T) {
-	// When ScalerContextKey is absent the RoundTripper should not panic and
-	// should complete normally — "unknown" is used as the scaler label value.
+	// When one or more of the five required context keys are absent, the
+	// RoundTripper should not panic, complete normally, and skip metric recording.
 	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(200)})
 
 	resp, err := rt.RoundTrip(newRequest(context.Background()))
@@ -103,12 +103,17 @@ func TestInstrumentedRoundTripper_ScalerContextKey_Missing(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 }
 
-func TestInstrumentedRoundTripper_ScalerContextKey(t *testing.T) {
-	// Requests with ScalerContextKey set should not panic or error — the key
-	// is read inside RoundTrip and forwarded to the metrics collector.
+func TestInstrumentedRoundTripper_AllContextKeys(t *testing.T) {
+	// When all five required context keys are present the RoundTripper should
+	// complete normally and forward the request to the underlying transport.
 	rt := NewInstrumentedRoundTripper(&mockRoundTripper{resp: fakeResponse(200)})
 
-	ctx := context.WithValue(context.Background(), ScalerContextKey, "prometheus")
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ScalerContextKey, "prometheus")
+	ctx = context.WithValue(ctx, TriggerNameContextKey, "my-trigger")
+	ctx = context.WithValue(ctx, MetricNameContextKey, "my-metric")
+	ctx = context.WithValue(ctx, NamespaceContextKey, "default")
+	ctx = context.WithValue(ctx, ScaledResourceContextKey, "my-so")
 	resp, err := rt.RoundTrip(newRequest(ctx))
 
 	require.NoError(t, err)
@@ -122,8 +127,8 @@ func TestCreateHTTPClient_TransportIsInstrumented(t *testing.T) {
 	assert.True(t, ok, "expected CreateHTTPClient to wrap transport with InstrumentedRoundTripper")
 }
 
-func TestCreateHTTPTransportWithTLSConfig_IsInstrumented(t *testing.T) {
-	rt := CreateHTTPTransportWithTLSConfig(nil)
+func TestCreateRTWithTLSConfig_IsInstrumented(t *testing.T) {
+	rt := CreateRTWithTLSConfig(nil)
 	_, ok := rt.(*InstrumentedRoundTripper)
-	assert.True(t, ok, "expected CreateHTTPTransportWithTLSConfig to return an InstrumentedRoundTripper")
+	assert.True(t, ok, "expected CreateRTWithTLSConfig to return an InstrumentedRoundTripper")
 }

--- a/pkg/util/http_roundtripper_test.go
+++ b/pkg/util/http_roundtripper_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KEDA Authors
+Copyright 2026 The KEDA Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -1306,10 +1306,13 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 			data.TestNamespace, wrongScaledObjectName, wrongScalerName)
 	}
 
+	matchHistogramLabels := func(labels []*prommodel.LabelPair) bool {
+		return ExtractPrometheusLabelValue("scaler", labels) == "prometheus"
+	}
 	if val, ok := family["keda_scaler_http_request_duration_seconds"]; ok {
 		var found bool
 		for _, metric := range val.GetMetric() {
-			if matchLabels(metric.GetLabel()) {
+			if matchHistogramLabels(metric.GetLabel()) {
 				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
 					"keda_scaler_http_request_duration_seconds sample count should be > 0")
 				found = true

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -43,10 +43,12 @@ var (
 	deploymentName                           = fmt.Sprintf("%s-deployment", testName)
 	monitoredDeploymentName                  = fmt.Sprintf("%s-monitored", testName)
 	scaledObjectName                         = fmt.Sprintf("%s-so", testName)
+	httpClientScaledObjectName               = fmt.Sprintf("%s-so-http-client", testName)
 	wrongScaledObjectName                    = fmt.Sprintf("%s-so-wrong", testName)
 	scaledObjectGrpcName                     = fmt.Sprintf("%s-so-grpc", testName)
 	scaledJobName                            = fmt.Sprintf("%s-sj", testName)
 	wrongScaledJobName                       = fmt.Sprintf("%s-sj-wrong", testName)
+	httpClientScalerName                     = fmt.Sprintf("%s-http-client-scaler", testName)
 	wrongScalerName                          = fmt.Sprintf("%s-wrong-scaler", testName)
 	cronScaledJobName                        = fmt.Sprintf("%s-cron-sj", testName)
 	clientName                               = fmt.Sprintf("%s-client", testName)
@@ -69,10 +71,12 @@ type templateData struct {
 	TestNamespace              string
 	DeploymentName             string
 	ScaledObjectName           string
+	HTTPClientScaledObjectName string
 	ScaledJobName              string
 	ScaledObjectGrpcName       string
 	WrongScaledObjectName      string
 	WrongScaledJobName         string
+	HTTPClientScalerName       string
 	WrongScalerName            string
 	CronScaledJobName          string
 	MonitoredDeploymentName    string
@@ -150,6 +154,30 @@ spec:
       metadata:
         podSelector: 'app={{.MonitoredDeploymentName}}'
         value: '1'
+`
+
+	httpClientScaledObjectTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.HTTPClientScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 2
+  idleReplicaCount: 0
+  minReplicaCount: 1
+  maxReplicaCount: 2
+  cooldownPeriod: 10
+  triggers:
+    - type: prometheus
+      name: {{.HTTPClientScalerName}}
+      metadata:
+        serverAddress: http://keda-prometheus.keda.svc.cluster.local:8080
+        metricName: vector_0
+        threshold: '1'
+        query: 'vector(0)'
 `
 
 	scaledObjectGrpcTemplate = `
@@ -502,10 +530,12 @@ func getTemplateData() (templateData, []Template) {
 			TestNamespace:              testNamespace,
 			DeploymentName:             deploymentName,
 			ScaledObjectName:           scaledObjectName,
+			HTTPClientScaledObjectName: httpClientScaledObjectName,
 			WrongScaledObjectName:      wrongScaledObjectName,
 			ScaledObjectGrpcName:       scaledObjectGrpcName,
 			ScaledJobName:              scaledJobName,
 			WrongScaledJobName:         wrongScaledJobName,
+			HTTPClientScalerName:       httpClientScalerName,
 			WrongScalerName:            wrongScalerName,
 			MonitoredDeploymentName:    monitoredDeploymentName,
 			ClientName:                 clientName,
@@ -1268,13 +1298,13 @@ func testCloudEventEmittedError(t *testing.T, data templateData) {
 func testHTTPClientMetrics(t *testing.T, data templateData) {
 	t.Log("--- testing HTTP client metrics ---")
 
-	// The wrongScaledObject uses a prometheus-type scaler that makes real HTTP
-	// requests on every poll interval, so its records should be present once at
-	// least one poll cycle has completed.
+	// The dedicated HTTP client scaler makes real HTTP requests on every poll
+	// interval without relying on the reused error-metric fixtures, so its
+	// records should be present once at least one poll cycle has completed.
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	KubectlApplyWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
 	defer func() {
-		KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+		KubectlDeleteWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
 		KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	}()
 
@@ -1284,11 +1314,12 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 
 	matchLabels := func(labels []*prommodel.LabelPair) bool {
 		return ExtractPrometheusLabelValue("namespace", labels) == data.TestNamespace &&
-			ExtractPrometheusLabelValue("scaled_resource", labels) == wrongScaledObjectName &&
+			ExtractPrometheusLabelValue("scaled_resource", labels) == httpClientScaledObjectName &&
 			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
-			ExtractPrometheusLabelValue("trigger_name", labels) == wrongScalerName &&
+			ExtractPrometheusLabelValue("trigger_name", labels) == httpClientScalerName &&
 			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus" &&
-			ExtractPrometheusLabelValue("http_request_method", labels) == "GET"
+			ExtractPrometheusLabelValue("http_request_method", labels) == "GET" &&
+			ExtractPrometheusLabelValue("http_response_status_code", labels) == "200"
 	}
 
 	val, ok := family["http_client_request_duration_seconds"]

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -1287,38 +1287,22 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 			ExtractPrometheusLabelValue("scaled_resource", labels) == wrongScaledObjectName &&
 			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
 			ExtractPrometheusLabelValue("trigger_name", labels) == wrongScalerName &&
-			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus"
+			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus" &&
+			ExtractPrometheusLabelValue("http_request_method", labels) == "GET"
 	}
 
-	val, ok := family["keda_scaler_http_requests_count_total"]
-	assert.True(t, ok, "keda_scaler_http_requests_count_total not available")
+	val, ok := family["http_client_request_duration_seconds"]
+	assert.True(t, ok, "http_client_request_duration_seconds not present")
 	if ok {
 		var found bool
 		for _, metric := range val.GetMetric() {
 			if matchLabels(metric.GetLabel()) {
-				assert.GreaterOrEqual(t, metric.GetCounter().GetValue(), float64(1))
-				found = true
-				break
-			}
-		}
-		assert.True(t, found,
-			"expected keda_scaler_http_requests_count_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
-			data.TestNamespace, wrongScaledObjectName, wrongScalerName)
-	}
-
-	matchHistogramLabels := func(labels []*prommodel.LabelPair) bool {
-		return ExtractPrometheusLabelValue("scaler", labels) == "prometheus"
-	}
-	if val, ok := family["keda_scaler_http_request_duration_seconds"]; ok {
-		var found bool
-		for _, metric := range val.GetMetric() {
-			if matchHistogramLabels(metric.GetLabel()) {
 				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
-					"keda_scaler_http_request_duration_seconds sample count should be > 0")
+					"http_client_request_duration_seconds sample count should be > 0")
 				found = true
 				break
 			}
 		}
-		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram for prometheus scaler")
+		assert.True(t, found, "expected http_client_request_duration_seconds histogram for prometheus scaler")
 	}
 }

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -487,6 +487,7 @@ func TestOpenTelemetryMetrics(t *testing.T) {
 	testScaledObjectPausedMetric(t, data)
 	testCloudEventEmitted(t, data)
 	testCloudEventEmittedError(t, data)
+	testHTTPClientMetrics(t, data)
 
 	changeOtlpProtocolInOperator(t, kc, "keda-operator", "keda")
 	testScalerGrpcMetricValue(t, kc, data)
@@ -1262,4 +1263,59 @@ func testCloudEventEmittedError(t *testing.T, data templateData) {
 
 	KubectlDeleteWithTemplate(t, data, "wrongCloudEventSourceTemplate", wrongCloudEventSourceTemplate)
 	KubectlApplyWithTemplate(t, data, "cloudEventSourceTemplate", cloudEventSourceTemplate)
+}
+
+func testHTTPClientMetrics(t *testing.T, data templateData) {
+	t.Log("--- testing HTTP client metrics ---")
+
+	// The wrongScaledObject uses a prometheus-type scaler that makes real HTTP
+	// requests on every poll interval, so its records should be present once at
+	// least one poll cycle has completed.
+	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	defer func() {
+		KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+		KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	}()
+
+	time.Sleep(20 * time.Second)
+
+	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
+
+	matchLabels := func(labels []*prommodel.LabelPair) bool {
+		return ExtractPrometheusLabelValue("namespace", labels) == data.TestNamespace &&
+			ExtractPrometheusLabelValue("scaled_resource", labels) == wrongScaledObjectName &&
+			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
+			ExtractPrometheusLabelValue("trigger_name", labels) == wrongScalerName &&
+			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus"
+	}
+
+	val, ok := family["keda_http_client_requests_count_total"]
+	assert.True(t, ok, "keda_http_client_requests_count_total not available")
+	if ok {
+		var found bool
+		for _, metric := range val.GetMetric() {
+			if matchLabels(metric.GetLabel()) {
+				assert.GreaterOrEqual(t, metric.GetCounter().GetValue(), float64(1))
+				found = true
+				break
+			}
+		}
+		assert.True(t, found,
+			"expected keda_http_client_requests_count_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
+			data.TestNamespace, wrongScaledObjectName, wrongScalerName)
+	}
+
+	if val, ok := family["keda_http_client_request_duration_seconds"]; ok {
+		var found bool
+		for _, metric := range val.GetMetric() {
+			if matchLabels(metric.GetLabel()) {
+				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
+					"keda_http_client_request_duration_seconds sample count should be > 0")
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected keda_http_client_request_duration_seconds histogram for prometheus scaler")
+	}
 }

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -1290,8 +1290,8 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus"
 	}
 
-	val, ok := family["keda_http_client_requests_count_total"]
-	assert.True(t, ok, "keda_http_client_requests_count_total not available")
+	val, ok := family["keda_scaler_http_requests_count_total"]
+	assert.True(t, ok, "keda_scaler_http_requests_count_total not available")
 	if ok {
 		var found bool
 		for _, metric := range val.GetMetric() {
@@ -1302,20 +1302,20 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 			}
 		}
 		assert.True(t, found,
-			"expected keda_http_client_requests_count_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
+			"expected keda_scaler_http_requests_count_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
 			data.TestNamespace, wrongScaledObjectName, wrongScalerName)
 	}
 
-	if val, ok := family["keda_http_client_request_duration_seconds"]; ok {
+	if val, ok := family["keda_scaler_http_request_duration_seconds"]; ok {
 		var found bool
 		for _, metric := range val.GetMetric() {
 			if matchLabels(metric.GetLabel()) {
 				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
-					"keda_http_client_request_duration_seconds sample count should be > 0")
+					"keda_scaler_http_request_duration_seconds sample count should be > 0")
 				found = true
 				break
 			}
 		}
-		assert.True(t, found, "expected keda_http_client_request_duration_seconds histogram for prometheus scaler")
+		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram for prometheus scaler")
 	}
 }

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -1462,23 +1462,23 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 		return false
 	}
 
-	families := WaitForPrometheusMetric(t, "keda_http_client_requests_total", familyValidator)
-	assert.True(t, familyValidator(families["keda_http_client_requests_total"]),
-		"expected keda_http_client_requests_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
+	families := WaitForPrometheusMetric(t, "keda_scaler_http_requests_total", familyValidator)
+	assert.True(t, familyValidator(families["keda_scaler_http_requests_total"]),
+		"expected keda_scaler_http_requests_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
 		testNamespace, wrongScaledObjectName, wrongScalerName)
 
-	family, ok := families["keda_http_client_request_duration_seconds"]
-	assert.True(t, ok, "keda_http_client_request_duration_seconds not present")
+	family, ok := families["keda_scaler_http_request_duration_seconds"]
+	assert.True(t, ok, "keda_scaler_http_request_duration_seconds not present")
 	if ok {
 		var found bool
 		for _, metric := range family.GetMetric() {
 			if matchLabels(metric.GetLabel()) {
 				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
-					"keda_http_client_request_duration_seconds sample count should be > 0")
+					"keda_scaler_http_request_duration_seconds sample count should be > 0")
 				found = true
 				break
 			}
 		}
-		assert.True(t, found, "expected keda_http_client_request_duration_seconds histogram for prometheus scaler")
+		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram for prometheus scaler")
 	}
 }

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -1446,7 +1446,8 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 	}()
 
 	matchLabels := func(labels []*prommodel.LabelPair) bool {
-		return ExtractPrometheusLabelValue("namespace", labels) == testNamespace &&
+		return ExtractPrometheusLabelValue("code", labels) == "200" &&
+			ExtractPrometheusLabelValue("namespace", labels) == testNamespace &&
 			ExtractPrometheusLabelValue("scaled_resource", labels) == wrongScaledObjectName &&
 			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
 			ExtractPrometheusLabelValue("trigger_name", labels) == wrongScalerName &&
@@ -1468,7 +1469,8 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 		testNamespace, wrongScaledObjectName, wrongScalerName)
 
 	matchHistogramLabels := func(labels []*prommodel.LabelPair) bool {
-		return ExtractPrometheusLabelValue("scaler", labels) == "prometheus"
+		return ExtractPrometheusLabelValue("code", labels) == "200" &&
+			ExtractPrometheusLabelValue("scaler", labels) == "prometheus"
 	}
 	family, ok := families["keda_scaler_http_request_duration_seconds"]
 	assert.True(t, ok, "keda_scaler_http_request_duration_seconds not present")

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -1467,12 +1467,15 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 		"expected keda_scaler_http_requests_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
 		testNamespace, wrongScaledObjectName, wrongScalerName)
 
+	matchHistogramLabels := func(labels []*prommodel.LabelPair) bool {
+		return ExtractPrometheusLabelValue("scaler", labels) == "prometheus"
+	}
 	family, ok := families["keda_scaler_http_request_duration_seconds"]
 	assert.True(t, ok, "keda_scaler_http_request_duration_seconds not present")
 	if ok {
 		var found bool
 		for _, metric := range family.GetMetric() {
-			if matchLabels(metric.GetLabel()) {
+			if matchHistogramLabels(metric.GetLabel()) {
 				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
 					"keda_scaler_http_request_duration_seconds sample count should be > 0")
 				found = true

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -450,6 +450,7 @@ func TestPrometheusMetrics(t *testing.T) {
 	testScaledObjectPausedMetric(t, data)
 	testCloudEventEmitted(t, data)
 	testCloudEventEmittedError(t, data)
+	testHTTPClientMetrics(t, data)
 	// cleanup
 	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
@@ -1429,4 +1430,55 @@ func testCloudEventEmittedError(t *testing.T, data templateData) {
 	metric := families["keda_cloudeventsource_events_emitted_total"]
 
 	assert.True(t, familyValidator(metric))
+}
+
+func testHTTPClientMetrics(t *testing.T, data templateData) {
+	t.Log("--- testing HTTP client metrics ---")
+
+	// The wrongScaledObject uses a prometheus-type scaler that makes real HTTP
+	// requests on every poll interval, so its records should be present once at
+	// least one poll cycle has completed.
+	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	defer func() {
+		KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+		KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	}()
+
+	matchLabels := func(labels []*prommodel.LabelPair) bool {
+		return ExtractPrometheusLabelValue("namespace", labels) == testNamespace &&
+			ExtractPrometheusLabelValue("scaled_resource", labels) == wrongScaledObjectName &&
+			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
+			ExtractPrometheusLabelValue("trigger_name", labels) == wrongScalerName &&
+			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus"
+	}
+
+	familyValidator := func(family *prommodel.MetricFamily) bool {
+		for _, metric := range family.GetMetric() {
+			if matchLabels(metric.GetLabel()) && metric.GetCounter().GetValue() >= 1 {
+				return true
+			}
+		}
+		return false
+	}
+
+	families := WaitForPrometheusMetric(t, "keda_http_client_requests_total", familyValidator)
+	assert.True(t, familyValidator(families["keda_http_client_requests_total"]),
+		"expected keda_http_client_requests_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
+		testNamespace, wrongScaledObjectName, wrongScalerName)
+
+	family, ok := families["keda_http_client_request_duration_seconds"]
+	assert.True(t, ok, "keda_http_client_request_duration_seconds not present")
+	if ok {
+		var found bool
+		for _, metric := range family.GetMetric() {
+			if matchLabels(metric.GetLabel()) {
+				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
+					"keda_http_client_request_duration_seconds sample count should be > 0")
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected keda_http_client_request_duration_seconds histogram for prometheus scaler")
+	}
 }

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -40,9 +40,11 @@ var (
 	deploymentName                 = fmt.Sprintf("%s-deployment", testName)
 	monitoredDeploymentName        = fmt.Sprintf("%s-monitored", testName)
 	scaledObjectName               = fmt.Sprintf("%s-so", testName)
+	httpClientScaledObjectName     = fmt.Sprintf("%s-so-http-client", testName)
 	wrongScaledObjectName          = fmt.Sprintf("%s-so-wrong", testName)
 	scaledJobName                  = fmt.Sprintf("%s-sj", testName)
 	wrongScaledJobName             = fmt.Sprintf("%s-sj-wrong", testName)
+	httpClientScalerName           = fmt.Sprintf("%s-http-client-scaler", testName)
 	wrongScalerName                = fmt.Sprintf("%s-wrong-scaler", testName)
 	cronScaledJobName              = fmt.Sprintf("%s-cron-sj", testName)
 	clientName                     = fmt.Sprintf("%s-client", testName)
@@ -62,9 +64,11 @@ type templateData struct {
 	TestNamespace              string
 	DeploymentName             string
 	ScaledObjectName           string
+	HTTPClientScaledObjectName string
 	ScaledJobName              string
 	WrongScaledObjectName      string
 	WrongScaledJobName         string
+	HTTPClientScalerName       string
 	WrongScalerName            string
 	CronScaledJobName          string
 	MonitoredDeploymentName    string
@@ -142,6 +146,30 @@ spec:
       metadata:
         podSelector: 'app={{.MonitoredDeploymentName}}'
         value: '1'
+`
+
+	httpClientScaledObjectTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.HTTPClientScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  pollingInterval: 2
+  idleReplicaCount: 0
+  minReplicaCount: 1
+  maxReplicaCount: 2
+  cooldownPeriod: 10
+  triggers:
+    - type: prometheus
+      name: {{.HTTPClientScalerName}}
+      metadata:
+        serverAddress: http://keda-prometheus.keda.svc.cluster.local:8080
+        metricName: vector_0
+        threshold: '1'
+        query: 'vector(0)'
 `
 
 	wrongScaledObjectTemplate = `
@@ -461,9 +489,11 @@ func getTemplateData() (templateData, []Template) {
 			TestNamespace:              testNamespace,
 			DeploymentName:             deploymentName,
 			ScaledObjectName:           scaledObjectName,
+			HTTPClientScaledObjectName: httpClientScaledObjectName,
 			WrongScaledObjectName:      wrongScaledObjectName,
 			ScaledJobName:              scaledJobName,
 			WrongScaledJobName:         wrongScaledJobName,
+			HTTPClientScalerName:       httpClientScalerName,
 			WrongScalerName:            wrongScalerName,
 			MonitoredDeploymentName:    monitoredDeploymentName,
 			ClientName:                 clientName,
@@ -1435,22 +1465,23 @@ func testCloudEventEmittedError(t *testing.T, data templateData) {
 func testHTTPClientMetrics(t *testing.T, data templateData) {
 	t.Log("--- testing HTTP client metrics ---")
 
-	// The wrongScaledObject uses a prometheus-type scaler that makes real HTTP
-	// requests on every poll interval, so its records should be present once at
-	// least one poll cycle has completed.
+	// The dedicated HTTP client scaler makes real HTTP requests on every poll
+	// interval without relying on the reused error-metric
+	// fixtures, so its records should be present once at least one poll cycle
+	// has completed.
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+	KubectlApplyWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
 	defer func() {
-		KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
+		KubectlDeleteWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
 		KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	}()
 
 	matchLabels := func(labels []*prommodel.LabelPair) bool {
 		return ExtractPrometheusLabelValue("code", labels) == "200" &&
 			ExtractPrometheusLabelValue("namespace", labels) == testNamespace &&
-			ExtractPrometheusLabelValue("scaled_resource", labels) == wrongScaledObjectName &&
+			ExtractPrometheusLabelValue("scaled_resource", labels) == httpClientScaledObjectName &&
 			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
-			ExtractPrometheusLabelValue("trigger_name", labels) == wrongScalerName &&
+			ExtractPrometheusLabelValue("trigger_name", labels) == httpClientScalerName &&
 			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus"
 	}
 
@@ -1466,7 +1497,7 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 	families := WaitForPrometheusMetric(t, "keda_scaler_http_requests_total", familyValidator)
 	assert.True(t, familyValidator(families["keda_scaler_http_requests_total"]),
 		"expected keda_scaler_http_requests_total with namespace=%s, scaled_resource=%s, scaler=prometheus, trigger_name=%s, metric_name=s0-prometheus",
-		testNamespace, wrongScaledObjectName, wrongScalerName)
+		testNamespace, httpClientScaledObjectName, httpClientScalerName)
 
 	matchHistogramLabels := func(labels []*prommodel.LabelPair) bool {
 		return ExtractPrometheusLabelValue("code", labels) == "200" &&


### PR DESCRIPTION
_Replace the custom outbound HTTP client instrumentation with `promhttp` for Prometheus and `otelhttp` for OpenTelemetry, while keeping scaler request metrics gated to scaler metric collection requests and only attaching OTel labels when OpenTelemetry metrics are enabled._

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #6600

Relates to #
