### PR TITLE
fix: use Server-Side Apply for ScaledObject label and finalizer mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Allow more control of TLS versions & ciphers via `KEDA_HTTP_TLS_CIPHER_LIST`, `KEDA_SERVICE_TLS_CIPHER_LIST` and `KEDA_SERVICE_MIN_TLS_VERSION` env vars ([#7617](https://github.com/kedacore/keda/pull/7617))
 - **General**: Make APIService cert injections optional ([#7559](https://github.com/kedacore/keda/pull/7559))
+- **General**: Use Server-Side Apply (SSA) with field manager `keda-operator` for the `scaledobject.keda.sh/name` label mutation so tooling that respects SSA field ownership will not treat this label as unwanted drift ([#7694](https://github.com/kedacore/keda/pull/7694))
 - **Elasticsearch Scaler**: Add HTTP status check for Elasticsearch errors ([#7480](https://github.com/kedacore/keda/pull/7480))
 - **Kubernetes Workload Scaler**: Add `groupByNode` parameter ([#7628](https://github.com/kedacore/keda/issues/7628))
 

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -356,18 +356,32 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(ctx context.Context, logg
 // ensureScaledObjectLabel ensures that scaledobject.keda.sh/name=<scaledObject.Name> label exist in the ScaledObject
 // This is how the MetricsAdapter will know which ScaledObject a metric is for when the HPA queries it.
 func (r *ScaledObjectReconciler) ensureScaledObjectLabel(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) error {
-	if scaledObject.Labels == nil {
-		scaledObject.Labels = map[string]string{kedav1alpha1.ScaledObjectOwnerAnnotation: scaledObject.Name}
-	} else {
+	if scaledObject.Labels != nil {
 		value, found := scaledObject.Labels[kedav1alpha1.ScaledObjectOwnerAnnotation]
 		if found && value == scaledObject.Name {
 			return nil
 		}
-		scaledObject.Labels[kedav1alpha1.ScaledObjectOwnerAnnotation] = scaledObject.Name
 	}
 
 	logger.V(1).Info("Adding \"scaledobject.keda.sh/name\" label on ScaledObject", "value", scaledObject.Name)
-	return r.Client.Update(ctx, scaledObject)
+	patchObj := &unstructured.Unstructured{}
+	patchObj.SetAPIVersion(kedav1alpha1.GroupVersion.String())
+	patchObj.SetKind("ScaledObject")
+	patchObj.SetName(scaledObject.Name)
+	patchObj.SetNamespace(scaledObject.Namespace)
+	patchObj.SetLabels(map[string]string{kedav1alpha1.ScaledObjectOwnerAnnotation: scaledObject.Name})
+	if err := r.Client.Patch(ctx, patchObj, client.Apply, client.ForceOwnership, client.FieldOwner("keda-operator")); err != nil {
+		return err
+	}
+	scaledObject.ResourceVersion = patchObj.GetResourceVersion()
+	if scaledObject.Labels == nil {
+		scaledObject.Labels = patchObj.GetLabels()
+	} else {
+		for k, v := range patchObj.GetLabels() {
+			scaledObject.Labels[k] = v
+		}
+	}
+	return nil
 }
 
 func (r *ScaledObjectReconciler) checkIfTargetResourceReachPausedCount(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) bool {

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -2059,6 +2060,76 @@ var _ = Describe("ScaledObjectController", func() {
 			return k8sClient.Get(context.Background(), types.NamespacedName{Name: fmt.Sprintf("keda-hpa-%s", soName), Namespace: "default"}, hpa)
 
 		}).Should(BeNil())
+	})
+
+	Describe("SSA metadata mutations", func() {
+		var (
+			patchReconciler ScaledObjectReconciler
+			mockClient      *mock_client.MockClient
+		)
+
+		BeforeEach(func() {
+			ctrl := gomock.NewController(util.GinkgoTestReporter{})
+			mockClient = mock_client.NewMockClient(ctrl)
+			patchReconciler = ScaledObjectReconciler{Client: mockClient}
+		})
+
+		Describe("ensureScaledObjectLabel", func() {
+			It("calls Patch when the labels map is nil", func() {
+				so := &kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{Name: "patch-label-nil", Namespace: "default"},
+				}
+				mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Eq(client.Apply), gomock.Any(), gomock.Any()).Return(nil)
+
+				Expect(patchReconciler.ensureScaledObjectLabel(context.Background(), testLogger, so)).To(Succeed())
+			})
+
+			It("calls Patch when the KEDA label is absent from an existing labels map", func() {
+				so := &kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "patch-label-missing",
+						Namespace: "default",
+						Labels:    map[string]string{"some-other": "label"},
+					},
+				}
+				mockClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Eq(client.Apply), gomock.Any(), gomock.Any()).Return(nil)
+
+				Expect(patchReconciler.ensureScaledObjectLabel(context.Background(), testLogger, so)).To(Succeed())
+			})
+
+			It("skips Patch when the correct KEDA label already exists", func() {
+				so := &kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "patch-label-present",
+						Namespace: "default",
+						Labels:    map[string]string{kedav1alpha1.ScaledObjectOwnerAnnotation: "patch-label-present"},
+					},
+				}
+				Expect(patchReconciler.ensureScaledObjectLabel(context.Background(), testLogger, so)).To(Succeed())
+			})
+		})
+
+		Describe("ensureFinalizer", func() {
+			It("calls Update when the finalizer is absent", func() {
+				so := &kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{Name: "patch-finalizer-add", Namespace: "default"},
+				}
+				mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+				Expect(patchReconciler.ensureFinalizer(context.Background(), testLogger, so)).To(Succeed())
+			})
+
+			It("skips Patch when the finalizer is already present", func() {
+				so := &kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "patch-finalizer-present",
+						Namespace:  "default",
+						Finalizers: []string{scaledObjectFinalizer},
+					},
+				}
+				Expect(patchReconciler.ensureFinalizer(context.Background(), testLogger, so)).To(Succeed())
+			})
+		})
 	})
 
 	// Fix issue 5520

--- a/controllers/keda/scaledobject_finalizer.go
+++ b/controllers/keda/scaledobject_finalizer.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	eventingv1alpha1 "github.com/kedacore/keda/v2/apis/eventing/v1alpha1"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -75,8 +76,9 @@ func (r *ScaledObjectReconciler) finalizeScaledObject(ctx context.Context, logge
 
 		// Remove scaledObjectFinalizer. Once all finalizers have been
 		// removed, the object will be deleted.
+		patch := client.MergeFrom(scaledObject.DeepCopy())
 		scaledObject.SetFinalizers(util.Remove(scaledObject.GetFinalizers(), scaledObjectFinalizer))
-		if err := r.Client.Update(ctx, scaledObject); err != nil {
+		if err := r.Client.Patch(ctx, scaledObject, patch); err != nil {
 			logger.Error(err, "Failed to update ScaledObject after removing a finalizer", "finalizer", scaledObjectFinalizer)
 			return err
 		}


### PR DESCRIPTION
## What

Replace the `scaledobject.keda.sh/name` label mutation in the ScaledObject controller with **Server-Side Apply (SSA)** using field manager `keda-operator`:
| Location | Operation | Method |
|---|---|---|
| `ensureScaledObjectLabel` (`scaledobject_controller.go`) | adds the `scaledobject.keda.sh/name` label | **SSA** (`client.Apply` + `FieldOwner("keda-operator")`) |
| `ensureFinalizer` (`scaledobject_finalizer.go`) | adds the `finalizer.keda.sh` finalizer | `Update` (unchanged) |
| `finalizeScaledObject` (`scaledobject_finalizer.go`) | removes the finalizer on deletion | `MergeFrom` (unchanged) |

## Why

Without SSA field ownership, the `scaledobject.keda.sh/name` label has no declared owner in the managed-fields table. Tools that perform drift correction by applying the desired state via SSA will see this label as an unmanaged extra field and remove it — causing a reconciliation loop where KEDA re-adds it immediately.
With `client.Apply` + `client.FieldOwner("keda-operator")` + `client.ForceOwnership`, KEDA **claims ownership** of the label in the API server's managed-fields table. Any tool that respects SSA field ownership will leave it untouched.

**Why not SSA for the finalizer?** Using the same `keda-operator` field manager for both SSA patches causes field-manager abandonment: each apply config only declares its own subset of fields, so the second patch abandons ownership of what the first declared. Concretely, the label SSA (which omits `metadata.finalizers`) would abandon finalizer ownership and physically remove the finalizer value from the live object. Kubernetes finalizer semantics protect objects from *deletion* but do not prevent the finalizer string from being overwritten by a Patch. Keeping `ensureFinalizer` as `r.Client.Update` avoids this entirely.

`unstructured.Unstructured` is used as the patch carrier for the label (rather than the typed `*ScaledObject` struct) to avoid serializing zero-valued required fields (`spec.triggers`) into the SSA payload, which would fail CRD validation.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))