### PR TITLE
General: Add flag to enable high-cardinality HTTP duration labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ New deprecation(s):
 
 - **General**: Add cooldownPeriod and pollingInterval checks for ScaledObject ([#7271](https://github.com/kedacore/keda/pull/7271))
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
+- **General**: Add `--enable-high-cardinality-metrics` to let users disable high-cardinality metrics such as HTTP and gRPC duration histograms ([#7731](https://github.com/kedacore/keda/issues/7731))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Add scaler HTTP request metrics (`keda_scaler_http_requests_total`, `keda_scaler_http_request_duration_seconds`) for outbound HTTP requests made during scaler metric collection ([#6600](https://github.com/kedacore/keda/issues/6600))
 - **General**: Allow more control of TLS versions & ciphers via `KEDA_HTTP_TLS_CIPHER_LIST`, `KEDA_SERVICE_TLS_CIPHER_LIST` and `KEDA_SERVICE_MIN_TLS_VERSION` env vars ([#7617](https://github.com/kedacore/keda/pull/7617))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ New deprecation(s):
 
 - **General**: Add cooldownPeriod and pollingInterval checks for ScaledObject ([#7271](https://github.com/kedacore/keda/pull/7271))
 - **General**: Add CRD-level validation markers (Minimum, MinLength, MinItems, Enum) for ScaledObject, ScaledJob, ScaleTriggers, and TriggerAuthentication API types ([#7533](https://github.com/kedacore/keda/pull/7533))
-- **General**: Add `--enable-high-cardinality-metrics` to let users disable high-cardinality metrics such as HTTP and gRPC duration histograms ([#7731](https://github.com/kedacore/keda/issues/7731))
+- **General**: Add `--enable-high-cardinality-metrics-labels` to let users enable high-cardinality labels on scaler HTTP request duration metrics ([#7731](https://github.com/kedacore/keda/issues/7731))
 - **General**: Add `--leader-election-id` flag to allow configuring the leader election Lease name ([#7564](https://github.com/kedacore/keda/issues/7564))
 - **General**: Add scaler HTTP request metrics (`keda_scaler_http_requests_total`, `keda_scaler_http_request_duration_seconds`) for outbound HTTP requests made during scaler metric collection ([#6600](https://github.com/kedacore/keda/issues/6600))
 - **General**: Allow more control of TLS versions & ciphers via `KEDA_HTTP_TLS_CIPHER_LIST`, `KEDA_SERVICE_TLS_CIPHER_LIST` and `KEDA_SERVICE_MIN_TLS_VERSION` env vars ([#7617](https://github.com/kedacore/keda/pull/7617))

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -58,16 +58,17 @@ type Adapter struct {
 var setupLog = ctrl.Log.WithName("keda_metrics_adapter")
 
 var (
-	adapterClientRequestQPS     float32
-	adapterClientRequestBurst   int
-	metricsAPIServerPort        int
-	disableCompression          bool
-	metricsServiceAddr          string
-	profilingAddr               string
-	metricsServiceGRPCAuthority string
-	logToSTDerr                 bool
-	verbosityLevel              int
-	stdErrThreshold             string
+	adapterClientRequestQPS      float32
+	adapterClientRequestBurst    int
+	enableHighCardinalityMetrics bool
+	metricsAPIServerPort         int
+	disableCompression           bool
+	metricsServiceAddr           string
+	profilingAddr                string
+	metricsServiceGRPCAuthority  string
+	logToSTDerr                  bool
+	verbosityLevel               int
+	stdErrThreshold              string
 )
 
 func (a *Adapter) makeProvider(ctx context.Context) (provider.ExternalMetricsProvider, error) {
@@ -92,7 +93,7 @@ func (a *Adapter) makeProvider(ctx context.Context) (provider.ExternalMetricsPro
 	cfg.Burst = adapterClientRequestBurst
 	cfg.DisableCompression = disableCompression
 
-	clientMetrics := getMetricInterceptor()
+	clientMetrics := getMetricInterceptor(enableHighCardinalityMetrics)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Metrics: server.Options{
@@ -145,7 +146,7 @@ func getMetricHandler() http.HandlerFunc {
 }
 
 // getMetricInterceptor returns a metrics inceptor that records metrics between the adapter and opertaor
-func getMetricInterceptor() *grpcprom.ClientMetrics {
+func getMetricInterceptor(enableHighCardinalityMetrics bool) *grpcprom.ClientMetrics {
 	metricsNamespace := "keda_internal_metricsservice"
 
 	counterNamespace := func(o *prometheus.CounterOpts) {
@@ -156,13 +157,19 @@ func getMetricInterceptor() *grpcprom.ClientMetrics {
 		o.Namespace = metricsNamespace
 	}
 
-	clientMetrics := grpcprom.NewClientMetrics(
-		grpcprom.WithClientHandlingTimeHistogram(
-			grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
-			histogramNamespace,
-		),
+	options := []grpcprom.ClientMetricsOption{
 		grpcprom.WithClientCounterOptions(counterNamespace),
-	)
+	}
+	if enableHighCardinalityMetrics {
+		options = append(options,
+			grpcprom.WithClientHandlingTimeHistogram(
+				grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
+				histogramNamespace,
+			),
+		)
+	}
+
+	clientMetrics := grpcprom.NewClientMetrics(options...)
 	legacyregistry.Registerer().MustRegister(clientMetrics)
 
 	return clientMetrics
@@ -243,6 +250,7 @@ func main() {
 	cmd.Flags().Float32Var(&adapterClientRequestQPS, "kube-api-qps", 20.0, "Set the QPS rate for throttling requests sent to the apiserver")
 	cmd.Flags().IntVar(&adapterClientRequestBurst, "kube-api-burst", 30, "Set the burst for throttling requests sent to the apiserver")
 	cmd.Flags().BoolVar(&disableCompression, "disable-compression", true, "Disable response compression for k8s restAPI in client-go. ")
+	cmd.Flags().BoolVar(&enableHighCardinalityMetrics, "enable-high-cardinality-metrics", true, "Enable high-cardinality metrics of keda-metrics-apiserver, such as gRPC duration histograms.")
 
 	// legacy klogr flags handled for backwards compatibility. Default set to -1 so it doesn't override values set via zap options
 	cmd.Flags().IntVar(&verbosityLevel, "v", -1, "Logging level for Metrics Server. (DEPRECATED)")

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -58,17 +58,16 @@ type Adapter struct {
 var setupLog = ctrl.Log.WithName("keda_metrics_adapter")
 
 var (
-	adapterClientRequestQPS      float32
-	adapterClientRequestBurst    int
-	enableHighCardinalityMetrics bool
-	metricsAPIServerPort         int
-	disableCompression           bool
-	metricsServiceAddr           string
-	profilingAddr                string
-	metricsServiceGRPCAuthority  string
-	logToSTDerr                  bool
-	verbosityLevel               int
-	stdErrThreshold              string
+	adapterClientRequestQPS     float32
+	adapterClientRequestBurst   int
+	metricsAPIServerPort        int
+	disableCompression          bool
+	metricsServiceAddr          string
+	profilingAddr               string
+	metricsServiceGRPCAuthority string
+	logToSTDerr                 bool
+	verbosityLevel              int
+	stdErrThreshold             string
 )
 
 func (a *Adapter) makeProvider(ctx context.Context) (provider.ExternalMetricsProvider, error) {
@@ -93,7 +92,7 @@ func (a *Adapter) makeProvider(ctx context.Context) (provider.ExternalMetricsPro
 	cfg.Burst = adapterClientRequestBurst
 	cfg.DisableCompression = disableCompression
 
-	clientMetrics := getMetricInterceptor(enableHighCardinalityMetrics)
+	clientMetrics := getMetricInterceptor()
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Metrics: server.Options{
@@ -146,7 +145,7 @@ func getMetricHandler() http.HandlerFunc {
 }
 
 // getMetricInterceptor returns a metrics inceptor that records metrics between the adapter and opertaor
-func getMetricInterceptor(enableHighCardinalityMetrics bool) *grpcprom.ClientMetrics {
+func getMetricInterceptor() *grpcprom.ClientMetrics {
 	metricsNamespace := "keda_internal_metricsservice"
 
 	counterNamespace := func(o *prometheus.CounterOpts) {
@@ -157,19 +156,13 @@ func getMetricInterceptor(enableHighCardinalityMetrics bool) *grpcprom.ClientMet
 		o.Namespace = metricsNamespace
 	}
 
-	options := []grpcprom.ClientMetricsOption{
+	clientMetrics := grpcprom.NewClientMetrics(
+		grpcprom.WithClientHandlingTimeHistogram(
+			grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
+			histogramNamespace,
+		),
 		grpcprom.WithClientCounterOptions(counterNamespace),
-	}
-	if enableHighCardinalityMetrics {
-		options = append(options,
-			grpcprom.WithClientHandlingTimeHistogram(
-				grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
-				histogramNamespace,
-			),
-		)
-	}
-
-	clientMetrics := grpcprom.NewClientMetrics(options...)
+	)
 	legacyregistry.Registerer().MustRegister(clientMetrics)
 
 	return clientMetrics
@@ -250,7 +243,6 @@ func main() {
 	cmd.Flags().Float32Var(&adapterClientRequestQPS, "kube-api-qps", 20.0, "Set the QPS rate for throttling requests sent to the apiserver")
 	cmd.Flags().IntVar(&adapterClientRequestBurst, "kube-api-burst", 30, "Set the burst for throttling requests sent to the apiserver")
 	cmd.Flags().BoolVar(&disableCompression, "disable-compression", true, "Disable response compression for k8s restAPI in client-go. ")
-	cmd.Flags().BoolVar(&enableHighCardinalityMetrics, "enable-high-cardinality-metrics", true, "Enable high-cardinality metrics of keda-metrics-apiserver, such as gRPC duration histograms.")
 
 	// legacy klogr flags handled for backwards compatibility. Default set to -1 so it doesn't override values set via zap options
 	cmd.Flags().IntVar(&verbosityLevel, "v", -1, "Logging level for Metrics Server. (DEPRECATED)")

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -69,6 +69,7 @@ func init() {
 func main() {
 	var enablePrometheusMetrics bool
 	var enableOpenTelemetryMetrics bool
+	var enableHighCardinalityMetrics bool
 	var metricsAddr string
 	var probeAddr string
 	var metricsServiceAddr string
@@ -93,6 +94,7 @@ func main() {
 	var filePathAuthRootPath string
 	pflag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", true, "Enable the prometheus metric of keda-operator.")
 	pflag.BoolVar(&enableOpenTelemetryMetrics, "enable-opentelemetry-metrics", false, "Enable the opentelemetry metric of keda-operator.")
+	pflag.BoolVar(&enableHighCardinalityMetrics, "enable-high-cardinality-metrics", true, "Enable high-cardinality metrics of keda-operator, such as HTTP and gRPC duration histograms.")
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the prometheus metric endpoint binds to.")
 	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	pflag.StringVar(&metricsServiceAddr, "metrics-service-bind-address", ":9666", "The address the gRPRC Metrics Service endpoint binds to.")
@@ -176,7 +178,11 @@ func main() {
 	if !enablePrometheusMetrics {
 		metricsAddr = "0"
 	}
-	metricscollector.NewMetricsCollectors(enablePrometheusMetrics, enableOpenTelemetryMetrics)
+	metricscollector.NewMetricsCollectors(metricscollector.Options{
+		EnablePrometheusMetrics:      enablePrometheusMetrics,
+		EnableOpenTelemetryMetrics:   enableOpenTelemetryMetrics,
+		EnableHighCardinalityMetrics: enableHighCardinalityMetrics,
+	})
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -69,7 +69,7 @@ func init() {
 func main() {
 	var enablePrometheusMetrics bool
 	var enableOpenTelemetryMetrics bool
-	var enableHighCardinalityMetrics bool
+	var enableHighCardinalityLabels bool
 	var metricsAddr string
 	var probeAddr string
 	var metricsServiceAddr string
@@ -94,7 +94,7 @@ func main() {
 	var filePathAuthRootPath string
 	pflag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", true, "Enable the prometheus metric of keda-operator.")
 	pflag.BoolVar(&enableOpenTelemetryMetrics, "enable-opentelemetry-metrics", false, "Enable the opentelemetry metric of keda-operator.")
-	pflag.BoolVar(&enableHighCardinalityMetrics, "enable-high-cardinality-metrics", true, "Enable high-cardinality metrics of keda-operator, such as HTTP and gRPC duration histograms.")
+	pflag.BoolVar(&enableHighCardinalityLabels, "enable-high-cardinality-metrics-labels", false, "Enable high-cardinality labels for scaler HTTP request duration metrics.")
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the prometheus metric endpoint binds to.")
 	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	pflag.StringVar(&metricsServiceAddr, "metrics-service-bind-address", ":9666", "The address the gRPRC Metrics Service endpoint binds to.")
@@ -179,9 +179,9 @@ func main() {
 		metricsAddr = "0"
 	}
 	metricscollector.NewMetricsCollectors(metricscollector.Options{
-		EnablePrometheusMetrics:      enablePrometheusMetrics,
-		EnableOpenTelemetryMetrics:   enableOpenTelemetryMetrics,
-		EnableHighCardinalityMetrics: enableHighCardinalityMetrics,
+		EnablePrometheusMetrics:     enablePrometheusMetrics,
+		EnableOpenTelemetryMetrics:  enableOpenTelemetryMetrics,
+		EnableHighCardinalityLabels: enableHighCardinalityLabels,
 	})
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{

--- a/pkg/metricscollector/http_roundtripper_test.go
+++ b/pkg/metricscollector/http_roundtripper_test.go
@@ -49,14 +49,19 @@ func fakeResponse(statusCode int) *http.Response {
 	}
 }
 
-func withPromCollector(t *testing.T) {
+func withPromCollector(t *testing.T) *PromMetrics {
 	t.Helper()
 
 	previousCollectors := collectors
-	collectors = []MetricsCollector{&PromMetrics{enableHighCardinalityMetrics: true}}
+	collector := &PromMetrics{
+		enableHighCardinalityLabels: true,
+		httpClientRequestDuration:   newHTTPClientRequestDuration(true),
+	}
+	collectors = []MetricsCollector{collector}
 	t.Cleanup(func() {
 		collectors = previousCollectors
 	})
+	return collector
 }
 
 func TestInstrumentedRoundTripper_RecordsSuccessfulResponses(t *testing.T) {
@@ -72,7 +77,7 @@ func TestInstrumentedRoundTripper_RecordsSuccessfulResponses(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			RegisterTestingT(t)
-			withPromCollector(t)
+			collector := withPromCollector(t)
 
 			scalerName := fmt.Sprintf("prometheus-%d", tc.statusCode)
 			triggerName := fmt.Sprintf("trigger-%d", tc.statusCode)
@@ -107,8 +112,8 @@ func TestInstrumentedRoundTripper_RecordsSuccessfulResponses(t *testing.T) {
 			Expect(err).To(BeNil())
 			Expect(m.Counter.GetValue()).To(BeNumerically("==", 1))
 
-			durationHistogram, err := httpClientRequestDuration.
-				GetMetricWithLabelValues(scalerName, fmt.Sprintf("%d", tc.statusCode))
+			durationHistogram, err := collector.httpClientRequestDuration.
+				GetMetricWithLabelValues("default", scaledResource, scalerName, triggerName, metricName, fmt.Sprintf("%d", tc.statusCode))
 			Expect(err).To(BeNil())
 			Expect(durationHistogram).NotTo(BeNil())
 			err = durationHistogram.(prometheus.Metric).Write(m)
@@ -120,7 +125,7 @@ func TestInstrumentedRoundTripper_RecordsSuccessfulResponses(t *testing.T) {
 
 func TestInstrumentedRoundTripper_RecordsTransportErrors(t *testing.T) {
 	RegisterTestingT(t)
-	withPromCollector(t)
+	collector := withPromCollector(t)
 
 	scalerName := "prometheus-transport-error"
 	triggerName := "trigger-transport-error"
@@ -156,8 +161,8 @@ func TestInstrumentedRoundTripper_RecordsTransportErrors(t *testing.T) {
 	Expect(err).To(BeNil())
 	Expect(m.Counter.GetValue()).To(BeNumerically("==", 1))
 
-	durationHistogram, err := httpClientRequestDuration.
-		GetMetricWithLabelValues(scalerName, "error")
+	durationHistogram, err := collector.httpClientRequestDuration.
+		GetMetricWithLabelValues("default", scaledResource, scalerName, triggerName, metricName, "error")
 	Expect(err).To(BeNil())
 	Expect(durationHistogram).NotTo(BeNil())
 	err = durationHistogram.(prometheus.Metric).Write(m)

--- a/pkg/metricscollector/http_roundtripper_test.go
+++ b/pkg/metricscollector/http_roundtripper_test.go
@@ -53,7 +53,7 @@ func withPromCollector(t *testing.T) {
 	t.Helper()
 
 	previousCollectors := collectors
-	collectors = []MetricsCollector{&PromMetrics{}}
+	collectors = []MetricsCollector{&PromMetrics{enableHighCardinalityMetrics: true}}
 	t.Cleanup(func() {
 		collectors = previousCollectors
 	})

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -38,6 +38,12 @@ var (
 	promServerMetrics *grpcprom.ServerMetrics
 )
 
+type Options struct {
+	EnablePrometheusMetrics      bool
+	EnableOpenTelemetryMetrics   bool
+	EnableHighCardinalityMetrics bool
+}
+
 type MetricsCollector interface {
 	RecordScalerMetric(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value float64)
 
@@ -91,18 +97,18 @@ type MetricsCollector interface {
 	RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string)
 }
 
-func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool) {
-	if enablePrometheusMetrics {
-		promometrics := NewPromMetrics()
+func NewMetricsCollectors(options Options) {
+	if options.EnablePrometheusMetrics {
+		promometrics := NewPromMetrics(options.EnableHighCardinalityMetrics)
 		collectors = append(collectors, promometrics)
 
 		if promServerMetrics == nil {
-			promServerMetrics = newPromServerMetrics()
+			promServerMetrics = newPromServerMetrics(options.EnableHighCardinalityMetrics)
 		}
 	}
 
-	if enableOpenTelemetryMetrics {
-		otelmetrics := NewOtelMetrics()
+	if options.EnableOpenTelemetryMetrics {
+		otelmetrics := NewOtelMetrics(options.EnableHighCardinalityMetrics)
 		collectors = append(collectors, otelmetrics)
 	}
 }

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -39,9 +39,9 @@ var (
 )
 
 type Options struct {
-	EnablePrometheusMetrics      bool
-	EnableOpenTelemetryMetrics   bool
-	EnableHighCardinalityMetrics bool
+	EnablePrometheusMetrics     bool
+	EnableOpenTelemetryMetrics  bool
+	EnableHighCardinalityLabels bool
 }
 
 type MetricsCollector interface {
@@ -99,16 +99,16 @@ type MetricsCollector interface {
 
 func NewMetricsCollectors(options Options) {
 	if options.EnablePrometheusMetrics {
-		promometrics := NewPromMetrics(options.EnableHighCardinalityMetrics)
+		promometrics := NewPromMetrics(options.EnableHighCardinalityLabels)
 		collectors = append(collectors, promometrics)
 
 		if promServerMetrics == nil {
-			promServerMetrics = newPromServerMetrics(options.EnableHighCardinalityMetrics)
+			promServerMetrics = newPromServerMetrics()
 		}
 	}
 
 	if options.EnableOpenTelemetryMetrics {
-		otelmetrics := NewOtelMetrics(options.EnableHighCardinalityMetrics)
+		otelmetrics := NewOtelMetrics(options.EnableHighCardinalityLabels)
 		collectors = append(collectors, otelmetrics)
 	}
 }

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -54,7 +54,7 @@ var (
 )
 
 type OtelMetrics struct {
-	enableHighCardinalityMetrics bool
+	enableHighCardinalityLabels bool
 }
 
 type OtelMetricInt64Val struct {
@@ -67,7 +67,7 @@ type OtelMetricFloat64Val struct {
 	measurementOption api.MeasurementOption
 }
 
-func NewOtelMetrics(enableHighCardinalityMetrics bool, options ...metric.Option) *OtelMetrics {
+func NewOtelMetrics(enableHighCardinalityLabels bool, options ...metric.Option) *OtelMetrics {
 	// create default options with env
 	if options == nil {
 		protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
@@ -94,14 +94,14 @@ func NewOtelMetrics(enableHighCardinalityMetrics bool, options ...metric.Option)
 	otel.SetMeterProvider(meterProvider)
 
 	meter = meterProvider.Meter(meterName)
-	initMeters(enableHighCardinalityMetrics)
+	initMeters()
 
-	otel := &OtelMetrics{enableHighCardinalityMetrics: enableHighCardinalityMetrics}
+	otel := &OtelMetrics{enableHighCardinalityLabels: enableHighCardinalityLabels}
 	otel.RecordBuildInfo()
 	return otel
 }
 
-func initMeters(enableHighCardinalityMetrics bool) {
+func initMeters() {
 	var err error
 	msg := "failed to create OpenTelemetry instrument"
 
@@ -239,16 +239,13 @@ func initMeters(enableHighCardinalityMetrics bool) {
 		otLog.Error(err, msg)
 	}
 
-	otHTTPClientRequestDuration = nil
-	if enableHighCardinalityMetrics {
-		otHTTPClientRequestDuration, err = meter.Float64Histogram(
-			"keda.scaler.http.request.duration.seconds",
-			api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric collection."),
-			api.WithUnit("s"),
-		)
-		if err != nil {
-			otLog.Error(err, msg)
-		}
+	otHTTPClientRequestDuration, err = meter.Float64Histogram(
+		"keda.scaler.http.request.duration.seconds",
+		api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric collection."),
+		api.WithUnit("s"),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
 	}
 }
 
@@ -537,11 +534,22 @@ func (o *OtelMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCod
 		attribute.Key("status_code").String(code),
 	)
 	otHTTPClientRequestsCounter.Add(context.Background(), 1, counterOpt)
-	if o.enableHighCardinalityMetrics && otHTTPClientRequestDuration != nil {
-		histOpt := api.WithAttributes(
+	if otHTTPClientRequestDuration != nil {
+		attrs := []attribute.KeyValue{
 			attribute.Key("scaler").String(scaler),
 			attribute.Key("status_code").String(code),
-		)
+		}
+		if o.enableHighCardinalityLabels {
+			attrs = append([]attribute.KeyValue{
+				attribute.Key("namespace").String(namespace),
+				attribute.Key("scaled_resource").String(scaledResource),
+			}, attrs...)
+			attrs = append(attrs,
+				attribute.Key("trigger_name").String(triggerName),
+				attribute.Key("metric_name").String(metricName),
+			)
+		}
+		histOpt := api.WithAttributes(attrs...)
 		otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, histOpt)
 	}
 }

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -54,6 +54,7 @@ var (
 )
 
 type OtelMetrics struct {
+	enableHighCardinalityMetrics bool
 }
 
 type OtelMetricInt64Val struct {
@@ -66,7 +67,7 @@ type OtelMetricFloat64Val struct {
 	measurementOption api.MeasurementOption
 }
 
-func NewOtelMetrics(options ...metric.Option) *OtelMetrics {
+func NewOtelMetrics(enableHighCardinalityMetrics bool, options ...metric.Option) *OtelMetrics {
 	// create default options with env
 	if options == nil {
 		protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
@@ -93,14 +94,14 @@ func NewOtelMetrics(options ...metric.Option) *OtelMetrics {
 	otel.SetMeterProvider(meterProvider)
 
 	meter = meterProvider.Meter(meterName)
-	initMeters()
+	initMeters(enableHighCardinalityMetrics)
 
-	otel := &OtelMetrics{}
+	otel := &OtelMetrics{enableHighCardinalityMetrics: enableHighCardinalityMetrics}
 	otel.RecordBuildInfo()
 	return otel
 }
 
-func initMeters() {
+func initMeters(enableHighCardinalityMetrics bool) {
 	var err error
 	msg := "failed to create OpenTelemetry instrument"
 
@@ -238,13 +239,16 @@ func initMeters() {
 		otLog.Error(err, msg)
 	}
 
-	otHTTPClientRequestDuration, err = meter.Float64Histogram(
-		"keda.scaler.http.request.duration.seconds",
-		api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric collection."),
-		api.WithUnit("s"),
-	)
-	if err != nil {
-		otLog.Error(err, msg)
+	otHTTPClientRequestDuration = nil
+	if enableHighCardinalityMetrics {
+		otHTTPClientRequestDuration, err = meter.Float64Histogram(
+			"keda.scaler.http.request.duration.seconds",
+			api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric collection."),
+			api.WithUnit("s"),
+		)
+		if err != nil {
+			otLog.Error(err, msg)
+		}
 	}
 }
 
@@ -532,12 +536,14 @@ func (o *OtelMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCod
 		attribute.Key("metric_name").String(metricName),
 		attribute.Key("status_code").String(code),
 	)
-	histOpt := api.WithAttributes(
-		attribute.Key("scaler").String(scaler),
-		attribute.Key("status_code").String(code),
-	)
 	otHTTPClientRequestsCounter.Add(context.Background(), 1, counterOpt)
-	otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, histOpt)
+	if o.enableHighCardinalityMetrics && otHTTPClientRequestDuration != nil {
+		histOpt := api.WithAttributes(
+			attribute.Key("scaler").String(scaler),
+			attribute.Key("status_code").String(code),
+		)
+		otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, histOpt)
+	}
 }
 
 // RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -21,10 +21,10 @@ func init() {
 	testOtel = NewOtelMetrics(true, options)
 }
 
-func resetTestOtel(enableHighCardinalityMetrics bool) {
+func resetTestOtel(enableHighCardinalityLabels bool) {
 	testReader = metric.NewManualReader()
 	options := metric.WithReader(testReader)
-	testOtel = NewOtelMetrics(enableHighCardinalityMetrics, options)
+	testOtel = NewOtelMetrics(enableHighCardinalityLabels, options)
 }
 
 func retrieveMetric(metrics []metricdata.Metrics, metricname string) *metricdata.Metrics {
@@ -166,11 +166,20 @@ func TestRecordHTTPClientRequest(t *testing.T) {
 			requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.request.duration.seconds")
 			assert.NotNil(t, requestDuration)
 			assert.Equal(t, "s", requestDuration.Unit)
+			histogramDataPoint := requestDuration.Data.(metricdata.Histogram[float64]).DataPoints[0]
+			triggerName, _ := histogramDataPoint.Attributes.Value("trigger_name")
+			assert.Equal(t, "my-trigger", triggerName.AsString())
+			metricName, _ := histogramDataPoint.Attributes.Value("metric_name")
+			assert.Equal(t, "my-metric", metricName.AsString())
+			ns, _ := histogramDataPoint.Attributes.Value("namespace")
+			assert.Equal(t, "default", ns.AsString())
+			sr, _ := histogramDataPoint.Attributes.Value("scaled_resource")
+			assert.Equal(t, "my-so", sr.AsString())
 		})
 	}
 }
 
-func TestRecordHTTPClientRequest_DisablesHighCardinalityMetrics(t *testing.T) {
+func TestRecordHTTPClientRequest_DisablesHighCardinalityLabels(t *testing.T) {
 	resetTestOtel(false)
 
 	testOtel.RecordHTTPClientRequest(0.1, 200, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
@@ -183,7 +192,23 @@ func TestRecordHTTPClientRequest_DisablesHighCardinalityMetrics(t *testing.T) {
 	assert.NotNil(t, requestCount)
 
 	requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.request.duration.seconds")
-	assert.Nil(t, requestDuration)
+	assert.NotNil(t, requestDuration)
+
+	dataPoint := requestDuration.Data.(metricdata.Histogram[float64]).DataPoints[0]
+	_, ok := dataPoint.Attributes.Value("namespace")
+	assert.False(t, ok)
+	_, ok = dataPoint.Attributes.Value("scaled_resource")
+	assert.False(t, ok)
+	_, ok = dataPoint.Attributes.Value("trigger_name")
+	assert.False(t, ok)
+	_, ok = dataPoint.Attributes.Value("metric_name")
+	assert.False(t, ok)
+	scaler, ok := dataPoint.Attributes.Value("scaler")
+	assert.True(t, ok)
+	assert.Equal(t, "prometheus", scaler.AsString())
+	statusCode, ok := dataPoint.Attributes.Value("status_code")
+	assert.True(t, ok)
+	assert.Equal(t, "200", statusCode.AsString())
 }
 
 func TestContinuousMetrics(t *testing.T) {

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -18,7 +18,13 @@ var (
 func init() {
 	testReader = metric.NewManualReader()
 	options := metric.WithReader(testReader)
-	testOtel = NewOtelMetrics(options)
+	testOtel = NewOtelMetrics(true, options)
+}
+
+func resetTestOtel(enableHighCardinalityMetrics bool) {
+	testReader = metric.NewManualReader()
+	options := metric.WithReader(testReader)
+	testOtel = NewOtelMetrics(enableHighCardinalityMetrics, options)
 }
 
 func retrieveMetric(metrics []metricdata.Metrics, metricname string) *metricdata.Metrics {
@@ -31,6 +37,8 @@ func retrieveMetric(metrics []metricdata.Metrics, metricname string) *metricdata
 }
 
 func TestBuildInfo(t *testing.T) {
+	resetTestOtel(true)
+
 	got := metricdata.ResourceMetrics{}
 	err := testReader.Collect(context.Background(), &got)
 
@@ -53,6 +61,8 @@ func TestBuildInfo(t *testing.T) {
 }
 
 func TestIncrementTriggerTotal(t *testing.T) {
+	resetTestOtel(true)
+
 	testOtel.IncrementTriggerTotal("testtrigger")
 	got := metricdata.ResourceMetrics{}
 	err := testReader.Collect(context.Background(), &got)
@@ -82,6 +92,8 @@ func TestIncrementTriggerTotal(t *testing.T) {
 }
 
 func TestLoopLatency(t *testing.T) {
+	resetTestOtel(true)
+
 	testOtel.RecordScalableObjectLatency("namespace", "name", true, 500*time.Millisecond)
 	got := metricdata.ResourceMetrics{}
 	err := testReader.Collect(context.Background(), &got)
@@ -119,6 +131,8 @@ func TestRecordHTTPClientRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			resetTestOtel(true)
+
 			testOtel.RecordHTTPClientRequest(0.1, tt.statusCode, tt.isError, "prometheus", "my-trigger", "my-metric", "default", "my-so")
 			got := metricdata.ResourceMetrics{}
 			err := testReader.Collect(context.Background(), &got)
@@ -156,7 +170,25 @@ func TestRecordHTTPClientRequest(t *testing.T) {
 	}
 }
 
+func TestRecordHTTPClientRequest_DisablesHighCardinalityMetrics(t *testing.T) {
+	resetTestOtel(false)
+
+	testOtel.RecordHTTPClientRequest(0.1, 200, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
+	got := metricdata.ResourceMetrics{}
+	err := testReader.Collect(context.Background(), &got)
+	assert.Nil(t, err)
+
+	scopeMetrics := got.ScopeMetrics[0]
+	requestCount := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.requests.count")
+	assert.NotNil(t, requestCount)
+
+	requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.http.request.duration.seconds")
+	assert.Nil(t, requestDuration)
+}
+
 func TestContinuousMetrics(t *testing.T) {
+	resetTestOtel(true)
+
 	testOtel.RecordScalerActive("testnamespace", "testresource", "testscaler", 0, "testmetric", true, true)
 	testOtel.RecordScalerActive("testnamespace2", "testresource2", "testscaler2", 0, "testmetric", false, false)
 	got := metricdata.ResourceMetrics{}

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -172,23 +172,16 @@ var (
 		[]string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"},
 	)
 
-	httpClientRequestDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: DefaultPromMetricsNamespace,
-			Subsystem: "scaler_http",
-			Name:      "request_duration_seconds",
-			Help:      "Duration in seconds of outbound HTTP requests issued during scaler metric collection.",
-			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
-		},
-		[]string{"scaler", "status_code"},
-	)
+	httpClientRequestDurationLabels                = []string{"scaler", "status_code"}
+	httpClientRequestDurationHighCardinalityLabels = []string{"namespace", "scaled_resource", "scaler", "trigger_name", "metric_name", "status_code"}
 )
 
 type PromMetrics struct {
-	enableHighCardinalityMetrics bool
+	enableHighCardinalityLabels bool
+	httpClientRequestDuration   *prometheus.HistogramVec
 }
 
-func NewPromMetrics(enableHighCardinalityMetrics bool) *PromMetrics {
+func NewPromMetrics(enableHighCardinalityLabels bool) *PromMetrics {
 	metrics.Registry.MustRegister(scalerMetricsValue)
 	metrics.Registry.MustRegister(scalerMetricsLatency)
 	metrics.Registry.MustRegister(internalLoopLatency)
@@ -207,12 +200,32 @@ func NewPromMetrics(enableHighCardinalityMetrics bool) *PromMetrics {
 	metrics.Registry.MustRegister(cloudeventQueueStatus)
 
 	metrics.Registry.MustRegister(httpClientRequestsTotal)
-	if enableHighCardinalityMetrics {
-		metrics.Registry.MustRegister(httpClientRequestDuration)
-	}
+	httpClientRequestDuration := newHTTPClientRequestDuration(enableHighCardinalityLabels)
+	metrics.Registry.MustRegister(httpClientRequestDuration)
 
 	RecordBuildInfo()
-	return &PromMetrics{enableHighCardinalityMetrics: enableHighCardinalityMetrics}
+	return &PromMetrics{
+		enableHighCardinalityLabels: enableHighCardinalityLabels,
+		httpClientRequestDuration:   httpClientRequestDuration,
+	}
+}
+
+func newHTTPClientRequestDuration(enableHighCardinalityLabels bool) *prometheus.HistogramVec {
+	labels := httpClientRequestDurationLabels
+	if enableHighCardinalityLabels {
+		labels = httpClientRequestDurationHighCardinalityLabels
+	}
+
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "scaler_http",
+			Name:      "request_duration_seconds",
+			Help:      "Duration in seconds of outbound HTTP requests issued during scaler metric collection.",
+			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		labels,
+	)
 }
 
 // RecordBuildInfo publishes information about KEDA version and runtime info through an info metric (gauge).
@@ -381,15 +394,17 @@ func (p *PromMetrics) RecordEmptyUpstreamResponse(namespace, scaledResource, tri
 func (p *PromMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
 	code := httpStatusCodeLabel(statusCode, isError)
 	httpClientRequestsTotal.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Inc()
-	if p.enableHighCardinalityMetrics {
-		httpClientRequestDuration.WithLabelValues(scaler, code).Observe(durationSeconds)
+	if p.enableHighCardinalityLabels {
+		p.httpClientRequestDuration.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Observe(durationSeconds)
+	} else {
+		p.httpClientRequestDuration.WithLabelValues(scaler, code).Observe(durationSeconds)
 	}
 }
 
 // Returns a grpcprom server Metrics object and registers the metrics. The object contains
 // interceptors to chain to the server so that all requests served are observed. Intended to be called
 // as part of initialization of metricscollector, hence why this function is not exported
-func newPromServerMetrics(enableHighCardinalityMetrics bool) *grpcprom.ServerMetrics {
+func newPromServerMetrics() *grpcprom.ServerMetrics {
 	metricsNamespace := "keda_internal_metricsservice"
 
 	counterNamespace := func(o *prometheus.CounterOpts) {
@@ -400,19 +415,13 @@ func newPromServerMetrics(enableHighCardinalityMetrics bool) *grpcprom.ServerMet
 		o.Namespace = metricsNamespace
 	}
 
-	options := []grpcprom.ServerMetricsOption{
+	serverMetrics := grpcprom.NewServerMetrics(
+		grpcprom.WithServerHandlingTimeHistogram(
+			grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
+			histogramNamespace,
+		),
 		grpcprom.WithServerCounterOptions(counterNamespace),
-	}
-	if enableHighCardinalityMetrics {
-		options = append(options,
-			grpcprom.WithServerHandlingTimeHistogram(
-				grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
-				histogramNamespace,
-			),
-		)
-	}
-
-	serverMetrics := grpcprom.NewServerMetrics(options...)
+	)
 	metrics.Registry.MustRegister(serverMetrics)
 
 	return serverMetrics

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -185,9 +185,10 @@ var (
 )
 
 type PromMetrics struct {
+	enableHighCardinalityMetrics bool
 }
 
-func NewPromMetrics() *PromMetrics {
+func NewPromMetrics(enableHighCardinalityMetrics bool) *PromMetrics {
 	metrics.Registry.MustRegister(scalerMetricsValue)
 	metrics.Registry.MustRegister(scalerMetricsLatency)
 	metrics.Registry.MustRegister(internalLoopLatency)
@@ -206,10 +207,12 @@ func NewPromMetrics() *PromMetrics {
 	metrics.Registry.MustRegister(cloudeventQueueStatus)
 
 	metrics.Registry.MustRegister(httpClientRequestsTotal)
-	metrics.Registry.MustRegister(httpClientRequestDuration)
+	if enableHighCardinalityMetrics {
+		metrics.Registry.MustRegister(httpClientRequestDuration)
+	}
 
 	RecordBuildInfo()
-	return &PromMetrics{}
+	return &PromMetrics{enableHighCardinalityMetrics: enableHighCardinalityMetrics}
 }
 
 // RecordBuildInfo publishes information about KEDA version and runtime info through an info metric (gauge).
@@ -378,13 +381,15 @@ func (p *PromMetrics) RecordEmptyUpstreamResponse(namespace, scaledResource, tri
 func (p *PromMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
 	code := httpStatusCodeLabel(statusCode, isError)
 	httpClientRequestsTotal.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Inc()
-	httpClientRequestDuration.WithLabelValues(scaler, code).Observe(durationSeconds)
+	if p.enableHighCardinalityMetrics {
+		httpClientRequestDuration.WithLabelValues(scaler, code).Observe(durationSeconds)
+	}
 }
 
 // Returns a grpcprom server Metrics object and registers the metrics. The object contains
 // interceptors to chain to the server so that all requests served are observed. Intended to be called
 // as part of initialization of metricscollector, hence why this function is not exported
-func newPromServerMetrics() *grpcprom.ServerMetrics {
+func newPromServerMetrics(enableHighCardinalityMetrics bool) *grpcprom.ServerMetrics {
 	metricsNamespace := "keda_internal_metricsservice"
 
 	counterNamespace := func(o *prometheus.CounterOpts) {
@@ -395,13 +400,19 @@ func newPromServerMetrics() *grpcprom.ServerMetrics {
 		o.Namespace = metricsNamespace
 	}
 
-	serverMetrics := grpcprom.NewServerMetrics(
-		grpcprom.WithServerHandlingTimeHistogram(
-			grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
-			histogramNamespace,
-		),
+	options := []grpcprom.ServerMetricsOption{
 		grpcprom.WithServerCounterOptions(counterNamespace),
-	)
+	}
+	if enableHighCardinalityMetrics {
+		options = append(options,
+			grpcprom.WithServerHandlingTimeHistogram(
+				grpcprom.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
+				histogramNamespace,
+			),
+		)
+	}
+
+	serverMetrics := grpcprom.NewServerMetrics(options...)
 	metrics.Registry.MustRegister(serverMetrics)
 
 	return serverMetrics

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -53,7 +53,11 @@ func TestHTTPStatusCodeLabel(t *testing.T) {
 }
 
 func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
-	p := &PromMetrics{enableHighCardinalityMetrics: true}
+	httpClientRequestDuration := newHTTPClientRequestDuration(true)
+	p := &PromMetrics{
+		enableHighCardinalityLabels: true,
+		httpClientRequestDuration:   httpClientRequestDuration,
+	}
 
 	// Verify no panic and label combinations are created without error.
 	p.RecordHTTPClientRequest(0.05, 200, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
@@ -83,14 +87,14 @@ func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
 	require.NoError(t, counter.Write(m))
 	assert.EqualValues(t, 1, m.Counter.GetValue())
 
-	hist, err := httpClientRequestDuration.GetMetricWithLabelValues("prometheus", "200")
+	hist, err := httpClientRequestDuration.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
 	require.NoError(t, err)
 	require.NoError(t, hist.(prometheus.Metric).Write(m))
 	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
 	assert.InDelta(t, 0.05, m.Histogram.GetSampleSum(), 0.001)
 }
 
-func TestNewPromMetrics_DisablesHighCardinalityMetrics(t *testing.T) {
+func TestNewPromMetrics_DisablesHighCardinalityLabels(t *testing.T) {
 	previousRegistry := ctrlmetrics.Registry
 	ctrlmetrics.Registry = prometheus.NewRegistry()
 	t.Cleanup(func() {
@@ -109,8 +113,17 @@ func TestNewPromMetrics_DisablesHighCardinalityMetrics(t *testing.T) {
 	}
 
 	_, ok := names["keda_scaler_http_requests_total"]
-	assert.True(t, ok, "keda_scaler_http_requests_total should be registered when high-cardinality metrics are disabled")
+	assert.True(t, ok, "keda_scaler_http_requests_total should be registered when high-cardinality labels are disabled")
 
 	_, ok = names["keda_scaler_http_request_duration_seconds"]
-	assert.False(t, ok, "keda_scaler_http_request_duration_seconds should not be registered when high-cardinality metrics are disabled")
+	assert.True(t, ok, "keda_scaler_http_request_duration_seconds should be registered when high-cardinality labels are disabled")
+
+	hist, err := p.httpClientRequestDuration.GetMetricWithLabelValues("prometheus", "200")
+	require.NoError(t, err)
+	m := &dto.Metric{}
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+
+	_, err = p.httpClientRequestDuration.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
+	assert.Error(t, err, "high-cardinality labels should not be accepted when disabled")
 }

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -23,6 +23,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 func TestHTTPStatusCodeLabel(t *testing.T) {
@@ -52,7 +53,7 @@ func TestHTTPStatusCodeLabel(t *testing.T) {
 }
 
 func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
-	p := &PromMetrics{}
+	p := &PromMetrics{enableHighCardinalityMetrics: true}
 
 	// Verify no panic and label combinations are created without error.
 	p.RecordHTTPClientRequest(0.05, 200, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
@@ -87,4 +88,29 @@ func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
 	require.NoError(t, hist.(prometheus.Metric).Write(m))
 	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
 	assert.InDelta(t, 0.05, m.Histogram.GetSampleSum(), 0.001)
+}
+
+func TestNewPromMetrics_DisablesHighCardinalityMetrics(t *testing.T) {
+	previousRegistry := ctrlmetrics.Registry
+	ctrlmetrics.Registry = prometheus.NewRegistry()
+	t.Cleanup(func() {
+		ctrlmetrics.Registry = previousRegistry
+	})
+
+	p := NewPromMetrics(false)
+	p.RecordHTTPClientRequest(0.05, 200, false, "prometheus", "my-trigger", "my-metric", "default", "my-so")
+
+	families, err := ctrlmetrics.Registry.Gather()
+	require.NoError(t, err)
+
+	names := map[string]struct{}{}
+	for _, family := range families {
+		names[family.GetName()] = struct{}{}
+	}
+
+	_, ok := names["keda_scaler_http_requests_total"]
+	assert.True(t, ok, "keda_scaler_http_requests_total should be registered when high-cardinality metrics are disabled")
+
+	_, ok = names["keda_scaler_http_request_duration_seconds"]
+	assert.False(t, ok, "keda_scaler_http_request_duration_seconds should not be registered when high-cardinality metrics are disabled")
 }

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -663,7 +663,7 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 
 func TestGetScaledObjectStateRecordsResourceScalerActiveMetric(t *testing.T) {
 	promMetricsCollectorOnce.Do(func() {
-		metricscollector.NewMetricsCollectors(true, false)
+		metricscollector.NewMetricsCollectors(metricscollector.Options{EnablePrometheusMetrics: true})
 	})
 
 	ctrl := gomock.NewController(t)
@@ -740,7 +740,7 @@ func TestGetScaledObjectStateRecordsResourceScalerActiveMetric(t *testing.T) {
 
 func TestGetScaledObjectStateSkipsResourceScalerActiveMetricWithModifiers(t *testing.T) {
 	promMetricsCollectorOnce.Do(func() {
-		metricscollector.NewMetricsCollectors(true, false)
+		metricscollector.NewMetricsCollectors(metricscollector.Options{EnablePrometheusMetrics: true})
 	})
 
 	ctrl := gomock.NewController(t)

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -812,10 +812,53 @@ func SetDeploymentContainerArg(t *testing.T, kc *kubernetes.Clientset, name, nam
 
 	require.Truef(t, updated, "container %s not found in deployment %s/%s", containerName, namespace, name)
 
-	_, err = kc.AppsV1().Deployments(namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+	updatedDeployment, err := kc.AppsV1().Deployments(namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
 	require.NoErrorf(t, err, "cannot update deployment %s/%s - %s", namespace, name, err)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, name, namespace, int(*deployment.Spec.Replicas), 60, 2),
-		"deployment %s/%s should become ready after updating %s", namespace, name, flagName)
+
+	targetReplicas := int32(1)
+	if updatedDeployment.Spec.Replicas != nil {
+		targetReplicas = *updatedDeployment.Spec.Replicas
+	}
+
+	assert.True(t, WaitForDeploymentRollout(t, kc, name, namespace, updatedDeployment.Generation, targetReplicas, 60, 2),
+		"deployment %s/%s should finish rollout after updating %s", namespace, name, flagName)
+}
+
+func WaitForDeploymentRollout(t *testing.T, kc *kubernetes.Clientset, name, namespace string, generation int64, targetReplicas int32, iterations, intervalSeconds int) bool {
+	t.Helper()
+
+	for i := 0; i < iterations; i++ {
+		deployment, err := kc.AppsV1().Deployments(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("Waiting for deployment rollout. Deployment - %s, error - %v", name, err)
+			time.Sleep(time.Duration(intervalSeconds) * time.Second)
+			continue
+		}
+
+		t.Logf(
+			"Waiting for deployment rollout. Deployment - %s, ObservedGeneration - %d/%d, Replicas - %d, UpdatedReplicas - %d, ReadyReplicas - %d, AvailableReplicas - %d, Target - %d",
+			name,
+			deployment.Status.ObservedGeneration,
+			generation,
+			deployment.Status.Replicas,
+			deployment.Status.UpdatedReplicas,
+			deployment.Status.ReadyReplicas,
+			deployment.Status.AvailableReplicas,
+			targetReplicas,
+		)
+
+		if deployment.Status.ObservedGeneration >= generation &&
+			deployment.Status.Replicas == targetReplicas &&
+			deployment.Status.UpdatedReplicas == targetReplicas &&
+			deployment.Status.ReadyReplicas == targetReplicas &&
+			deployment.Status.AvailableReplicas == targetReplicas {
+			return true
+		}
+
+		time.Sleep(time.Duration(intervalSeconds) * time.Second)
+	}
+
+	return false
 }
 
 type Template struct {

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -780,6 +780,44 @@ func KubernetesScaleDeployment(t *testing.T, kc *kubernetes.Clientset, name stri
 	}
 }
 
+func SetDeploymentContainerArg(t *testing.T, kc *kubernetes.Clientset, name, namespace, containerName, flagName, flagValue string) {
+	t.Helper()
+
+	deployment, err := kc.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	require.NoErrorf(t, err, "cannot get deployment %s/%s - %s", namespace, name, err)
+
+	newArg := fmt.Sprintf("%s=%s", flagName, flagValue)
+	var updated bool
+	for i, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+
+		replaced := false
+		for j, arg := range container.Args {
+			if arg == flagName || strings.HasPrefix(arg, flagName+"=") {
+				container.Args[j] = newArg
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			container.Args = append(container.Args, newArg)
+		}
+
+		deployment.Spec.Template.Spec.Containers[i].Args = container.Args
+		updated = true
+		break
+	}
+
+	require.Truef(t, updated, "container %s not found in deployment %s/%s", containerName, namespace, name)
+
+	_, err = kc.AppsV1().Deployments(namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+	require.NoErrorf(t, err, "cannot update deployment %s/%s - %s", namespace, name, err)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, name, namespace, int(*deployment.Spec.Replicas), 60, 2),
+		"deployment %s/%s should become ready after updating %s", namespace, name, flagName)
+}
+
 type Template struct {
 	Name, Config string
 }

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -647,6 +647,9 @@ func TestOpenTelemetryMetrics(t *testing.T) {
 	testScalerMetricValue(t)
 	testScalerMetricLatency(t)
 	testScalerActiveMetric(t, kc)
+	// Run this before any prometheus-based scaler scenarios, otherwise the collector
+	// already contains the HTTP duration histogram family from earlier requests.
+	testHighCardinalityMetricsDisabled(t, kc, data)
 	testScaledObjectErrors(t, data)
 	testScaledJobErrors(t, data)
 	testScalerErrors(t, data)
@@ -657,7 +660,6 @@ func TestOpenTelemetryMetrics(t *testing.T) {
 	testCloudEventEmittedError(t, data)
 	testEmptyUpstreamResponse(t, data)
 	testHTTPClientMetrics(t, data)
-	testHighCardinalityMetricsDisabled(t, kc, data)
 
 	changeOtlpProtocolInOperator(t, kc, "keda-operator", "keda")
 	testScalerGrpcMetricValue(t, kc, data)
@@ -946,8 +948,10 @@ func testScalerErrors(t *testing.T, data templateData) {
 
 	time.Sleep(15 * time.Second)
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
-	val, ok := family["keda_scaler_errors_total"]
+	families := waitForCollectorMetric(t, "keda_scaler_errors_total", func(family *prommodel.MetricFamily) bool {
+		return getErrorMetricsValue(family) > 0
+	})
+	val, ok := families["keda_scaler_errors_total"]
 	assert.True(t, ok, "keda_scaler_errors_total not available")
 	if ok {
 		errCounterVal1 := getErrorMetricsValue(val)
@@ -955,8 +959,10 @@ func testScalerErrors(t *testing.T, data templateData) {
 		// wait for 10 seconds to correctly fetch metrics.
 		time.Sleep(5 * time.Second)
 
-		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
-		val, ok := family["keda_scaler_errors_total"]
+		families = waitForCollectorMetric(t, "keda_scaler_errors_total", func(family *prommodel.MetricFamily) bool {
+			return getErrorMetricsValue(family) >= errCounterVal1
+		})
+		val, ok = families["keda_scaler_errors_total"]
 		assert.True(t, ok, "keda_scaler_errors_total not available")
 		if ok {
 			errCounterVal2 := getErrorMetricsValue(val)

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -649,7 +649,7 @@ func TestOpenTelemetryMetrics(t *testing.T) {
 	testScalerActiveMetric(t, kc)
 	// Run this before any prometheus-based scaler scenarios, otherwise the collector
 	// already contains the HTTP duration histogram family from earlier requests.
-	testHighCardinalityMetricsDisabled(t, kc, data)
+	testHighCardinalityLabelsDisabled(t, kc, data)
 	testScaledObjectErrors(t, data)
 	testScaledJobErrors(t, data)
 	testScalerErrors(t, data)
@@ -659,7 +659,7 @@ func TestOpenTelemetryMetrics(t *testing.T) {
 	testCloudEventEmitted(t, data)
 	testCloudEventEmittedError(t, data)
 	testEmptyUpstreamResponse(t, data)
-	testHTTPClientMetrics(t, data)
+	testHTTPClientMetrics(t, kc, data)
 
 	changeOtlpProtocolInOperator(t, kc, "keda-operator", "keda")
 	testScalerGrpcMetricValue(t, kc, data)
@@ -1569,8 +1569,10 @@ func testEmptyUpstreamResponse(t *testing.T, data templateData) {
 	}
 }
 
-func testHTTPClientMetrics(t *testing.T, data templateData) {
+func testHTTPClientMetrics(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing HTTP client metrics ---")
+	SetDeploymentContainerArg(t, kc, kedaOperatorDeploymentName, kedaNamespace, kedaOperatorDeploymentName, "--enable-high-cardinality-metrics-labels", "true")
+	defer SetDeploymentContainerArg(t, kc, kedaOperatorDeploymentName, kedaNamespace, kedaOperatorDeploymentName, "--enable-high-cardinality-metrics-labels", "false")
 
 	// The dedicated HTTP client metrics ScaledObject uses a prometheus-type
 	// scaler that makes real HTTP requests on every poll interval, so its
@@ -1611,7 +1613,7 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 	}
 
 	matchHistogramLabels := func(labels []*prommodel.LabelPair) bool {
-		return ExtractPrometheusLabelValue("scaler", labels) == "prometheus"
+		return matchLabels(labels)
 	}
 	if val, ok := family["keda_scaler_http_request_duration_seconds"]; ok {
 		var found bool
@@ -1627,11 +1629,10 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 	}
 }
 
-func testHighCardinalityMetricsDisabled(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing high-cardinality metrics disabled ---")
+func testHighCardinalityLabelsDisabled(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing high-cardinality labels disabled ---")
 
-	SetDeploymentContainerArg(t, kc, kedaOperatorDeploymentName, kedaNamespace, kedaOperatorDeploymentName, "--enable-high-cardinality-metrics", "false")
-	defer SetDeploymentContainerArg(t, kc, kedaOperatorDeploymentName, kedaNamespace, kedaOperatorDeploymentName, "--enable-high-cardinality-metrics", "true")
+	SetDeploymentContainerArg(t, kc, kedaOperatorDeploymentName, kedaNamespace, kedaOperatorDeploymentName, "--enable-high-cardinality-metrics-labels", "false")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	KubectlApplyWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
@@ -1659,6 +1660,23 @@ func testHighCardinalityMetricsDisabled(t *testing.T, kc *kubernetes.Clientset, 
 		return false
 	})
 
-	_, ok := families["keda_scaler_http_request_duration_seconds"]
-	assert.False(t, ok, "keda_scaler_http_request_duration_seconds should not be emitted when high-cardinality metrics are disabled")
+	family, ok := families["keda_scaler_http_request_duration_seconds"]
+	assert.True(t, ok, "keda_scaler_http_request_duration_seconds should be emitted when high-cardinality labels are disabled")
+	if ok {
+		var found bool
+		for _, metric := range family.GetMetric() {
+			labels := metric.GetLabel()
+			if ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
+				ExtractPrometheusLabelValue("namespace", labels) == "" &&
+				ExtractPrometheusLabelValue("scaled_resource", labels) == "" &&
+				ExtractPrometheusLabelValue("trigger_name", labels) == "" &&
+				ExtractPrometheusLabelValue("metric_name", labels) == "" {
+				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
+					"keda_scaler_http_request_duration_seconds sample count should be > 0")
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram without high-cardinality labels")
+	}
 }

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -657,6 +657,7 @@ func TestOpenTelemetryMetrics(t *testing.T) {
 	testCloudEventEmittedError(t, data)
 	testEmptyUpstreamResponse(t, data)
 	testHTTPClientMetrics(t, data)
+	testHighCardinalityMetricsDisabled(t, kc, data)
 
 	changeOtlpProtocolInOperator(t, kc, "keda-operator", "keda")
 	testScalerGrpcMetricValue(t, kc, data)
@@ -816,6 +817,27 @@ func waitForOpenTelemetryMetric(t *testing.T, metricToWaitFor string, familyVali
 	}
 
 	return family
+}
+
+func waitForCollectorMetric(t *testing.T, metricToWaitFor string, familyValidator func(family *prommodel.MetricFamily) bool) map[string]*prommodel.MetricFamily {
+	contextWithTimeout, cancel := context.WithTimeout(context.Background(), WaitShort)
+	defer cancel()
+
+	var families map[string]*prommodel.MetricFamily
+	err := KedaEventually(contextWithTimeout, func(ctx context.Context) (bool, error) {
+		t.Logf("Waiting for metric %s", metricToWaitFor)
+		families = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorCollectorPrometheusExportURL))
+
+		family, ok := families[metricToWaitFor]
+		if !ok {
+			return false, nil
+		}
+
+		return familyValidator(family), nil
+	}, IntervalShort)
+	require.NoErrorf(t, err, "error waiting for metric %s", metricToWaitFor)
+
+	return families
 }
 
 func testScalerMetricValue(t *testing.T) {
@@ -1597,4 +1619,40 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 		}
 		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram for prometheus scaler")
 	}
+}
+
+func testHighCardinalityMetricsDisabled(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing high-cardinality metrics disabled ---")
+
+	SetDeploymentContainerArg(t, kc, kedaOperatorDeploymentName, kedaNamespace, kedaOperatorDeploymentName, "--enable-high-cardinality-metrics", "false")
+	defer SetDeploymentContainerArg(t, kc, kedaOperatorDeploymentName, kedaNamespace, kedaOperatorDeploymentName, "--enable-high-cardinality-metrics", "true")
+
+	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	KubectlApplyWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
+	defer func() {
+		KubectlDeleteWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
+		KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	}()
+
+	time.Sleep(20 * time.Second)
+
+	matchLabels := func(labels []*prommodel.LabelPair) bool {
+		return ExtractPrometheusLabelValue("namespace", labels) == data.TestNamespace &&
+			ExtractPrometheusLabelValue("scaled_resource", labels) == data.HTTPClientScaledObjectName &&
+			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
+			ExtractPrometheusLabelValue("trigger_name", labels) == data.HTTPClientScalerName &&
+			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus"
+	}
+
+	families := waitForCollectorMetric(t, "keda_scaler_http_requests_count_total", func(family *prommodel.MetricFamily) bool {
+		for _, metric := range family.GetMetric() {
+			if matchLabels(metric.GetLabel()) && metric.GetCounter().GetValue() >= 1 {
+				return true
+			}
+		}
+		return false
+	})
+
+	_, ok := families["keda_scaler_http_request_duration_seconds"]
+	assert.False(t, ok, "keda_scaler_http_request_duration_seconds should not be emitted when high-cardinality metrics are disabled")
 }

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	prommodel "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -620,6 +621,7 @@ func TestPrometheusMetrics(t *testing.T) {
 	testCloudEventEmittedError(t, data)
 	testEmptyUpstreamResponse(t, data)
 	testHTTPClientMetrics(t, data)
+	testHighCardinalityMetricsDisabled(t, kc, data)
 	// cleanup
 	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
@@ -675,16 +677,23 @@ func fetchAndParsePrometheusMetrics(t *testing.T, cmd string) map[string]*prommo
 	return families
 }
 
-// WaitForPrometheusMetric waits for a specific metric to appear in the Prometheus metrics endpoint
-// and validates that the MetricFamily it has certain conditions using the provided familyValidator function.
+// WaitForPrometheusMetric waits for a specific metric to appear in the KEDA operator Prometheus endpoint
+// and validates that the MetricFamily has certain conditions using the provided familyValidator function.
 // Returns the parsed MetricFamily.
 func WaitForPrometheusMetric(t *testing.T, metricToWaitFor string, familyValidator func(family *prommodel.MetricFamily) bool) map[string]*prommodel.MetricFamily {
+	return WaitForPrometheusMetricAtURL(t, kedaOperatorPrometheusURL, metricToWaitFor, familyValidator)
+}
+
+// WaitForPrometheusMetricAtURL waits for a specific metric to appear in the provided Prometheus endpoint
+// and validates that the MetricFamily has certain conditions using the provided familyValidator function.
+// Returns the parsed MetricFamily.
+func WaitForPrometheusMetricAtURL(t *testing.T, metricsURL string, metricToWaitFor string, familyValidator func(family *prommodel.MetricFamily) bool) map[string]*prommodel.MetricFamily {
 	contextWithTimeout, cancel := context.WithTimeout(context.Background(), WaitShort)
 	defer cancel()
 	var family map[string]*prommodel.MetricFamily
 	err := KedaEventually(contextWithTimeout, func(ctx context.Context) (bool, error) {
-		t.Logf("Waiting for metric %s", metricToWaitFor)
-		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+		t.Logf("Waiting for metric %s on %s", metricToWaitFor, metricsURL)
+		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", metricsURL))
 
 		if _, ok := family[metricToWaitFor]; ok {
 			if familyValidator(family[metricToWaitFor]) {
@@ -700,6 +709,14 @@ func WaitForPrometheusMetric(t *testing.T, metricToWaitFor string, familyValidat
 	}
 
 	return family
+}
+
+func metricFamilyCounterSumGreaterThanZero(family *prommodel.MetricFamily) bool {
+	sum := 0.0
+	for _, metric := range family.GetMetric() {
+		sum += metric.GetCounter().GetValue()
+	}
+	return sum > 0
 }
 
 func testScalerMetricValue(t *testing.T) {
@@ -1736,4 +1753,50 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 		}
 		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram for prometheus scaler")
 	}
+}
+
+func testHighCardinalityMetricsDisabled(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing high-cardinality metrics disabled ---")
+
+	SetDeploymentContainerArg(t, kc, KEDAOperator, KEDANamespace, KEDAOperator, "--enable-high-cardinality-metrics", "false")
+	defer SetDeploymentContainerArg(t, kc, KEDAOperator, KEDANamespace, KEDAOperator, "--enable-high-cardinality-metrics", "true")
+
+	SetDeploymentContainerArg(t, kc, KEDAMetricsAPIServer, KEDANamespace, KEDAMetricsAPIServer, "--enable-high-cardinality-metrics", "false")
+	defer SetDeploymentContainerArg(t, kc, KEDAMetricsAPIServer, KEDANamespace, KEDAMetricsAPIServer, "--enable-high-cardinality-metrics", "true")
+
+	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	KubectlApplyWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
+	defer func() {
+		KubectlDeleteWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
+		KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
+	}()
+
+	time.Sleep(20 * time.Second)
+
+	matchLabels := func(labels []*prommodel.LabelPair) bool {
+		return ExtractPrometheusLabelValue("namespace", labels) == data.TestNamespace &&
+			ExtractPrometheusLabelValue("scaled_resource", labels) == data.HTTPClientScaledObjectName &&
+			ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
+			ExtractPrometheusLabelValue("trigger_name", labels) == data.HTTPClientScalerName &&
+			ExtractPrometheusLabelValue("metric_name", labels) == "s0-prometheus"
+	}
+
+	families := WaitForPrometheusMetricAtURL(t, kedaOperatorPrometheusURL, "keda_scaler_http_requests_total", func(family *prommodel.MetricFamily) bool {
+		for _, metric := range family.GetMetric() {
+			if matchLabels(metric.GetLabel()) && metric.GetCounter().GetValue() >= 1 {
+				return true
+			}
+		}
+		return false
+	})
+	_, ok := families["keda_scaler_http_request_duration_seconds"]
+	assert.False(t, ok, "keda_scaler_http_request_duration_seconds should not be emitted when high-cardinality metrics are disabled")
+
+	families = WaitForPrometheusMetricAtURL(t, kedaOperatorPrometheusURL, "keda_internal_metricsservice_grpc_server_handled_total", metricFamilyCounterSumGreaterThanZero)
+	_, ok = families["keda_internal_metricsservice_grpc_server_handling_seconds"]
+	assert.False(t, ok, "keda_internal_metricsservice_grpc_server_handling_seconds should not be emitted when high-cardinality metrics are disabled")
+
+	families = WaitForPrometheusMetricAtURL(t, kedaMetricsServerPrometheusURL, "keda_internal_metricsservice_grpc_client_handled_total", metricFamilyCounterSumGreaterThanZero)
+	_, ok = families["keda_internal_metricsservice_grpc_client_handling_seconds"]
+	assert.False(t, ok, "keda_internal_metricsservice_grpc_client_handling_seconds should not be emitted when high-cardinality metrics are disabled")
 }

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -620,8 +620,8 @@ func TestPrometheusMetrics(t *testing.T) {
 	testCloudEventEmitted(t, data)
 	testCloudEventEmittedError(t, data)
 	testEmptyUpstreamResponse(t, data)
-	testHTTPClientMetrics(t, data)
-	testHighCardinalityMetricsDisabled(t, kc, data)
+	testHTTPClientMetrics(t, kc, data)
+	testHighCardinalityLabelsDisabled(t, kc, data)
 	// cleanup
 	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
@@ -1701,8 +1701,10 @@ func testEmptyUpstreamResponse(t *testing.T, data templateData) {
 	assert.True(t, familyValidator(metric))
 }
 
-func testHTTPClientMetrics(t *testing.T, data templateData) {
+func testHTTPClientMetrics(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing HTTP client metrics ---")
+	SetDeploymentContainerArg(t, kc, KEDAOperator, KEDANamespace, KEDAOperator, "--enable-high-cardinality-metrics-labels", "true")
+	defer SetDeploymentContainerArg(t, kc, KEDAOperator, KEDANamespace, KEDAOperator, "--enable-high-cardinality-metrics-labels", "false")
 
 	// The dedicated HTTP client metrics ScaledObject uses a prometheus-type
 	// scaler that makes real HTTP requests on every poll interval, so its
@@ -1737,7 +1739,7 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 		testNamespace, data.HTTPClientScaledObjectName, data.HTTPClientScalerName)
 
 	matchHistogramLabels := func(labels []*prommodel.LabelPair) bool {
-		return ExtractPrometheusLabelValue("scaler", labels) == "prometheus"
+		return matchLabels(labels)
 	}
 	family, ok := families["keda_scaler_http_request_duration_seconds"]
 	assert.True(t, ok, "keda_scaler_http_request_duration_seconds not present")
@@ -1755,14 +1757,10 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 	}
 }
 
-func testHighCardinalityMetricsDisabled(t *testing.T, kc *kubernetes.Clientset, data templateData) {
-	t.Log("--- testing high-cardinality metrics disabled ---")
+func testHighCardinalityLabelsDisabled(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing high-cardinality labels disabled ---")
 
-	SetDeploymentContainerArg(t, kc, KEDAOperator, KEDANamespace, KEDAOperator, "--enable-high-cardinality-metrics", "false")
-	defer SetDeploymentContainerArg(t, kc, KEDAOperator, KEDANamespace, KEDAOperator, "--enable-high-cardinality-metrics", "true")
-
-	SetDeploymentContainerArg(t, kc, KEDAMetricsAPIServer, KEDANamespace, KEDAMetricsAPIServer, "--enable-high-cardinality-metrics", "false")
-	defer SetDeploymentContainerArg(t, kc, KEDAMetricsAPIServer, KEDANamespace, KEDAMetricsAPIServer, "--enable-high-cardinality-metrics", "true")
+	SetDeploymentContainerArg(t, kc, KEDAOperator, KEDANamespace, KEDAOperator, "--enable-high-cardinality-metrics-labels", "false")
 
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	KubectlApplyWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
@@ -1789,14 +1787,31 @@ func testHighCardinalityMetricsDisabled(t *testing.T, kc *kubernetes.Clientset, 
 		}
 		return false
 	})
-	_, ok := families["keda_scaler_http_request_duration_seconds"]
-	assert.False(t, ok, "keda_scaler_http_request_duration_seconds should not be emitted when high-cardinality metrics are disabled")
+	family, ok := families["keda_scaler_http_request_duration_seconds"]
+	assert.True(t, ok, "keda_scaler_http_request_duration_seconds should be emitted when high-cardinality labels are disabled")
+	if ok {
+		var found bool
+		for _, metric := range family.GetMetric() {
+			labels := metric.GetLabel()
+			if ExtractPrometheusLabelValue("scaler", labels) == "prometheus" &&
+				ExtractPrometheusLabelValue("namespace", labels) == "" &&
+				ExtractPrometheusLabelValue("scaled_resource", labels) == "" &&
+				ExtractPrometheusLabelValue("trigger_name", labels) == "" &&
+				ExtractPrometheusLabelValue("metric_name", labels) == "" {
+				assert.Greater(t, metric.GetHistogram().GetSampleCount(), uint64(0),
+					"keda_scaler_http_request_duration_seconds sample count should be > 0")
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram without high-cardinality labels")
+	}
 
 	families = WaitForPrometheusMetricAtURL(t, kedaOperatorPrometheusURL, "keda_internal_metricsservice_grpc_server_handled_total", metricFamilyCounterSumGreaterThanZero)
 	_, ok = families["keda_internal_metricsservice_grpc_server_handling_seconds"]
-	assert.False(t, ok, "keda_internal_metricsservice_grpc_server_handling_seconds should not be emitted when high-cardinality metrics are disabled")
+	assert.True(t, ok, "keda_internal_metricsservice_grpc_server_handling_seconds should still be emitted when high-cardinality labels are disabled")
 
 	families = WaitForPrometheusMetricAtURL(t, kedaMetricsServerPrometheusURL, "keda_internal_metricsservice_grpc_client_handled_total", metricFamilyCounterSumGreaterThanZero)
 	_, ok = families["keda_internal_metricsservice_grpc_client_handling_seconds"]
-	assert.False(t, ok, "keda_internal_metricsservice_grpc_client_handling_seconds should not be emitted when high-cardinality metrics are disabled")
+	assert.True(t, ok, "keda_internal_metricsservice_grpc_client_handling_seconds should still be emitted when high-cardinality labels are disabled")
 }


### PR DESCRIPTION
_Provide a description of what has been changed_

This adds `--enable-high-cardinality-metrics-labels` to the KEDA operator, defaulting to `false`.

When the flag is enabled, `keda_scaler_http_request_duration_seconds` includes the high-cardinality `namespace`, `scaled_resource`, `trigger_name`, and `metric_name` labels in addition to the existing low-cardinality labels. When the flag is disabled, the histogram is still emitted with only `scaler` and `status_code` labels.

The existing scaler HTTP request counter labels are unchanged, and the internal Metrics Service gRPC histograms are no longer gated by this flag.

This also updates unit and e2e coverage for both label modes and updates the changelog.

The e2e coverage was also hardened so the new flag assertions are reliable:
- deployment arg mutations now wait for a full rollout, so the tests do not assert against old operator pods after toggling the flag
- the OpenTelemetry disabled-path assertion now runs before the Prometheus HTTP-client scenarios, so the collector validates the low-cardinality histogram shape before the high-cardinality path runs
- the OpenTelemetry scaler error assertion now waits for the collector export instead of relying on a fixed sleep

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7731

Relates to kedacore/keda-docs#1772, kedacore/charts#855