### PR TITLE
fix(github-runner): bound etag and per-repo caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Forgejo Scaler**: Return correct activity to enable scale-to-zero ([#7527](https://github.com/kedacore/keda/issues/7527))
 - **GCP Cloud Tasks Scaler**: Implement escapeFilterValue for metric filtering ([#7482](https://github.com/kedacore/keda/pull/7482))
 - **GCP Scaler**: Validate Pub/Sub resource name in BuildMQLQuery ([#7468](https://github.com/kedacore/keda/pull/7468))
+- **Github Runner Scaler**: Bound etag and per-repo caches to prevent unbounded memory growth when `enableEtags` is on ([#7685](https://github.com/kedacore/keda/issues/7685))
 - **Github Runner Scaler**: Improve URL construction and error handling ([#7495](https://github.com/kedacore/keda/pull/7495))
 - **Github Runner Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **InfluxDB Scaler**: Make `authToken` optional to support unauthenticated InfluxDB instances ([#7616](https://github.com/kedacore/keda/issues/7616))

--- a/go.mod
+++ b/go.mod
@@ -349,7 +349,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.temporal.io/api v1.62.2 // indirect
-	go.uber.org/atomic v1.11.0
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -349,7 +349,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.temporal.io/api v1.62.2 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/atomic v1.11.0
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -29,6 +29,11 @@ const (
 	ENT                  = "ent"
 	REPO                 = "repo"
 	githubDefaultPerPage = 30
+	// githubScalerMaxCacheEntries caps the etags and previousJobs maps. Without
+	// it the etags map grows once per workflow run for the lifetime of the
+	// operator pod (the URL contains the run ID), and previousJobs grows once
+	// per distinct workflow repository name returned by the API.
+	githubScalerMaxCacheEntries = 5000
 )
 
 var reservedLabels = []string{"self-hosted", "linux", "x64"}
@@ -743,6 +748,36 @@ func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 	return -1, fmt.Errorf("GitHub API rate limit exceeded. No cached queue length available")
 }
 
+// pruneCaches removes previousWfrs entries for repos missing from currentRepos
+// and caps all three caches to githubScalerMaxCacheEntries.
+func (s *githubRunnerScaler) pruneCaches(currentRepos []string) {
+	repoSet := make(map[string]struct{}, len(currentRepos))
+	for _, r := range currentRepos {
+		repoSet[r] = struct{}{}
+	}
+	for repo := range s.previousWfrs {
+		if _, ok := repoSet[repo]; !ok {
+			delete(s.previousWfrs, repo)
+		}
+	}
+	evictExcess(s.previousWfrs, githubScalerMaxCacheEntries)
+	evictExcess(s.previousJobs, githubScalerMaxCacheEntries)
+	evictExcess(s.etags, githubScalerMaxCacheEntries)
+}
+
+// evictExcess removes arbitrary entries from m until len(m) <= limit. Map
+// iteration is randomized in Go, so this is a simple bound rather than LRU.
+func evictExcess[K comparable, V any](m map[K]V, limit int) {
+	over := len(m) - limit
+	for k := range m {
+		if over <= 0 {
+			break
+		}
+		delete(m, k)
+		over--
+	}
+}
+
 // GetWorkflowQueueLength returns the number of workflow jobs in the queue
 func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64, error) {
 	if s.isRateLimited() {
@@ -758,6 +793,10 @@ func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64,
 			return s.getCachedQueueLength()
 		}
 		return -1, err
+	}
+
+	if s.metadata.EnableEtags {
+		s.pruneCaches(repos)
 	}
 
 	var allWfrs []WorkflowRuns

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -29,10 +29,11 @@ const (
 	ENT                  = "ent"
 	REPO                 = "repo"
 	githubDefaultPerPage = 30
-	// githubScalerMaxCacheEntries caps the etags and previousJobs maps. Without
-	// it the etags map grows once per workflow run for the lifetime of the
-	// operator pod (the URL contains the run ID), and previousJobs grows once
-	// per distinct workflow repository name returned by the API.
+	// githubScalerMaxCacheEntries caps the etags, previousJobs, and
+	// previousWfrs maps. Without it the etags map grows once per workflow run
+	// for the lifetime of the operator pod (the URL contains the run ID), and
+	// previousJobs and previousWfrs grow once per distinct repository name
+	// returned by the API.
 	githubScalerMaxCacheEntries = 5000
 )
 
@@ -635,8 +636,16 @@ func (s *githubRunnerScaler) getWorkflowRunJobs(ctx context.Context, workflowRun
 		if s.previousJobs[repoName] != nil {
 			return s.previousJobs[repoName], nil
 		}
-
-		return nil, fmt.Errorf("request for jobs returned status: %d %s but previous jobs is not set", statusCode, http.StatusText(statusCode))
+		// Stale etag without a paired previousJobs entry, e.g. after pruneCaches
+		// evicted the previous entry. Drop the etag and retry as a cache miss.
+		delete(s.etags, apiURL)
+		body, statusCode, err = s.getGithubRequest(ctx, apiURL, s.metadata, s.httpClient)
+		if err != nil {
+			return nil, err
+		}
+		if statusCode == 304 {
+			return nil, fmt.Errorf("request for jobs returned status: %d %s but previous jobs is not set", statusCode, http.StatusText(statusCode))
+		}
 	}
 
 	var jobs Jobs
@@ -670,8 +679,18 @@ func (s *githubRunnerScaler) getWorkflowRuns(ctx context.Context, repoName strin
 		if s.previousWfrs[repoName][status] != nil {
 			return s.previousWfrs[repoName][status], nil
 		}
-
-		return nil, fmt.Errorf("request for workflow runs returned status: %d %s but previous workflow runs is not set. Repo: %s, Status: %s", statusCode, http.StatusText(statusCode), repoName, status)
+		// Stale etag without a paired previousWfrs entry, e.g. after pruneCaches
+		// evicted the previous entry. Drop the etag and retry as a cache miss.
+		delete(s.etags, apiURL)
+		body, statusCode, err = s.getGithubRequest(ctx, apiURL, s.metadata, s.httpClient)
+		if err != nil && statusCode == 404 {
+			return nil, nil
+		} else if err != nil {
+			return nil, err
+		}
+		if statusCode == 304 {
+			return nil, fmt.Errorf("request for workflow runs returned status: %d %s but previous workflow runs is not set. Repo: %s, Status: %s", statusCode, http.StatusText(statusCode), repoName, status)
+		}
 	}
 
 	var wfrs WorkflowRuns

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
 
@@ -916,14 +918,14 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 }
 
 func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
-	var sawIfNoneMatch, sawNoIfNoneMatch bool
+	var sawIfNoneMatch, sawNoIfNoneMatch atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("If-None-Match") != "" {
-			sawIfNoneMatch = true
+			sawIfNoneMatch.Store(true)
 			w.WriteHeader(http.StatusNotModified)
 			return
 		}
-		sawNoIfNoneMatch = true
+		sawNoIfNoneMatch.Store(true)
 		w.Header().Set("ETag", `"fresh-etag"`)
 		// nosemgrep: no-direct-write-to-responsewriter
 		_, _ = w.Write([]byte(testGhWFJobResponse))
@@ -950,8 +952,8 @@ func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
 	if len(jobs) == 0 {
 		t.Fatalf("expected jobs from retry, got empty slice")
 	}
-	if !sawIfNoneMatch || !sawNoIfNoneMatch {
-		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch, sawNoIfNoneMatch)
+	if !sawIfNoneMatch.Load() || !sawNoIfNoneMatch.Load() {
+		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch.Load(), sawNoIfNoneMatch.Load())
 	}
 	if got := s.etags[apiURL]; got != `"fresh-etag"` {
 		t.Fatalf("expected etag to be refreshed to %q, got %q", `"fresh-etag"`, got)
@@ -959,14 +961,14 @@ func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
 }
 
 func TestGetWorkflowRuns_StaleEtagWithoutPreviousRetries(t *testing.T) {
-	var sawIfNoneMatch, sawNoIfNoneMatch bool
+	var sawIfNoneMatch, sawNoIfNoneMatch atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("If-None-Match") != "" {
-			sawIfNoneMatch = true
+			sawIfNoneMatch.Store(true)
 			w.WriteHeader(http.StatusNotModified)
 			return
 		}
-		sawNoIfNoneMatch = true
+		sawNoIfNoneMatch.Store(true)
 		w.Header().Set("ETag", `"fresh-etag"`)
 		// nosemgrep: no-direct-write-to-responsewriter
 		_, _ = w.Write([]byte(testGhWorkflowResponse))
@@ -993,8 +995,8 @@ func TestGetWorkflowRuns_StaleEtagWithoutPreviousRetries(t *testing.T) {
 	if wfrs == nil || len(wfrs.WorkflowRuns) == 0 {
 		t.Fatalf("expected workflow runs from retry, got empty result")
 	}
-	if !sawIfNoneMatch || !sawNoIfNoneMatch {
-		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch, sawNoIfNoneMatch)
+	if !sawIfNoneMatch.Load() || !sawNoIfNoneMatch.Load() {
+		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch.Load(), sawNoIfNoneMatch.Load())
 	}
 	if got := s.etags[apiURL]; got != `"fresh-etag"` {
 		t.Fatalf("expected etag to be refreshed to %q, got %q", `"fresh-etag"`, got)

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -10,10 +10,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
-
-	"go.uber.org/atomic"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
@@ -918,14 +917,18 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 }
 
 func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
-	var sawIfNoneMatch, sawNoIfNoneMatch atomic.Bool
+	var mu sync.Mutex
+	var sawIfNoneMatch, sawNoIfNoneMatch bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		if r.Header.Get("If-None-Match") != "" {
-			sawIfNoneMatch.Store(true)
+			sawIfNoneMatch = true
+			mu.Unlock()
 			w.WriteHeader(http.StatusNotModified)
 			return
 		}
-		sawNoIfNoneMatch.Store(true)
+		sawNoIfNoneMatch = true
+		mu.Unlock()
 		w.Header().Set("ETag", `"fresh-etag"`)
 		// nosemgrep: no-direct-write-to-responsewriter
 		_, _ = w.Write([]byte(testGhWFJobResponse))
@@ -952,8 +955,11 @@ func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
 	if len(jobs) == 0 {
 		t.Fatalf("expected jobs from retry, got empty slice")
 	}
-	if !sawIfNoneMatch.Load() || !sawNoIfNoneMatch.Load() {
-		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch.Load(), sawNoIfNoneMatch.Load())
+	mu.Lock()
+	gotIfNoneMatch, gotNoIfNoneMatch := sawIfNoneMatch, sawNoIfNoneMatch
+	mu.Unlock()
+	if !gotIfNoneMatch || !gotNoIfNoneMatch {
+		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", gotIfNoneMatch, gotNoIfNoneMatch)
 	}
 	if got := s.etags[apiURL]; got != `"fresh-etag"` {
 		t.Fatalf("expected etag to be refreshed to %q, got %q", `"fresh-etag"`, got)
@@ -961,14 +967,18 @@ func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
 }
 
 func TestGetWorkflowRuns_StaleEtagWithoutPreviousRetries(t *testing.T) {
-	var sawIfNoneMatch, sawNoIfNoneMatch atomic.Bool
+	var mu sync.Mutex
+	var sawIfNoneMatch, sawNoIfNoneMatch bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		if r.Header.Get("If-None-Match") != "" {
-			sawIfNoneMatch.Store(true)
+			sawIfNoneMatch = true
+			mu.Unlock()
 			w.WriteHeader(http.StatusNotModified)
 			return
 		}
-		sawNoIfNoneMatch.Store(true)
+		sawNoIfNoneMatch = true
+		mu.Unlock()
 		w.Header().Set("ETag", `"fresh-etag"`)
 		// nosemgrep: no-direct-write-to-responsewriter
 		_, _ = w.Write([]byte(testGhWorkflowResponse))
@@ -995,8 +1005,11 @@ func TestGetWorkflowRuns_StaleEtagWithoutPreviousRetries(t *testing.T) {
 	if wfrs == nil || len(wfrs.WorkflowRuns) == 0 {
 		t.Fatalf("expected workflow runs from retry, got empty result")
 	}
-	if !sawIfNoneMatch.Load() || !sawNoIfNoneMatch.Load() {
-		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch.Load(), sawNoIfNoneMatch.Load())
+	mu.Lock()
+	gotIfNoneMatch, gotNoIfNoneMatch := sawIfNoneMatch, sawNoIfNoneMatch
+	mu.Unlock()
+	if !gotIfNoneMatch || !gotNoIfNoneMatch {
+		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", gotIfNoneMatch, gotNoIfNoneMatch)
 	}
 	if got := s.etags[apiURL]; got != `"fresh-etag"` {
 		t.Fatalf("expected etag to be refreshed to %q, got %q", `"fresh-etag"`, got)

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -863,6 +863,58 @@ var githubRunnerMetricIdentifiers = []githubRunnerMetricIdentifier{
 	{&testGitHubRunnerMetadata[1].metadata, 1, "s1-github-runner-ownername"},
 }
 
+func TestGithubRunnerPruneCachesDropsAbsentWfrRepos(t *testing.T) {
+	s := githubRunnerScaler{
+		metadata:     &githubRunnerMetadata{},
+		previousJobs: map[string][]Job{},
+		previousWfrs: map[string]map[string]*WorkflowRuns{
+			"keep-1": {"queued": &WorkflowRuns{}},
+			"drop-2": {"queued": &WorkflowRuns{}},
+		},
+		etags: map[string]string{},
+	}
+
+	s.pruneCaches([]string{"keep-1"})
+
+	if _, ok := s.previousWfrs["drop-2"]; ok {
+		t.Errorf("previousWfrs still contains drop-2 after prune")
+	}
+	if _, ok := s.previousWfrs["keep-1"]; !ok {
+		t.Errorf("previousWfrs lost keep-1 after prune")
+	}
+}
+
+func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
+	overflow := githubScalerMaxCacheEntries + 100
+	currentRepos := make([]string, overflow)
+
+	s := githubRunnerScaler{
+		metadata:     &githubRunnerMetadata{},
+		previousJobs: make(map[string][]Job, overflow),
+		previousWfrs: make(map[string]map[string]*WorkflowRuns, overflow),
+		etags:        make(map[string]string, overflow),
+	}
+	for i := 0; i < overflow; i++ {
+		repo := fmt.Sprintf("repo-%d", i)
+		currentRepos[i] = repo
+		s.etags[fmt.Sprintf("https://api.github.com/run/%d", i)] = "etag"
+		s.previousJobs[repo] = nil
+		s.previousWfrs[repo] = map[string]*WorkflowRuns{"queued": {}}
+	}
+
+	s.pruneCaches(currentRepos)
+
+	if got := len(s.etags); got > githubScalerMaxCacheEntries {
+		t.Errorf("etags map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
+	}
+	if got := len(s.previousJobs); got > githubScalerMaxCacheEntries {
+		t.Errorf("previousJobs map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
+	}
+	if got := len(s.previousWfrs); got > githubScalerMaxCacheEntries {
+		t.Errorf("previousWfrs map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
+	}
+}
+
 func TestGithubRunnerGetMetricSpecForScaling(t *testing.T) {
 	for i, testData := range githubRunnerMetricIdentifiers {
 		ctx := context.Background()

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -915,6 +915,92 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 	}
 }
 
+func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
+	var sawIfNoneMatch, sawNoIfNoneMatch bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") != "" {
+			sawIfNoneMatch = true
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		sawNoIfNoneMatch = true
+		w.Header().Set("ETag", `"fresh-etag"`)
+		// nosemgrep: no-direct-write-to-responsewriter
+		_, _ = w.Write([]byte(testGhWFJobResponse))
+	}))
+	defer srv.Close()
+
+	meta := getGitHubTestMetaData(srv.URL)
+	meta.EnableEtags = true
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?per_page=100",
+		meta.GithubAPIURL, meta.Owner, "Hello-World", int64(30433642))
+
+	s := githubRunnerScaler{
+		metadata:     meta,
+		httpClient:   http.DefaultClient,
+		etags:        map[string]string{apiURL: `"stale-etag"`},
+		previousJobs: map[string][]Job{},
+		previousWfrs: map[string]map[string]*WorkflowRuns{},
+	}
+
+	jobs, err := s.getWorkflowRunJobs(context.Background(), 30433642, "Hello-World")
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got error: %v", err)
+	}
+	if len(jobs) == 0 {
+		t.Fatalf("expected jobs from retry, got empty slice")
+	}
+	if !sawIfNoneMatch || !sawNoIfNoneMatch {
+		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch, sawNoIfNoneMatch)
+	}
+	if got := s.etags[apiURL]; got != `"fresh-etag"` {
+		t.Fatalf("expected etag to be refreshed to %q, got %q", `"fresh-etag"`, got)
+	}
+}
+
+func TestGetWorkflowRuns_StaleEtagWithoutPreviousRetries(t *testing.T) {
+	var sawIfNoneMatch, sawNoIfNoneMatch bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") != "" {
+			sawIfNoneMatch = true
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		sawNoIfNoneMatch = true
+		w.Header().Set("ETag", `"fresh-etag"`)
+		// nosemgrep: no-direct-write-to-responsewriter
+		_, _ = w.Write([]byte(testGhWorkflowResponse))
+	}))
+	defer srv.Close()
+
+	meta := getGitHubTestMetaData(srv.URL)
+	meta.EnableEtags = true
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs?status=%s&per_page=100",
+		meta.GithubAPIURL, meta.Owner, "Hello-World", "queued")
+
+	s := githubRunnerScaler{
+		metadata:     meta,
+		httpClient:   http.DefaultClient,
+		etags:        map[string]string{apiURL: `"stale-etag"`},
+		previousJobs: map[string][]Job{},
+		previousWfrs: map[string]map[string]*WorkflowRuns{},
+	}
+
+	wfrs, err := s.getWorkflowRuns(context.Background(), "Hello-World", "queued")
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got error: %v", err)
+	}
+	if wfrs == nil || len(wfrs.WorkflowRuns) == 0 {
+		t.Fatalf("expected workflow runs from retry, got empty result")
+	}
+	if !sawIfNoneMatch || !sawNoIfNoneMatch {
+		t.Fatalf("expected one request with If-None-Match and one without, got ifNoneMatch=%v noIfNoneMatch=%v", sawIfNoneMatch, sawNoIfNoneMatch)
+	}
+	if got := s.etags[apiURL]; got != `"fresh-etag"` {
+		t.Fatalf("expected etag to be refreshed to %q, got %q", `"fresh-etag"`, got)
+	}
+}
+
 func TestGithubRunnerGetMetricSpecForScaling(t *testing.T) {
 	for i, testData := range githubRunnerMetricIdentifiers {
 		ctx := context.Background()


### PR DESCRIPTION
the etags map is keyed by the request URL, and workflow run job URLs include the run ID, so the cache grows once per workflow run for the lifetime of the operator pod. previousJobs and previousWfrs are keyed by repo names returned from the API, so a misbehaving or malicious server that rotates repo names accumulates entries the same way.

added pruneCaches that drops previousWfrs entries for repos no longer in the current list and caps all three maps at 5000 entries. called from GetWorkflowQueueLength when enableEtags is on, matching the gate that populates the maps in the first place.

Fixes #7685