### PR TITLE
feat: deprecate subscriptionSize in GCP PubSub scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ New deprecation(s):
 
 ### Breaking Changes
 
+- **GCP PubSub Scaler**: The 'subscriptionSize' setting is DEPRECATED and is removed in v2.20 - Use 'mode' and 'value' instead ([#7720](https://github.com/kedacore/keda/issues/7720))
 - **Huawei Cloudeye Scaler**: The `minMetricValue` setting is DEPRECATED and is removed - Use `activationTargetMetricValue` instead ([#7436](https://github.com/kedacore/keda/issues/7436))
 - **IBM MQ scaler**: The `tls` setting code is removed ([#6094](https://github.com/kedacore/keda/issues/6094))
 

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -37,7 +37,7 @@ type pubsubScaler struct {
 }
 
 type pubsubMetadata struct {
-	SubscriptionSize int           `keda:"name=subscriptionSize, order=triggerMetadata, optional, deprecatedAnnounce=The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead"`
+	SubscriptionSize int           `keda:"name=subscriptionSize, order=triggerMetadata, optional, deprecated=The 'subscriptionSize' setting is DEPRECATED and is removed in v2.20 - Use 'mode' and 'value' instead"`
 	Mode             string        `keda:"name=mode, order=triggerMetadata, default=SubscriptionSize"`
 	Value            float64       `keda:"name=value, order=triggerMetadata, default=10, deprecatedAnnounce=This scaler is deprecated. More info -> 'https://keda.sh/blog/2025-09-15-gcp-deprecations'"`
 	ActivationValue  float64       `keda:"name=activationValue, order=triggerMetadata, default=0"`
@@ -82,11 +82,6 @@ func parsePubSubMetadata(config *scalersconfig.ScalerConfig) (*pubsubMetadata, e
 		return nil, fmt.Errorf("error parsing gcp pubsub metadata: %w", err)
 	}
 
-	if meta.SubscriptionSize != 0 {
-		meta.Mode = pubSubDefaultModeSubscriptionSize
-		meta.Value = float64(meta.SubscriptionSize)
-	}
-
 	if meta.SubscriptionName != "" {
 		meta.resourceName = meta.SubscriptionName
 		meta.resourceType = resourceTypePubSubSubscription
@@ -117,12 +112,6 @@ func (s *pubsubScaler) Close(context.Context) error {
 }
 
 func (meta *pubsubMetadata) Validate() error {
-	if meta.SubscriptionSize != 0 {
-		if meta.TopicName != "" {
-			return fmt.Errorf("you cannot use subscriptionSize field together with topicName field. Use subscriptionName field instead")
-		}
-	}
-
 	hasSub := meta.SubscriptionName != ""
 	hasTopic := meta.TopicName != ""
 	if (!hasSub && !hasTopic) || (hasSub && hasTopic) {

--- a/pkg/scalers/gcp_pubsub_scaler_test.go
+++ b/pkg/scalers/gcp_pubsub_scaler_test.go
@@ -37,8 +37,8 @@ type gcpPubSubSubscription struct {
 
 var testPubSubMetadata = []parsePubSubMetadataTestData{
 	{"empty", map[string]string{}, map[string]string{}, true},
-	// all properly formed with deprecated field
-	{"all properly formed with deprecated field", nil, map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	// all properly formed with value
+	{"all properly formed with value", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// all properly formed with subscriptionName
 	{"all properly formed with subscriptionName", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "5"}, false},
 	// all properly formed with oldest unacked message age mode
@@ -47,8 +47,8 @@ var testPubSubMetadata = []parsePubSubMetadataTestData{
 	{"missing subscriptionName", nil, map[string]string{"subscriptionName": "", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// missing credentials
 	{"missing credentials", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7", "credentialsFromEnv": ""}, true},
-	// malformed subscriptionSize
-	{"malformed subscriptionSize", nil, map[string]string{"subscriptionName": "mysubscription", "value": "AA", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	// malformed value
+	{"malformed value", nil, map[string]string{"subscriptionName": "mysubscription", "value": "AA", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// malformed mode
 	{"malformed mode", nil, map[string]string{"subscriptionName": "", "mode": "AA", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// malformed activationTargetValue
@@ -56,11 +56,11 @@ var testPubSubMetadata = []parsePubSubMetadataTestData{
 	// Credentials from AuthParams
 	{"Credentials from AuthParams", map[string]string{"GoogleApplicationCredentials": "Creds"}, map[string]string{"subscriptionName": "mysubscription", "value": "7"}, false},
 	// Credentials from AuthParams with empty creds
-	{"Credentials from AuthParams with empty creds", map[string]string{"GoogleApplicationCredentials": ""}, map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7"}, true},
+	{"Credentials from AuthParams with empty creds", map[string]string{"GoogleApplicationCredentials": ""}, map[string]string{"subscriptionName": "mysubscription", "value": "7"}, true},
 	// with full link to subscription
-	{"with full link to subscription", nil, map[string]string{"subscriptionName": "projects/myproject/subscriptions/mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"with full link to subscription", nil, map[string]string{"subscriptionName": "projects/myproject/subscriptions/mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// with full (bad) link to subscription
-	{"with full (bad) link to subscription", nil, map[string]string{"subscriptionName": "projects/myproject/mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
+	{"with full (bad) link to subscription", nil, map[string]string{"subscriptionName": "projects/myproject/mysubscription", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// properly formed float value and activationTargetValue
 	{"properly formed float value and activationTargetValue", nil, map[string]string{"subscriptionName": "mysubscription", "value": "7.1", "credentialsFromEnv": "SAMPLE_CREDS", "activationValue": "2.1"}, false},
 	// All optional omitted
@@ -77,8 +77,8 @@ var testPubSubMetadata = []parsePubSubMetadataTestData{
 	{"both subscriptionName and topicName present", nil, map[string]string{"subscriptionName": "mysubscription", "topicName": "mytopic", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// both subscriptionName and topicName missing
 	{"both subscriptionName and topicName missing", nil, map[string]string{"value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
-	// both subscriptionSize and topicName present
-	{"both subscriptionSize and topicName present", nil, map[string]string{"subscriptionSize": "7", "topicName": "mytopic", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
+	// deprecated subscriptionSize errors
+	{"deprecated subscriptionSize errors", nil, map[string]string{"subscriptionName": "mysubscription", "subscriptionSize": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, true},
 	// both subscriptionName and subscriptionNameFromEnv present
 	{"both subscriptionName and subscriptionNameFromEnv present", nil, map[string]string{"subscriptionName": "mysubscription", "subscriptionNameFromEnv": "MY_ENV_SUBSCRIPTION", "value": "7", "credentialsFromEnv": "SAMPLE_CREDS"}, false},
 	// both topicName and topicNameFromEnv present

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -3784,7 +3784,7 @@
                     "name": "subscriptionSize",
                     "type": "string",
                     "optional": true,
-                    "deprecatedAnnounce": "The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead",
+                    "deprecated": "The 'subscriptionSize' setting is DEPRECATED and is removed in v2.20 - Use 'mode' and 'value' instead",
                     "metadataVariableReadable": true
                 },
                 {

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -2470,7 +2470,7 @@ scalers:
         - name: subscriptionSize
           type: string
           optional: true
-          deprecatedAnnounce: The 'subscriptionSize' setting is DEPRECATED and will be removed in v2.20 - Use 'mode' and 'value' instead
+          deprecated: The 'subscriptionSize' setting is DEPRECATED and is removed in v2.20 - Use 'mode' and 'value' instead
           metadataVariableReadable: true
         - name: mode
           type: string


### PR DESCRIPTION
Deprecate subscriptionSize in GCP PubSub scaler

### Checklist

- [X] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7720
Docs: https://github.com/kedacore/keda-docs/pull/1758
