### PR TITLE
refactor: remove unused scaledJobGenerations sync.Map

### DIFF
--- a/controllers/keda/scaledjob_controller.go
+++ b/controllers/keda/scaledjob_controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,8 +60,7 @@ type ScaledJobReconciler struct {
 	EventEmitter      eventemitter.EventHandler
 	AuthClientSet     *authentication.AuthClientSet
 
-	scaledJobGenerations *sync.Map
-	scaleHandler         scaling.ScaleHandler
+	scaleHandler scaling.ScaleHandler
 }
 
 type scaledJobMetricsData struct {
@@ -83,7 +81,6 @@ func init() {
 // SetupWithManager initializes the ScaledJobReconciler instance and starts a new controller managed by the passed Manager instance.
 func (r *ScaledJobReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	r.scaleHandler = scaling.NewScaleHandler(mgr.GetClient(), nil, mgr.GetScheme(), r.GlobalHTTPTimeout, mgr.GetEventRecorderFor("scale-handler"), r.AuthClientSet)
-	r.scaledJobGenerations = &sync.Map{}
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
 		// Ignore updates to ScaledJob Status (in this case metadata.Generation does not change)
@@ -321,37 +318,13 @@ func (r *ScaledJobReconciler) deletePreviousVersionScaleJobs(ctx context.Context
 // requestScaleLoop request ScaleLoop handler for the respective ScaledJob
 func (r *ScaledJobReconciler) requestScaleLoop(ctx context.Context, logger logr.Logger, scaledJob *kedav1alpha1.ScaledJob) error {
 	logger.V(1).Info("Starting a new ScaleLoop")
-	key, err := cache.MetaNamespaceKeyFunc(scaledJob)
-	if err != nil {
-		logger.Error(err, "Error getting key for scaledJob")
-		return err
-	}
-
-	if err = r.scaleHandler.HandleScalableObject(ctx, scaledJob); err != nil {
-		return err
-	}
-
-	r.scaledJobGenerations.Store(key, scaledJob.Generation)
-
-	return nil
+	return r.scaleHandler.HandleScalableObject(ctx, scaledJob)
 }
 
 // stopScaleLoop stops ScaleLoop handler for the respective ScaledJob
 func (r *ScaledJobReconciler) stopScaleLoop(ctx context.Context, logger logr.Logger, scaledJob *kedav1alpha1.ScaledJob) error {
 	logger.V(1).Info("Stopping a ScaleLoop")
-
-	key, err := cache.MetaNamespaceKeyFunc(scaledJob)
-	if err != nil {
-		logger.Error(err, "Error getting key for scaledJob")
-		return err
-	}
-
-	if err = r.scaleHandler.DeleteScalableObject(ctx, scaledJob); err != nil {
-		return err
-	}
-
-	r.scaledJobGenerations.Delete(key)
-	return nil
+	return r.scaleHandler.DeleteScalableObject(ctx, scaledJob)
 }
 
 func (r *ScaledJobReconciler) updatePromMetrics(scaledJob *kedav1alpha1.ScaledJob, namespacedName string) {


### PR DESCRIPTION
The `scaledJobGenerations` `sync.Map` field on `ScaledJobReconciler` was written to (`Store` in `requestScaleLoop`, `Delete` in `stopScaleLoop`) but never read from.

Unlike `ScaledObjectReconciler`, which uses `scaledObjectsGenerations` via `scaledObjectGenerationChanged()` to skip unnecessary scale-loop restarts when the spec hasn't changed, `ScaledJobReconciler` unconditionally calls `requestScaleLoop` on every successful reconcile. This made the generation tracking dead code.

This PR removes:
- The `scaledJobGenerations *sync.Map` field from the struct
- Its initialization in `SetupWithManager`
- The `cache.MetaNamespaceKeyFunc` key computation and `Store`/`Delete` calls in `requestScaleLoop`/`stopScaleLoop`
- The now-unused `"k8s.io/client-go/tools/cache"` import

`requestScaleLoop` and `stopScaleLoop` are simplified to directly delegate to `HandleScalableObject` / `DeleteScalableObject`.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #
Relates to #