### PR TITLE
e2e: skip dynatrace tests due to licensing issues

### DIFF
--- a/tests/scalers/dynatrace/dynatrace_test.go
+++ b/tests/scalers/dynatrace/dynatrace_test.go
@@ -131,6 +131,7 @@ spec:
 )
 
 func TestDynatraceScaler(t *testing.T) {
+	t.Skip("Disabled - Dynatrace tenant access is currently unavailable due to licensing; see https://github.com/kedacore/keda/issues/6995 for details")
 	// setup
 	t.Log("--- setting up ---")
 	require.NotEmpty(t, dynatraceToken, "DYNATRACE_METRICS_TOKEN env variable is required for dynatrace tests")

--- a/tests/scalers/dynatrace_dql/dynatrace_dql_test.go
+++ b/tests/scalers/dynatrace_dql/dynatrace_dql_test.go
@@ -132,6 +132,7 @@ spec:
 )
 
 func TestDynatraceDQLScaler(t *testing.T) {
+	t.Skip("Disabled - Dynatrace tenant access is currently unavailable due to licensing; see https://github.com/kedacore/keda/issues/6995 for details")
 	// setup
 	t.Log("--- setting up ---")
 	require.NotEmpty(t, dynatraceToken, "DYNATRACE_METRICS_TOKEN env variable is required for dynatrace tests")


### PR DESCRIPTION
the tests have been failing past couple of weeks, no need to keep running them until licensing is resolved.

see also: https://github.com/kedacore/keda/issues/6995
