### PR TITLE
fix: defer HPA creation when scalers return empty metric specs

### DIFF
--- a/controllers/keda/hpa.go
+++ b/controllers/keda/hpa.go
@@ -271,6 +271,12 @@ func (r *ScaledObjectReconciler) getScaledObjectMetricSpecs(ctx context.Context,
 
 	metricSpecs := cache.GetMetricSpecForScaling(ctx)
 
+	if len(metricSpecs) == 0 {
+		err := fmt.Errorf("no metric specs returned from scalers for ScaledObject %s/%s", scaledObject.Namespace, scaledObject.Name)
+		logger.Error(err, "Scalers may be unreachable, will retry")
+		return nil, err
+	}
+
 	for _, metricSpec := range metricSpecs {
 		if metricSpec.Resource != nil {
 			resourceMetricNames = append(resourceMetricNames, string(metricSpec.Resource.Name))

--- a/controllers/keda/hpa_test.go
+++ b/controllers/keda/hpa_test.go
@@ -85,6 +85,66 @@ var _ = Describe("hpa", func() {
 		Expect(capturedScaledObject.Status.Health).To(BeEmpty())
 	})
 
+	It("should return error when scalers return empty metric specs", func() {
+		scaledObject := &v1alpha1.ScaledObject{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-scaled-object",
+				Namespace: "test-namespace",
+			},
+		}
+
+		emptyScaler := mock_scalers.NewMockScaler(ctrl)
+		scalersCache := cache.ScalersCache{
+			Scalers: []cache.ScalerBuilder{{
+				Scaler: emptyScaler,
+				Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+					return emptyScaler, &scalersconfig.ScalerConfig{}, nil
+				},
+			}},
+			Recorder: nil,
+		}
+
+		ctx := context.Background()
+		emptyScaler.EXPECT().GetMetricSpecForScaling(ctx).Return([]v2.MetricSpec{})
+		scaleHandler.EXPECT().GetScalersCache(ctx, gomock.Eq(scaledObject)).Return(&scalersCache, nil)
+
+		specs, err := reconciler.getScaledObjectMetricSpecs(ctx, logger, scaledObject)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no metric specs returned from scalers"))
+		Expect(specs).To(BeNil())
+	})
+
+	It("should return error when scalers return nil metric specs", func() {
+		scaledObject := &v1alpha1.ScaledObject{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-scaled-object",
+				Namespace: "test-namespace",
+			},
+		}
+
+		emptyScaler := mock_scalers.NewMockScaler(ctrl)
+		scalersCache := cache.ScalersCache{
+			Scalers: []cache.ScalerBuilder{{
+				Scaler: emptyScaler,
+				Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+					return emptyScaler, &scalersconfig.ScalerConfig{}, nil
+				},
+			}},
+			Recorder: nil,
+		}
+
+		ctx := context.Background()
+		emptyScaler.EXPECT().GetMetricSpecForScaling(ctx).Return(nil)
+		scaleHandler.EXPECT().GetScalersCache(ctx, gomock.Eq(scaledObject)).Return(&scalersCache, nil)
+
+		specs, err := reconciler.getScaledObjectMetricSpecs(ctx, logger, scaledObject)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no metric specs returned from scalers"))
+		Expect(specs).To(BeNil())
+	})
+
 	It("should not remove existing metric from health status", func() {
 		numberOfFailures := int32(87)
 		health := make(map[string]v1alpha1.HealthStatus)


### PR DESCRIPTION
When an external gRPC scaler is unavailable at ScaledObject creation time,
`GetMetricSpecForScaling` returns an empty slice. Previously this caused
the HPA to be created with no metrics, making Kubernetes default to CPU 80%
utilization — a metric never configured by the user. Once the scaler became
available, the HPA was never reconciled to use the correct external metric.

This change adds a guard in `getScaledObjectMetricSpecs` that returns an error
when no metric specs are available. This prevents HPA creation with empty metrics
and causes controller-runtime to requeue with exponential backoff until the scaler
becomes reachable and returns valid metric specs.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7729

Relates to #236, #1629