### PR TITLE
feat: post single combined reaction for PR e2e/smoke tests

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -207,6 +207,8 @@ jobs:
     name: Execute e2e tests
     container: ghcr.io/kedacore/keda-tools:1.26.2
     if: needs.triage.outputs.run-e2e == 'true'
+    outputs:
+      test-outcome: ${{ steps.test.outcome }}
     steps:
       - name: Set status in-progress
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -332,14 +334,6 @@ jobs:
           NODE_POOL_SIZE: 1
           TEST_CLUSTER_NAME: keda-e2e-cluster-pr
 
-      - name: React to comment with success
-        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
-        if: steps.test.outcome == 'success'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commentId: ${{ github.event.comment.id }}
-          reaction: "+1"
-
       - name: Set status success
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
         if: steps.test.outcome == 'success'
@@ -351,14 +345,6 @@ jobs:
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
             {"summary": "🟢 Tests Passed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
-
-      - name: React to comment with failure
-        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
-        if: steps.test.outcome != 'success'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commentId: ${{ github.event.comment.id }}
-          reaction: "-1"
 
       - name: Set status failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -384,6 +370,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     name: Execute ARM smoke tests
     if: needs.triage.outputs.run-e2e == 'true'
+    outputs:
+      test-outcome: ${{ steps.test.outcome }}
     steps:
       - name: Set status in-progress
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -427,14 +415,6 @@ jobs:
           VERSION: ${{ needs.triage.outputs.image_tag }}
           SUFFIX: "-test"
 
-      - name: React to comment with success
-        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
-        if: steps.test.outcome == 'success'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commentId: ${{ github.event.comment.id }}
-          reaction: "+1"
-
       - name: Set status success
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
         if: steps.test.outcome == 'success'
@@ -446,14 +426,6 @@ jobs:
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
             {"summary": "🟢 Tests Passed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
-
-      - name: React to comment with failure
-        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
-        if: steps.test.outcome != 'success'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commentId: ${{ github.event.comment.id }}
-          reaction: "-1"
 
       - name: Set status failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -479,6 +451,8 @@ jobs:
     runs-on: s390x
     name: Execute s390x smoke tests
     if: needs.triage.outputs.run-e2e == 'true'
+    outputs:
+      test-outcome: ${{ steps.test.outcome }}
     steps:
       - name: Set status in-progress
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -529,14 +503,6 @@ jobs:
           VERSION: ${{ needs.triage.outputs.image_tag }}
           SUFFIX: "-test"
 
-      - name: React to comment with success
-        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
-        if: steps.test.outcome == 'success'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commentId: ${{ github.event.comment.id }}
-          reaction: "+1"
-
       - name: Set status success
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
         if: steps.test.outcome == 'success'
@@ -548,14 +514,6 @@ jobs:
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
             {"summary": "🟢 Tests Passed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
-
-      - name: React to comment with failure
-        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
-        if: steps.test.outcome != 'success'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commentId: ${{ github.event.comment.id }}
-          reaction: "-1"
 
       - name: Set status failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -582,3 +540,31 @@ jobs:
           name: s390x-smoke-test-logs
           path: "${{ github.workspace }}/**/*.log"
           if-no-files-found: ignore
+
+  report-reaction:
+    needs: [triage, run-e2e-test, run-arm-smoke-test, run-s390x-smoke-test]
+    runs-on: ubuntu-latest
+    name: Report combined reaction
+    if: ${{ always() && needs.triage.outputs.run-e2e == 'true' }}
+    steps:
+      - name: React to comment with success
+        if: >-
+          needs.run-e2e-test.outputs.test-outcome == 'success' &&
+          needs.run-arm-smoke-test.outputs.test-outcome == 'success' &&
+          needs.run-s390x-smoke-test.outputs.test-outcome == 'success'
+        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commentId: ${{ github.event.comment.id }}
+          reaction: "+1"
+
+      - name: React to comment with failure
+        if: >-
+          needs.run-e2e-test.outputs.test-outcome != 'success' ||
+          needs.run-arm-smoke-test.outputs.test-outcome != 'success' ||
+          needs.run-s390x-smoke-test.outputs.test-outcome != 'success'
+        uses: dkershner6/reaction-action@97ede302a1b145b3739dec3ca84a489a34ef48b5 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commentId: ${{ github.event.comment.id }}
+          reaction: "-1"


### PR DESCRIPTION
Jan's PR (https://github.com/kedacore/keda/pull/7760) is already a huge help in seeing whether there are successful or failed tests.

Therefore, let's use this next PR to correct the status. It is a small improvement, but I once experienced someone thinking that the thumbs-up was the direct result of the e2e while the other test was still running.

For the notes; each test job (e2e, ARM smoke, s390x smoke) previously posted its own reaction to the triggering comment. Because reactions are added rather than replaced, a mix of passing and failing jobs resulted in both, a thumbs up and a thumbs down being shown at the same time.

Test jobs now expose their outcome as a job output and no longer react themselves. A new report-reaction job aggregates the results and posts exactly one reaction: thumbs up only when all jobs pass, otherwise thumbs down. The per-test check statuses are unchanged.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))