### PR TITLE
fix: aws credentials cache uses the right key on cedentials removal

### DIFF
--- a/pkg/scalers/aws/aws_config_cache.go
+++ b/pkg/scalers/aws/aws_config_cache.go
@@ -137,7 +137,7 @@ func (a *sharedConfigCache) RemoveCachedEntry(awsAuthorization AuthorizationMeta
 		if len(cachedEntry.usages) == 0 {
 			delete(a.items, key)
 		} else {
-			a.items[awsAuthorization.AwsRoleArn] = cachedEntry
+			a.items[key] = cachedEntry
 		}
 	}
 }

--- a/pkg/scalers/aws/aws_config_cache_test.go
+++ b/pkg/scalers/aws/aws_config_cache_test.go
@@ -79,6 +79,7 @@ func TestRemoveCachedEntryRemovesCachedItemIfNotUsages(t *testing.T) {
 	}
 	cache.RemoveCachedEntry(awsAuthorization)
 	assert.NotContains(t, cache.items, cacheKey)
+	assert.Len(t, cache.items, 0)
 }
 
 func TestRemoveCachedEntryNotRemoveCachedItemIfUsages(t *testing.T) {
@@ -99,7 +100,8 @@ func TestRemoveCachedEntryNotRemoveCachedItemIfUsages(t *testing.T) {
 		},
 	}
 	cache.RemoveCachedEntry(awsAuthorization)
-	assert.Contains(t, cache.items, cacheKey)
+	assert.Len(t, cache.items, 1)
+	assert.Len(t, cache.items[cacheKey].usages, 1)
 }
 
 func TestCredentialsShouldBeCachedPerRegion(t *testing.T) {


### PR DESCRIPTION
As @rickbrouwer [found, there is a bug with the removal of the items from AWS cache](https://github.com/kedacore/keda/pull/7665#issuecomment-4346687224).

This PR fixes the bug and includes a test to validate that it works

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/pull/7665#issuecomment-4346687224
