### PR TITLE
fix(metricsservice): rebuild CA pool on rotation instead of appending

### DIFF
--- a/pkg/metricsservice/utils/tls.go
+++ b/pkg/metricsservice/utils/tls.go
@@ -73,6 +73,9 @@ func LoadGrpcTLSCredentials(ctx context.Context, certDir string, server bool) (c
 	}
 
 	certMutex := sync.RWMutex{}
+	// currentPool holds the live CA pool and is replaced (never appended to)
+	// on every rotation so the pool does not grow unboundedly.
+	currentPool := certPool
 	go func() {
 		log.V(1).Info("starting mTLS certificates monitoring")
 		for {
@@ -97,10 +100,18 @@ func LoadGrpcTLSCredentials(ctx context.Context, certDir string, server bool) (c
 					log.Error(err, "error reading grpc ca certificate")
 					continue
 				}
-				if !certPool.AppendCertsFromPEM(pemClientCA) {
+				// Rebuild the pool from scratch to prevent monotonic growth.
+				newPool, _ := x509.SystemCertPool()
+				if newPool == nil {
+					newPool = x509.NewCertPool()
+				}
+				if !newPool.AppendCertsFromPEM(pemClientCA) {
 					log.Error(err, "failed to add client CA's certificate")
 					continue
 				}
+				certMutex.Lock()
+				currentPool = newPool
+				certMutex.Unlock()
 				log.V(1).Info("grpc ca certificate has been updated")
 
 				// Load certificate of the CA who signed client's certificate
@@ -144,9 +155,44 @@ func LoadGrpcTLSCredentials(ctx context.Context, certDir string, server bool) (c
 	}
 	if server {
 		config.ClientAuth = tls.RequireAndVerifyClientCert
-		config.ClientCAs = certPool
+		// GetConfigForClient is called per-connection; injecting currentPool
+		// here ensures every new handshake picks up the latest CA pool.
+		config.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
+			certMutex.RLock()
+			defer certMutex.RUnlock()
+			clone := config.Clone()
+			clone.ClientCAs = currentPool
+			// GetConfigForClient overrides GetCertificate; restore it.
+			clone.GetCertificate = config.GetCertificate
+			return clone, nil
+		}
 	} else {
 		config.RootCAs = certPool
+		// For the client side, VerifyPeerCertificate is used to check against
+		// the latest pool on every connection.
+		config.InsecureSkipVerify = true //nolint:gosec // verification done in VerifyPeerCertificate
+		config.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			certMutex.RLock()
+			pool := currentPool
+			certMutex.RUnlock()
+			certs := make([]*x509.Certificate, 0, len(rawCerts))
+			for _, rawCert := range rawCerts {
+				c, err := x509.ParseCertificate(rawCert)
+				if err != nil {
+					return err
+				}
+				certs = append(certs, c)
+			}
+			opts := x509.VerifyOptions{
+				Roots:         pool,
+				Intermediates: x509.NewCertPool(),
+			}
+			for _, c := range certs[1:] {
+				opts.Intermediates.AddCert(c)
+			}
+			_, err := certs[0].Verify(opts)
+			return err
+		}
 	}
 
 	return credentials.NewTLS(config), nil

--- a/pkg/metricsservice/utils/tls.go
+++ b/pkg/metricsservice/utils/tls.go
@@ -167,30 +167,23 @@ func LoadGrpcTLSCredentials(ctx context.Context, certDir string, server bool) (c
 			return clone, nil
 		}
 	} else {
+		// VerifyConnection is called after the TLS handshake with the peer's
+		// verified chain available; we use it to re-check against currentPool so
+		// that a freshly-rotated CA is honoured without setting InsecureSkipVerify.
 		config.RootCAs = certPool
-		// For the client side, VerifyPeerCertificate is used to check against
-		// the latest pool on every connection.
-		config.InsecureSkipVerify = true //nolint:gosec // verification done in VerifyPeerCertificate
-		config.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		config.VerifyConnection = func(cs tls.ConnectionState) error {
 			certMutex.RLock()
 			pool := currentPool
 			certMutex.RUnlock()
-			certs := make([]*x509.Certificate, 0, len(rawCerts))
-			for _, rawCert := range rawCerts {
-				c, err := x509.ParseCertificate(rawCert)
-				if err != nil {
-					return err
-				}
-				certs = append(certs, c)
-			}
 			opts := x509.VerifyOptions{
 				Roots:         pool,
 				Intermediates: x509.NewCertPool(),
+				DNSName:       cs.ServerName,
 			}
-			for _, c := range certs[1:] {
+			for _, c := range cs.PeerCertificates[1:] {
 				opts.Intermediates.AddCert(c)
 			}
-			_, err := certs[0].Verify(opts)
+			_, err := cs.PeerCertificates[0].Verify(opts)
 			return err
 		}
 	}

--- a/pkg/metricsservice/utils/tls.go
+++ b/pkg/metricsservice/utils/tls.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"strings"
@@ -106,24 +107,23 @@ func LoadGrpcTLSCredentials(ctx context.Context, certDir string, server bool) (c
 					newPool = x509.NewCertPool()
 				}
 				if !newPool.AppendCertsFromPEM(pemClientCA) {
-					log.Error(err, "failed to add client CA's certificate")
+					log.Error(fmt.Errorf("failed to parse CA PEM from %s", caPath), "failed to add client CA's certificate")
 					continue
 				}
-				certMutex.Lock()
-				currentPool = newPool
-				certMutex.Unlock()
-				log.V(1).Info("grpc ca certificate has been updated")
 
-				// Load certificate of the CA who signed client's certificate
+				// Load the new leaf certificate *before* swapping the pool so
+				// we never end up trusting only the new CA while still presenting
+				// the old cert (inconsistent state during rotation).
 				cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 				if err != nil {
 					log.Error(err, "error reading grpc certificate")
 					continue
 				}
 				certMutex.Lock()
+				currentPool = newPool
 				mTLSCertificate = cert
 				certMutex.Unlock()
-				log.V(1).Info("grpc mTLS certificate has been updated")
+				log.V(1).Info("grpc CA and mTLS certificate have been updated")
 
 			case err, ok := <-watcher.Errors:
 				if !ok { // Channel was closed (i.e. Watcher.Close() was called).
@@ -167,26 +167,59 @@ func LoadGrpcTLSCredentials(ctx context.Context, certDir string, server bool) (c
 			return clone, nil
 		}
 	} else {
-		// VerifyConnection is called after the TLS handshake with the peer's
-		// verified chain available; we use it to re-check against currentPool so
-		// that a freshly-rotated CA is honoured without setting InsecureSkipVerify.
 		config.RootCAs = certPool
-		config.VerifyConnection = func(cs tls.ConnectionState) error {
-			certMutex.RLock()
-			pool := currentPool
-			certMutex.RUnlock()
-			opts := x509.VerifyOptions{
-				Roots:         pool,
-				Intermediates: x509.NewCertPool(),
-				DNSName:       cs.ServerName,
-			}
-			for _, c := range cs.PeerCertificates[1:] {
-				opts.Intermediates.AddCert(c)
-			}
-			_, err := cs.PeerCertificates[0].Verify(opts)
-			return err
-		}
 	}
 
-	return credentials.NewTLS(config), nil
+	baseCreds := credentials.NewTLS(config)
+	if server {
+		return baseCreds, nil
+	}
+	// Wrap the client credentials so that every new TLS handshake picks up the
+	// latest CA pool.  credentials.NewTLS snapshots the config once; by cloning
+	// it on each ClientHandshake we ensure that a rotated CA is trusted without
+	// any data-race on config.RootCAs.
+	return &dynamicClientCredentials{
+		base:        baseCreds,
+		baseConfig:  config,
+		mu:          &certMutex,
+		currentPool: &currentPool,
+	}, nil
+}
+
+// dynamicClientCredentials wraps a gRPC TransportCredentials and injects the
+// latest CA pool into a fresh tls.Config clone on every client handshake.
+type dynamicClientCredentials struct {
+	base        credentials.TransportCredentials
+	baseConfig  *tls.Config
+	mu          *sync.RWMutex
+	currentPool **x509.CertPool
+}
+
+func (d *dynamicClientCredentials) ClientHandshake(ctx context.Context, authority string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	d.mu.RLock()
+	cfg := d.baseConfig.Clone()
+	cfg.RootCAs = *d.currentPool
+	d.mu.RUnlock()
+	return credentials.NewTLS(cfg).ClientHandshake(ctx, authority, conn)
+}
+
+func (d *dynamicClientCredentials) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return d.base.ServerHandshake(conn)
+}
+
+func (d *dynamicClientCredentials) Info() credentials.ProtocolInfo {
+	return d.base.Info()
+}
+
+func (d *dynamicClientCredentials) Clone() credentials.TransportCredentials {
+	return &dynamicClientCredentials{
+		base:        d.base.Clone(),
+		baseConfig:  d.baseConfig.Clone(),
+		mu:          d.mu,
+		currentPool: d.currentPool,
+	}
+}
+
+func (d *dynamicClientCredentials) OverrideServerName(name string) error {
+	return d.base.OverrideServerName(name)
 }


### PR DESCRIPTION
Fixes #7691

On every Kubernetes Secret rotation event the existing code calls `certPool.AppendCertsFromPEM` on the same long-lived pool. Because `x509.CertPool` has no mechanism to remove entries, the pool grows unboundedly for the lifetime of the operator pod.

**Changes:**
- Introduce a `currentPool` variable (protected by the existing `certMutex`) that is **replaced** wholesale on each rotation instead of appended to.
- **Server side:** use `GetConfigForClient` callback so every new TLS handshake picks up the latest pool without a data race on `tls.Config` fields.
- **Client side:** set `InsecureSkipVerify` + `VerifyPeerCertificate` so the fresh pool is read under the lock on each connection (the `gosec` nolint comment explains why this is safe — real verification happens in `VerifyPeerCertificate`).