### PR TITLE
fix(pulsar): scope auth header re-application on redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **NATS JetStream Scaler**: URL-encode user input in monitoring URL construction ([#7483](https://github.com/kedacore/keda/pull/7483))
 - **Prometheus Scaler**: Handle NaN results in the same manner as Inf ([#7475](https://github.com/kedacore/keda/issues/7475))
 - **Prometheus Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
+- **Pulsar Scaler**: Drop bearer/basic auth headers on redirects to a different host or on https->http downgrades to prevent credential leakage ([#7686](https://github.com/kedacore/keda/issues/7686))
 - **RabbitMQ Scaler**: Fix AMQP connection leak by recovering channels on the existing connection and closing connections properly ([#6266](https://github.com/kedacore/keda/issues/6266))
 - **RabbitMQ Scaler**: Use SASL EXTERNAL for RabbitMQ AMQP TLS without credentials ([#6840](https://github.com/kedacore/keda/issues/6840))
 - **Solace Scaler**: Fix URL escaping for Message VPN and Queue names ([#7481](https://github.com/kedacore/keda/pull/7481))

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -169,11 +169,26 @@ func NewPulsarScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 		}
 
 		if pulsarMetadata.PulsarAuth.EnabledBearerAuth() || pulsarMetadata.PulsarAuth.EnabledBasicAuth() {
-			// The pulsar broker redirects HTTP calls to other brokers and expects the Authorization header
+			// The pulsar broker redirects HTTP calls to other brokers and expects the Authorization header.
+			// Re-apply credentials only when the redirect target shares the original host and does not
+			// downgrade the scheme; otherwise let the redirect proceed without auth so that an
+			// attacker-controlled or open-redirect target cannot harvest the bearer/basic credentials.
 			client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-				if len(via) != 0 && via[0] != nil && via[0].Response != nil && via[0].Response.StatusCode == http.StatusTemporaryRedirect {
-					addAuthHeaders(req, pulsarMetadata)
+				if len(via) == 0 || via[0] == nil || via[0].Response == nil ||
+					via[0].Response.StatusCode != http.StatusTemporaryRedirect {
+					return nil
 				}
+				origURL := via[0].URL
+				if origURL == nil || req.URL == nil {
+					return nil
+				}
+				if !strings.EqualFold(origURL.Hostname(), req.URL.Hostname()) {
+					return nil
+				}
+				if strings.EqualFold(origURL.Scheme, "https") && !strings.EqualFold(req.URL.Scheme, "https") {
+					return nil
+				}
+				addAuthHeaders(req, pulsarMetadata)
 				return nil
 			}
 		}

--- a/pkg/scalers/pulsar_scaler_test.go
+++ b/pkg/scalers/pulsar_scaler_test.go
@@ -470,3 +470,66 @@ func TestPulsarScalerRedirectNilPointerFix(t *testing.T) {
 		t.Error("Expected at least one HTTP call to trigger redirect")
 	}
 }
+
+// TestPulsarRedirectAuthHostScopeGuard exercises the host/scheme guard added
+// for issue #7686: auth headers must follow same-host redirects but must not
+// be forwarded to a different host or to an https->http downgrade.
+func TestPulsarRedirectAuthHostScopeGuard(t *testing.T) {
+	scaler, err := NewPulsarScaler(&scalersconfig.ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"adminURL":     "https://pulsar.example.com:8080",
+			"topic":        "persistent://public/default/test-topic",
+			"subscription": "test-subscription",
+			"authModes":    "bearer",
+		},
+		AuthParams: map[string]string{
+			"bearerToken": "test-token",
+		},
+	})
+	if err != nil {
+		t.Fatalf("create scaler: %v", err)
+	}
+	ps, ok := scaler.(*pulsarScaler)
+	if !ok {
+		t.Fatal("expected *pulsarScaler")
+	}
+	if ps.httpClient.CheckRedirect == nil {
+		t.Fatal("CheckRedirect not configured")
+	}
+
+	cases := []struct {
+		name      string
+		origURL   string
+		targetURL string
+		wantAuth  bool
+	}{
+		{"same host different port retains auth", "https://pulsar.example.com:8080/admin", "https://pulsar.example.com:8443/admin", true},
+		{"same host case-insensitive retains auth", "https://Pulsar.Example.com/admin", "https://pulsar.example.COM/admin/redirected", true},
+		{"different host drops auth", "https://pulsar.example.com/admin", "https://attacker.example.org/steal", false},
+		{"https to http downgrade drops auth", "https://pulsar.example.com/admin", "http://pulsar.example.com/admin", false},
+		{"http to http same host retains auth", "http://pulsar.example.com/admin", "http://pulsar.example.com/admin/redirected", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origReq, err := http.NewRequest(http.MethodGet, tc.origURL, nil)
+			if err != nil {
+				t.Fatalf("orig request: %v", err)
+			}
+			origReq.Response = &http.Response{StatusCode: http.StatusTemporaryRedirect}
+			next, err := http.NewRequest(http.MethodGet, tc.targetURL, nil)
+			if err != nil {
+				t.Fatalf("target request: %v", err)
+			}
+			if err := ps.httpClient.CheckRedirect(next, []*http.Request{origReq}); err != nil {
+				t.Fatalf("CheckRedirect returned error: %v", err)
+			}
+			got := next.Header.Get("Authorization")
+			if tc.wantAuth && got == "" {
+				t.Errorf("expected auth header to be set, got empty")
+			}
+			if !tc.wantAuth && got != "" {
+				t.Errorf("expected no auth header, got %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
the pulsar scaler overrides `CheckRedirect` so 307 redirects between brokers keep their `Authorization` header. it does that unconditionally, which means a redirect to a different host (or an https->http downgrade from a trusted adminURL with an open redirect) re-applies the bearer/basic credentials to the new target.

re-apply auth only when the redirect target shares the original request's hostname (port-stripped, case-insensitive) and does not downgrade the scheme. cross-host and https->http redirects fall through without setting the headers, so the redirect still happens but the credentials don't follow.

added `TestPulsarRedirectAuthHostScopeGuard` covering same-host (with port change), case-insensitive host match, cross-host, https->http downgrade, and plain http same-host. existing `TestPulsarScalerRedirectNilPointerFix` still passes.

note: pulsar deployments where peer brokers run on entirely different hostnames will now lose auth on the broker-to-broker hop, same as Go's stdlib default would. happy to relax the host check (subdomain match, or configurable allowlist) if that turns out to break legitimate setups.

Fixes #7686