### PR TITLE
feat: Handle rate limit errors by respecting X-RateLimit-Reset and Retry-After headers and returning cached queue length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Allow more control of TLS versions & ciphers via `KEDA_HTTP_TLS_CIPHER_LIST`, `KEDA_SERVICE_TLS_CIPHER_LIST` and `KEDA_SERVICE_MIN_TLS_VERSION` env vars ([#7617](https://github.com/kedacore/keda/pull/7617))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
-- **Github Runner Scaler**: Handle rate limit errors by respecting `X-RateLimit-Reset` and `Retry-After` headers and returning cached queue length ([#7683](https://github.com/kedacore/keda/issues/7683))
+- **Github Runner Scaler**: Handle rate limit errors by respecting X-RateLimit-Reset and Retry-After headers and returning cached queue length ([#7683](https://github.com/kedacore/keda/issues/7683))
 - **Kubernetes Workload Scaler**: Add `groupByNode` parameter ([#7628](https://github.com/kedacore/keda/issues/7628))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Allow more control of TLS versions & ciphers via `KEDA_HTTP_TLS_CIPHER_LIST`, `KEDA_SERVICE_TLS_CIPHER_LIST` and `KEDA_SERVICE_MIN_TLS_VERSION` env vars ([#7617](https://github.com/kedacore/keda/pull/7617))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
+- **Github Runner Scaler**: Handle rate limit errors by respecting `X-RateLimit-Reset` and `Retry-After` headers and returning cached queue length ([#7683](https://github.com/kedacore/keda/issues/7683))
 - **Kubernetes Workload Scaler**: Add `groupByNode` parameter ([#7628](https://github.com/kedacore/keda/issues/7628))
 
 ### Fixes

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -733,22 +733,14 @@ func (s *githubRunnerScaler) isRateLimited() bool {
 // getCachedQueueLength returns the cached previous queue length
 func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 	if !s.previousQueueLengthTime.IsZero() {
-		msg := fmt.Sprintf(
-			"Github API rate limit exceeded. Cached queue length: %d, last checked at %s",
-			s.previousQueueLength,
-			s.previousQueueLengthTime,
-		)
 		if s.recorder != nil {
-			s.recorder.Event(s.scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalersInfo, msg)
+			s.recorder.Event(s.scaledObject, corev1.EventTypeNormal, eventreason.KEDAScalersInfo,
+				fmt.Sprintf("GitHub API rate limit exceeded. Returning cached queue length: %d", s.previousQueueLength))
 		}
 		return s.previousQueueLength, nil
 	}
 
-	msg := "GitHub API rate limit exceeded. No cached queue length available"
-	if s.recorder != nil {
-		s.recorder.Event(s.scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalersInfo, msg)
-	}
-	return -1, fmt.Errorf("%s", msg)
+	return -1, fmt.Errorf("GitHub API rate limit exceeded. No cached queue length available")
 }
 
 // GetWorkflowQueueLength returns the number of workflow jobs in the queue

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -735,7 +735,8 @@ func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 	if !s.previousQueueLengthTime.IsZero() {
 		if s.recorder != nil {
 			s.recorder.Event(s.scaledObject, corev1.EventTypeNormal, eventreason.KEDAScalersInfo,
-				fmt.Sprintf("GitHub API rate limit exceeded. Returning cached queue length: %d", s.previousQueueLength))
+				fmt.Sprintf("Github API rate limit exceeded. Cached queue length: %d, last checked at %s",
+					s.previousQueueLength, s.previousQueueLengthTime))
 		}
 		return s.previousQueueLength, nil
 	}

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -738,7 +738,6 @@ func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 			s.previousQueueLength,
 			s.previousQueueLengthTime,
 		)
-		s.logger.V(1).Info(msg)
 		if s.recorder != nil {
 			s.recorder.Event(s.scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalersInfo, msg)
 		}

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -570,13 +570,12 @@ func (s *githubRunnerScaler) getGithubRequest(ctx context.Context, apiURL string
 	}
 
 	if r.StatusCode != 200 {
+		_, _ = io.Copy(io.Discard, r.Body)
+
 		if r.StatusCode == 304 && s.metadata.EnableEtags {
-			_, _ = io.Copy(io.Discard, r.Body)
 			s.logger.V(1).Info(fmt.Sprintf("The github rest api for the url: %s returned status %d %s", apiURL, r.StatusCode, http.StatusText(r.StatusCode)))
 			return []byte{}, r.StatusCode, nil
 		}
-
-		_, _ = io.Copy(io.Discard, r.Body)
 
 		if s.rateLimit.Remaining == 0 && !s.rateLimit.ResetTime.IsZero() && time.Now().Before(s.rateLimit.ResetTime) {
 			return []byte{}, r.StatusCode, fmt.Errorf("GitHub API rate limit exceeded, reset time %s", s.rateLimit.ResetTime)
@@ -735,7 +734,7 @@ func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 	if !s.previousQueueLengthTime.IsZero() {
 		if s.recorder != nil {
 			s.recorder.Event(s.scaledObject, corev1.EventTypeNormal, eventreason.KEDAScalersInfo,
-				fmt.Sprintf("Github API rate limit exceeded. Cached queue length: %d, last checked at %s",
+				fmt.Sprintf("Github API rate limit exceeded. Cached queue length: %d, last successful cache at %s",
 					s.previousQueueLength, s.previousQueueLengthTime))
 		}
 		return s.previousQueueLength, nil

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -14,8 +14,12 @@ import (
 	gha "github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/go-logr/logr"
 	v2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	"github.com/kedacore/keda/v2/pkg/eventreason"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
 )
@@ -34,6 +38,8 @@ type githubRunnerScaler struct {
 	metadata                *githubRunnerMetadata
 	httpClient              *http.Client
 	logger                  logr.Logger
+	recorder                record.EventRecorder
+	scaledObject            runtime.Object
 	etags                   map[string]string
 	previousRepos           []string
 	previousWfrs            map[string]map[string]*WorkflowRuns
@@ -379,6 +385,8 @@ func NewGitHubRunnerScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 		metadata:                meta,
 		httpClient:              httpClient,
 		logger:                  InitializeLogger(config, "github_runner_scaler"),
+		recorder:                config.Recorder,
+		scaledObject:            config.ScaledObject,
 		etags:                   etags,
 		previousRepos:           previousRepos,
 		previousJobs:            previousJobs,
@@ -492,40 +500,39 @@ func (s *githubRunnerScaler) getRepositories(ctx context.Context) ([]string, err
 }
 
 func (s *githubRunnerScaler) getRateLimit(header http.Header) (RateLimit, error) {
-	var retryAfterTime time.Time
+	var rateLimit RateLimit
 
-	remainingStr := header.Get("X-RateLimit-Remaining")
-	remaining, err := strconv.ParseInt(remainingStr, 10, 64)
-	if err != nil {
-		return RateLimit{}, fmt.Errorf("failed to parse X-RateLimit-Remaining header: %w", err)
+	if remainingStr := header.Get("X-RateLimit-Remaining"); remainingStr != "" {
+		remaining, err := strconv.ParseInt(remainingStr, 10, 64)
+		if err != nil {
+			return RateLimit{}, fmt.Errorf("failed to parse X-RateLimit-Remaining header: %w", err)
+		}
+		rateLimit.Remaining = remaining
 	}
 
-	resetStr := header.Get("X-RateLimit-Reset")
-	reset, err := strconv.ParseInt(resetStr, 10, 64)
-	if err != nil {
-		return RateLimit{}, fmt.Errorf("failed to parse X-RateLimit-Reset header: %w", err)
+	if resetStr := header.Get("X-RateLimit-Reset"); resetStr != "" {
+		reset, err := strconv.ParseInt(resetStr, 10, 64)
+		if err != nil {
+			return RateLimit{}, fmt.Errorf("failed to parse X-RateLimit-Reset header: %w", err)
+		}
+		rateLimit.ResetTime = time.Unix(reset, 0)
 	}
-	resetTime := time.Unix(reset, 0)
 
 	if retryAfterStr := header.Get("Retry-After"); retryAfterStr != "" {
 		retrySeconds, err := strconv.ParseInt(retryAfterStr, 10, 64)
 		if err != nil {
 			return RateLimit{}, fmt.Errorf("failed to parse Retry-After header: %w", err)
 		}
-		retryAfterTime = time.Now().Add(time.Duration(retrySeconds) * time.Second)
+		rateLimit.RetryAfterTime = time.Now().Add(time.Duration(retrySeconds) * time.Second)
 	}
 
-	if retryAfterTime.IsZero() {
-		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit: Remaining: %d, ResetTime: %s", remaining, resetTime))
+	if rateLimit.RetryAfterTime.IsZero() {
+		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit: Remaining: %d, ResetTime: %s", rateLimit.Remaining, rateLimit.ResetTime))
 	} else {
-		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit: Remaining: %d, ResetTime: %s, Retry-After: %s", remaining, resetTime, retryAfterTime))
+		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit: Remaining: %d, ResetTime: %s, Retry-After: %s", rateLimit.Remaining, rateLimit.ResetTime, rateLimit.RetryAfterTime))
 	}
 
-	return RateLimit{
-		Remaining:      remaining,
-		ResetTime:      resetTime,
-		RetryAfterTime: retryAfterTime,
-	}, nil
+	return rateLimit, nil
 }
 
 func (s *githubRunnerScaler) getGithubRequest(ctx context.Context, apiURL string, metadata *githubRunnerMetadata, httpClient *http.Client) ([]byte, int, error) {
@@ -726,15 +733,23 @@ func (s *githubRunnerScaler) isRateLimited() bool {
 // getCachedQueueLength returns the cached previous queue length
 func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 	if !s.previousQueueLengthTime.IsZero() {
-		s.logger.V(1).Info(fmt.Sprintf(
+		msg := fmt.Sprintf(
 			"Github API rate limit exceeded. Cached queue length: %d, last checked at %s",
 			s.previousQueueLength,
 			s.previousQueueLengthTime,
-		))
+		)
+		s.logger.V(1).Info(msg)
+		if s.recorder != nil {
+			s.recorder.Event(s.scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalersInfo, msg)
+		}
 		return s.previousQueueLength, nil
 	}
 
-	return -1, fmt.Errorf("GitHub API rate limit exceeded. No cached queue length available")
+	msg := "GitHub API rate limit exceeded. No cached queue length available"
+	if s.recorder != nil {
+		s.recorder.Event(s.scaledObject, corev1.EventTypeWarning, eventreason.KEDAScalersInfo, msg)
+	}
+	return -1, fmt.Errorf("%s", msg)
 }
 
 // GetWorkflowQueueLength returns the number of workflow jobs in the queue

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -30,14 +30,17 @@ const (
 var reservedLabels = []string{"self-hosted", "linux", "x64"}
 
 type githubRunnerScaler struct {
-	metricType    v2.MetricTargetType
-	metadata      *githubRunnerMetadata
-	httpClient    *http.Client
-	logger        logr.Logger
-	etags         map[string]string
-	previousRepos []string
-	previousWfrs  map[string]map[string]*WorkflowRuns
-	previousJobs  map[string][]Job
+	metricType              v2.MetricTargetType
+	metadata                *githubRunnerMetadata
+	httpClient              *http.Client
+	logger                  logr.Logger
+	etags                   map[string]string
+	previousRepos           []string
+	previousWfrs            map[string]map[string]*WorkflowRuns
+	previousJobs            map[string][]Job
+	rateLimit               RateLimit
+	previousQueueLength     int64
+	previousQueueLengthTime time.Time
 }
 
 type githubRunnerMetadata struct {
@@ -332,6 +335,13 @@ type Job struct {
 	HeadBranch      string   `json:"head_branch"`
 }
 
+// RateLimit holds rate limit information from GitHub API response headers
+type RateLimit struct {
+	Remaining      int       `json:"remaining"`
+	ResetTime      time.Time `json:"resetTime"`
+	RetryAfterTime time.Time `json:"retryAfterTime"`
+}
+
 // NewGitHubRunnerScaler creates a new GitHub Runner Scaler
 func NewGitHubRunnerScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	httpClient := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
@@ -360,16 +370,22 @@ func NewGitHubRunnerScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 	previousRepos := []string{}
 	previousJobs := make(map[string][]Job)
 	previousWfrs := make(map[string]map[string]*WorkflowRuns)
+	rateLimit := RateLimit{}
+	previousQueueLength := int64(0)
+	previousQueueLengthTime := time.Time{}
 
 	return &githubRunnerScaler{
-		metricType:    metricType,
-		metadata:      meta,
-		httpClient:    httpClient,
-		logger:        InitializeLogger(config, "github_runner_scaler"),
-		etags:         etags,
-		previousRepos: previousRepos,
-		previousJobs:  previousJobs,
-		previousWfrs:  previousWfrs,
+		metricType:              metricType,
+		metadata:                meta,
+		httpClient:              httpClient,
+		logger:                  InitializeLogger(config, "github_runner_scaler"),
+		etags:                   etags,
+		previousRepos:           previousRepos,
+		previousJobs:            previousJobs,
+		previousWfrs:            previousWfrs,
+		rateLimit:               rateLimit,
+		previousQueueLength:     previousQueueLength,
+		previousQueueLengthTime: previousQueueLengthTime,
 	}, nil
 }
 
@@ -475,6 +491,43 @@ func (s *githubRunnerScaler) getRepositories(ctx context.Context) ([]string, err
 	return repoList, nil
 }
 
+func (s *githubRunnerScaler) getRateLimit(header http.Header) (RateLimit, error) {
+	var retryAfterTime time.Time
+
+	remainingStr := header.Get("X-RateLimit-Remaining")
+	remaining, err := strconv.Atoi(remainingStr)
+	if err != nil {
+		return RateLimit{}, fmt.Errorf("failed to parse X-RateLimit-Remaining header: %w", err)
+	}
+
+	resetStr := header.Get("X-RateLimit-Reset")
+	reset, err := strconv.ParseInt(resetStr, 10, 64)
+	if err != nil {
+		return RateLimit{}, fmt.Errorf("failed to parse X-RateLimit-Reset header: %w", err)
+	}
+	resetTime := time.Unix(reset, 0)
+
+	if retryAfterStr := header.Get("Retry-After"); retryAfterStr != "" {
+		retrySeconds, err := strconv.Atoi(retryAfterStr)
+		if err != nil {
+			return RateLimit{}, fmt.Errorf("failed to parse Retry-After header: %w", err)
+		}
+		retryAfterTime = time.Now().Add(time.Duration(retrySeconds) * time.Second)
+	}
+
+	if retryAfterTime.IsZero() {
+		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit: Remaining: %d, ResetTime: %s", remaining, resetTime))
+	} else {
+		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit: Remaining: %d, ResetTime: %s, Retry-After: %s", remaining, resetTime, retryAfterTime))
+	}
+
+	return RateLimit{
+		Remaining:      remaining,
+		ResetTime:      resetTime,
+		RetryAfterTime: retryAfterTime,
+	}, nil
+}
+
 func (s *githubRunnerScaler) getGithubRequest(ctx context.Context, apiURL string, metadata *githubRunnerMetadata, httpClient *http.Client) ([]byte, int, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
@@ -500,6 +553,15 @@ func (s *githubRunnerScaler) getGithubRequest(ctx context.Context, apiURL string
 	}
 	defer r.Body.Close()
 
+	if r.Header.Get("X-RateLimit-Remaining") != "" {
+		rateLimit, err := s.getRateLimit(r.Header)
+		if err != nil {
+			s.logger.Error(err, "error getting rate limit")
+		} else {
+			s.rateLimit = rateLimit
+		}
+	}
+
 	if r.StatusCode != 200 {
 		if r.StatusCode == 304 && s.metadata.EnableEtags {
 			_, _ = io.Copy(io.Discard, r.Body)
@@ -507,17 +569,16 @@ func (s *githubRunnerScaler) getGithubRequest(ctx context.Context, apiURL string
 			return []byte{}, r.StatusCode, nil
 		}
 
-		if r.Header.Get("X-RateLimit-Remaining") != "" {
-			githubAPIRemaining, _ := strconv.Atoi(r.Header.Get("X-RateLimit-Remaining"))
+		_, _ = io.Copy(io.Discard, r.Body)
 
-			if githubAPIRemaining == 0 {
-				resetTime, _ := strconv.ParseInt(r.Header.Get("X-RateLimit-Reset"), 10, 64)
-				_, _ = io.Copy(io.Discard, r.Body)
-				return []byte{}, r.StatusCode, fmt.Errorf("GitHub API rate limit exceeded, resets at %s", time.Unix(resetTime, 0))
-			}
+		if s.rateLimit.Remaining == 0 && !s.rateLimit.ResetTime.IsZero() {
+			return []byte{}, r.StatusCode, fmt.Errorf("GitHub API rate limit exceeded, reset time %s", s.rateLimit.ResetTime)
 		}
 
-		_, _ = io.Copy(io.Discard, r.Body)
+		if !s.rateLimit.RetryAfterTime.IsZero() && time.Now().Before(s.rateLimit.RetryAfterTime) {
+			return []byte{}, r.StatusCode, fmt.Errorf("GitHub API rate limit exceeded, retry after %s", s.rateLimit.RetryAfterTime)
+		}
+
 		return []byte{}, r.StatusCode, fmt.Errorf("the GitHub REST API returned error. url: %s status: %d", apiURL, r.StatusCode)
 	}
 
@@ -645,13 +706,51 @@ func (s *githubRunnerScaler) canRunnerMatchLabels(jobLabels []string, runnerLabe
 	return true
 }
 
+// isRateLimited determines whether to use the cached previousQueueLength to avoid further calls to the Github API
+func (s *githubRunnerScaler) isRateLimited() bool {
+	now := time.Now()
+
+	if s.rateLimit.Remaining == 0 && !s.rateLimit.ResetTime.IsZero() && now.Before(s.rateLimit.ResetTime) {
+		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit exceeded. Rate limited until %s", s.rateLimit.ResetTime))
+		return true
+	}
+
+	if !s.rateLimit.RetryAfterTime.IsZero() && now.Before(s.rateLimit.RetryAfterTime) {
+		s.logger.V(1).Info(fmt.Sprintf("Github API rate limit exceeded. Rate limited until %s", s.rateLimit.RetryAfterTime))
+		return true
+	}
+
+	return false
+}
+
+// getCachedQueueLength returns the cached previous queue length
+func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
+	if !s.previousQueueLengthTime.IsZero() {
+		s.logger.V(1).Info(fmt.Sprintf(
+			"Github API rate limit exceeded. Cached queue length: %d, last checked at %s",
+			s.previousQueueLength,
+			s.previousQueueLengthTime,
+		))
+		return s.previousQueueLength, nil
+	}
+
+	return -1, fmt.Errorf("GitHub API rate limit exceeded. No cached queue length available")
+}
+
 // GetWorkflowQueueLength returns the number of workflow jobs in the queue
 func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64, error) {
+	if s.isRateLimited() {
+		return s.getCachedQueueLength()
+	}
+
 	var repos []string
 	var err error
 
 	repos, err = s.getRepositories(ctx)
 	if err != nil {
+		if s.isRateLimited() {
+			return s.getCachedQueueLength()
+		}
 		return -1, err
 	}
 
@@ -660,6 +759,9 @@ func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64,
 	for _, repo := range repos {
 		wfrsQueued, err := s.getWorkflowRuns(ctx, repo, "queued")
 		if err != nil {
+			if s.isRateLimited() {
+				return s.getCachedQueueLength()
+			}
 			return -1, err
 		}
 		if wfrsQueued != nil {
@@ -667,6 +769,9 @@ func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64,
 		}
 		wfrsInProgress, err := s.getWorkflowRuns(ctx, repo, "in_progress")
 		if err != nil {
+			if s.isRateLimited() {
+				return s.getCachedQueueLength()
+			}
 			return -1, err
 		}
 		if wfrsInProgress != nil {
@@ -680,6 +785,9 @@ func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64,
 	for _, wfr := range wfrs {
 		jobs, err := s.getWorkflowRunJobs(ctx, wfr.ID, wfr.Repository.Name)
 		if err != nil {
+			if s.isRateLimited() {
+				return s.getCachedQueueLength()
+			}
 			return -1, err
 		}
 		for _, job := range jobs {
@@ -688,6 +796,14 @@ func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64,
 			}
 		}
 	}
+
+	s.previousQueueLength = queueCount
+	s.previousQueueLengthTime = time.Now()
+	s.logger.V(1).Info(fmt.Sprintf(
+		"Successful workflow queue count. Caching previous queue length %d, previous queue length time %s",
+		s.previousQueueLength,
+		s.previousQueueLengthTime,
+	))
 
 	return queueCount, nil
 }

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -337,7 +337,7 @@ type Job struct {
 
 // RateLimit holds rate limit information from GitHub API response headers
 type RateLimit struct {
-	Remaining      int       `json:"remaining"`
+	Remaining      int64     `json:"remaining"`
 	ResetTime      time.Time `json:"resetTime"`
 	RetryAfterTime time.Time `json:"retryAfterTime"`
 }
@@ -495,7 +495,7 @@ func (s *githubRunnerScaler) getRateLimit(header http.Header) (RateLimit, error)
 	var retryAfterTime time.Time
 
 	remainingStr := header.Get("X-RateLimit-Remaining")
-	remaining, err := strconv.Atoi(remainingStr)
+	remaining, err := strconv.ParseInt(remainingStr, 10, 64)
 	if err != nil {
 		return RateLimit{}, fmt.Errorf("failed to parse X-RateLimit-Remaining header: %w", err)
 	}
@@ -508,7 +508,7 @@ func (s *githubRunnerScaler) getRateLimit(header http.Header) (RateLimit, error)
 	resetTime := time.Unix(reset, 0)
 
 	if retryAfterStr := header.Get("Retry-After"); retryAfterStr != "" {
-		retrySeconds, err := strconv.Atoi(retryAfterStr)
+		retrySeconds, err := strconv.ParseInt(retryAfterStr, 10, 64)
 		if err != nil {
 			return RateLimit{}, fmt.Errorf("failed to parse Retry-After header: %w", err)
 		}

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -571,7 +571,7 @@ func (s *githubRunnerScaler) getGithubRequest(ctx context.Context, apiURL string
 
 		_, _ = io.Copy(io.Discard, r.Body)
 
-		if s.rateLimit.Remaining == 0 && !s.rateLimit.ResetTime.IsZero() {
+		if s.rateLimit.Remaining == 0 && !s.rateLimit.ResetTime.IsZero() && time.Now().Before(s.rateLimit.ResetTime) {
 			return []byte{}, r.StatusCode, fmt.Errorf("GitHub API rate limit exceeded, reset time %s", s.rateLimit.ResetTime)
 		}
 

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -819,6 +819,39 @@ func TestNewGitHubRunnerScaler_QueueLength_MultiRepo_PulledRepos_NoRate(t *testi
 	}
 }
 
+func TestNewGitHubRunnerScaler_QueueLength_SingleRepo_WithRateLimit(t *testing.T) {
+	// First call sets the cached queue length
+	apiStub := apiStubHandler(true, false)
+	meta := getGitHubTestMetaData(apiStub.URL)
+
+	scaler := githubRunnerScaler{
+		metadata:   meta,
+		httpClient: http.DefaultClient,
+	}
+	scaler.metadata.Repos = []string{"test"}
+	scaler.metadata.Labels = []string{"foo", "bar"}
+
+	if queueLen, err := scaler.GetWorkflowQueueLength(context.Background()); err != nil {
+		fmt.Println(err)
+		t.Fail()
+	} else if queueLen != 1 {
+		fmt.Printf("Expected queue length of 1 got %d\n", queueLen)
+		t.Fail()
+	}
+
+	// Simulate rate limit - should return cached queue length
+	scaler.rateLimit.Remaining = 0
+	scaler.rateLimit.ResetTime = time.Now().Add(5 * time.Minute)
+
+	if queueLen, err := scaler.GetWorkflowQueueLength(context.Background()); err != nil {
+		fmt.Println(err)
+		t.Fail()
+	} else if queueLen != 1 {
+		fmt.Printf("Expected cached queue length of 1 after rate limit, got %d\n", queueLen)
+		t.Fail()
+	}
+}
+
 type githubRunnerMetricIdentifier struct {
 	metadataTestData *map[string]string
 	triggerIndex     int


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [N/A] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [N/A] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7683 

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to: https://github.com/kedacore/keda-docs/pull/1749

Follow on from #7192 and comment https://github.com/kedacore/keda/pull/7192#pullrequestreview-3675746798
