### PR TITLE
fix: validate Jolokia template parameters safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))
+- **ActiveMQ Scaler, Artemis Scaler**: Validate malformed `restAPITemplate` metadata without recovered panics ([#7750](https://github.com/kedacore/keda/pull/7750))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))
 - **Azure Event Hub Scaler**: Reject non-positive `unprocessedEventThreshold` to prevent integer division by zero when computing lag ([#7732](https://github.com/kedacore/keda/issues/7732))
 - **Cron Scaler**: Fix metric name generation so cron expressions with comma-separated values no longer produce invalid metric names ([#7448](https://github.com/kedacore/keda/issues/7448))

--- a/pkg/scalers/activemq_scaler.go
+++ b/pkg/scalers/activemq_scaler.go
@@ -55,21 +55,30 @@ func (a *activeMQMetadata) Validate() error {
 		}
 		a.ManagementEndpoint = u.Host
 		// This returns : type=Broker,brokerName=<<brokerName>>,destinationType=Queue,destinationName=<<destinationName>>
-		splitURL := strings.Split(strings.Split(u.Path, ":")[1], "/")[0]
+		objectNameParts := strings.SplitN(u.Path, ":", 2)
+		if len(objectNameParts) != 2 {
+			return fmt.Errorf("unable to parse ActiveMQ restAPITemplate: missing Jolokia object name")
+		}
+		splitURL := strings.SplitN(objectNameParts[1], "/", 2)[0]
+		if splitURL == "" {
+			return fmt.Errorf("unable to parse ActiveMQ restAPITemplate: missing Jolokia object name")
+		}
 		replacer := strings.NewReplacer(",", "&")
 		// This returns a map with key: string types and element type [] string. : map[brokerName:[<<brokerName>>] destinationName:[<<destinationName>>] destinationType:[Queue] type:[Broker]]
 		v, err := url.ParseQuery(replacer.Replace(splitURL))
 		if err != nil {
 			return fmt.Errorf("unable to parse ActiveMQ restAPITemplate: %w", err)
 		}
-		if len(v["destinationName"][0]) == 0 {
+		destinationName := v["destinationName"]
+		if len(destinationName) == 0 || len(destinationName[0]) == 0 {
 			return fmt.Errorf("no destinationName is given")
 		}
-		a.DestinationName = v["destinationName"][0]
-		if len(v["brokerName"][0]) == 0 {
+		a.DestinationName = destinationName[0]
+		brokerName := v["brokerName"]
+		if len(brokerName) == 0 || len(brokerName[0]) == 0 {
 			return fmt.Errorf("no brokerName given: %s", a.RestAPITemplate)
 		}
-		a.BrokerName = v["brokerName"][0]
+		a.BrokerName = brokerName[0]
 	} else {
 		a.RestAPITemplate = defaultActiveMQRestAPITemplate
 		if a.ManagementEndpoint == "" {

--- a/pkg/scalers/activemq_scaler_test.go
+++ b/pkg/scalers/activemq_scaler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -243,6 +244,24 @@ func TestActiveMQCorsHeader(t *testing.T) {
 	}
 	if meta.CorsHeader != "test" {
 		t.Errorf("Expected test but got %s", meta.CorsHeader)
+	}
+}
+
+func TestActiveMQInvalidRestAPITemplateDoesNotPanic(t *testing.T) {
+	metadata := map[string]string{
+		"restAPITemplate": "http://localhost:8161/api/jolokia/read/org.apache.activemq/QueueSize",
+	}
+	authParams := map[string]string{
+		"username": "testUsername",
+		"password": "pass123",
+	}
+
+	_, err := parseActiveMQMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: metadata, AuthParams: authParams})
+	if err == nil {
+		t.Fatal("Expected error but got success")
+	}
+	if strings.Contains(err.Error(), "resulted in panic") {
+		t.Fatalf("Expected validation error but got recovered panic: %v", err)
 	}
 }
 

--- a/pkg/scalers/artemis_scaler.go
+++ b/pkg/scalers/artemis_scaler.go
@@ -138,27 +138,41 @@ func getAPIParameters(meta artemisMetadata) (artemisMetadata, error) {
 		return meta, fmt.Errorf("unable to parse the artemis restAPITemplate: %w", err)
 	}
 	meta.ManagementEndpoint = u.Host
-	splitURL := strings.Split(strings.Split(u.RawPath, ":")[1], "/")[0] // This returns : broker="<<brokerName>>",component=addresses,address="<<brokerAddress>>",subcomponent=queues,routing-type="anycast",queue="<<queueName>>"
+	path := u.RawPath
+	if path == "" {
+		path = u.Path
+	}
+	objectNameParts := strings.SplitN(path, ":", 2)
+	if len(objectNameParts) != 2 {
+		return meta, errors.New("unable to parse the artemis restAPITemplate: missing Jolokia object name")
+	}
+	splitURL := strings.SplitN(objectNameParts[1], "/", 2)[0] // This returns : broker="<<brokerName>>",component=addresses,address="<<brokerAddress>>",subcomponent=queues,routing-type="anycast",queue="<<queueName>>"
+	if splitURL == "" {
+		return meta, errors.New("unable to parse the artemis restAPITemplate: missing Jolokia object name")
+	}
 	replacer := strings.NewReplacer(",", "&", "\"\"", "")
 	v, err := url.ParseQuery(replacer.Replace(splitURL)) // This returns a map with key: string types and element type [] string. : map[address:["<<brokerAddress>>"] broker:["<<brokerName>>"] component:[addresses] queue:["<<queueName>>"] routing-type:["anycast"] subcomponent:[queues]]
 	if err != nil {
 		return meta, fmt.Errorf("unable to parse the artemis restAPITemplate: %w", err)
 	}
 
-	if len(v["address"][0]) == 0 {
+	address := v["address"]
+	if len(address) == 0 || len(address[0]) == 0 {
 		return meta, errors.New("no brokerAddress given")
 	}
-	meta.BrokerAddress = v["address"][0]
+	meta.BrokerAddress = address[0]
 
-	if len(v["queue"][0]) == 0 {
+	queue := v["queue"]
+	if len(queue) == 0 || len(queue[0]) == 0 {
 		return meta, errors.New("no queueName is given")
 	}
-	meta.QueueName = v["queue"][0]
+	meta.QueueName = queue[0]
 
-	if len(v["broker"][0]) == 0 {
+	broker := v["broker"]
+	if len(broker) == 0 || len(broker[0]) == 0 {
 		return meta, fmt.Errorf("no brokerName given: %s", meta.RestAPITemplate)
 	}
-	meta.BrokerName = v["broker"][0]
+	meta.BrokerName = broker[0]
 
 	return meta, nil
 }

--- a/pkg/scalers/artemis_scaler_test.go
+++ b/pkg/scalers/artemis_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -115,6 +116,22 @@ func TestArtemisCorsHeader(t *testing.T) {
 	}
 	if meta.CorsHeader != "test" {
 		t.Errorf("Expected test but got %s", meta.CorsHeader)
+	}
+}
+
+func TestArtemisInvalidRestAPITemplateDoesNotPanic(t *testing.T) {
+	metadata := map[string]string{
+		"restApiTemplate": "http://localhost:8161/console/jolokia/read/org.apache.activemq.artemis/MessageCount",
+		"username":        "myUserName",
+		"password":        "myPassword",
+	}
+
+	_, err := parseArtemisMetadata(&scalersconfig.ScalerConfig{ResolvedEnv: sampleArtemisResolvedEnv, TriggerMetadata: metadata, AuthParams: nil})
+	if err == nil {
+		t.Fatal("Expected error but got success")
+	}
+	if strings.Contains(err.Error(), "resulted in panic") {
+		t.Fatalf("Expected validation error but got recovered panic: %v", err)
 	}
 }
 


### PR DESCRIPTION
_Provide a description of what has been changed_

Small papercut fix for ActiveMQ and Artemis `restAPITemplate` parsing.

A valid URL with the wrong Jolokia shape used to hit a recovered bounds panic. now it returns a normal validation error, no drama.

Repro:
```bash
go test ./pkg/scalers -run "Test(ActiveMQ|Artemis)InvalidRestAPITemplateDoesNotPanic"
```

Before this fix those cases fail with `resulted in panic`. After it, they fail cleanly during metadata validation.

Related: #2097

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #2097