### PR TITLE
fix(metrics-api): prevent response value reflection in scaler errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Loki Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **Loki Scaler**: `serverAddress` now appends `/loki/api/v1/query` to the end of existing path instead of overriding ([#7648](https://github.com/kedacore/keda/pull/7648))
 - **Metrics API Scaler**: Fix `aggregateFromKubeServiceEndpoints` using empty label selector that matched all EndpointSlices in the namespace instead of only the target service's ([#7641](https://github.com/kedacore/keda/issues/7641))
+- **Metrics API Scaler**: Prevent response value reflection in scaler errors ([#7693](https://github.com/kedacore/keda/pull/7693))
 - **NATS JetStream Scaler**: Return an error from `getMaxMsgLag` when the configured consumer is missing instead of falling back to the stream's last sequence, preventing incorrect scale-up to `maxReplicaCount` ([#7657](https://github.com/kedacore/keda/issues/7657))
 - **NATS JetStream Scaler**: URL-encode user input in monitoring URL construction ([#7483](https://github.com/kedacore/keda/pull/7483))
 - **Prometheus Scaler**: Handle NaN results in the same manner as Inf ([#7475](https://github.com/kedacore/keda/issues/7475))

--- a/pkg/scalers/metrics_api_scaler.go
+++ b/pkg/scalers/metrics_api_scaler.go
@@ -56,7 +56,7 @@ type metricsAPIScalerMetadata struct {
 
 const (
 	methodValueQuery           = "query"
-	valueLocationWrongErrorMsg = "valueLocation must point to value of type number or a string representing a Quantity got: '%s'"
+	valueLocationWrongErrorMsg = "valueLocation %q must point to a numeric value or a string parseable as a Quantity, got %s"
 )
 
 const secureHTTPScheme = "https"
@@ -227,12 +227,12 @@ func getValueFromJSONResponse(body []byte, valueLocation string) (float64, error
 	if r.Type == gjson.String {
 		v, err := resource.ParseQuantity(r.String())
 		if err != nil {
-			return 0, fmt.Errorf(valueLocationWrongErrorMsg, r.String())
+			return 0, fmt.Errorf("valueLocation %q points to a string that is not parseable as a Quantity", valueLocation)
 		}
 		return v.AsApproximateFloat64(), nil
 	}
 	if r.Type != gjson.Number {
-		return 0, fmt.Errorf(valueLocationWrongErrorMsg, r.Type.String())
+		return 0, fmt.Errorf(valueLocationWrongErrorMsg, valueLocation, r.Type.String())
 	}
 	return r.Num, nil
 }
@@ -260,11 +260,11 @@ func getValueFromXMLResponse(body []byte, valueLocation string) (float64, error)
 	case string:
 		r, err := resource.ParseQuantity(v)
 		if err != nil {
-			return 0, fmt.Errorf(valueLocationWrongErrorMsg, v)
+			return 0, fmt.Errorf("valueLocation %q points to a string that is not parseable as a Quantity", valueLocation)
 		}
 		return r.AsApproximateFloat64(), nil
 	default:
-		return 0, fmt.Errorf(valueLocationWrongErrorMsg, v)
+		return 0, fmt.Errorf(valueLocationWrongErrorMsg, valueLocation, fmt.Sprintf("%T", v))
 	}
 }
 
@@ -292,11 +292,11 @@ func getValueFromYAMLResponse(body []byte, valueLocation string) (float64, error
 	case string:
 		r, err := resource.ParseQuantity(v)
 		if err != nil {
-			return 0, fmt.Errorf(valueLocationWrongErrorMsg, v)
+			return 0, fmt.Errorf("valueLocation %q points to a string that is not parseable as a Quantity", valueLocation)
 		}
 		return r.AsApproximateFloat64(), nil
 	default:
-		return 0, fmt.Errorf(valueLocationWrongErrorMsg, v)
+		return 0, fmt.Errorf(valueLocationWrongErrorMsg, valueLocation, fmt.Sprintf("%T", v))
 	}
 }
 


### PR DESCRIPTION
Removes raw response values from metrics-api scaler error messages to prevent them from being surfaced on ScaledObject Events.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))