### PR TITLE
feat(metrics): add histograms for scaler and internal-scale-loop latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
+- **General**: Add histograms `keda_scaler_metrics_duration_seconds` and `keda_internal_scale_loop_duration_seconds` alongside the existing latency gauges, which are now deprecated. The gauges continue to be emitted for backward compatibility. ([#7675](https://github.com/kedacore/keda/issues/7675))
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Allow more control of TLS versions & ciphers via `KEDA_HTTP_TLS_CIPHER_LIST`, `KEDA_SERVICE_TLS_CIPHER_LIST` and `KEDA_SERVICE_MIN_TLS_VERSION` env vars ([#7617](https://github.com/kedacore/keda/pull/7617))

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -68,6 +68,7 @@ func init() {
 func main() {
 	var enablePrometheusMetrics bool
 	var enableOpenTelemetryMetrics bool
+	var enableHighCardinalityLabels bool
 	var metricsAddr string
 	var probeAddr string
 	var metricsServiceAddr string
@@ -92,6 +93,7 @@ func main() {
 	var filePathAuthRootPath string
 	pflag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", true, "Enable the prometheus metric of keda-operator.")
 	pflag.BoolVar(&enableOpenTelemetryMetrics, "enable-opentelemetry-metrics", false, "Enable the opentelemetry metric of keda-operator.")
+	pflag.BoolVar(&enableHighCardinalityLabels, "metrics-high-cardinality-labels", false, "When enabled, duration histograms include high-cardinality labels (scaler, metric, triggerIndex). Disabled by default to limit metric series count.")
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the prometheus metric endpoint binds to.")
 	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	pflag.StringVar(&metricsServiceAddr, "metrics-service-bind-address", ":9666", "The address the gRPRC Metrics Service endpoint binds to.")
@@ -164,7 +166,7 @@ func main() {
 	if !enablePrometheusMetrics {
 		metricsAddr = "0"
 	}
-	metricscollector.NewMetricsCollectors(enablePrometheusMetrics, enableOpenTelemetryMetrics)
+	metricscollector.NewMetricsCollectors(enablePrometheusMetrics, enableOpenTelemetryMetrics, enableHighCardinalityLabels)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -81,9 +81,9 @@ type MetricsCollector interface {
 	RecordCloudEventQueueStatus(namespace string, value int)
 }
 
-func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool) {
+func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool, highCardinalityLabels bool) {
 	if enablePrometheusMetrics {
-		promometrics := NewPromMetrics()
+		promometrics := NewPromMetrics(highCardinalityLabels)
 		collectors = append(collectors, promometrics)
 
 		if promServerMetrics == nil {

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -34,6 +34,8 @@ var (
 	otCrdTotalsCounterDeprecated     api.Int64UpDownCounter
 	otTriggerRegisteredTotalsCounter api.Int64UpDownCounter
 	otCrdRegisteredTotalsCounter     api.Int64UpDownCounter
+	otScalerMetricsDurationHistogram api.Float64Histogram
+	otInternalLoopDurationHistogram  api.Float64Histogram
 
 	otelScalerMetricVals                  []OtelMetricFloat64Val
 	otelScalerMetricsLatencyVals          []OtelMetricFloat64Val
@@ -154,9 +156,18 @@ func initMeters() {
 	}
 	_, err = meter.Float64ObservableGauge(
 		"keda.scaler.metrics.latency.seconds",
-		api.WithDescription("The latency of retrieving current metric from each scaler"),
+		api.WithDescription("DEPRECATED - use 'keda.scaler.metrics.duration.seconds' histogram instead. The latency of retrieving current metric from each scaler"),
 		api.WithUnit("s"),
 		api.WithFloat64Callback(ScalerMetricsLatencyCallback),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
+	otScalerMetricsDurationHistogram, err = meter.Float64Histogram(
+		"keda.scaler.metrics.duration.seconds",
+		api.WithDescription("Histogram of the latency of retrieving current metric from each scaler"),
+		api.WithUnit("s"),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
@@ -172,9 +183,18 @@ func initMeters() {
 	}
 	_, err = meter.Float64ObservableGauge(
 		"keda.internal.scale.loop.latency.seconds",
-		api.WithDescription("Internal latency of ScaledObject/ScaledJob loop execution"),
+		api.WithDescription("DEPRECATED - use 'keda.internal.scale.loop.duration.seconds' histogram instead. Internal latency of ScaledObject/ScaledJob loop execution"),
 		api.WithUnit("s"),
 		api.WithFloat64Callback(ScalableObjectLatencyCallback),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
+	otInternalLoopDurationHistogram, err = meter.Float64Histogram(
+		"keda.internal.scale.loop.duration.seconds",
+		api.WithDescription("Histogram of the internal latency of ScaledObject/ScaledJob loop execution"),
+		api.WithUnit("s"),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
@@ -278,17 +298,25 @@ func ScalerMetricsLatencyCallbackDeprecated(_ context.Context, obsrv api.Float64
 	return nil
 }
 
-// RecordScalerLatency create a measurement of the latency to external metric
+// RecordScalerLatency create a measurement of the latency to external metric.
+// Emits three streams: the existing deprecated ms gauge, the deprecated seconds
+// gauge, and the new `keda.scaler.metrics.duration.seconds` histogram.
 func (o *OtelMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
+	measurementOption := getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
+
 	otelScalerMetricsLatency := OtelMetricFloat64Val{}
 	otelScalerMetricsLatency.val = value.Seconds()
-	otelScalerMetricsLatency.measurementOption = getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
+	otelScalerMetricsLatency.measurementOption = measurementOption
 	otelScalerMetricsLatencyVals = append(otelScalerMetricsLatencyVals, otelScalerMetricsLatency)
 
 	otelScalerMetricsLatencyValD := OtelMetricFloat64Val{}
 	otelScalerMetricsLatencyValD.val = float64(value.Milliseconds())
-	otelScalerMetricsLatencyValD.measurementOption = getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
+	otelScalerMetricsLatencyValD.measurementOption = measurementOption
 	otelScalerMetricsLatencyValDeprecated = append(otelScalerMetricsLatencyValDeprecated, otelScalerMetricsLatencyValD)
+
+	if otScalerMetricsDurationHistogram != nil {
+		otScalerMetricsDurationHistogram.Record(context.Background(), value.Seconds(), measurementOption)
+	}
 }
 
 func ScalableObjectLatencyCallback(_ context.Context, obsrv api.Float64Observer) error {
@@ -307,7 +335,9 @@ func ScalableObjectLatencyCallbackDeprecated(_ context.Context, obsrv api.Float6
 	return nil
 }
 
-// RecordScalableObjectLatency create a measurement of the latency executing scalable object loop
+// RecordScalableObjectLatency create a measurement of the latency executing scalable object loop.
+// Emits three streams: the existing deprecated ms gauge, the deprecated seconds
+// gauge, and the new `keda.internal.scale.loop.duration.seconds` histogram.
 func (o *OtelMetrics) RecordScalableObjectLatency(namespace string, name string, isScaledObject bool, value time.Duration) {
 	resourceType := "scaledjob"
 	if isScaledObject {
@@ -323,6 +353,10 @@ func (o *OtelMetrics) RecordScalableObjectLatency(namespace string, name string,
 	otelInternalLoopLatency.val = value.Seconds()
 	otelInternalLoopLatency.measurementOption = opt
 	otelInternalLoopLatencyVals = append(otelInternalLoopLatencyVals, otelInternalLoopLatency)
+
+	if otInternalLoopDurationHistogram != nil {
+		otInternalLoopDurationHistogram.Record(context.Background(), value.Seconds(), opt)
+	}
 
 	otelInternalLoopLatencyD := OtelMetricFloat64Val{}
 	otelInternalLoopLatencyD.val = float64(value.Milliseconds())

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -55,7 +55,17 @@ var (
 			Namespace: DefaultPromMetricsNamespace,
 			Subsystem: "scaler",
 			Name:      "metrics_latency_seconds",
-			Help:      "The latency of retrieving current metric from each scaler, in seconds.",
+			Help:      "DEPRECATED - use 'keda_scaler_metrics_duration_seconds' histogram instead. The latency of retrieving current metric from each scaler, in seconds.",
+		},
+		metricLabels,
+	)
+	scalerMetricsDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "scaler",
+			Name:      "metrics_duration_seconds",
+			Help:      "Histogram of the latency of retrieving current metric from each scaler, in seconds.",
+			Buckets:   prometheus.DefBuckets,
 		},
 		metricLabels,
 	)
@@ -127,7 +137,17 @@ var (
 			Namespace: DefaultPromMetricsNamespace,
 			Subsystem: "internal_scale_loop",
 			Name:      "latency_seconds",
-			Help:      "Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop.",
+			Help:      "DEPRECATED - use 'keda_internal_scale_loop_duration_seconds' histogram instead. Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop.",
+		},
+		[]string{"namespace", "type", "resource"},
+	)
+	internalLoopDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "internal_scale_loop",
+			Name:      "duration_seconds",
+			Help:      "Histogram of the deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop.",
+			Buckets:   prometheus.DefBuckets,
 		},
 		[]string{"namespace", "type", "resource"},
 	)
@@ -160,7 +180,9 @@ type PromMetrics struct {
 func NewPromMetrics() *PromMetrics {
 	metrics.Registry.MustRegister(scalerMetricsValue)
 	metrics.Registry.MustRegister(scalerMetricsLatency)
+	metrics.Registry.MustRegister(scalerMetricsDuration)
 	metrics.Registry.MustRegister(internalLoopLatency)
+	metrics.Registry.MustRegister(internalLoopDuration)
 	metrics.Registry.MustRegister(scalerActive)
 	metrics.Registry.MustRegister(scalerErrors)
 	metrics.Registry.MustRegister(scaledObjectErrors)
@@ -194,16 +216,26 @@ func (p *PromMetrics) DeleteScalerMetrics(namespace string, scaledResource strin
 	scalerActive.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerErrors.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerMetricsLatency.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
+	scalerMetricsDuration.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 }
 
-// RecordScalerLatency create a measurement of the latency to external metric
+// RecordScalerLatency create a measurement of the latency to external metric.
+// Emits both the deprecated `keda_scaler_metrics_latency_seconds` gauge and the
+// `keda_scaler_metrics_duration_seconds` histogram so existing dashboards keep
+// working while users migrate to the histogram.
 func (p *PromMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
-	scalerMetricsLatency.With(getLabels(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)).Set(value.Seconds())
+	labels := getLabels(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
+	scalerMetricsLatency.With(labels).Set(value.Seconds())
+	scalerMetricsDuration.With(labels).Observe(value.Seconds())
 }
 
-// RecordScalableObjectLatency create a measurement of the latency executing scalable object loop
+// RecordScalableObjectLatency create a measurement of the latency executing scalable object loop.
+// Emits both the deprecated `keda_internal_scale_loop_latency_seconds` gauge and the
+// `keda_internal_scale_loop_duration_seconds` histogram.
 func (p *PromMetrics) RecordScalableObjectLatency(namespace string, name string, isScaledObject bool, value time.Duration) {
-	internalLoopLatency.WithLabelValues(namespace, getResourceType(isScaledObject), name).Set(value.Seconds())
+	resourceType := getResourceType(isScaledObject)
+	internalLoopLatency.WithLabelValues(namespace, resourceType, name).Set(value.Seconds())
+	internalLoopDuration.WithLabelValues(namespace, resourceType, name).Observe(value.Seconds())
 }
 
 // RecordScalerActive create a measurement of the activity of the scaler

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -32,7 +32,13 @@ import (
 var log = logf.Log.WithName("prometheus_server")
 
 var (
+	// metricLabels is the full, high-cardinality label set used when
+	// --metrics-high-cardinality-labels is enabled.
 	metricLabels = []string{"namespace", "metric", "scaledObject", "scaler", "triggerIndex", "type"}
+
+	// metricLabelsLowCard is the reduced label set used by default to keep
+	// histogram cardinality under control.
+	metricLabelsLowCard = []string{"namespace", "type"}
 	buildInfo    = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: DefaultPromMetricsNamespace,
@@ -68,6 +74,16 @@ var (
 			Buckets:   prometheus.DefBuckets,
 		},
 		metricLabels,
+	)
+	scalerMetricsDurationLowCard = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "scaler",
+			Name:      "metrics_duration_seconds",
+			Help:      "Histogram of the latency of retrieving current metric from each scaler, in seconds.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		metricLabelsLowCard,
 	)
 	scalerActive = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -151,6 +167,16 @@ var (
 		},
 		[]string{"namespace", "type", "resource"},
 	)
+	internalLoopDurationLowCard = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "internal_scale_loop",
+			Name:      "duration_seconds",
+			Help:      "Histogram of the deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"namespace", "type"},
+	)
 
 	// Total emitted cloudevents.
 	cloudeventEmitted = prometheus.NewCounterVec(
@@ -175,14 +201,23 @@ var (
 )
 
 type PromMetrics struct {
+	highCardinality bool
 }
 
-func NewPromMetrics() *PromMetrics {
+func NewPromMetrics(highCardinality bool) *PromMetrics {
 	metrics.Registry.MustRegister(scalerMetricsValue)
 	metrics.Registry.MustRegister(scalerMetricsLatency)
-	metrics.Registry.MustRegister(scalerMetricsDuration)
+	if highCardinality {
+		metrics.Registry.MustRegister(scalerMetricsDuration)
+	} else {
+		metrics.Registry.MustRegister(scalerMetricsDurationLowCard)
+	}
 	metrics.Registry.MustRegister(internalLoopLatency)
-	metrics.Registry.MustRegister(internalLoopDuration)
+	if highCardinality {
+		metrics.Registry.MustRegister(internalLoopDuration)
+	} else {
+		metrics.Registry.MustRegister(internalLoopDurationLowCard)
+	}
 	metrics.Registry.MustRegister(scalerActive)
 	metrics.Registry.MustRegister(scalerErrors)
 	metrics.Registry.MustRegister(scaledObjectErrors)
@@ -197,7 +232,7 @@ func NewPromMetrics() *PromMetrics {
 	metrics.Registry.MustRegister(cloudeventQueueStatus)
 
 	RecordBuildInfo()
-	return &PromMetrics{}
+	return &PromMetrics{highCardinality: highCardinality}
 }
 
 // RecordBuildInfo publishes information about KEDA version and runtime info through an info metric (gauge).
@@ -217,25 +252,41 @@ func (p *PromMetrics) DeleteScalerMetrics(namespace string, scaledResource strin
 	scalerErrors.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerMetricsLatency.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerMetricsDuration.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
+	scalerMetricsDurationLowCard.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "type": getResourceType(isScaledObject)})
 }
 
 // RecordScalerLatency create a measurement of the latency to external metric.
 // Emits both the deprecated `keda_scaler_metrics_latency_seconds` gauge and the
 // `keda_scaler_metrics_duration_seconds` histogram so existing dashboards keep
 // working while users migrate to the histogram.
+// When high-cardinality labels are disabled (default), the histogram uses only
+// {namespace, type} labels to limit series count.
 func (p *PromMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
 	labels := getLabels(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
 	scalerMetricsLatency.With(labels).Set(value.Seconds())
-	scalerMetricsDuration.With(labels).Observe(value.Seconds())
+	if p.highCardinality {
+		scalerMetricsDuration.With(labels).Observe(value.Seconds())
+	} else {
+		scalerMetricsDurationLowCard.With(prometheus.Labels{
+			"namespace": namespace,
+			"type":      getResourceType(isScaledObject),
+		}).Observe(value.Seconds())
+	}
 }
 
 // RecordScalableObjectLatency create a measurement of the latency executing scalable object loop.
 // Emits both the deprecated `keda_internal_scale_loop_latency_seconds` gauge and the
 // `keda_internal_scale_loop_duration_seconds` histogram.
+// When high-cardinality labels are disabled (default), the histogram uses only
+// {namespace, type} labels to limit series count.
 func (p *PromMetrics) RecordScalableObjectLatency(namespace string, name string, isScaledObject bool, value time.Duration) {
 	resourceType := getResourceType(isScaledObject)
 	internalLoopLatency.WithLabelValues(namespace, resourceType, name).Set(value.Seconds())
-	internalLoopDuration.WithLabelValues(namespace, resourceType, name).Observe(value.Seconds())
+	if p.highCardinality {
+		internalLoopDuration.WithLabelValues(namespace, resourceType, name).Observe(value.Seconds())
+	} else {
+		internalLoopDurationLowCard.WithLabelValues(namespace, resourceType).Observe(value.Seconds())
+	}
 }
 
 // RecordScalerActive create a measurement of the activity of the scaler


### PR DESCRIPTION
## Summary

Fixes #7675 by adding histogram metrics alongside the two existing latency gauges. The gauges stay in place (marked deprecated in their help text) so nothing downstream breaks immediately — users can migrate dashboards/alerts to the histograms at their own pace.

### Prometheus

New:
- \`keda_scaler_metrics_duration_seconds\` — histogram of scaler metric retrieval latency.
- \`keda_internal_scale_loop_duration_seconds\` — histogram of scale-loop deviation.

Deprecated (kept emitting for backward compatibility):
- \`keda_scaler_metrics_latency_seconds\` (gauge)
- \`keda_internal_scale_loop_latency_seconds\` (gauge)

Buckets use \`prometheus.DefBuckets\` — happy to tune these if maintainers have preferred ranges (e.g. sub-millisecond resolution for fast scalers, or a longer tail for slow scrapers).

### OpenTelemetry

Same pattern via synchronous \`Float64Histogram\` instruments:
- \`keda.scaler.metrics.duration.seconds\` (new)
- \`keda.internal.scale.loop.duration.seconds\` (new)
- \`keda.scaler.metrics.latency.seconds\` / \`keda.internal.scale.loop.latency.seconds\` gauges marked deprecated in their descriptions.

### Why dual-write instead of changing the type in place

Prometheus treats a TYPE change on an existing metric name as a breaking change — it confuses scrapers and any dashboards that assume the type. Keeping the gauges and adding histograms under new names (the convention used elsewhere: \`workqueue_work_duration_seconds\`, \`controller_runtime_webhook_latency_seconds\`, etc.) lets us migrate without a disruptive release. The gauges can be removed in a later major release once enough users are on the histograms.

## Testing

- \`go build ./...\` green.
- \`go test ./pkg/metricscollector/ -count=1\` green.

## Out of scope

- Tuning histogram bucket boundaries — defaulted to Prometheus's standard \`DefBuckets\`.
- Removing the deprecated gauges — follow-up once users have had a release cycle to migrate.

Fixes #7675