### PR TITLE
feat: cron-min-replicas scaler - time-based dynamic minReplicas and m…

### DIFF
--- a/pkg/scalers/cron_min_replicas_scaler.go
+++ b/pkg/scalers/cron_min_replicas_scaler.go
@@ -1,0 +1,183 @@
+package scalers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/robfig/cron/v3"
+	v2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+)
+
+type cronMinReplicasScaler struct {
+	metricType    v2.MetricTargetType
+	metadata      cronMinReplicasMetadata
+	logger        logr.Logger
+	startSchedule cron.Schedule
+	endSchedule   cron.Schedule
+	kubeClient    client.Client
+}
+
+type cronMinReplicasMetadata struct {
+	Start        string `keda:"name=start,       order=triggerMetadata"`
+	End          string `keda:"name=end,         order=triggerMetadata"`
+	Timezone     string `keda:"name=timezone,    order=triggerMetadata"`
+	MinReplicas  int64  `keda:"name=minReplicas, order=triggerMetadata"`
+	MaxReplicas  int64  `keda:"name=maxReplicas, order=triggerMetadata, optional"`
+	TriggerIndex int
+
+	scalableObjectName      string
+	scalableObjectNamespace string
+}
+
+func (m *cronMinReplicasMetadata) Validate() error {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	if _, err := parser.Parse(m.Start); err != nil {
+		return fmt.Errorf("error parsing start schedule: %w", err)
+	}
+
+	if _, err := parser.Parse(m.End); err != nil {
+		return fmt.Errorf("error parsing end schedule: %w", err)
+	}
+
+	if m.Start == m.End {
+		return fmt.Errorf("start and end can not have exactly same time input")
+	}
+
+	if m.MinReplicas <= 0 {
+		return fmt.Errorf("minReplicas must be greater than 0")
+	}
+
+	if m.MaxReplicas < 0 {
+		return fmt.Errorf("maxReplicas must not be negative")
+	}
+
+	if m.MaxReplicas > 0 && m.MaxReplicas < m.MinReplicas {
+		return fmt.Errorf("maxReplicas (%d) must be greater than or equal to minReplicas (%d)", m.MaxReplicas, m.MinReplicas)
+	}
+
+	return nil
+}
+
+func NewCronMinReplicasScaler(kubeClient client.Client, config *scalersconfig.ScalerConfig) (Scaler, error) {
+	metricType, err := GetMetricTargetType(config)
+	if err != nil {
+		return nil, fmt.Errorf("error getting scaler metric type: %w", err)
+	}
+
+	meta, err := parseCronMinReplicasMetadata(config)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing cron-min-replicas metadata: %w", err)
+	}
+
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+	startSchedule, _ := parser.Parse(meta.Start)
+	endSchedule, _ := parser.Parse(meta.End)
+
+	return &cronMinReplicasScaler{
+		metricType:    metricType,
+		metadata:      meta,
+		logger:        InitializeLogger(config, "cron_min_replicas_scaler"),
+		startSchedule: startSchedule,
+		endSchedule:   endSchedule,
+		kubeClient:    kubeClient,
+	}, nil
+}
+
+func parseCronMinReplicasMetadata(config *scalersconfig.ScalerConfig) (cronMinReplicasMetadata, error) {
+	meta := cronMinReplicasMetadata{
+		TriggerIndex:            config.TriggerIndex,
+		scalableObjectName:      config.ScalableObjectName,
+		scalableObjectNamespace: config.ScalableObjectNamespace,
+	}
+	if err := config.TypedConfig(&meta); err != nil {
+		return meta, err
+	}
+	return meta, nil
+}
+
+func (s *cronMinReplicasScaler) Close(context.Context) error {
+	return nil
+}
+
+func parseCronMinReplicasTimeFormat(s string) string {
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "*", "x")
+	s = strings.ReplaceAll(s, "/", "Sl")
+	s = strings.ReplaceAll(s, "?", "Qm")
+	s = strings.ReplaceAll(s, ",", "Cm")
+	return s
+}
+
+func (s *cronMinReplicasScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	var specReplicas int64 = 1
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
+			Name: GenerateMetricNameWithIndex(s.metadata.TriggerIndex, kedautil.NormalizeString(fmt.Sprintf("cron-min-replicas-%s-%s-%s", s.metadata.Timezone, parseCronMinReplicasTimeFormat(s.metadata.Start), parseCronMinReplicasTimeFormat(s.metadata.End)))),
+		},
+		Target: GetMetricTarget(s.metricType, specReplicas),
+	}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: cronMetricType}
+	return []v2.MetricSpec{metricSpec}
+}
+
+func (s *cronMinReplicasScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
+	location, err := time.LoadLocation(s.metadata.Timezone)
+	if err != nil {
+		return []external_metrics.ExternalMetricValue{}, false, fmt.Errorf("unable to load timezone: %w", err)
+	}
+
+	currentTime := time.Now().In(location)
+
+	nextStartTime := s.startSchedule.Next(currentTime)
+	nextEndTime := s.endSchedule.Next(currentTime)
+
+	isWithinInterval := false
+	if nextStartTime.Before(nextEndTime) {
+		isWithinInterval = currentTime.After(nextStartTime) && currentTime.Before(nextEndTime)
+	} else {
+		isWithinInterval = currentTime.After(nextStartTime) || currentTime.Before(nextEndTime)
+	}
+
+	if isWithinInterval && s.metadata.MaxReplicas > 0 {
+		if err := s.patchMaxReplicas(ctx, int32(s.metadata.MaxReplicas)); err != nil {
+			s.logger.Error(err, "failed to patch ScaledObject maxReplicaCount")
+		}
+	}
+
+	metricValue := float64(0)
+	if isWithinInterval {
+		metricValue = float64(s.metadata.MinReplicas)
+	}
+
+	metric := GenerateMetricInMili(metricName, metricValue)
+	return []external_metrics.ExternalMetricValue{metric}, isWithinInterval, nil
+}
+
+func (s *cronMinReplicasScaler) patchMaxReplicas(ctx context.Context, desired int32) error {
+	if s.kubeClient == nil {
+		return nil
+	}
+	so := &kedav1alpha1.ScaledObject{}
+	if err := s.kubeClient.Get(ctx, types.NamespacedName{Name: s.metadata.scalableObjectName, Namespace: s.metadata.scalableObjectNamespace}, so); err != nil {
+		return fmt.Errorf("failed to get ScaledObject: %w", err)
+	}
+
+	if so.Spec.MaxReplicaCount != nil && *so.Spec.MaxReplicaCount == desired {
+		return nil
+	}
+
+	patch := client.MergeFrom(so.DeepCopy())
+	so.Spec.MaxReplicaCount = &desired
+	return s.kubeClient.Patch(ctx, so, patch)
+}

--- a/pkg/scalers/cron_min_replicas_scaler_test.go
+++ b/pkg/scalers/cron_min_replicas_scaler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
@@ -74,8 +75,7 @@ var cronMinReplicasMetricIdentifiers = []cronMinReplicasMetricIdentifier{
 	{&testCronMinReplicasMetadata[3], 1, "s1-cron-min-replicas-Etc-UTC-06xxx-022xxx"},
 }
 
-var tzMinReplicas, _ = time.LoadLocation("Etc/UTC")
-var currentHourForMinReplicas = time.Now().In(tzMinReplicas).Hour()
+var currentHourForMinReplicas = time.Now().In(time.UTC).Hour()
 
 func TestCronMinReplicasParseMetadata(t *testing.T) {
 	for i, testData := range testCronMinReplicasMetadata {
@@ -90,30 +90,36 @@ func TestCronMinReplicasParseMetadata(t *testing.T) {
 }
 
 func TestCronMinReplicasIsActiveNight(t *testing.T) {
-	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
-	_, isActive, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	scaler, err := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
+	require.NoError(t, err)
+	_, isActive, err := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	require.NoError(t, err)
 	// night window: 22:00-06:00
 	if currentHourForMinReplicas >= 22 || currentHourForMinReplicas < 6 {
-		assert.Equal(t, true, isActive)
+		assert.True(t, isActive)
 	} else {
-		assert.Equal(t, false, isActive)
+		assert.False(t, isActive)
 	}
 }
 
 func TestCronMinReplicasIsActiveDay(t *testing.T) {
-	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataDay})
-	_, isActive, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	scaler, err := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataDay})
+	require.NoError(t, err)
+	_, isActive, err := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	require.NoError(t, err)
 	// day window: 06:00-22:00
 	if currentHourForMinReplicas >= 6 && currentHourForMinReplicas < 22 {
-		assert.Equal(t, true, isActive)
+		assert.True(t, isActive)
 	} else {
-		assert.Equal(t, false, isActive)
+		assert.False(t, isActive)
 	}
 }
 
 func TestCronMinReplicasGetMetricsNight(t *testing.T) {
-	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
-	metrics, _, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	scaler, err := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
+	require.NoError(t, err)
+	metrics, _, err := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	require.NoError(t, err)
 	assert.Equal(t, "ReplicaCount", metrics[0].MetricName)
 	if currentHourForMinReplicas >= 22 || currentHourForMinReplicas < 6 {
 		assert.Equal(t, int64(2), metrics[0].Value.Value())
@@ -123,8 +129,10 @@ func TestCronMinReplicasGetMetricsNight(t *testing.T) {
 }
 
 func TestCronMinReplicasGetMetricsDay(t *testing.T) {
-	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataDay})
-	metrics, _, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	scaler, err := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataDay})
+	require.NoError(t, err)
+	metrics, _, err := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	require.NoError(t, err)
 	assert.Equal(t, "ReplicaCount", metrics[0].MetricName)
 	if currentHourForMinReplicas >= 6 && currentHourForMinReplicas < 22 {
 		assert.Equal(t, int64(10), metrics[0].Value.Value())
@@ -135,27 +143,27 @@ func TestCronMinReplicasGetMetricsDay(t *testing.T) {
 
 func TestCronMinReplicasMaxReplicasMetadata(t *testing.T) {
 	meta, err := parseCronMinReplicasMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataWithMax})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(2), meta.MinReplicas)
 	assert.Equal(t, int64(5), meta.MaxReplicas)
 }
 
 func TestCronMinReplicasMaxReplicasAbsent(t *testing.T) {
 	meta, err := parseCronMinReplicasMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(0), meta.MaxReplicas)
 }
 
 func TestCronMinReplicasGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range cronMinReplicasMetricIdentifiers {
 		meta, err := parseCronMinReplicasMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, TriggerIndex: testData.triggerIndex})
-		if err != nil {
-			t.Fatal("Could not parse metadata:", err)
-		}
+		require.NoError(t, err)
 
 		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
-		startSchedule, _ := parser.Parse(meta.Start)
-		endSchedule, _ := parser.Parse(meta.End)
+		startSchedule, err := parser.Parse(meta.Start)
+		require.NoError(t, err)
+		endSchedule, err := parser.Parse(meta.End)
+		require.NoError(t, err)
 
 		mockScaler := cronMinReplicasScaler{
 			metricType:    "",
@@ -167,8 +175,6 @@ func TestCronMinReplicasGetMetricSpecForScaling(t *testing.T) {
 
 		metricSpec := mockScaler.GetMetricSpecForScaling(context.Background())
 		metricName := metricSpec[0].External.Metric.Name
-		if metricName != testData.name {
-			t.Error("Wrong External metric source name:", metricName)
-		}
+		assert.Equal(t, testData.name, metricName)
 	}
 }

--- a/pkg/scalers/cron_min_replicas_scaler_test.go
+++ b/pkg/scalers/cron_min_replicas_scaler_test.go
@@ -1,0 +1,174 @@
+package scalers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+)
+
+type parseCronMinReplicasMetadataTestData struct {
+	metadata map[string]string
+	isError  bool
+}
+
+type cronMinReplicasMetricIdentifier struct {
+	metadataTestData *parseCronMinReplicasMetadataTestData
+	triggerIndex     int
+	name             string
+}
+
+var validCronMinReplicasMetadata = map[string]string{
+	"timezone":    "Etc/UTC",
+	"start":       "0 22 * * *",
+	"end":         "0 6 * * *",
+	"minReplicas": "2",
+}
+
+var validCronMinReplicasMetadataWithMax = map[string]string{
+	"timezone":    "Etc/UTC",
+	"start":       "0 22 * * *",
+	"end":         "0 6 * * *",
+	"minReplicas": "2",
+	"maxReplicas": "5",
+}
+
+var validCronMinReplicasMetadataDay = map[string]string{
+	"timezone":    "Etc/UTC",
+	"start":       "0 6 * * *",
+	"end":         "0 22 * * *",
+	"minReplicas": "10",
+	"maxReplicas": "50",
+}
+
+var testCronMinReplicasMetadata = []parseCronMinReplicasMetadataTestData{
+	{map[string]string{}, true},
+	{validCronMinReplicasMetadata, false},
+	{validCronMinReplicasMetadataWithMax, false},
+	{validCronMinReplicasMetadataDay, false},
+	// missing timezone
+	{map[string]string{"start": "0 22 * * *", "end": "0 6 * * *", "minReplicas": "2"}, true},
+	// same start and end
+	{map[string]string{"timezone": "Etc/UTC", "start": "0 22 * * *", "end": "0 22 * * *", "minReplicas": "2"}, true},
+	// minReplicas = 0
+	{map[string]string{"timezone": "Etc/UTC", "start": "0 22 * * *", "end": "0 6 * * *", "minReplicas": "0"}, true},
+	// missing minReplicas
+	{map[string]string{"timezone": "Etc/UTC", "start": "0 22 * * *", "end": "0 6 * * *"}, true},
+	// maxReplicas < minReplicas
+	{map[string]string{"timezone": "Etc/UTC", "start": "0 22 * * *", "end": "0 6 * * *", "minReplicas": "10", "maxReplicas": "5"}, true},
+	// maxReplicas negative
+	{map[string]string{"timezone": "Etc/UTC", "start": "0 22 * * *", "end": "0 6 * * *", "minReplicas": "2", "maxReplicas": "-1"}, true},
+	// invalid start expression
+	{map[string]string{"timezone": "Etc/UTC", "start": "-30 * * * *", "end": "0 6 * * *", "minReplicas": "2"}, true},
+	// invalid end expression
+	{map[string]string{"timezone": "Etc/UTC", "start": "0 22 * * *", "end": "-30 * * * *", "minReplicas": "2"}, true},
+}
+
+var cronMinReplicasMetricIdentifiers = []cronMinReplicasMetricIdentifier{
+	{&testCronMinReplicasMetadata[1], 0, "s0-cron-min-replicas-Etc-UTC-022xxx-06xxx"},
+	{&testCronMinReplicasMetadata[3], 1, "s1-cron-min-replicas-Etc-UTC-06xxx-022xxx"},
+}
+
+var tzMinReplicas, _ = time.LoadLocation("Etc/UTC")
+var currentHourForMinReplicas = time.Now().In(tzMinReplicas).Hour()
+
+func TestCronMinReplicasParseMetadata(t *testing.T) {
+	for i, testData := range testCronMinReplicasMetadata {
+		_, err := parseCronMinReplicasMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadata})
+		if err != nil && !testData.isError {
+			t.Errorf("test case %d: expected success but got error: %v", i, err)
+		}
+		if testData.isError && err == nil {
+			t.Errorf("test case %d: expected error but got success", i)
+		}
+	}
+}
+
+func TestCronMinReplicasIsActiveNight(t *testing.T) {
+	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
+	_, isActive, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	// night window: 22:00-06:00
+	if currentHourForMinReplicas >= 22 || currentHourForMinReplicas < 6 {
+		assert.Equal(t, true, isActive)
+	} else {
+		assert.Equal(t, false, isActive)
+	}
+}
+
+func TestCronMinReplicasIsActiveDay(t *testing.T) {
+	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataDay})
+	_, isActive, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	// day window: 06:00-22:00
+	if currentHourForMinReplicas >= 6 && currentHourForMinReplicas < 22 {
+		assert.Equal(t, true, isActive)
+	} else {
+		assert.Equal(t, false, isActive)
+	}
+}
+
+func TestCronMinReplicasGetMetricsNight(t *testing.T) {
+	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
+	metrics, _, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	assert.Equal(t, "ReplicaCount", metrics[0].MetricName)
+	if currentHourForMinReplicas >= 22 || currentHourForMinReplicas < 6 {
+		assert.Equal(t, int64(2), metrics[0].Value.Value())
+	} else {
+		assert.Equal(t, int64(0), metrics[0].Value.Value())
+	}
+}
+
+func TestCronMinReplicasGetMetricsDay(t *testing.T) {
+	scaler, _ := NewCronMinReplicasScaler(nil, &scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataDay})
+	metrics, _, _ := scaler.GetMetricsAndActivity(context.TODO(), "ReplicaCount")
+	assert.Equal(t, "ReplicaCount", metrics[0].MetricName)
+	if currentHourForMinReplicas >= 6 && currentHourForMinReplicas < 22 {
+		assert.Equal(t, int64(10), metrics[0].Value.Value())
+	} else {
+		assert.Equal(t, int64(0), metrics[0].Value.Value())
+	}
+}
+
+func TestCronMinReplicasMaxReplicasMetadata(t *testing.T) {
+	meta, err := parseCronMinReplicasMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadataWithMax})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), meta.MinReplicas)
+	assert.Equal(t, int64(5), meta.MaxReplicas)
+}
+
+func TestCronMinReplicasMaxReplicasAbsent(t *testing.T) {
+	meta, err := parseCronMinReplicasMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: validCronMinReplicasMetadata})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), meta.MaxReplicas)
+}
+
+func TestCronMinReplicasGetMetricSpecForScaling(t *testing.T) {
+	for _, testData := range cronMinReplicasMetricIdentifiers {
+		meta, err := parseCronMinReplicasMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, TriggerIndex: testData.triggerIndex})
+		if err != nil {
+			t.Fatal("Could not parse metadata:", err)
+		}
+
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+		startSchedule, _ := parser.Parse(meta.Start)
+		endSchedule, _ := parser.Parse(meta.End)
+
+		mockScaler := cronMinReplicasScaler{
+			metricType:    "",
+			metadata:      meta,
+			logger:        logr.Discard(),
+			startSchedule: startSchedule,
+			endSchedule:   endSchedule,
+		}
+
+		metricSpec := mockScaler.GetMetricSpecForScaling(context.Background())
+		metricName := metricSpec[0].External.Metric.Name
+		if metricName != testData.name {
+			t.Error("Wrong External metric source name:", metricName)
+		}
+	}
+}

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -169,6 +169,8 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 		return scalers.NewCPUMemoryScaler(corev1.ResourceCPU, config)
 	case "cron":
 		return scalers.NewCronScaler(config)
+	case "cron-min-replicas":
+		return scalers.NewCronMinReplicasScaler(client, config)
 	case "datadog":
 		return scalers.NewDatadogScaler(config)
 	case "dynatrace":


### PR DESCRIPTION
# The problem

KEDA's existing cron scaler sets a desiredReplicas count for a given time window. When the window is active, it emits a metric equal to that count; when inactive, it emits zero and yields control to other triggers.

This works well for "scale to exactly N during this period", but it does not cleanly express "ensure at least N replicas during this period while still allowing other scalers to push higher".
Users who try to use the cron scaler as a floor must set desiredReplicas high enough to cover peak load, which defeats the purpose of having additional scalers (CPU, RPS, queue depth, etc.).

The other option is to set ScaledObject.spec.minReplicaCount to the desired floor, but that field is static - it cannot vary by time of day without external tooling (scripts, CronJobs, GitOps
pipelines) that patch the ScaledObject on a schedule. That approach is fragile, requires additional infrastructure, and creates a race condition between the patcher and KEDA's reconciler.

There is also no supported way to change maxReplicaCount on a schedule at all. A workload that should be capped at 5 replicas overnight and 50 during business hours has no first-class mechanism
in KEDA today.

# Desired behavior

night  (22:00–06:00):  min = 2,  max = 5   - skeleton crew, hard cap to save cost
day    (06:00–22:00):  min = 10, max = 50  - full capacity, CPU/RPS scalers can push up to 50

At any point, an independent CPU or queue scaler should be able to drive replicas above the current minReplicas floor, up to the current maxReplicas ceiling - without any changes to the scaler
configuration.

# Why the existing cron scaler is not sufficient

 | scenario | cron | desired behavior |
  |---|---|---|
  | CPU spikes above `desiredReplicas` | [+] scales up | [+] scales up |
  | Naming makes intent clear | [x] `desiredReplicas` implies a target, not a floor | [+] |
  | Time-based `maxReplicas` | [x] | [+] |
  | Static `minReplicaCount` in spec | [x] required workaround | [+] not needed |

# Proposed solution

A new trigger type cron-min-replicas that:

1. Emits minReplicas as an external metric while the cron window is active. Because HPA always picks the maximum across all active metric targets, this metric acts as a replica-count floor
without preventing other scalers from scaling higher.
2. Optionally patches ScaledObject.spec.maxReplicaCount on each poll while the window is active (idempotent - only writes when the value changes). KEDA's reconciler propagates the change to the
HPA's maxReplicas field.

```yaml
triggers:
- type: cron-min-replicas
metadata:
  timezone: Europe/Kiev
  start: "0 22 * * *"
  end:   "0 6 * * *"
  minReplicas: "2"
  maxReplicas: "5"

- type: cron-min-replicas
metadata:
  timezone: Europe/Kiev
  start: "0 6 * * *"
  end:   "0 22 * * *"
  minReplicas: "10"
  maxReplicas: "50"

- type: cpu
metricType: Utilization
metadata:
  value: "70"
```

# Known limitations of the proposed approach

- maxReplicas is patched only when a window is active; if there is a gap in window coverage the field retains the last written value until the next active window takes over.
- A GitOps re-apply of the ScaledObject manifest overwrites the patched maxReplicaCount; it self-corrects on the next polling interval.
- spec.minReplicaCount is not patched - it remains the static absolute floor for when no window is active.
