### PR TITLE
rfac: remove dead code from authentication package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ New deprecation(s):
 
 ### Other
 
+- **General**: Remove dead code from authentication package and drop unused `authModes` field from ArangoDB, Loki, Prometheus and PredictKube scalers ([#7726](https://github.com/kedacore/keda/pull/7726))
 - **General**: Use informer cache for ReplicaSet lookups in GetCurrentReplicas to reduce API server load ([#7466](https://github.com/kedacore/keda/pull/7466))
 - **External Scaler**: Fix race condition in `TestWaitForState` causing flaky test under `-race` detector ([#7542](https://github.com/kedacore/keda/issues/7542))
 - **GCP scaler**: Replaced credentialsFromJSON to credentialsFromJSONWithType ([#7523](https://github.com/kedacore/keda/pull/7523))

--- a/pkg/scalers/arangodb_scaler.go
+++ b/pkg/scalers/arangodb_scaler.go
@@ -61,8 +61,6 @@ type arangoDBMetadata struct {
 	// Specify the max size of the active connection pool.
 	// +optional
 	ConnectionLimit int64 `keda:"name=connectionLimit, order=triggerMetadata, optional"`
-	// +optional
-	AuthModes string `keda:"name=authModes, order=triggerMetadata, optional"`
 
 	// The index of the scaler inside the ScaledObject
 	// +internal

--- a/pkg/scalers/authentication/authentication_helpers.go
+++ b/pkg/scalers/authentication/authentication_helpers.go
@@ -1,13 +1,9 @@
 package authentication
 
 import (
-	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
-	"strings"
 	"time"
 
 	libs "github.com/dysnix/predictkube-libs/external/configs"
@@ -28,152 +24,12 @@ const (
 	AuthModesKey = "authModes"
 )
 
-func GetAuthConfigs(triggerMetadata, authParams map[string]string) (out *AuthMeta, err error) {
-	out = &AuthMeta{}
-
-	authModes, ok := triggerMetadata[AuthModesKey]
-	// no authMode specified
-	if !ok {
-		return nil, nil
-	}
-
-	authTypes := strings.Split(authModes, ",")
-	for _, t := range authTypes {
-		authType := Type(strings.TrimSpace(t))
-
-		switch authType {
-		case BearerAuthType:
-			if len(authParams["bearerToken"]) == 0 {
-				return nil, errors.New("no bearer token provided")
-			}
-			if out.EnableBasicAuth {
-				return nil, errors.New("both bearer and basic authentication can not be set")
-			}
-			if out.EnableOAuth {
-				return nil, errors.New("both bearer and OAuth can not be set")
-			}
-			out.BearerToken = strings.TrimSuffix(authParams["bearerToken"], "\n")
-			out.EnableBearerAuth = true
-		case BasicAuthType:
-			if len(authParams["username"]) == 0 {
-				return nil, errors.New("no username given")
-			}
-			if out.EnableBearerAuth {
-				return nil, errors.New("both bearer and basic authentication can not be set")
-			}
-			if out.EnableOAuth {
-				return nil, errors.New("both bearer and OAuth can not be set")
-			}
-
-			out.Username = authParams["username"]
-			// password is optional. For convenience, many application implement basic auth with
-			// username as apikey and password as empty
-			out.Password = authParams["password"]
-			out.EnableBasicAuth = true
-		case TLSAuthType:
-			if len(authParams["cert"]) == 0 {
-				return nil, errors.New("no cert given")
-			}
-			out.Cert = authParams["cert"]
-
-			if len(authParams["key"]) == 0 {
-				return nil, errors.New("no key given")
-			}
-
-			out.Key = authParams["key"]
-			out.EnableTLS = true
-		case CustomAuthType:
-			if len(authParams["customAuthHeader"]) == 0 {
-				return nil, errors.New("no custom auth header given")
-			}
-			out.CustomAuthHeader = strings.TrimSuffix(authParams["customAuthHeader"], "\n")
-
-			if len(authParams["customAuthValue"]) == 0 {
-				return nil, errors.New("no custom auth value given")
-			}
-			out.CustomAuthValue = strings.TrimSuffix(authParams["customAuthValue"], "\n")
-			out.EnableCustomAuth = true
-		case OAuthType:
-			if out.EnableBasicAuth {
-				return nil, errors.New("both oauth and basic authentication can not be set")
-			}
-			if out.EnableBearerAuth {
-				return nil, errors.New("both oauth and bearer authentication can not be set")
-			}
-			out.EnableOAuth = true
-			out.OauthTokenURI = authParams["oauthTokenURI"]
-			out.Scopes = ParseScope(authParams["scope"])
-			out.ClientID = authParams["clientID"]
-			out.ClientSecret = authParams["clientSecret"]
-
-			v, err := ParseEndpointParams(authParams["endpointParams"])
-			if err != nil {
-				return nil, fmt.Errorf("incorrect value for endpointParams is given: %s", authParams["endpointParams"])
-			}
-			out.EndpointParams = v
-		default:
-			return nil, fmt.Errorf("incorrect value for authMode is given: %s", t)
-		}
-	}
-
-	if len(authParams["ca"]) > 0 {
-		out.CA = authParams["ca"]
-	}
-
-	return out, err
-}
-
-// ParseScope parse OAuth scopes from a comma separated string
-// whitespace is trimmed
-func ParseScope(inputStr string) []string {
-	scope := strings.TrimSpace(inputStr)
-	if scope != "" {
-		scopes := make([]string, 0)
-		list := strings.Split(scope, ",")
-		for _, sc := range list {
-			sc := strings.TrimSpace(sc)
-			if sc != "" {
-				scopes = append(scopes, sc)
-			}
-		}
-		if len(scopes) == 0 {
-			return nil
-		}
-		return scopes
-	}
-	return nil
-}
-
-// ParseEndpointParams parse OAuth endpoint params from URL-encoded query string.
-func ParseEndpointParams(inputStr string) (url.Values, error) {
-	v, err := url.ParseQuery(inputStr)
-	if err != nil {
-		return nil, err
-	}
-	if len(v) == 0 {
-		return nil, nil
-	}
-	return v, nil
-}
-
-func GetBearerToken(auth *AuthMeta) string {
-	return fmt.Sprintf("Bearer %s", auth.BearerToken)
-}
-
-func NewTLSConfig(auth *AuthMeta, unsafeSsl bool) (*tls.Config, error) {
-	return kedautil.NewTLSConfig(
-		auth.Cert,
-		auth.Key,
-		auth.CA,
-		unsafeSsl,
-	)
-}
-
-func CreateHTTPRoundTripper(roundTripperType TransportType, auth *AuthMeta, conf ...*HTTPTransport) (rt http.RoundTripper, err error) {
+// CreateHTTPRoundTripper builds an http.RoundTripper using the auth settings from the given Config (TLS, basic, bearer).
+func CreateHTTPRoundTripper(roundTripperType TransportType, auth *Config, conf ...*HTTPTransport) (rt http.RoundTripper, err error) {
 	unsafeSsl := false
 	tlsConfig := kedautil.CreateTLSClientConfig(unsafeSsl)
-	if auth != nil && (auth.CA != "" || auth.EnableTLS) {
-		tlsConfig, err = NewTLSConfig(auth, unsafeSsl)
+	if auth != nil && (auth.CA != "" || auth.EnabledTLS()) {
+		tlsConfig, err = auth.NewTLSConfig(unsafeSsl)
 		if err != nil || tlsConfig == nil {
 			return nil, fmt.Errorf("error creating the TLS config: %w", err)
 		}
@@ -215,8 +71,8 @@ func CreateHTTPRoundTripper(roundTripperType TransportType, auth *AuthMeta, conf
 			return nil, fmt.Errorf("error creating fast http round tripper: %w", err)
 		}
 
-		if auth != nil {
-			if auth.EnableBasicAuth {
+		if !auth.Disabled() {
+			if auth.EnabledBasicAuth() {
 				rt = pConfig.NewBasicAuthRoundTripper(
 					pConfig.NewInlineSecret(auth.Username),
 					pConfig.NewInlineSecret(auth.Password),
@@ -224,14 +80,15 @@ func CreateHTTPRoundTripper(roundTripperType TransportType, auth *AuthMeta, conf
 				)
 			}
 
-			if auth.EnableBearerAuth {
+			if auth.EnabledBearerAuth() {
 				rt = pConfig.NewAuthorizationCredentialsRoundTripper(
 					"Bearer",
 					pConfig.NewInlineSecret(auth.BearerToken),
 					roundTripper,
 				)
 			}
-		} else {
+		}
+		if rt == nil {
 			rt = roundTripper
 		}
 

--- a/pkg/scalers/authentication/authentication_types.go
+++ b/pkg/scalers/authentication/authentication_types.go
@@ -36,39 +36,6 @@ const (
 	FastHTTP                      // FastHTTP Fast http client.
 )
 
-// AuthMeta is the metadata for the authentication types
-//
-// Deprecated: use Config instead
-type AuthMeta struct {
-	// bearer auth
-	EnableBearerAuth bool
-	BearerToken      string
-
-	// basic auth
-	EnableBasicAuth bool
-	Username        string
-	Password        string // +optional
-
-	// client certification
-	EnableTLS bool
-	Cert      string
-	Key       string
-	CA        string
-
-	// oAuth2
-	EnableOAuth    bool
-	OauthTokenURI  string
-	Scopes         []string
-	ClientID       string
-	ClientSecret   string
-	EndpointParams url.Values
-
-	// custom auth header
-	EnableCustomAuth bool
-	CustomAuthHeader string
-	CustomAuthValue  string
-}
-
 // BasicAuth is a basic authentication type
 type BasicAuth struct {
 	Username string `keda:"name=username, order=authParams"`
@@ -197,42 +164,6 @@ func empty(a string) string {
 		return "<empty>"
 	}
 	return "<present>"
-}
-
-// ToAuthMeta converts the Config to deprecated AuthMeta
-func (c *Config) ToAuthMeta() *AuthMeta {
-	if c.Disabled() {
-		return nil
-	}
-	return &AuthMeta{
-		// bearer auth
-		EnableBearerAuth: c.EnabledBearerAuth(),
-		BearerToken:      c.BearerToken,
-
-		// basic auth
-		EnableBasicAuth: c.EnabledBasicAuth(),
-		Username:        c.Username,
-		Password:        c.Password,
-
-		// client certification
-		EnableTLS: c.EnabledTLS(),
-		Cert:      c.Cert,
-		Key:       c.Key,
-		CA:        c.CA,
-
-		// oAuth2
-		EnableOAuth:    c.EnabledOAuth(),
-		OauthTokenURI:  c.OauthTokenURI,
-		Scopes:         c.Scopes,
-		ClientID:       c.ClientID,
-		ClientSecret:   c.ClientSecret,
-		EndpointParams: c.EndpointParams,
-
-		// custom auth header
-		EnableCustomAuth: c.EnabledCustomAuth(),
-		CustomAuthHeader: c.CustomAuthHeader,
-		CustomAuthValue:  c.CustomAuthValue,
-	}
 }
 
 type HTTPTransport struct {

--- a/pkg/scalers/loki_scaler.go
+++ b/pkg/scalers/loki_scaler.go
@@ -40,7 +40,6 @@ type lokiMetadata struct {
 	TenantName          string  `keda:"name=tenantName,order=triggerMetadata,optional"`
 	IgnoreNullValues    bool    `keda:"name=ignoreNullValues,order=triggerMetadata,default=true"`
 	UnsafeSsl           bool    `keda:"name=unsafeSsl,order=triggerMetadata,default=false"`
-	AuthModes           string  `keda:"name=authModes, order=triggerMetadata, optional"`
 	TriggerIndex        int
 
 	authentication.Config `keda:"optional"`

--- a/pkg/scalers/predictkube_scaler.go
+++ b/pkg/scalers/predictkube_scaler.go
@@ -92,7 +92,6 @@ type predictKubeMetadata struct {
 	APIKey              string                 `keda:"name=apiKey, order=authParams"`
 	Threshold           float64                `keda:"name=threshold, order=triggerMetadata, optional"`
 	ActivationThreshold float64                `keda:"name=activationThreshold, order=triggerMetadata, optional"`
-	AuthModes           string                 `keda:"name=authModes, order=triggerMetadata, optional"`
 
 	predictHorizon    time.Duration
 	historyTimeWindow time.Duration
@@ -402,7 +401,7 @@ func (s *PredictKubeScaler) initPredictKubePrometheusConn(ctx context.Context) (
 	// create http.RoundTripper with auth settings from ScalerConfig
 	roundTripper, err := authentication.CreateHTTPRoundTripper(
 		authentication.FastHTTP,
-		s.metadata.PrometheusAuth.ToAuthMeta(),
+		s.metadata.PrometheusAuth,
 	)
 	if err != nil {
 		s.logger.V(1).Error(err, "init Prometheus client http transport")

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -52,7 +52,6 @@ type prometheusMetadata struct {
 	AwsRegion           string                 `keda:"name=awsRegion,           order=triggerMetadata;authParams, optional"`
 	Timeout             time.Duration          `keda:"name=timeout,             order=triggerMetadata,            optional"` // custom HTTP client timeout
 	IdentityOwner       string                 `keda:"name=identityOwner,       order=triggerMetadata,            optional"`
-	AuthModes           string                 `keda:"name=authModes,           order=triggerMetadata,            optional"`
 }
 
 type promQueryResult struct {
@@ -94,7 +93,7 @@ func NewPrometheusScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 			// create http.RoundTripper with auth settings from ScalerConfig
 			transport, err := authentication.CreateHTTPRoundTripper(
 				authentication.NetHTTP,
-				meta.PrometheusAuth.ToAuthMeta(),
+				meta.PrometheusAuth,
 			)
 			if err != nil {
 				logger.V(1).Error(err, "init Prometheus client http transport")

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -262,12 +262,6 @@
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true
-                },
-                {
-                    "name": "authModes",
-                    "type": "string",
-                    "optional": true,
-                    "metadataVariableReadable": true
                 }
             ]
         },
@@ -2964,12 +2958,6 @@
                     "type": "string",
                     "default": "false",
                     "metadataVariableReadable": true
-                },
-                {
-                    "name": "authModes",
-                    "type": "string",
-                    "optional": true,
-                    "metadataVariableReadable": true
                 }
             ]
         },
@@ -3693,12 +3681,6 @@
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true
-                },
-                {
-                    "name": "authModes",
-                    "type": "string",
-                    "optional": true,
-                    "metadataVariableReadable": true
                 }
             ]
         },
@@ -3771,12 +3753,6 @@
                 },
                 {
                     "name": "identityOwner",
-                    "type": "string",
-                    "optional": true,
-                    "metadataVariableReadable": true
-                },
-                {
-                    "name": "authModes",
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -176,10 +176,6 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
-        - name: authModes
-          type: string
-          optional: true
-          metadataVariableReadable: true
     - type: artemis-queue
       parameters:
         - name: managementEndpoint
@@ -1936,10 +1932,6 @@ scalers:
           type: string
           default: "false"
           metadataVariableReadable: true
-        - name: authModes
-          type: string
-          optional: true
-          metadataVariableReadable: true
     - type: mssql
       parameters:
         - name: connectionString
@@ -2413,10 +2405,6 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
-        - name: authModes
-          type: string
-          optional: true
-          metadataVariableReadable: true
     - type: prometheus
       parameters:
         - name: serverAddress
@@ -2462,10 +2450,6 @@ scalers:
           optional: true
           metadataVariableReadable: true
         - name: identityOwner
-          type: string
-          optional: true
-          metadataVariableReadable: true
-        - name: authModes
           type: string
           optional: true
           metadataVariableReadable: true


### PR DESCRIPTION
Removes dead code from the `authentication` package and drops redundant `AuthModes string` fields from a few scalers.
    
### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))