### PR TITLE
chore: add AI agent config directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,11 @@ report.xml
 # KEDA Certs
 certs/*
 
-# Claude config
+# AI agent configs
 .claude
+.codex
+.cursor
+.copilot
+.aider*
+.continue
+.windsurf


### PR DESCRIPTION
## Summary

- Expands the existing `.claude` entry into a dedicated section covering popular AI coding agents
- Adds `.codex` (OpenAI Codex), `.cursor` (Cursor), `.copilot` (GitHub Copilot), `.aider*` (Aider), `.continue` (Continue.dev), `.windsurf` (Windsurf)

Prevents contributor-local AI agent config/session directories from being accidentally committed.

## Test plan

- [x] Verify `.gitignore` entries match the local directories created by each agent

I have only manually verified cursor, codex, and claude as those are what I have access to. The rest I verfied via looking up agent references.