### PR TITLE
fix(azure-event-hub): Fix division by 0 for threshold value in azure eventhub scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
-- **Azure Event Hub Scaler**: Reject non-positive `unprocessedEventThreshold` to prevent integer division by zero when computing lag ([#7733](https://github.com/kedacore/keda/pull/7733))
+- **Azure Event Hub Scaler**: Reject non-positive `unprocessedEventThreshold` to prevent integer division by zero when computing lag ([#7732](https://github.com/kedacore/keda/issues/7732))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **Forgejo Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **Forgejo Scaler**: Return correct activity to enable scale-to-zero ([#7527](https://github.com/kedacore/keda/issues/7527))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
+- **Azure Event Hub Scaler**: Reject non-positive `unprocessedEventThreshold` to prevent integer division by zero when computing lag ([#7733](https://github.com/kedacore/keda/pull/7733))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))
 - **Forgejo Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))
 - **Forgejo Scaler**: Return correct activity to enable scale-to-zero ([#7527](https://github.com/kedacore/keda/issues/7527))

--- a/pkg/scalers/azure_eventhub_scaler.go
+++ b/pkg/scalers/azure_eventhub_scaler.go
@@ -41,6 +41,7 @@ const (
 	defaultBlobContainer               = ""
 	defaultCheckpointStrategy          = ""
 	defaultStalePartitionInfoThreshold = 10000
+	unprocessedEventThresholdParam     = "unprocessedEventThreshold"
 )
 
 type azureEventHubScaler struct {
@@ -57,6 +58,13 @@ type eventHubMetadata struct {
 	StalePartitionInfoThreshold int64              `keda:"name=stalePartitionInfoThreshold,          order=triggerMetadata, default=10000"`
 	EventHubInfo                azure.EventHubInfo `keda:"optional"`
 	triggerIndex                int
+}
+
+func (m *eventHubMetadata) Validate() error {
+	if m.Threshold <= 0 {
+		return fmt.Errorf("%q must be a positive number", unprocessedEventThresholdParam)
+	}
+	return nil
 }
 
 // NewAzureEventHubScaler creates a new scaler for eventHub

--- a/pkg/scalers/azure_eventhub_scaler_test.go
+++ b/pkg/scalers/azure_eventhub_scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2"
@@ -84,6 +85,18 @@ var parseEventHubMetadataDataset = []parseEventHubMetadataTestData{
 		metadata:    map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connectionFromEnv": eventHubConnectionSetting},
 		resolvedEnv: sampleEventHubResolvedEnv,
 		isError:     false,
+	},
+	// unprocessed event threshold zero would cause division by zero when computing lag
+	{
+		metadata:    map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connectionFromEnv": eventHubConnectionSetting, "unprocessedEventThreshold": "0"},
+		resolvedEnv: sampleEventHubResolvedEnv,
+		isError:     true,
+	},
+	// unprocessed event threshold non-positive
+	{
+		metadata:    map[string]string{"storageConnectionFromEnv": storageConnectionSetting, "consumerGroup": eventHubConsumerGroup, "connectionFromEnv": eventHubConnectionSetting, "unprocessedEventThreshold": "-1"},
+		resolvedEnv: sampleEventHubResolvedEnv,
+		isError:     true,
 	},
 	// invalid activation unprocessed event threshold
 	{
@@ -266,6 +279,26 @@ var testEventHubScaler = azureEventHubScaler{
 			StorageConnection:  "none",
 		},
 	},
+}
+
+func TestParseAzureEventHubMetadataRejectsNonPositiveUnprocessedEventThreshold(t *testing.T) {
+	md := map[string]string{
+		"storageConnectionFromEnv":  storageConnectionSetting,
+		"consumerGroup":             eventHubConsumerGroup,
+		"connectionFromEnv":         eventHubConnectionSetting,
+		"unprocessedEventThreshold": "0",
+	}
+	_, err := parseAzureEventHubMetadata(logr.Discard(), &scalersconfig.ScalerConfig{
+		TriggerMetadata: md,
+		ResolvedEnv:     sampleEventHubResolvedEnv,
+		AuthParams:      map[string]string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for unprocessedEventThreshold=0")
+	}
+	if !strings.Contains(err.Error(), unprocessedEventThresholdParam) {
+		t.Fatalf("expected error to mention %q, got: %v", unprocessedEventThresholdParam, err)
+	}
 }
 
 func TestParseEventHubMetadata(t *testing.T) {


### PR DESCRIPTION
I'm adding a validation step to guard against having threshold to be set at 0, resulting in division by zero


### Checklist
 
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/keda/issues/7732

