### PR TITLE
ci: send test summary to /run-e2e comment

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -254,7 +254,9 @@ jobs:
           SUFFIX: "-test"
           TEST_CLUSTER_NAME: keda-e2e-cluster-pr
           COMMENT_BODY: ${{ github.event.comment.body }}
+          E2E_RESULTS_DIR: ${{ github.workspace }}/_e2e_results
         run: |
+          set -euo pipefail
           MESSAGE="$COMMENT_BODY"
           REGEX='/run-e2e (.+)'
           if [[ "$MESSAGE" =~ $REGEX ]]
@@ -263,6 +265,55 @@ jobs:
           fi
           echo "${{ needs.triage.outputs.pr_num }}"
           make e2e-test
+
+      - name: Build test results comment body
+        if: ${{ always() }}
+        id: results
+        env:
+          E2E_RESULTS_DIR: ${{ github.workspace }}/_e2e_results
+        run: |
+          set -euo pipefail
+          PASSED="$E2E_RESULTS_DIR/passed.txt"
+          FAILED="$E2E_RESULTS_DIR/failed.txt"
+          if [[ ! -f "$PASSED" && ! -f "$FAILED" ]]; then
+            echo "no results files produced under $E2E_RESULTS_DIR; skipping comment update" >&2
+            echo "should_post=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          passed_count=0
+          failed_count=0
+          [[ -f "$PASSED" ]] && passed_count=$(cat "$PASSED" | wc -l)
+          [[ -f "$FAILED" ]] && failed_count=$(cat "$FAILED" | wc -l)
+          {
+            echo 'body<<E2E_RESULTS_EOF'
+            echo ''
+            echo '<details>'
+            echo "<summary>passed tests: ${passed_count}</summary>"
+            echo ''
+            if [[ -s "$PASSED" ]]; then
+              cat "$PASSED"
+            fi
+            echo ''
+            echo '</details>'
+            echo ''
+            echo '<details>'
+            echo "<summary>failed tests: ${failed_count}</summary>"
+            echo ''
+            if [[ -s "$FAILED" ]]; then
+              cat "$FAILED"
+            fi
+            echo ''
+            echo '</details>'
+            echo 'E2E_RESULTS_EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "should_post=true" >> "$GITHUB_OUTPUT"
+
+      - name: Append test results to comment
+        if: ${{ always() && steps.results.outputs.should_post == 'true' }}
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: ${{ steps.results.outputs.body }}
 
       - name: Delete all e2e related namespaces
         if: ${{ always() }}

--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -347,7 +347,43 @@ func evaluateExecution(testResults []TestResult) int {
 		}
 	}
 
+	dumpResults(passSummary, failSummary)
 	return exitCode
+}
+
+// dumpResults writes the summary of passed and failed tests to files in a directory specified by E2E_RESULTS_DIR environment variable if specified.
+func dumpResults(passSummary []string, failSummary []string) {
+	e2eDir := os.Getenv("E2E_RESULTS_DIR")
+	if e2eDir == "" {
+		return
+	}
+	if err := os.MkdirAll(e2eDir, 0o755); err != nil {
+		fmt.Printf("WARN: cannot create results dir %s: %v\n", e2eDir, err)
+		return
+	}
+
+	passFile := "passed.txt"
+	failFile := "failed.txt"
+	dumpLogsToFile(failSummary, failFile, e2eDir)
+	dumpLogsToFile(passSummary, passFile, e2eDir)
+}
+
+// dumpLogsToFile writes the summary to a file in the specified directory. If the file already exists, it will be overwritten.
+// Leading tabs from the summary lines are stripped so the file embeds cleanly into Markdown
+// (a line beginning with a tab would otherwise render as a code block inside the PR comment).
+func dumpLogsToFile(summary []string, fileName string, e2eDir string) {
+	stripped := make([]string, len(summary))
+	for i, s := range summary {
+		stripped[i] = strings.TrimLeft(s, "\t")
+	}
+	tests := strings.Join(stripped, "\n")
+	if len(stripped) > 0 {
+		tests += "\n"
+	}
+	filePath := filepath.Join(e2eDir, fileName)
+	if err := os.WriteFile(filePath, []byte(tests), 0o644); err != nil {
+		fmt.Printf("WARN: cannot write %s: %v\n", filePath, err)
+	}
 }
 
 // numberToWord converts input integer (0-20) to corresponding word (zero-twenty)


### PR DESCRIPTION
When reviewers post `/run-e2e` comments on PRs, the github actions triggers an e2e test suite. The workflow then posts thumbs-up or thumbs-down depending on whether the e2e test suite passed or not on the original comment. But looking through what tests passed or failed requires manual labour, the reviewer has to go through the e2e test logs. I'd like to enhance this reporting by also posting a brief summary back to the original PR comment.

The e2e test runner can now get a directory through `E2E_RESULTS_DIR` where it will create two files:
* `passed.txt` - summary of passed tests
* `failed.txt` - summary of failed tests

The github workflow then parses those two tests and on top of thumbs-up/thumbs-down the comment, it will also append the content of those two summaries in [collapsible markdown](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections).