### PR TITLE
feat: deprecate authToken from triggerMetadata in InfluxDB scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ New deprecation(s):
 
 - **Huawei Cloudeye Scaler**: The `minMetricValue` setting is DEPRECATED and is removed - Use `activationTargetMetricValue` instead ([#7436](https://github.com/kedacore/keda/issues/7436))
 - **IBM MQ scaler**: The `tls` setting code is removed ([#6094](https://github.com/kedacore/keda/issues/6094))
+- **InfluxDB scaler**: The 'authToken' setting from triggerMetadata is DEPRECATED and is removed in v2.20 - Use 'authToken' from resolvedEnv or authParams instead ([#7722](https://github.com/kedacore/keda/issues/7722))
 
 ### Other
 

--- a/pkg/scalers/influxdb_scaler.go
+++ b/pkg/scalers/influxdb_scaler.go
@@ -31,7 +31,7 @@ type influxDBScalerV3 struct {
 }
 
 type influxDBMetadata struct {
-	AuthTokenOld             string  `keda:"name=authToken,                order=triggerMetadata,                        optional,        deprecatedAnnounce=The 'authToken' setting from triggerMetadata is DEPRECATED and will be removed in v2.20 - Use 'authToken' from resolvedEnv or authParams instead"`
+	AuthTokenOld             string  `keda:"name=authToken,                order=triggerMetadata,                        optional,        deprecated=The 'authToken' setting from triggerMetadata is DEPRECATED and is removed in v2.20 - Use 'authToken' from resolvedEnv or authParams instead"`
 	AuthToken                string  `keda:"name=authToken,                order=resolvedEnv;authParams,                 optional"`
 	OrganizationName         string  `keda:"name=organizationName,         order=triggerMetadata;resolvedEnv;authParams, optional"`
 	Query                    string  `keda:"name=query,                    order=triggerMetadata"`
@@ -48,14 +48,6 @@ type influxDBMetadata struct {
 }
 
 func (i *influxDBMetadata) Validate() error {
-	if i.AuthTokenOld != "" && i.AuthToken != "" {
-		return fmt.Errorf("authToken cannot be specified in both triggerMetadata and resolvedEnv/authParams")
-	}
-
-	if i.AuthTokenOld != "" {
-		i.AuthToken = i.AuthTokenOld
-	}
-
 	if i.InfluxVersion == "3" {
 		if i.Database == "" {
 			return fmt.Errorf("database is required if influxVersion is 3")

--- a/pkg/scalers/influxdb_scaler_test.go
+++ b/pkg/scalers/influxdb_scaler_test.go
@@ -31,40 +31,42 @@ type influxDBMetricIdentifier struct {
 var testInfluxDBMetadata = []parseInfluxDBMetadataTestData{
 	// 1 nothing passed
 	{map[string]string{}, true, map[string]string{}},
-	// 2 everything is passed in verbatim
-	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, false, map[string]string{}},
+	// 2 everything is passed in verbatim (authToken via authParams)
+	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{"authToken": "myToken"}},
 	// 3 everything is passed in (environment variables)
 	{map[string]string{"serverURL": "https://influxdata.com", "organizationNameFromEnv": "INFLUX_ORG", "query": "from(bucket: hello)", "thresholdValue": "10", "authTokenFromEnv": "INFLUX_TOKEN", "unsafeSsl": "false"}, false, map[string]string{}},
 	// 4 no serverURL passed
-	{map[string]string{"metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 5 no organization name passed
-	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "query": "from(bucket: hello)", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 6 no query passed
-	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "thresholdValue": "10", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 7 no threshold value passed
-	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "query": "from(bucket: hello)", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "query": "from(bucket: hello)", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 8 no auth token passed (optional, for unauthenticated instances)
 	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{}},
 	// 9 authToken, organizationName, and serverURL are defined in authParams
 	{map[string]string{"query": "from(bucket: hello)", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "authToken": "myToken"}},
 	// 10 no unsafeSsl value passed
-	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "authToken": "myToken"}, false, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10"}, false, map[string]string{"authToken": "myToken"}},
 	// 11 wrong activationThreshold value
-	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "activationThresholdValue": "aa", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "metricName": "influx_metric", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "activationThresholdValue": "aa", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 12 unsupported influxVersion
-	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "1", "database": "test", "metricKey": "mymetric", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "1", "database": "test", "metricKey": "mymetric", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 13 valid influxVersion but no database
-	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "metricKey": "mymetric", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "metricKey": "mymetric", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 14 influxVersion 3 with all required values
-	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, false, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{"authToken": "myToken"}},
 	// 15 influxVersion 3 with queryType InfluxQL
-	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "queryType": "InfluxQL", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, false, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "queryType": "InfluxQL", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{"authToken": "myToken"}},
 	// 16 influxVersion 3 with no metricKey
-	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "queryType": "InfluxQL", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "queryType": "InfluxQL", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "unsafeSsl": "false"}, true, map[string]string{"authToken": "myToken"}},
 	// 17 influxVersion 3 with queryType FlightSQL
-	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "queryType": "FlightSQL", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, false, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "queryType": "FlightSQL", "metricName": "influx_metric", "organizationName": "influx_org", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{"authToken": "myToken"}},
 	// 18 influxVersion 3 with no organization
-	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "queryType": "FlightSQL", "metricName": "influx_metric", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, false, map[string]string{}},
+	{map[string]string{"serverURL": "https://influxdata.com", "influxVersion": "3", "database": "test", "metricKey": "mymetric", "queryType": "FlightSQL", "metricName": "influx_metric", "query": "SELECT \"water_level\" FROM \"h2o_feet\" WHERE \"location\"='coyote_creek' ORDER BY time DESC LIMIT 1;", "thresholdValue": "10", "unsafeSsl": "false"}, false, map[string]string{"authToken": "myToken"}},
+	// 19 deprecated authToken in triggerMetadata errors
+	{map[string]string{"serverURL": "https://influxdata.com", "organizationName": "influx_org", "query": "from(bucket: hello)", "thresholdValue": "10", "authToken": "myToken", "unsafeSsl": "false"}, true, map[string]string{}},
 }
 
 func TestInfluxDBParseMetadata(t *testing.T) {

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2495,7 +2495,7 @@
                     "name": "authToken",
                     "type": "string",
                     "optional": true,
-                    "deprecatedAnnounce": "The 'authToken' setting from triggerMetadata is DEPRECATED and will be removed in v2.20 - Use 'authToken' from resolvedEnv or authParams instead",
+                    "deprecated": "The 'authToken' setting from triggerMetadata is DEPRECATED and is removed in v2.20 - Use 'authToken' from resolvedEnv or authParams instead",
                     "metadataVariableReadable": true
                 },
                 {

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1626,7 +1626,7 @@ scalers:
         - name: authToken
           type: string
           optional: true
-          deprecatedAnnounce: The 'authToken' setting from triggerMetadata is DEPRECATED and will be removed in v2.20 - Use 'authToken' from resolvedEnv or authParams instead
+          deprecated: The 'authToken' setting from triggerMetadata is DEPRECATED and is removed in v2.20 - Use 'authToken' from resolvedEnv or authParams instead
           metadataVariableReadable: true
         - name: authToken
           type: string

--- a/tests/scalers/influxdb/influxdb_v2/influxdb_v2_test.go
+++ b/tests/scalers/influxdb/influxdb_v2/influxdb_v2_test.go
@@ -27,6 +27,8 @@ var (
 	testNamespace           = fmt.Sprintf("%s-ns", testName)
 	influxdbStatefulsetName = fmt.Sprintf("%s-deployment", testName)
 	scaledObjectName        = fmt.Sprintf("%s-so", testName)
+	secretName              = fmt.Sprintf("%s-secret", testName)
+	triggerAuthName         = fmt.Sprintf("%s-ta", testName)
 	authToken               = ""
 	orgName                 = ""
 )
@@ -37,6 +39,8 @@ type templateData struct {
 	InfluxdbWriteJobName    string
 	ScaledObjectName        string
 	DeploymentName          string
+	SecretName              string
+	TriggerAuthName         string
 	AuthToken               string
 	OrgName                 string
 }
@@ -88,6 +92,30 @@ spec:
     type: ClusterIP
 `
 
+	secretTemplate = `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretName}}
+  namespace: {{.TestNamespace}}
+type: Opaque
+stringData:
+  authToken: {{.AuthToken}}
+`
+
+	triggerAuthenticationTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{.TriggerAuthName}}
+  namespace: {{.TestNamespace}}
+spec:
+  secretTargetRef:
+  - parameter: authToken
+    name: {{.SecretName}}
+    key: authToken
+`
+
 	scaledObjectActivationTemplate = `
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -101,7 +129,6 @@ spec:
   triggers:
   - type: influxdb
     metadata:
-      authToken: {{.AuthToken}}
       organizationName: {{.OrgName}}
       serverURL: http://influxdb.{{.TestNamespace}}.svc:8086
       thresholdValue: "80"
@@ -111,6 +138,8 @@ spec:
         |> range(start: -1h)
         |> filter(fn: (r) => r._measurement == "stat")
         |> map(fn: (r) => ({r with _value: float(v: r._value)}))
+    authenticationRef:
+      name: {{.TriggerAuthName}}
 `
 	scaledObjectTemplateFloat = `
 apiVersion: keda.sh/v1alpha1
@@ -125,7 +154,6 @@ spec:
   triggers:
   - type: influxdb
     metadata:
-      authToken: {{.AuthToken}}
       organizationName: {{.OrgName}}
       serverURL: http://influxdb.{{.TestNamespace}}.svc:8086
       thresholdValue: "3"
@@ -134,6 +162,8 @@ spec:
         |> range(start: -1h)
         |> filter(fn: (r) => r._measurement == "stat")
         |> map(fn: (r) => ({r with _value: float(v: r._value)}))
+    authenticationRef:
+      name: {{.TriggerAuthName}}
 `
 
 	influxdbWriteJobTemplate = `
@@ -198,6 +228,10 @@ func TestInfluxScaler(t *testing.T) {
 	// get token
 	updateDataWithInfluxAuth(t, kc, &data)
 
+	// create secret and trigger authentication using the retrieved token
+	KubectlApplyWithTemplate(t, data, "secretTemplate", secretTemplate)
+	KubectlApplyWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
+
 	// test activation
 	testActivation(t, kc, data)
 	// test scaling
@@ -231,6 +265,8 @@ func getTemplateData() (templateData, []Template) {
 			InfluxdbWriteJobName:    influxdbJobName,
 			ScaledObjectName:        scaledObjectName,
 			DeploymentName:          deploymentName,
+			SecretName:              secretName,
+			TriggerAuthName:         triggerAuthName,
 			AuthToken:               authToken,
 			OrgName:                 orgName,
 		}, []Template{

--- a/tests/scalers/influxdb/influxdb_v3/influxdb_v3_test.go
+++ b/tests/scalers/influxdb/influxdb_v3/influxdb_v3_test.go
@@ -27,6 +27,8 @@ var (
 	testNamespace           = fmt.Sprintf("%s-ns", testName)
 	influxdbStatefulsetName = fmt.Sprintf("%s-deployment", testName)
 	scaledObjectName        = fmt.Sprintf("%s-so", testName)
+	secretName              = fmt.Sprintf("%s-secret", testName)
+	triggerAuthName         = fmt.Sprintf("%s-ta", testName)
 	authToken               = ""
 	databaseName            = "testdb"
 )
@@ -37,6 +39,8 @@ type templateData struct {
 	InfluxdbWriteJobName    string
 	ScaledObjectName        string
 	DeploymentName          string
+	SecretName              string
+	TriggerAuthName         string
 	AuthToken               string
 	DatabaseName            string
 }
@@ -91,6 +95,30 @@ spec:
     type: ClusterIP
 `
 
+	secretTemplate = `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.SecretName}}
+  namespace: {{.TestNamespace}}
+type: Opaque
+stringData:
+  authToken: {{.AuthToken}}
+`
+
+	triggerAuthenticationTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{.TriggerAuthName}}
+  namespace: {{.TestNamespace}}
+spec:
+  secretTargetRef:
+  - parameter: authToken
+    name: {{.SecretName}}
+    key: authToken
+`
+
 	scaledObjectActivationTemplate = `
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -105,7 +133,6 @@ spec:
   - type: influxdb
     metadata:
       influxVersion: "3"
-      authToken: {{.AuthToken}}
       organizationName: "testorg"
       serverURL: http://influxdb-v3.{{.TestNamespace}}.svc:8181
       database: {{.DatabaseName}}
@@ -114,6 +141,8 @@ spec:
       activationThresholdValue: "10"
       query: |
         SELECT value FROM stat ORDER BY time DESC LIMIT 1
+    authenticationRef:
+      name: {{.TriggerAuthName}}
 `
 
 	scaledObjectTemplateFloat = `
@@ -130,7 +159,6 @@ spec:
   - type: influxdb
     metadata:
       influxVersion: "3"
-      authToken: {{.AuthToken}}
       organizationName: "testorg"
       serverURL: http://influxdb-v3.{{.TestNamespace}}.svc:8181
       database: {{.DatabaseName}}
@@ -138,6 +166,8 @@ spec:
       thresholdValue: "5"
       query: |
         SELECT value FROM stat ORDER BY time DESC LIMIT 1
+    authenticationRef:
+      name: {{.TriggerAuthName}}
 `
 
 	influxdbWriteJobTemplate = `
@@ -261,6 +291,10 @@ func TestInfluxV3Scaler(t *testing.T) {
 	// get token
 	updateDataWithInfluxAuth(t, kc, &data)
 
+	// create secret and trigger authentication using the retrieved token
+	KubectlApplyWithTemplate(t, data, "secretTemplate", secretTemplate)
+	KubectlApplyWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
+
 	// test activation (should not scale with low values)
 	testActivation(t, kc, data)
 
@@ -309,6 +343,8 @@ func getTemplateData() (templateData, []Template) {
 			InfluxdbWriteJobName:    influxdbJobName,
 			ScaledObjectName:        scaledObjectName,
 			DeploymentName:          deploymentName,
+			SecretName:              secretName,
+			TriggerAuthName:         triggerAuthName,
 			AuthToken:               authToken,
 			DatabaseName:            databaseName,
 		}, []Template{


### PR DESCRIPTION
Deprecate authToken from triggerMetadata in InfluxDB scaler

### Checklist

- [X] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7722
Docs: https://github.com/kedacore/keda-docs/pull/1759