### PR TITLE
Escape PostgreSQL connection string whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Metrics API Scaler**: Prevent response value reflection in scaler errors ([#7693](https://github.com/kedacore/keda/pull/7693))
 - **NATS JetStream Scaler**: Return an error from `getMaxMsgLag` when the configured consumer is missing instead of falling back to the stream's last sequence, preventing incorrect scale-up to `maxReplicaCount` ([#7657](https://github.com/kedacore/keda/issues/7657))
 - **NATS JetStream Scaler**: URL-encode user input in monitoring URL construction ([#7483](https://github.com/kedacore/keda/pull/7483))
+- **PostgreSQL Scaler**: Quote whitespace-containing connection parameters in generated connection strings ([#7784](https://github.com/kedacore/keda/issues/7784))
 - **PredictKube Scaler**: Bump `dysnix/predictkube-libs` to `v0.1.0` (drops the predictkube path to the archived/EOL `go-grpc-prometheus` and to the deprecated `golang/protobuf`) and use a portable Prometheus-API instant query for the health check so the scaler works against VictoriaMetrics, Thanos and other Prometheus-API-compatible backends ([#7745](https://github.com/kedacore/keda/pull/7745))
 - **Prometheus Scaler**: Handle NaN results in the same manner as Inf ([#7475](https://github.com/kedacore/keda/issues/7475))
 - **Prometheus Scaler**: Limit HTTP error response logging ([#7469](https://github.com/kedacore/keda/pull/7469))

--- a/pkg/scalers/postgresql_scaler.go
+++ b/pkg/scalers/postgresql_scaler.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -248,10 +249,11 @@ func (s *postgreSQLScaler) GetMetricsAndActivity(ctx context.Context, metricName
 }
 
 func escapePostgreConnectionParameter(str string) string {
-	if !strings.Contains(str, " ") {
+	if strings.IndexFunc(str, unicode.IsSpace) == -1 && !strings.ContainsAny(str, `'\`) {
 		return str
 	}
 
+	str = strings.ReplaceAll(str, `\`, `\\`)
 	str = strings.ReplaceAll(str, "'", "\\'")
 	return fmt.Sprintf("'%s'", str)
 }

--- a/pkg/scalers/postgresql_scaler_test.go
+++ b/pkg/scalers/postgresql_scaler_test.go
@@ -91,6 +91,54 @@ func TestPostgreSQLConnectionStringGeneration(t *testing.T) {
 	}
 }
 
+func TestEscapePostgreConnectionParameter(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"simple":              {input: "simple", want: "simple"},
+		"space":               {input: "with space", want: "'with space'"},
+		"tab":                 {input: "user\tsslmode=disable", want: "'user\tsslmode=disable'"},
+		"newline":             {input: "user\nhost=attacker", want: "'user\nhost=attacker'"},
+		"single quote":        {input: "user'name", want: "'user\\'name'"},
+		"backslash":           {input: `user\name`, want: `'user\\name'`},
+		"quote and backslash": {input: `user\'name`, want: `'user\\\'name'`},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := escapePostgreConnectionParameter(tt.input); got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestPostgreSQLConnectionStringGenerationEscapesWhitespace(t *testing.T) {
+	meta, _, err := parsePostgreSQLMetadata(logr.Discard(), &scalersconfig.ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"query":            "test_query",
+			"targetQueryValue": "5",
+			"host":             "db.example",
+			"port":             "5432",
+			"dbName":           "testdb",
+			"userName":         "user\tsslmode=disable",
+			"sslmode":          "require",
+		},
+		AuthParams: map[string]string{
+			"password": "secret\nhost=attacker",
+		},
+	})
+	if err != nil {
+		t.Fatal("Could not parse metadata:", err)
+	}
+
+	expected := "host=db.example port=5432 user='user\tsslmode=disable' dbname=testdb sslmode=require password='secret\nhost=attacker'"
+	if meta.Connection != expected {
+		t.Errorf("Error generating connectionString, expected %q and got %q", expected, meta.Connection)
+	}
+}
+
 var testPodIdentityAzureWorkloadPostgreSQLConnectionstring = []postgreSQLConnectionStringTestData{
 	// from meta
 	{metadata: map[string]string{"query": "test_query", "targetQueryValue": "5", "host": "localhost", "port": "1234", "dbName": "testDb", "userName": "user", "sslmode": "required"}, connectionString: "host=localhost port=1234 user=user dbname=testDb sslmode=required %PASSWORD%"},


### PR DESCRIPTION
Escapes PostgreSQL scaler generated keyword/value connection string parameters more defensively.

Generated connection strings previously quoted parameters only when they contained a literal space. This now quotes values containing any whitespace and escapes quote/backslash characters so user-provided values cannot split into additional connection parameters.

### Checklist

- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7784
