### PR TITLE
fix: report correct namespace in error log when secret access is rest…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,8 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
 - **General**: Fail fast in `GetMetrics` when the gRPC connection is in Shutdown state instead of waiting for context timeout ([#7251](https://github.com/kedacore/keda/issues/7251))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
-- **General**: Fix race in scalers cache rebuild that caused transient scaler errors ([#7574](https://github.com/kedacore/keda/issues/7574))
 - **General**: Fix misleading namespace in error log when secret access is restricted ([#7739](https://github.com/kedacore/keda/issues/7739))
-
+- **General**: Fix race in scalers cache rebuild that caused transient scaler errors ([#7574](https://github.com/kedacore/keda/issues/7574))
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fail fast in `GetMetrics` when the gRPC connection is in Shutdown state instead of waiting for context timeout ([#7251](https://github.com/kedacore/keda/issues/7251))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix race in scalers cache rebuild that caused transient scaler errors ([#7574](https://github.com/kedacore/keda/issues/7574))
+- **General**: Fix misleading namespace in error log when secret access is restricted ([#7739](https://github.com/kedacore/keda/issues/7739))
+
 - **General**: Fix ScaledObject admission webhook to return validation error from `verifyReplicaCount`, preventing invalid ScaledObjects from being created ([#5954](https://github.com/kedacore/keda/issues/5954))
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -677,13 +677,15 @@ func resolveAuthSecret(ctx context.Context, client client.Client, logger logr.Lo
 
 	secret := &corev1.Secret{}
 	var err error
+	resolvedNamespace := namespace
 	if isSecretAccessRestricted(logger) {
 		secret, err = secretsLister.Secrets(kedaNamespace).Get(name)
+		resolvedNamespace = kedaNamespace
 	} else {
 		err = client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret)
 	}
 	if err != nil {
-		logger.Error(err, "error trying to get secret from namespace", "Secret.Namespace", namespace, "Secret.Name", name)
+		logger.Error(err, "error trying to get secret from namespace", "Secret.Namespace", resolvedNamespace, "Secret.Name", name)
 		return ""
 	}
 	result := secret.Data[key]

--- a/pkg/scaling/resolver/scale_resolvers_test.go
+++ b/pkg/scaling/resolver/scale_resolvers_test.go
@@ -19,6 +19,7 @@ package resolver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1123,4 +1124,114 @@ func TestReadAuthParamsFromFile_Errors(t *testing.T) {
 	_, err = readAuthParamsFromFile("../test.json")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "filePath must be relative")
+}
+
+func TestResolveAuthSecret_RestrictedAccess_UsesKedaNamespace(t *testing.T) {
+	origRestrictSecretAccess := restrictSecretAccess
+	origKedaNamespace := kedaNamespace
+	defer func() {
+		restrictSecretAccess = origRestrictSecretAccess
+		kedaNamespace = origKedaNamespace
+	}()
+
+	tests := []struct {
+		name           string
+		secretExists   bool
+		secretName     string
+		secretKey      string
+		secretValue    string
+		inputNamespace string
+		expectedResult string
+	}{
+		{
+			name:           "restricted access, secret found in keda namespace",
+			secretExists:   true,
+			secretName:     secretName,
+			secretKey:      secretKey,
+			secretValue:    secretData,
+			inputNamespace: "my-app",
+			expectedResult: secretData,
+		},
+		{
+			name:           "restricted access, secret not found in keda namespace",
+			secretExists:   false,
+			secretName:     secretName,
+			secretKey:      secretKey,
+			inputNamespace: "my-app",
+			expectedResult: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restrictSecretAccess = "true"
+			kedaNamespace = "keda"
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockSecretNamespaceLister := mock_v1.NewMockSecretNamespaceLister(ctrl)
+			mockSecretLister := mock_v1.NewMockSecretLister(ctrl)
+
+			mockSecretLister.EXPECT().Secrets(kedaNamespace).Return(mockSecretNamespaceLister).Times(1)
+
+			if test.secretExists {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: kedaNamespace,
+						Name:      test.secretName,
+					},
+					Data: map[string][]byte{test.secretKey: []byte(test.secretValue)},
+				}
+				mockSecretNamespaceLister.EXPECT().Get(test.secretName).Return(secret, nil).Times(1)
+			} else {
+				mockSecretNamespaceLister.EXPECT().Get(test.secretName).Return(nil, fmt.Errorf("secret %q not found", test.secretName)).Times(1)
+			}
+
+			ctx := context.Background()
+			result := resolveAuthSecret(
+				ctx,
+				fake.NewClientBuilder().Build(),
+				logf.Log.WithName("test"),
+				test.secretName,
+				test.inputNamespace,
+				test.secretKey,
+				mockSecretLister,
+			)
+
+			assert.Equal(t, test.expectedResult, result)
+		})
+	}
+}
+
+func TestResolveAuthSecret_UnrestrictedAccess_UsesOriginalNamespace(t *testing.T) {
+	origRestrictSecretAccess := restrictSecretAccess
+	defer func() {
+		restrictSecretAccess = origRestrictSecretAccess
+	}()
+
+	restrictSecretAccess = ""
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      secretName,
+		},
+		Data: map[string][]byte{secretKey: []byte(secretData)},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(secret).Build()
+
+	ctx := context.Background()
+	result := resolveAuthSecret(
+		ctx,
+		fakeClient,
+		logf.Log.WithName("test"),
+		secretName,
+		namespace,
+		secretKey,
+		nil,
+	)
+
+	assert.Equal(t, secretData, result)
 }


### PR DESCRIPTION
What's the problem?
When KEDA's secret access restriction is enabled, secret lookups are performed against kedaNamespace instead of the TriggerAuthentication's own namespace. That's intentional, but the error log that fires on failure still reports the original namespace variable, not the one actually used for the lookup.
So if your secret lookup fails, KEDA tells you it couldn't find the secret in namespace my-app when it actually looked in keda. That's confusing and makes debugging harder than it needs to be.
What's the fix?
A small change introduced a resolvedNamespace variable that starts as a namespace and gets updated to kedaNamespace when the secret restriction is in effect. The error log now uses resolvedNamespace, so it always reflects where KEDA actually looked.
Testing
All existing tests in pkg/scaling/resolver pass. The fix touches a single function, resolveAuthSecret in scale_resolvers.go.
Fixes #7739