### PR TITLE
fix(aws): close idle HTTP connections in AWS scaler Close() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))
+- **AWS Scalers**: Fix TCP connection leak by closing HTTP idle connections on scaler `Close()` for SQS, Kinesis, DynamoDB, DynamoDB Streams, and CloudWatch scalers ([#7756](https://github.com/kedacore/keda/issues/7756))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Azure Event Hub Scaler**: Reject non-positive `unprocessedEventThreshold` to prevent integer division by zero when computing lag ([#7732](https://github.com/kedacore/keda/issues/7732))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))

--- a/pkg/scalers/aws/aws_http.go
+++ b/pkg/scalers/aws/aws_http.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"net/http"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+)
+
+// NewHTTPClient returns an *http.Client configured for use with AWS SDK clients.
+// Each call allocates a fresh *http.Transport so that callers have independent
+// connection pools with independent lifecycles — this is required because each
+// scaler calls CloseIdleConnections on its own client at teardown.
+//
+// We deliberately use a raw *http.Transport (via GetTransport) rather than the
+// SDK's BuildableClient.Freeze(), because Freeze wraps the transport in
+// suppressBadHTTPRedirectTransport which does not implement CloseIdleConnections.
+// That would make http.Client.CloseIdleConnections() a no-op and leak TCP
+// connections across scaler restarts.
+//
+// To satisfy the AWS SDK's expectation that custom HTTP clients do not follow
+// 301/302 redirects (see aws.HTTPClient interface docs and
+// https://github.com/aws/aws-sdk-go-v2/blob/v1.41.7/aws/transport/http/client.go#L283-L318),
+// we apply limitRedirect as the CheckRedirect policy. This mirrors the SDK's
+// own limitedRedirect behavior.
+func NewHTTPClient() *http.Client {
+	return &http.Client{
+		Transport:     awshttp.NewBuildableClient().GetTransport(),
+		CheckRedirect: limitRedirect,
+	}
+}
+
+// limitRedirect replicates the AWS SDK's redirect policy:
+//   - Only 307/308 are followed (they preserve the HTTP method).
+//   - X-Amz-Security-Token is stripped on cross-host redirects to prevent
+//     credential leakage when awsEndpoint is user-supplied.
+//   - All other redirects (301, 302, etc.) are suppressed.
+//
+// Reference: https://github.com/aws/aws-sdk-go-v2/blob/v1.41.7/aws/transport/http/client.go#L291-L318
+func limitRedirect(req *http.Request, via []*http.Request) error {
+	resp := req.Response
+	switch resp.StatusCode {
+	case 307, 308:
+		// len(via) > 0 is always true when CheckRedirect is called, but we keep
+		// the guard to mirror the SDK implementation and as defensive bounds-checking.
+		// See: https://github.com/aws/aws-sdk-go-v2/blob/v1.41.7/aws/transport/http/client.go#L307
+		if len(via) > 0 {
+			last := via[len(via)-1]
+			if last.URL.Host != req.URL.Host {
+				req.Header.Del("X-Amz-Security-Token")
+			}
+		}
+		return nil
+	}
+	return http.ErrUseLastResponse
+}

--- a/pkg/scalers/aws/aws_http_test.go
+++ b/pkg/scalers/aws/aws_http_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPClientCloseIdleConnections(t *testing.T) {
+	client := NewHTTPClient()
+
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	_, ok := client.Transport.(closeIdler)
+	assert.True(t, ok, "Transport should implement CloseIdleConnections")
+
+	// Should not panic
+	client.CloseIdleConnections()
+}
+
+func TestNewHTTPClientBlocksNon307Redirects(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer target.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound) // 302
+	}))
+	defer origin.Close()
+
+	client := NewHTTPClient()
+	resp, err := client.Get(origin.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// If the redirect were followed, we'd get 200 from target
+	assert.Equal(t, http.StatusFound, resp.StatusCode, "302 should not be followed")
+}
+
+func TestNewHTTPClientAllows307Redirect(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer target.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect) // 307
+	}))
+	defer origin.Close()
+
+	client := NewHTTPClient()
+	resp, err := client.Get(origin.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "307 should be followed")
+}
+
+// Note on synchronization: httptest handlers write to local variables that are read after
+// client.Do returns. This is safe because client.Do blocks until the response is fully
+// received, which requires the handler to have completed — establishing happens-before
+// without explicit synchronization. This matches the httptest pattern used throughout
+// this repository (e.g. azure_pipelines_scaler_test.go, dynatrace_scaler_test.go).
+
+func TestNewHTTPClientStripsSecurityTokenOnCrossHostRedirect(t *testing.T) {
+	var receivedToken string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedToken = r.Header.Get("X-Amz-Security-Token")
+		w.WriteHeader(200)
+	}))
+	defer target.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect) // 307
+	}))
+	defer origin.Close()
+
+	client := NewHTTPClient()
+	req, err := http.NewRequest("GET", origin.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Amz-Security-Token", "secret-token")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// The origin and target are different hosts (different ports), so token should be stripped
+	assert.Empty(t, receivedToken, "X-Amz-Security-Token should be stripped on cross-host 307 redirect")
+}
+
+func TestNewHTTPClientAllows308Redirect(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer target.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusPermanentRedirect) // 308
+	}))
+	defer origin.Close()
+
+	client := NewHTTPClient()
+	resp, err := client.Get(origin.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "308 should be followed")
+}
+
+func TestNewHTTPClientPreservesTokenOnSameHostRedirect(t *testing.T) {
+	var receivedToken string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/target", func(w http.ResponseWriter, r *http.Request) {
+		receivedToken = r.Header.Get("X-Amz-Security-Token")
+		w.WriteHeader(200)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/target", http.StatusTemporaryRedirect) // 307 same host
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := NewHTTPClient()
+	req, err := http.NewRequest("GET", server.URL+"/", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Amz-Security-Token", "secret-token")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "secret-token", receivedToken, "X-Amz-Security-Token should be preserved on same-host redirect")
+}

--- a/pkg/scalers/aws_cloudwatch_scaler.go
+++ b/pkg/scalers/aws_cloudwatch_scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -21,6 +22,7 @@ type awsCloudwatchScaler struct {
 	metricType v2.MetricTargetType
 	metadata   *awsCloudwatchMetadata
 	cwClient   cloudwatch.GetMetricDataAPIClient
+	httpClient *http.Client
 	logger     logr.Logger
 }
 
@@ -102,7 +104,8 @@ func NewAwsCloudwatchScaler(ctx context.Context, config *scalersconfig.ScalerCon
 		return nil, fmt.Errorf("error parsing cloudwatch metadata: %w", err)
 	}
 
-	cloudwatchClient, err := createCloudwatchClient(ctx, meta)
+	httpClient := awsutils.NewHTTPClient()
+	cloudwatchClient, err := createCloudwatchClient(ctx, meta, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error creating cloudwatch client: %w", err)
 	}
@@ -110,11 +113,12 @@ func NewAwsCloudwatchScaler(ctx context.Context, config *scalersconfig.ScalerCon
 		metricType: metricType,
 		metadata:   meta,
 		cwClient:   cloudwatchClient,
+		httpClient: httpClient,
 		logger:     InitializeLogger(config, "aws_cloudwatch_scaler"),
 	}, nil
 }
 
-func createCloudwatchClient(ctx context.Context, metadata *awsCloudwatchMetadata) (*cloudwatch.Client, error) {
+func createCloudwatchClient(ctx context.Context, metadata *awsCloudwatchMetadata, httpClient *http.Client) (*cloudwatch.Client, error) {
 	cfg, err := awsutils.GetAwsConfig(ctx, metadata.awsAuthorization)
 
 	if err != nil {
@@ -123,6 +127,9 @@ func createCloudwatchClient(ctx context.Context, metadata *awsCloudwatchMetadata
 	return cloudwatch.NewFromConfig(*cfg, func(options *cloudwatch.Options) {
 		if metadata.AwsEndpoint != "" {
 			options.BaseEndpoint = aws.String(metadata.AwsEndpoint)
+		}
+		if httpClient != nil {
+			options.HTTPClient = httpClient
 		}
 	}), nil
 }
@@ -268,6 +275,9 @@ func (s *awsCloudwatchScaler) GetMetricSpecForScaling(context.Context) []v2.Metr
 
 func (s *awsCloudwatchScaler) Close(context.Context) error {
 	awsutils.ClearAwsConfig(s.metadata.awsAuthorization)
+	if s.httpClient != nil {
+		s.httpClient.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/pkg/scalers/aws_cloudwatch_scaler_test.go
+++ b/pkg/scalers/aws_cloudwatch_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -756,7 +757,7 @@ func TestAWSCloudwatchGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockAWSCloudwatchScaler := awsCloudwatchScaler{"", meta, &mockCloudwatch{}, logr.Discard()}
+		mockAWSCloudwatchScaler := awsCloudwatchScaler{"", meta, &mockCloudwatch{}, nil, logr.Discard()}
 
 		metricSpec := mockAWSCloudwatchScaler.GetMetricSpecForScaling(ctx)
 		metricName := metricSpec[0].External.Metric.Name
@@ -768,7 +769,7 @@ func TestAWSCloudwatchGetMetricSpecForScaling(t *testing.T) {
 
 func TestAWSCloudwatchScalerGetMetrics(t *testing.T) {
 	for _, meta := range awsCloudwatchGetMetricTestData {
-		mockAWSCloudwatchScaler := awsCloudwatchScaler{"", &meta, &mockCloudwatch{}, logr.Discard()}
+		mockAWSCloudwatchScaler := awsCloudwatchScaler{"", &meta, &mockCloudwatch{}, nil, logr.Discard()}
 		value, _, err := mockAWSCloudwatchScaler.GetMetricsAndActivity(context.Background(), meta.MetricsName)
 		switch meta.MetricsName {
 		case testAWSCloudwatchErrorMetric:
@@ -855,4 +856,47 @@ func TestCreateCloudwatchMetricDataInput(t *testing.T) {
 	}
 
 	assert.Equal(t, "123456789012", awsMeta.AwsAccountID, "AWSAccountID should equal '123456789012'")
+}
+
+// mockCWTransport is an http.RoundTripper that tracks whether CloseIdleConnections was called.
+type mockCWTransport struct {
+	closeIdleCalled bool
+}
+
+func (m *mockCWTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+}
+
+func (m *mockCWTransport) CloseIdleConnections() {
+	m.closeIdleCalled = true
+}
+
+func TestAWSCloudwatchScalerCloseClosesHTTPConnections(t *testing.T) {
+	transport := &mockCWTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	meta := &awsCloudwatchMetadata{
+		Namespace:   "AWS/SQS",
+		MetricsName: "ApproximateNumberOfMessagesVisible",
+		AwsRegion:   "eu-west-1",
+		awsAuthorization: awsutils.AuthorizationMetadata{
+			TriggerUniqueKey: "test-cw-close-trigger",
+			AwsRegion:        "eu-west-1",
+		},
+	}
+
+	scaler := &awsCloudwatchScaler{
+		metricType: "",
+		metadata:   meta,
+		cwClient:   &mockCloudwatch{},
+		httpClient: httpClient,
+		logger:     logr.Discard(),
+	}
+
+	assert.False(t, transport.closeIdleCalled, "CloseIdleConnections should not have been called yet")
+
+	err := scaler.Close(context.Background())
+	assert.NoError(t, err)
+
+	assert.True(t, transport.closeIdleCalled, "CloseIdleConnections should have been called after Close()")
 }

--- a/pkg/scalers/aws_dynamodb_scaler.go
+++ b/pkg/scalers/aws_dynamodb_scaler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -23,6 +24,7 @@ type awsDynamoDBScaler struct {
 	metricType v2.MetricTargetType
 	metadata   *awsDynamoDBMetadata
 	dbClient   dynamodb.QueryAPIClient
+	httpClient *http.Client
 	logger     logr.Logger
 }
 
@@ -57,7 +59,8 @@ func NewAwsDynamoDBScaler(ctx context.Context, config *scalersconfig.ScalerConfi
 	if err != nil {
 		return nil, fmt.Errorf("error parsing DynamoDb metadata: %w", err)
 	}
-	dbClient, err := createDynamoDBClient(ctx, meta)
+	httpClient := awsutils.NewHTTPClient()
+	dbClient, err := createDynamoDBClient(ctx, meta, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error when creating dynamodb client: %w", err)
 	}
@@ -65,6 +68,7 @@ func NewAwsDynamoDBScaler(ctx context.Context, config *scalersconfig.ScalerConfi
 		metricType: metricType,
 		metadata:   meta,
 		dbClient:   dbClient,
+		httpClient: httpClient,
 		logger:     InitializeLogger(config, "aws_dynamodb_scaler"),
 	}, nil
 }
@@ -129,7 +133,7 @@ func parseAwsDynamoDBMetadata(config *scalersconfig.ScalerConfig) (*awsDynamoDBM
 	return meta, nil
 }
 
-func createDynamoDBClient(ctx context.Context, metadata *awsDynamoDBMetadata) (*dynamodb.Client, error) {
+func createDynamoDBClient(ctx context.Context, metadata *awsDynamoDBMetadata, httpClient *http.Client) (*dynamodb.Client, error) {
 	cfg, err := awsutils.GetAwsConfig(ctx, metadata.awsAuthorization)
 	if err != nil {
 		return nil, err
@@ -138,6 +142,9 @@ func createDynamoDBClient(ctx context.Context, metadata *awsDynamoDBMetadata) (*
 	return dynamodb.NewFromConfig(*cfg, func(options *dynamodb.Options) {
 		if metadata.AwsEndpoint != "" {
 			options.BaseEndpoint = aws.String(metadata.AwsEndpoint)
+		}
+		if httpClient != nil {
+			options.HTTPClient = httpClient
 		}
 	}), nil
 }
@@ -170,6 +177,9 @@ func (s *awsDynamoDBScaler) GetMetricSpecForScaling(context.Context) []v2.Metric
 
 func (s *awsDynamoDBScaler) Close(context.Context) error {
 	awsutils.ClearAwsConfig(s.metadata.awsAuthorization)
+	if s.httpClient != nil {
+		s.httpClient.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/pkg/scalers/aws_dynamodb_scaler_test.go
+++ b/pkg/scalers/aws_dynamodb_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -466,7 +467,7 @@ var awsDynamoDBGetMetricTestData = []awsDynamoDBMetadata{
 func TestDynamoGetMetrics(t *testing.T) {
 	for _, meta := range awsDynamoDBGetMetricTestData {
 		t.Run(meta.TableName, func(t *testing.T) {
-			scaler := awsDynamoDBScaler{"", &meta, &mockDynamoDB{}, logr.Discard()}
+			scaler := awsDynamoDBScaler{"", &meta, &mockDynamoDB{}, nil, logr.Discard()}
 
 			value, _, err := scaler.GetMetricsAndActivity(context.Background(), "aws-dynamodb")
 			switch meta.TableName {
@@ -486,7 +487,7 @@ func TestDynamoGetMetrics(t *testing.T) {
 func TestDynamoGetQueryMetrics(t *testing.T) {
 	for _, meta := range awsDynamoDBGetMetricTestData {
 		t.Run(meta.TableName, func(t *testing.T) {
-			scaler := awsDynamoDBScaler{"", &meta, &mockDynamoDB{}, logr.Discard()}
+			scaler := awsDynamoDBScaler{"", &meta, &mockDynamoDB{}, nil, logr.Discard()}
 
 			value, err := scaler.GetQueryMetrics(context.Background())
 			switch meta.TableName {
@@ -506,7 +507,7 @@ func TestDynamoGetQueryMetrics(t *testing.T) {
 func TestDynamoIsActive(t *testing.T) {
 	for _, meta := range awsDynamoDBGetMetricTestData {
 		t.Run(meta.TableName, func(t *testing.T) {
-			scaler := awsDynamoDBScaler{"", &meta, &mockDynamoDB{}, logr.Discard()}
+			scaler := awsDynamoDBScaler{"", &meta, &mockDynamoDB{}, nil, logr.Discard()}
 
 			_, value, err := scaler.GetMetricsAndActivity(context.Background(), "aws-dynamodb")
 			switch meta.TableName {
@@ -521,4 +522,46 @@ func TestDynamoIsActive(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockDynamoDBTransport is an http.RoundTripper that tracks whether CloseIdleConnections was called.
+type mockDynamoDBTransport struct {
+	closeIdleCalled bool
+}
+
+func (m *mockDynamoDBTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+}
+
+func (m *mockDynamoDBTransport) CloseIdleConnections() {
+	m.closeIdleCalled = true
+}
+
+func TestAWSDynamoDBScalerCloseClosesHTTPConnections(t *testing.T) {
+	transport := &mockDynamoDBTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	meta := &awsDynamoDBMetadata{
+		TableName: "test-table",
+		AwsRegion: "eu-west-1",
+		awsAuthorization: awsutils.AuthorizationMetadata{
+			TriggerUniqueKey: "test-dynamodb-close-trigger",
+			AwsRegion:        "eu-west-1",
+		},
+	}
+
+	scaler := &awsDynamoDBScaler{
+		metricType: "",
+		metadata:   meta,
+		dbClient:   &mockDynamoDB{},
+		httpClient: httpClient,
+		logger:     logr.Discard(),
+	}
+
+	assert.False(t, transport.closeIdleCalled, "CloseIdleConnections should not have been called yet")
+
+	err := scaler.Close(context.Background())
+	assert.NoError(t, err)
+
+	assert.True(t, transport.closeIdleCalled, "CloseIdleConnections should have been called after Close()")
 }

--- a/pkg/scalers/aws_dynamodb_streams_scaler.go
+++ b/pkg/scalers/aws_dynamodb_streams_scaler.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -26,6 +27,7 @@ type awsDynamoDBStreamsScaler struct {
 	metadata              *awsDynamoDBStreamsMetadata
 	streamArn             *string
 	dbStreamWrapperClient DynamodbStreamWrapperClient
+	httpClient            *http.Client
 	logger                logr.Logger
 }
 
@@ -55,7 +57,8 @@ func NewAwsDynamoDBStreamsScaler(ctx context.Context, config *scalersconfig.Scal
 		return nil, fmt.Errorf("error parsing dynamodb stream metadata: %w", err)
 	}
 
-	dbClient, dbStreamClient, err := createClientsForDynamoDBStreamsScaler(ctx, meta)
+	httpClient := awsutils.NewHTTPClient()
+	dbClient, dbStreamClient, err := createClientsForDynamoDBStreamsScaler(ctx, meta, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error when creating dynamodbstream client: %w", err)
 	}
@@ -71,7 +74,8 @@ func NewAwsDynamoDBStreamsScaler(ctx context.Context, config *scalersconfig.Scal
 		dbStreamWrapperClient: &dynamodbStreamWrapperClient{
 			dbStreamClient: dbStreamClient,
 		},
-		logger: logger,
+		httpClient: httpClient,
+		logger:     logger,
 	}, nil
 }
 
@@ -93,7 +97,7 @@ func parseAwsDynamoDBStreamsMetadata(config *scalersconfig.ScalerConfig) (*awsDy
 	return &meta, nil
 }
 
-func createClientsForDynamoDBStreamsScaler(ctx context.Context, metadata *awsDynamoDBStreamsMetadata) (*dynamodb.Client, *dynamodbstreams.Client, error) {
+func createClientsForDynamoDBStreamsScaler(ctx context.Context, metadata *awsDynamoDBStreamsMetadata, httpClient *http.Client) (*dynamodb.Client, *dynamodbstreams.Client, error) {
 	cfg, err := awsutils.GetAwsConfig(ctx, metadata.awsAuthorization)
 	if err != nil {
 		return nil, nil, err
@@ -102,10 +106,16 @@ func createClientsForDynamoDBStreamsScaler(ctx context.Context, metadata *awsDyn
 		if metadata.AwsEndpoint != "" {
 			options.BaseEndpoint = aws.String(metadata.AwsEndpoint)
 		}
+		if httpClient != nil {
+			options.HTTPClient = httpClient
+		}
 	})
 	dbStreamClient := dynamodbstreams.NewFromConfig(*cfg, func(options *dynamodbstreams.Options) {
 		if metadata.AwsEndpoint != "" {
 			options.BaseEndpoint = aws.String(metadata.AwsEndpoint)
+		}
+		if httpClient != nil {
+			options.HTTPClient = httpClient
 		}
 	})
 
@@ -139,6 +149,9 @@ func getDynamoDBStreamsArn(ctx context.Context, db dynamodb.DescribeTableAPIClie
 
 func (s *awsDynamoDBStreamsScaler) Close(_ context.Context) error {
 	awsutils.ClearAwsConfig(s.metadata.awsAuthorization)
+	if s.httpClient != nil {
+		s.httpClient.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/pkg/scalers/aws_dynamodb_streams_scaler_test.go
+++ b/pkg/scalers/aws_dynamodb_streams_scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -402,7 +403,7 @@ func TestAwsDynamoDBStreamsGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not get dynamodb stream arn:", err)
 		}
-		mockAwsDynamoDBStreamsScaler := awsDynamoDBStreamsScaler{"", meta, streamArn, &mockAwsDynamoDBStreams{}, logr.Discard()}
+		mockAwsDynamoDBStreamsScaler := awsDynamoDBStreamsScaler{"", meta, streamArn, &mockAwsDynamoDBStreams{}, nil, logr.Discard()}
 		metricSpec := mockAwsDynamoDBStreamsScaler.GetMetricSpecForScaling(ctx)
 		metricName := metricSpec[0].External.Metric.Name
 		if metricName != testData.name {
@@ -419,7 +420,7 @@ func TestAwsDynamoDBStreamsScalerGetMetrics(t *testing.T) {
 		ctx := context.Background()
 		streamArn, err = getDynamoDBStreamsArn(ctx, &mockAwsDynamoDB{}, &meta.TableName)
 		if err == nil {
-			scaler := awsDynamoDBStreamsScaler{"", meta, streamArn, &mockAwsDynamoDBStreams{}, logr.Discard()}
+			scaler := awsDynamoDBStreamsScaler{"", meta, streamArn, &mockAwsDynamoDBStreams{}, nil, logr.Discard()}
 			value, _, err = scaler.GetMetricsAndActivity(context.Background(), "MetricName")
 		}
 		switch meta.TableName {
@@ -443,7 +444,7 @@ func TestAwsDynamoDBStreamsScalerIsActive(t *testing.T) {
 		ctx := context.Background()
 		streamArn, err = getDynamoDBStreamsArn(ctx, &mockAwsDynamoDB{}, &meta.TableName)
 		if err == nil {
-			scaler := awsDynamoDBStreamsScaler{"", meta, streamArn, &mockAwsDynamoDBStreams{}, logr.Discard()}
+			scaler := awsDynamoDBStreamsScaler{"", meta, streamArn, &mockAwsDynamoDBStreams{}, nil, logr.Discard()}
 			_, value, err = scaler.GetMetricsAndActivity(context.Background(), "MetricName")
 		}
 		switch meta.TableName {
@@ -455,4 +456,49 @@ func TestAwsDynamoDBStreamsScalerIsActive(t *testing.T) {
 			assert.EqualValues(t, true, value)
 		}
 	}
+}
+
+// mockDynamoDBStreamsTransport is an http.RoundTripper that tracks whether CloseIdleConnections was called.
+type mockDynamoDBStreamsTransport struct {
+	closeIdleCalled bool
+}
+
+func (m *mockDynamoDBStreamsTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+}
+
+func (m *mockDynamoDBStreamsTransport) CloseIdleConnections() {
+	m.closeIdleCalled = true
+}
+
+func TestAWSDynamoDBStreamsScalerCloseClosesHTTPConnections(t *testing.T) {
+	transport := &mockDynamoDBStreamsTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	meta := &awsDynamoDBStreamsMetadata{
+		TableName: "test-stream-table",
+		AwsRegion: "eu-west-1",
+		awsAuthorization: awsutils.AuthorizationMetadata{
+			TriggerUniqueKey: "test-dynamodb-streams-close-trigger",
+			AwsRegion:        "eu-west-1",
+		},
+	}
+
+	streamArn := aws.String("arn:aws:dynamodb:eu-west-1:123456789012:table/test-stream-table/stream/2021-01-01T00:00:00.000")
+
+	scaler := &awsDynamoDBStreamsScaler{
+		metricType:            "",
+		metadata:              meta,
+		streamArn:             streamArn,
+		dbStreamWrapperClient: &mockAwsDynamoDBStreams{},
+		httpClient:            httpClient,
+		logger:                logr.Discard(),
+	}
+
+	assert.False(t, transport.closeIdleCalled, "CloseIdleConnections should not have been called yet")
+
+	err := scaler.Close(context.Background())
+	assert.NoError(t, err)
+
+	assert.True(t, transport.closeIdleCalled, "CloseIdleConnections should have been called after Close()")
 }

--- a/pkg/scalers/aws_kinesis_stream_scaler.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
@@ -24,6 +25,7 @@ type awsKinesisStreamScaler struct {
 	metricType           v2.MetricTargetType
 	metadata             *awsKinesisStreamMetadata
 	kinesisWrapperClient KinesisWrapperClient
+	httpClient           *http.Client
 	logger               logr.Logger
 }
 
@@ -64,7 +66,8 @@ func NewAwsKinesisStreamScaler(ctx context.Context, config *scalersconfig.Scaler
 	if err != nil {
 		return nil, fmt.Errorf("error parsing Kinesis stream metadata: %w", err)
 	}
-	awsKinesisClient, err := createKinesisClient(ctx, meta)
+	httpClient := awsutils.NewHTTPClient()
+	awsKinesisClient, err := createKinesisClient(ctx, meta, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error creating kinesis client: %w", err)
 	}
@@ -75,7 +78,8 @@ func NewAwsKinesisStreamScaler(ctx context.Context, config *scalersconfig.Scaler
 		kinesisWrapperClient: &kinesisWrapperClient{
 			kinesisClient: awsKinesisClient,
 		},
-		logger: logger,
+		httpClient: httpClient,
+		logger:     logger,
 	}, nil
 }
 
@@ -97,7 +101,7 @@ func parseAwsKinesisStreamMetadata(config *scalersconfig.ScalerConfig) (*awsKine
 	return meta, nil
 }
 
-func createKinesisClient(ctx context.Context, metadata *awsKinesisStreamMetadata) (*kinesis.Client, error) {
+func createKinesisClient(ctx context.Context, metadata *awsKinesisStreamMetadata, httpClient *http.Client) (*kinesis.Client, error) {
 	cfg, err := awsutils.GetAwsConfig(ctx, metadata.awsAuthorization)
 	if err != nil {
 		return nil, err
@@ -106,11 +110,17 @@ func createKinesisClient(ctx context.Context, metadata *awsKinesisStreamMetadata
 		if metadata.AwsEndpoint != "" {
 			options.BaseEndpoint = aws.String(metadata.AwsEndpoint)
 		}
+		if httpClient != nil {
+			options.HTTPClient = httpClient
+		}
 	}), nil
 }
 
 func (s *awsKinesisStreamScaler) Close(context.Context) error {
 	awsutils.ClearAwsConfig(s.metadata.awsAuthorization)
+	if s.httpClient != nil {
+		s.httpClient.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/pkg/scalers/aws_kinesis_stream_scaler_test.go
+++ b/pkg/scalers/aws_kinesis_stream_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -340,7 +341,7 @@ func TestAWSKinesisGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockAWSKinesisStreamScaler := awsKinesisStreamScaler{"", meta, &mockKinesis{}, logr.Discard()}
+		mockAWSKinesisStreamScaler := awsKinesisStreamScaler{"", meta, &mockKinesis{}, nil, logr.Discard()}
 
 		metricSpec := mockAWSKinesisStreamScaler.GetMetricSpecForScaling(ctx)
 		metricName := metricSpec[0].External.Metric.Name
@@ -352,7 +353,7 @@ func TestAWSKinesisGetMetricSpecForScaling(t *testing.T) {
 
 func TestAWSKinesisStreamScalerGetMetrics(t *testing.T) {
 	for _, meta := range awsKinesisGetMetricTestData {
-		scaler := awsKinesisStreamScaler{"", meta, &mockKinesis{}, logr.Discard()}
+		scaler := awsKinesisStreamScaler{"", meta, &mockKinesis{}, nil, logr.Discard()}
 		value, _, err := scaler.GetMetricsAndActivity(context.Background(), "MetricName")
 		switch meta.StreamName {
 		case testAWSKinesisErrorStream:
@@ -361,4 +362,48 @@ func TestAWSKinesisStreamScalerGetMetrics(t *testing.T) {
 			assert.EqualValues(t, int64(100.0), value[0].Value.Value())
 		}
 	}
+}
+
+// mockKinesisTransport is an http.RoundTripper that tracks whether CloseIdleConnections was called.
+type mockKinesisTransport struct {
+	closeIdleCalled bool
+}
+
+func (m *mockKinesisTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+}
+
+func (m *mockKinesisTransport) CloseIdleConnections() {
+	m.closeIdleCalled = true
+}
+
+func TestAWSKinesisStreamScalerCloseClosesHTTPConnections(t *testing.T) {
+	transport := &mockKinesisTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	meta := &awsKinesisStreamMetadata{
+		StreamName: "test-stream",
+		AwsRegion:  "eu-west-1",
+		awsAuthorization: awsutils.AuthorizationMetadata{
+			TriggerUniqueKey: "test-kinesis-close-trigger",
+			AwsRegion:        "eu-west-1",
+		},
+	}
+
+	scaler := &awsKinesisStreamScaler{
+		metricType: "",
+		metadata:   meta,
+		kinesisWrapperClient: &kinesisWrapperClient{
+			kinesisClient: nil,
+		},
+		httpClient: httpClient,
+		logger:     logr.Discard(),
+	}
+
+	assert.False(t, transport.closeIdleCalled, "CloseIdleConnections should not have been called yet")
+
+	err := scaler.Close(context.Background())
+	assert.NoError(t, err)
+
+	assert.True(t, transport.closeIdleCalled, "CloseIdleConnections should have been called after Close()")
 }

--- a/pkg/scalers/aws_sqs_queue_scaler.go
+++ b/pkg/scalers/aws_sqs_queue_scaler.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -23,6 +24,7 @@ type awsSqsQueueScaler struct {
 	metricType       v2.MetricTargetType
 	metadata         *awsSqsQueueMetadata
 	sqsWrapperClient SqsWrapperClient
+	httpClient       *http.Client
 	logger           logr.Logger
 }
 
@@ -55,7 +57,8 @@ func NewAwsSqsQueueScaler(ctx context.Context, config *scalersconfig.ScalerConfi
 	if err != nil {
 		return nil, fmt.Errorf("error parsing SQS queue metadata: %w", err)
 	}
-	awsSqsClient, err := createSqsClient(ctx, meta)
+	httpClient := awsutils.NewHTTPClient()
+	awsSqsClient, err := createSqsClient(ctx, meta, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error when creating sqs client: %w", err)
 	}
@@ -65,7 +68,8 @@ func NewAwsSqsQueueScaler(ctx context.Context, config *scalersconfig.ScalerConfi
 		sqsWrapperClient: &sqsWrapperClient{
 			sqsClient: awsSqsClient,
 		},
-		logger: logger,
+		httpClient: httpClient,
+		logger:     logger,
 	}, nil
 }
 
@@ -123,7 +127,7 @@ func parseAwsSqsQueueMetadata(config *scalersconfig.ScalerConfig) (*awsSqsQueueM
 	return meta, nil
 }
 
-func createSqsClient(ctx context.Context, metadata *awsSqsQueueMetadata) (*sqs.Client, error) {
+func createSqsClient(ctx context.Context, metadata *awsSqsQueueMetadata, httpClient *http.Client) (*sqs.Client, error) {
 	cfg, err := awsutils.GetAwsConfig(ctx, metadata.awsAuthorization)
 	if err != nil {
 		return nil, err
@@ -132,11 +136,17 @@ func createSqsClient(ctx context.Context, metadata *awsSqsQueueMetadata) (*sqs.C
 		if metadata.AwsEndpoint != "" {
 			options.BaseEndpoint = aws.String(metadata.AwsEndpoint)
 		}
+		if httpClient != nil {
+			options.HTTPClient = httpClient
+		}
 	}), nil
 }
 
 func (s *awsSqsQueueScaler) Close(context.Context) error {
 	awsutils.ClearAwsConfig(s.metadata.awsAuthorization)
+	if s.httpClient != nil {
+		s.httpClient.CloseIdleConnections()
+	}
 	return nil
 }
 

--- a/pkg/scalers/aws_sqs_queue_scaler_test.go
+++ b/pkg/scalers/aws_sqs_queue_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strconv"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	awsutils "github.com/kedacore/keda/v2/pkg/scalers/aws"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
 
@@ -489,7 +491,7 @@ func TestAWSSQSGetMetricSpecForScaling(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		mockAWSSQSScaler := awsSqsQueueScaler{"", meta, &mockSqs{}, logr.Discard()}
+		mockAWSSQSScaler := awsSqsQueueScaler{"", meta, &mockSqs{}, nil, logr.Discard()}
 
 		metricSpec := mockAWSSQSScaler.GetMetricSpecForScaling(ctx)
 		metricName := metricSpec[0].External.Metric.Name
@@ -505,7 +507,7 @@ func TestAWSSQSScalerGetMetrics(t *testing.T) {
 		if err != nil {
 			t.Fatal("Could not parse metadata:", err)
 		}
-		scaler := awsSqsQueueScaler{"", meta, &mockSqs{}, logr.Discard()}
+		scaler := awsSqsQueueScaler{"", meta, &mockSqs{}, nil, logr.Discard()}
 
 		value, _, err := scaler.GetMetricsAndActivity(context.Background(), "MetricName")
 		switch meta.QueueURL {
@@ -687,4 +689,71 @@ func TestQueueURLFromEnvResolution(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mockTransport is an http.RoundTripper that tracks whether CloseIdleConnections was called.
+type mockTransport struct {
+	closeIdleCalled bool
+}
+
+func (m *mockTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+}
+
+func (m *mockTransport) CloseIdleConnections() {
+	m.closeIdleCalled = true
+}
+
+func TestAWSSQSScalerCloseClosesHTTPConnections(t *testing.T) {
+	transport := &mockTransport{}
+	httpClient := &http.Client{Transport: transport}
+
+	meta := &awsSqsQueueMetadata{
+		QueueURL:  testAWSSQSProperQueueURL,
+		queueName: "DeleteArtifactQ",
+		AwsRegion: "eu-west-1",
+		awsAuthorization: awsutils.AuthorizationMetadata{
+			TriggerUniqueKey: "test-close-trigger",
+			AwsRegion:        "eu-west-1",
+		},
+	}
+
+	scaler := &awsSqsQueueScaler{
+		metricType:       "",
+		metadata:         meta,
+		sqsWrapperClient: &mockSqs{},
+		httpClient:       httpClient,
+		logger:           logr.Discard(),
+	}
+
+	assert.False(t, transport.closeIdleCalled, "CloseIdleConnections should not have been called yet")
+
+	err := scaler.Close(context.Background())
+	assert.NoError(t, err)
+
+	assert.True(t, transport.closeIdleCalled, "CloseIdleConnections should have been called after Close()")
+}
+
+func TestAWSSQSScalerCloseWithNilHTTPClient(t *testing.T) {
+	meta := &awsSqsQueueMetadata{
+		QueueURL:  testAWSSQSProperQueueURL,
+		queueName: "DeleteArtifactQ",
+		AwsRegion: "eu-west-1",
+		awsAuthorization: awsutils.AuthorizationMetadata{
+			TriggerUniqueKey: "test-nil-http-trigger",
+			AwsRegion:        "eu-west-1",
+		},
+	}
+
+	scaler := &awsSqsQueueScaler{
+		metricType:       "",
+		metadata:         meta,
+		sqsWrapperClient: &mockSqs{},
+		httpClient:       nil,
+		logger:           logr.Discard(),
+	}
+
+	// Should not panic when httpClient is nil
+	err := scaler.Close(context.Background())
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
The AWS SDK-based scalers (SQS, Kinesis, DynamoDB, DynamoDB Streams, CloudWatch) never closed their underlying HTTP transport connections when Close() was called. ClearAwsConfig() only removes credential cache entries but does not shut down the HTTP client. This causes TCP connections to accumulate indefinitely, eventually exhausting file descriptors and causing the operator to lose connectivity.

Store an explicit *http.Client on each scaler struct, inject it into the AWS SDK client via options.HTTPClient, and call CloseIdleConnections() in Close(). This matches the pattern established in PR #5293 for non-AWS scalers.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7756