### PR TITLE
ci: e2e response in code blocks

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -290,18 +290,22 @@ jobs:
             echo '<details>'
             echo "<summary>passed tests: ${passed_count}</summary>"
             echo ''
+            echo '```'
             if [[ -s "$PASSED" ]]; then
               cat "$PASSED"
             fi
+            echo '```'
             echo ''
             echo '</details>'
             echo ''
             echo '<details>'
             echo "<summary>failed tests: ${failed_count}</summary>"
             echo ''
+            echo '```'
             if [[ -s "$FAILED" ]]; then
               cat "$FAILED"
             fi
+            echo '```'
             echo ''
             echo '</details>'
             echo 'E2E_RESULTS_EOF'


### PR DESCRIPTION
followup to https://github.com/kedacore/keda/pull/7760. Example can be seen https://github.com/kedacore/keda/pull/7740#issuecomment-4519502038.

the tests in code blocks look much more readable than just plaintext