### PR TITLE
fix: strip unused fields from cached objects to reduce memory footprint

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -100,6 +100,7 @@ func (a *Adapter) makeProvider(ctx context.Context) (provider.ExternalMetricsPro
 		Scheme: scheme,
 		Cache: ctrlcache.Options{
 			DefaultNamespaces: namespaces,
+			DefaultTransform:  kedautil.CacheObjectTransform,
 		},
 		PprofBindAddress: profilingAddr,
 	})

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -176,6 +176,7 @@ func main() {
 		}),
 		Cache: ctrlcache.Options{
 			DefaultNamespaces: namespaces,
+			DefaultTransform:  kedautil.CacheObjectTransform,
 		},
 		HealthProbeBindAddress:  probeAddr,
 		PprofBindAddress:        profilingAddr,

--- a/pkg/util/cache_transform.go
+++ b/pkg/util/cache_transform.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CacheObjectTransform is a controller-runtime cache.DefaultTransform that
+// strips fields KEDA never reads from cached objects. This significantly
+// reduces the memory footprint of the informer cache in large clusters.
+//
+// For all objects: removes ManagedFields.
+// For Pods: preserves ObjectMeta (name, namespace, labels, etc.) but clears
+// annotations; replaces Spec with only NodeName; replaces Status with only
+// Phase and Conditions. Everything else (containers, volumes, env,
+// containerStatuses, etc.) is cleared.
+func CacheObjectTransform(obj any) (any, error) {
+	if accessor, ok := obj.(metav1.Object); ok {
+		if accessor.GetManagedFields() != nil {
+			accessor.SetManagedFields(nil)
+		}
+	}
+
+	if pod, ok := obj.(*corev1.Pod); ok {
+		stripPodFields(pod)
+	}
+
+	return obj, nil
+}
+
+// stripPodFields removes Pod fields that KEDA never reads. KEDA only uses:
+//   - status.phase (workload scaler, fallback, scale_jobs)
+//   - status.conditions (fallback, scale_jobs)
+//   - spec.nodeName (workload scaler with groupByNode)
+func stripPodFields(pod *corev1.Pod) {
+	pod.Annotations = nil
+
+	nodeName := pod.Spec.NodeName
+	pod.Spec = corev1.PodSpec{
+		NodeName: nodeName,
+	}
+
+	phase := pod.Status.Phase
+	conditions := pod.Status.Conditions
+	pod.Status = corev1.PodStatus{
+		Phase:      phase,
+		Conditions: conditions,
+	}
+}

--- a/pkg/util/cache_transform_test.go
+++ b/pkg/util/cache_transform_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCacheObjectTransform_StripsManagedFields(t *testing.T) {
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubectl", Operation: "Apply"},
+			},
+		},
+	}
+
+	result, err := CacheObjectTransform(obj)
+	require.NoError(t, err)
+	cm := result.(*corev1.ConfigMap)
+	assert.Nil(t, cm.ManagedFields)
+	assert.Equal(t, "test", cm.Name)
+}
+
+func TestCacheObjectTransform_StripsPodFields(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "test",
+			},
+			Annotations: map[string]string{
+				"big-annotation": "lots-of-data",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubelet"},
+				{Manager: "kube-scheduler"},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "nginx:latest",
+					Env: []corev1.EnvVar{
+						{Name: "FOO", Value: "bar"},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "data", MountPath: "/data"},
+					},
+				},
+				{
+					Name:  "sidecar",
+					Image: "envoy:latest",
+				},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "init", Image: "busybox"},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+			Tolerations: []corev1.Toleration{
+				{Key: "node.kubernetes.io/not-ready"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			PodIP:  "10.0.0.1",
+			HostIP: "192.168.1.1",
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "app",
+					Ready: true,
+					Image: "nginx:latest",
+				},
+			},
+		},
+	}
+
+	result, err := CacheObjectTransform(pod)
+	require.NoError(t, err)
+
+	p := result.(*corev1.Pod)
+
+	// Metadata: ManagedFields and Annotations stripped, Name/Labels preserved
+	assert.Equal(t, "my-pod", p.Name)
+	assert.Equal(t, "default", p.Namespace)
+	assert.Equal(t, map[string]string{"app": "test"}, p.Labels)
+	assert.Nil(t, p.ManagedFields)
+	assert.Nil(t, p.Annotations)
+
+	// Spec: only NodeName preserved
+	assert.Equal(t, "node-1", p.Spec.NodeName)
+	assert.Nil(t, p.Spec.Containers)
+	assert.Nil(t, p.Spec.InitContainers)
+	assert.Nil(t, p.Spec.Volumes)
+	assert.Nil(t, p.Spec.Tolerations)
+
+	// Status: only Phase and Conditions preserved
+	assert.Equal(t, corev1.PodRunning, p.Status.Phase)
+	assert.Len(t, p.Status.Conditions, 1)
+	assert.Equal(t, corev1.PodReady, p.Status.Conditions[0].Type)
+	assert.Empty(t, p.Status.PodIP)
+	assert.Empty(t, p.Status.HostIP)
+	assert.Nil(t, p.Status.ContainerStatuses)
+}
+
+func TestCacheObjectTransform_NilManagedFields(t *testing.T) {
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+
+	result, err := CacheObjectTransform(obj)
+	require.NoError(t, err)
+	cm := result.(*corev1.ConfigMap)
+	assert.Nil(t, cm.ManagedFields)
+	assert.Equal(t, "test", cm.Name)
+}
+
+func TestCacheObjectTransform_NonMetaObject(t *testing.T) {
+	plain := "not-a-k8s-object"
+	result, err := CacheObjectTransform(plain)
+	require.NoError(t, err)
+	assert.Equal(t, "not-a-k8s-object", result)
+}


### PR DESCRIPTION
Add a `DefaultTransform` to the controller-runtime cache that strips
fields KEDA never reads from cached objects:

- **All types:** `ManagedFields` are removed.
- **Pods:** Only `Status.Phase`, `Status.Conditions`, and `Spec.NodeName`
  are retained — everything else (containers, volumes, env, annotations,
  containerStatuses) is cleared.

KEDA's production code lists live Pods in only three places (workload
scaler, fallback ready-replica count, ScaledJob pending detection), and
across those call sites it reads only `Status.Phase`,
`Status.Conditions`, and optionally `Spec.NodeName` (for `groupByNode`).
All other Pod fields are dead weight in the informer cache.

### Results (KWOK load test with large pods — 92 labels, 91 annotations, 5 containers)

| | baseline | 100 pods | 1000 pods | delta |
|---|---|---|---|---|
| **Before** | 28 Mi | 53 Mi | 269 Mi | **+241 Mi** |
| **After** | 23 Mi | 32 Mi | 46 Mi | **+23 Mi** |

Per-pod memory cost drops from ~241 KB to ~23 KB — a **~90% reduction**.

The reporter's data from #7728 showed OOMKill at ~3000 pods (1000 Mi limit).
With this fix, 3000 pods would use ~69 Mi of additional memory, well within
the default limit.

> **Load test:** A KWOK-based load test to reproduce and measure the issue is available at
> [`Fedosin/keda:load-test-kwok`](https://github.com/Fedosin/keda/tree/load-test-kwok/hack/load-test).

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7728