### PR TITLE
Limit Vault service account token reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix ScaledObject Ready condition not reflecting HPA status ([#7649](https://github.com/kedacore/keda/issues/7649))
 - **General**: Handle paused scaling directly in reconciler ([#7663](https://github.com/kedacore/keda/issues/7663))
 - **General**: Honor `stderrthreshold` when `logtostderr` is enabled by updating klog to v2.140.0 ([#7568](https://github.com/kedacore/keda/pull/7568))
+- **General**: Limit projected service account token reads during Vault authentication ([#7783](https://github.com/kedacore/keda/issues/7783))
 - **General**: Reject ScaledObject creation and update when the name exceeds 63 characters ([#6998](https://github.com/kedacore/keda/issues/6998))
 - **AWS Scalers**: Fix TCP connection leak by closing HTTP idle connections on scaler `Close()` for SQS, Kinesis, DynamoDB, DynamoDB Streams, and CloudWatch scalers ([#7756](https://github.com/kedacore/keda/issues/7756))
 - **Azure Data Explorer Scaler**: Remove clientSecretFromEnv support ([#7554](https://github.com/kedacore/keda/pull/7554))

--- a/pkg/scaling/resolver/hashicorpvault_handler_test.go
+++ b/pkg/scaling/resolver/hashicorpvault_handler_test.go
@@ -669,7 +669,7 @@ var tokenTestDataSet = []tokenTestData{
 		},
 		role:         "my-role",
 		mount:        "my-mount",
-		errorMessage: "open random/path: no such file or directory",
+		errorMessage: "random/path: no such file or directory",
 	},
 	{
 		name:           "Wrong Authentication Method",

--- a/pkg/scaling/resolver/k8s_validator.go
+++ b/pkg/scaling/resolver/k8s_validator.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -10,10 +11,32 @@ import (
 
 var parser = jwt.NewParser()
 
+const maxProjectedServiceAccountTokenSize = 1 << 20
+
 func readKubernetesServiceAccountProjectedToken(path string) ([]byte, error) {
-	jwt, err := os.ReadFile(path)
+	info, err := os.Stat(path)
 	if err != nil {
 		return []byte{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return []byte{}, fmt.Errorf("service account token path %s is not a regular file", path)
+	}
+	if info.Size() > maxProjectedServiceAccountTokenSize {
+		return []byte{}, fmt.Errorf("service account token file %s exceeds maximum size of %d bytes", path, maxProjectedServiceAccountTokenSize)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer file.Close()
+
+	jwt, err := io.ReadAll(io.LimitReader(file, maxProjectedServiceAccountTokenSize+1))
+	if err != nil {
+		return []byte{}, err
+	}
+	if len(jwt) > maxProjectedServiceAccountTokenSize {
+		return []byte{}, fmt.Errorf("service account token file %s exceeds maximum size of %d bytes", path, maxProjectedServiceAccountTokenSize)
 	}
 	if err = validateK8sSAToken(jwt); err != nil {
 		return []byte{}, err

--- a/pkg/scaling/resolver/k8s_validator.go
+++ b/pkg/scaling/resolver/k8s_validator.go
@@ -14,7 +14,13 @@ var parser = jwt.NewParser()
 const maxProjectedServiceAccountTokenSize = 1 << 20
 
 func readKubernetesServiceAccountProjectedToken(path string) ([]byte, error) {
-	info, err := os.Stat(path)
+	file, err := os.Open(path)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -24,12 +30,6 @@ func readKubernetesServiceAccountProjectedToken(path string) ([]byte, error) {
 	if info.Size() > maxProjectedServiceAccountTokenSize {
 		return []byte{}, fmt.Errorf("service account token file %s exceeds maximum size of %d bytes", path, maxProjectedServiceAccountTokenSize)
 	}
-
-	file, err := os.Open(path)
-	if err != nil {
-		return []byte{}, err
-	}
-	defer file.Close()
 
 	jwt, err := io.ReadAll(io.LimitReader(file, maxProjectedServiceAccountTokenSize+1))
 	if err != nil {

--- a/pkg/scaling/resolver/k8s_validator_test.go
+++ b/pkg/scaling/resolver/k8s_validator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resolver
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"os"
@@ -100,6 +101,20 @@ func TestReadKubernetesServiceAccountProjectedToken(t *testing.T) {
 				tokenPath := createTempFile(t, tokenBytes)
 
 				return tokenPath
+			},
+			expectError: true,
+		},
+		{
+			name: "token file exceeds maximum size",
+			setupToken: func() string {
+				return createTempFile(t, bytes.Repeat([]byte("x"), maxProjectedServiceAccountTokenSize+1))
+			},
+			expectError: true,
+		},
+		{
+			name: "token path is not a regular file",
+			setupToken: func() string {
+				return t.TempDir()
 			},
 			expectError: true,
 		},


### PR DESCRIPTION
Limits projected service account token reads used by Vault Kubernetes authentication.

The resolver previously read the configured token path without a size bound. This rejects non-regular files and caps the token read before JWT validation.

### Checklist

- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7783
