### PR TITLE
General: Support StreamMetricSpec RPC in external scaler proto for dynamic HPA target updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### New
 
+- **General**: Add optional `StreamMetricSpec` server-streaming RPC to external scaler gRPC proto, allowing external-push scalers to dynamically update HPA target values without modifying the ScaledObject ([#7793](https://github.com/kedacore/keda/issues/7793))
 - **General**: Introduce new ClickHouse Scaler ([#7418](https://github.com/kedacore/keda/issues/7418))
 
 #### Experimental

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -38,8 +38,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	eventingv1alpha1 "github.com/kedacore/keda/v2/apis/eventing/v1alpha1"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -148,6 +150,9 @@ func (r *ScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager, options cont
 				predicate.AnnotationChangedPredicate{},
 				kedacontrollerutil.HPASpecChangedPredicate{},
 			))).
+		// Reconcile when an external-push scaler streams updated metric specs
+		// (StreamMetricSpec), so the HPA is rebuilt from the freshly cached specs.
+		WatchesRawSource(source.Channel(r.ScaleHandler.MetricSpecReconcileChan(), &handler.EnqueueRequestForObject{})).
 		Complete(r)
 }
 

--- a/pkg/mock/mock_scaler/mock_scaler.go
+++ b/pkg/mock/mock_scaler/mock_scaler.go
@@ -165,3 +165,41 @@ func (mr *MockPushScalerMockRecorder) Run(ctx, active any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockPushScaler)(nil).Run), ctx, active)
 }
+
+// MockMetricSpecStreamer is a mock of MetricSpecStreamer interface.
+type MockMetricSpecStreamer struct {
+	ctrl     *gomock.Controller
+	recorder *MockMetricSpecStreamerMockRecorder
+	isgomock struct{}
+}
+
+// MockMetricSpecStreamerMockRecorder is the mock recorder for MockMetricSpecStreamer.
+type MockMetricSpecStreamerMockRecorder struct {
+	mock *MockMetricSpecStreamer
+}
+
+// NewMockMetricSpecStreamer creates a new mock instance.
+func NewMockMetricSpecStreamer(ctrl *gomock.Controller) *MockMetricSpecStreamer {
+	mock := &MockMetricSpecStreamer{ctrl: ctrl}
+	mock.recorder = &MockMetricSpecStreamerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMetricSpecStreamer) EXPECT() *MockMetricSpecStreamerMockRecorder {
+	return m.recorder
+}
+
+// MetricSpecChan mocks base method.
+func (m *MockMetricSpecStreamer) MetricSpecChan() <-chan []v2.MetricSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MetricSpecChan")
+	ret0, _ := ret[0].(<-chan []v2.MetricSpec)
+	return ret0
+}
+
+// MetricSpecChan indicates an expected call of MetricSpecChan.
+func (mr *MockMetricSpecStreamerMockRecorder) MetricSpecChan() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricSpecChan", reflect.TypeOf((*MockMetricSpecStreamer)(nil).MetricSpecChan))
+}

--- a/pkg/mock/mock_scaling/mock_interface.go
+++ b/pkg/mock/mock_scaling/mock_interface.go
@@ -19,6 +19,7 @@ import (
 	cache "github.com/kedacore/keda/v2/pkg/scaling/cache"
 	gomock "go.uber.org/mock/gomock"
 	external_metrics "k8s.io/metrics/pkg/apis/external_metrics"
+	event "sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 // MockScaleHandler is a mock of ScaleHandler interface.
@@ -86,6 +87,20 @@ func (m *MockScaleHandler) GetRawMetricsChan(subscriber string) (chan scaling.Ra
 func (mr *MockScaleHandlerMockRecorder) GetRawMetricsChan(subscriber any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawMetricsChan", reflect.TypeOf((*MockScaleHandler)(nil).GetRawMetricsChan), subscriber)
+}
+
+// MetricSpecReconcileChan mocks base method.
+func (m *MockScaleHandler) MetricSpecReconcileChan() <-chan event.GenericEvent {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MetricSpecReconcileChan")
+	ret0, _ := ret[0].(<-chan event.GenericEvent)
+	return ret0
+}
+
+// MetricSpecReconcileChan indicates an expected call of MetricSpecReconcileChan.
+func (mr *MockScaleHandlerMockRecorder) MetricSpecReconcileChan() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricSpecReconcileChan", reflect.TypeOf((*MockScaleHandler)(nil).MetricSpecReconcileChan))
 }
 
 // GetScaledObjectMetrics mocks base method.

--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -12,9 +12,11 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/mitchellh/hashstructure"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
@@ -32,6 +34,7 @@ type externalScaler struct {
 
 type externalPushScaler struct {
 	externalScaler
+	metricSpecCh chan []v2.MetricSpec
 }
 
 type externalScalerMetadata struct {
@@ -104,7 +107,7 @@ func NewExternalPushScaler(config *scalersconfig.ScalerConfig) (PushScaler, erro
 	}
 
 	return &externalPushScaler{
-		externalScaler{
+		externalScaler: externalScaler{
 			metricType: metricType,
 			metadata:   meta,
 			scaledObjectRef: pb.ScaledObjectRef{
@@ -114,6 +117,7 @@ func NewExternalPushScaler(config *scalersconfig.ScalerConfig) (PushScaler, erro
 			},
 			logger: InitializeLogger(config, "external_push_scaler"),
 		},
+		metricSpecCh: make(chan []v2.MetricSpec, 1),
 	}, nil
 }
 
@@ -145,12 +149,10 @@ func (s *externalScaler) Close(context.Context) error {
 
 // GetMetricSpecForScaling returns the metric spec for the HPA
 func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
-	var result []v2.MetricSpec
-
 	grpcClient, err := getClientForConnectionPool(s.metadata)
 	if err != nil {
 		s.logger.Error(err, "error building grpc connection")
-		return result
+		return nil
 	}
 
 	response, err := grpcClient.GetMetricSpec(ctx, &s.scaledObjectRef)
@@ -159,6 +161,13 @@ func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2.Metri
 		return nil
 	}
 
+	return s.buildMetricSpecs(response)
+}
+
+// buildMetricSpecs converts a GetMetricSpecResponse into Kubernetes metric specs.
+// Always returns a non-nil slice (possibly empty).
+func (s *externalScaler) buildMetricSpecs(response *pb.GetMetricSpecResponse) []v2.MetricSpec {
+	result := make([]v2.MetricSpec, 0, len(response.MetricSpecs))
 	for _, spec := range response.MetricSpecs {
 		externalMetric := &v2.ExternalMetricSource{
 			Metric: v2.MetricIdentifier{
@@ -170,16 +179,11 @@ func (s *externalScaler) GetMetricSpecForScaling(ctx context.Context) []v2.Metri
 		} else {
 			externalMetric.Target = GetMetricTarget(s.metricType, spec.TargetSize)
 		}
-
-		// Create the metric spec for the HPA
-		metricSpec := v2.MetricSpec{
+		result = append(result, v2.MetricSpec{
 			External: externalMetric,
 			Type:     externalMetricType,
-		}
-
-		result = append(result, metricSpec)
+		})
 	}
-
 	return result
 }
 
@@ -226,57 +230,144 @@ func (s *externalScaler) GetMetricsAndActivity(ctx context.Context, metricName s
 	return metrics, isActiveResponse.Result, nil
 }
 
-// handleIsActiveStream is the only writer to the active channel and will close it on return.
+// Run starts both the StreamIsActive and StreamMetricSpec stream handlers.
 func (s *externalPushScaler) Run(ctx context.Context, active chan<- bool) {
 	defer close(active)
 
-	// retry on error from runWithLog() starting by 2 sec backing off * 2 with a max of 2 minutes
-	retryDuration := time.Second * 2
+	go s.runStreamMetricSpec(ctx)
+	s.runStreamIsActive(ctx, active)
+}
 
-	// It's possible for the connection to get terminated anytime, we need to run this in a retry loop
-	runWithLog := func() {
+func (s *externalPushScaler) runStreamIsActive(ctx context.Context, active chan<- bool) {
+	retryDuration := 2 * time.Second
+
+	runOnce := func() {
 		grpcClient, err := getClientForConnectionPool(s.metadata)
 		if err != nil {
 			s.logger.Error(err, "unable to get connection from the pool")
 			return
 		}
 		if err := handleIsActiveStream(ctx, &s.scaledObjectRef, grpcClient, active); err != nil {
-			if !errors.Is(err, io.EOF) { // If io.EOF is returned, the stream has terminated with an OK status
-				s.logger.Error(err, "error running internalRun")
+			if !errors.Is(err, io.EOF) {
+				s.logger.Error(err, "error running StreamIsActive")
 				return
 			}
-			// if the connection is properly closed, we reset the timer
-			retryDuration = time.Second * 2
+			retryDuration = 2 * time.Second
 			return
 		}
 	}
 
-	// the caller of this function needs to ensure that they call Stop() on the resulting
-	// timer, to release background resources.
-	retryBackoff := func() *time.Timer {
-		tmr := time.NewTimer(retryDuration)
-		s.logger.V(1).Info("external push retry backoff", "duration", retryDuration)
-		retryDuration *= 2
-		if retryDuration > time.Minute {
-			retryDuration = time.Minute * 1
-		}
-		return tmr
-	}
-
-	// start the first run without delay
-	runWithLog()
+	runOnce()
 
 	for {
-		backoffTimer := retryBackoff()
+		tmr := time.NewTimer(retryDuration)
+		s.logger.V(1).Info("StreamIsActive retry backoff", "duration", retryDuration)
+		retryDuration = min(retryDuration*2, time.Minute)
 		select {
 		case <-ctx.Done():
-			backoffTimer.Stop()
+			tmr.Stop()
 			return
-		case <-backoffTimer.C:
-			backoffTimer.Stop()
-			runWithLog()
+		case <-tmr.C:
+			runOnce()
 		}
 	}
+}
+
+// runStreamMetricSpec opens a StreamMetricSpec stream and forwards updates
+// to metricSpecCh. The channel is closed when this goroutine exits — either
+// because the context was cancelled or because the server returned
+// Unimplemented. In the latter case the channel is permanently closed; if
+// the ScaledObject generation changes, startPushScalers re-creates the
+// externalPushScaler (with a fresh channel) and launches a new watcher.
+func (s *externalPushScaler) runStreamMetricSpec(ctx context.Context) {
+	defer close(s.metricSpecCh)
+
+	retryDuration := 2 * time.Second
+
+	for {
+		shouldStop, resetRetry := s.streamMetricSpecOnce(ctx)
+		if shouldStop {
+			return
+		}
+		if resetRetry {
+			retryDuration = 2 * time.Second
+		}
+		tmr := time.NewTimer(retryDuration)
+		s.logger.V(1).Info("StreamMetricSpec retry backoff", "duration", retryDuration)
+		retryDuration = min(retryDuration*2, time.Minute)
+		select {
+		case <-ctx.Done():
+			tmr.Stop()
+			return
+		case <-tmr.C:
+		}
+	}
+}
+
+// streamMetricSpecOnce opens a StreamMetricSpec stream and processes updates
+// until the stream closes or an error occurs.
+// Returns (shouldStop, resetRetry): shouldStop=true means the caller should
+// exit the retry loop; resetRetry=true means the retry backoff should be
+// reset because the stream terminated cleanly (io.EOF) or delivered at least
+// one update before failing. A stream that opens but errors before delivering
+// anything keeps the growing backoff, so a persistently broken server is not
+// retried in a tight loop.
+func (s *externalPushScaler) streamMetricSpecOnce(ctx context.Context) (bool, bool) {
+	grpcClient, err := getClientForConnectionPool(s.metadata)
+	if err != nil {
+		s.logger.Error(err, "StreamMetricSpec: unable to get gRPC connection")
+		return false, false
+	}
+
+	stream, err := grpcClient.StreamMetricSpec(ctx, &s.scaledObjectRef)
+	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			s.logger.V(1).Info("StreamMetricSpec not implemented by scaler, skipping")
+			return true, false
+		}
+		s.logger.Error(err, "StreamMetricSpec: failed to open stream")
+		return false, false
+	}
+
+	received := false
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			if status.Code(err) == codes.Unimplemented {
+				s.logger.V(1).Info("StreamMetricSpec not implemented by scaler, skipping")
+				return true, false
+			}
+			if errors.Is(err, io.EOF) {
+				return false, true
+			}
+			s.logger.Error(err, "StreamMetricSpec: stream error")
+			return false, received
+		}
+		received = true
+
+		specs := s.buildMetricSpecs(resp)
+		// Single-producer drain-then-send: safe because only one goroutine
+		// (runStreamMetricSpec) writes to metricSpecCh.
+		select {
+		case s.metricSpecCh <- specs:
+		default:
+			select {
+			case <-s.metricSpecCh:
+			default:
+			}
+			select {
+			case s.metricSpecCh <- specs:
+			case <-ctx.Done():
+				return true, false
+			}
+		}
+	}
+}
+
+// MetricSpecChan returns the channel that receives updated metric specs
+// from the StreamMetricSpec stream.
+func (s *externalPushScaler) MetricSpecChan() <-chan []v2.MetricSpec {
+	return s.metricSpecCh
 }
 
 // handleIsActiveStream calls blocks on a stream call from the GRPC server. It'll only terminate on error, stream completion, or ctx cancellation.

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -310,8 +310,9 @@ type testExternalScaler struct {
 	// Embed the unimplemented server
 	pb.UnimplementedExternalScalerServer
 
-	t      *testing.T
-	active chan bool
+	t           *testing.T
+	active      chan bool
+	metricSpecs chan *pb.GetMetricSpecResponse
 }
 
 func (e *testExternalScaler) IsActive(context.Context, *pb.ScaledObjectRef) (*pb.IsActiveResponse, error) {
@@ -340,6 +341,26 @@ func (e *testExternalScaler) GetMetricSpec(context.Context, *pb.ScaledObjectRef)
 
 func (e *testExternalScaler) GetMetrics(context.Context, *pb.GetMetricsRequest) (*pb.GetMetricsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetMetrics not implemented")
+}
+
+func (e *testExternalScaler) StreamMetricSpec(_ *pb.ScaledObjectRef, server pb.ExternalScaler_StreamMetricSpecServer) error {
+	if e.metricSpecs == nil {
+		return status.Errorf(codes.Unimplemented, "method StreamMetricSpec not implemented")
+	}
+	for {
+		select {
+		case <-server.Context().Done():
+			return nil
+		case spec, ok := <-e.metricSpecs:
+			if !ok {
+				return nil
+			}
+			if err := server.Send(spec); err != nil {
+				e.t.Error(err)
+				return err
+			}
+		}
+	}
 }
 
 func TestWaitForState(t *testing.T) {
@@ -420,5 +441,233 @@ func TestWaitForState(t *testing.T) {
 		return
 	case <-time.After(time.Second * 5):
 		t.Error("waitForState should be get connectivity.Shutdown.")
+	}
+}
+
+func TestExternalPushScaler_StreamMetricSpec(t *testing.T) {
+	metricSpecsCh := make(chan *pb.GetMetricSpecResponse, 1)
+	activeCh := make(chan bool, 1)
+
+	grpcServer := grpc.NewServer()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	address := lis.Addr().String()
+	pb.RegisterExternalScalerServer(grpcServer, &testExternalScaler{
+		t:           t,
+		active:      activeCh,
+		metricSpecs: metricSpecsCh,
+	})
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			t.Error(err)
+		}
+	}()
+	defer grpcServer.GracefulStop()
+
+	pushScaler, err := NewExternalPushScaler(&scalersconfig.ScalerConfig{
+		ScalableObjectName:      "app",
+		ScalableObjectNamespace: "namespace",
+		TriggerMetadata:         map[string]string{"scalerAddress": address},
+		ResolvedEnv:             map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("NewExternalPushScaler: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan bool, 10)
+	go pushScaler.Run(ctx, resultCh)
+
+	// Send a metric spec update
+	metricSpecsCh <- &pb.GetMetricSpecResponse{
+		MetricSpecs: []*pb.MetricSpec{
+			{MetricName: "test-metric", TargetSize: 100},
+		},
+	}
+
+	// Verify the metric spec is received on the channel
+	streamer, ok := pushScaler.(MetricSpecStreamer)
+	if !ok {
+		t.Fatal("externalPushScaler should implement MetricSpecStreamer")
+	}
+
+	select {
+	case specs := <-streamer.MetricSpecChan():
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 metric spec, got %d", len(specs))
+		}
+		if specs[0].External == nil {
+			t.Fatal("expected external metric spec")
+		}
+		expectedTarget := int64(100)
+		actualTarget := specs[0].External.Target.AverageValue.Value()
+		if actualTarget != expectedTarget {
+			t.Fatalf("expected target %d, got %d", expectedTarget, actualTarget)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for metric spec update")
+	}
+}
+
+func TestExternalPushScaler_StreamMetricSpecUnimplemented(t *testing.T) {
+	activeCh := make(chan bool, 1)
+
+	grpcServer := grpc.NewServer()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	address := lis.Addr().String()
+	pb.RegisterExternalScalerServer(grpcServer, &testExternalScaler{
+		t:           t,
+		active:      activeCh,
+		metricSpecs: nil, // nil causes StreamMetricSpec to return Unimplemented
+	})
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			t.Error(err)
+		}
+	}()
+	defer grpcServer.GracefulStop()
+
+	pushScaler, err := NewExternalPushScaler(&scalersconfig.ScalerConfig{
+		ScalableObjectName:      "app",
+		ScalableObjectNamespace: "namespace",
+		TriggerMetadata:         map[string]string{"scalerAddress": address},
+		ResolvedEnv:             map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("NewExternalPushScaler: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan bool, 10)
+	go pushScaler.Run(ctx, resultCh)
+
+	// When StreamMetricSpec returns Unimplemented, no actual specs should
+	// be sent. The channel will be closed when the goroutine exits.
+	streamer := pushScaler.(MetricSpecStreamer)
+	select {
+	case specs, ok := <-streamer.MetricSpecChan():
+		if ok {
+			t.Fatalf("should not receive metric spec when server returns Unimplemented, got %v", specs)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for channel close on Unimplemented")
+	}
+}
+
+// erroringStreamMetricSpecServer sends the configured responses and then
+// fails the stream with a non-Unimplemented error.
+type erroringStreamMetricSpecServer struct {
+	pb.UnimplementedExternalScalerServer
+	specsBeforeError []*pb.GetMetricSpecResponse
+}
+
+func (e *erroringStreamMetricSpecServer) StreamMetricSpec(_ *pb.ScaledObjectRef, server pb.ExternalScaler_StreamMetricSpecServer) error {
+	for _, spec := range e.specsBeforeError {
+		if err := server.Send(spec); err != nil {
+			return err
+		}
+	}
+	return status.Errorf(codes.Internal, "stream failed")
+}
+
+func TestStreamMetricSpecOnce_BackoffReset(t *testing.T) {
+	tests := []struct {
+		name             string
+		specsBeforeError []*pb.GetMetricSpecResponse
+		wantResetRetry   bool
+	}{
+		{
+			name:             "error before any update keeps growing backoff",
+			specsBeforeError: nil,
+			wantResetRetry:   false,
+		},
+		{
+			name: "error after a delivered update resets backoff",
+			specsBeforeError: []*pb.GetMetricSpecResponse{
+				{MetricSpecs: []*pb.MetricSpec{{MetricName: "test-metric", TargetSize: 1}}},
+			},
+			wantResetRetry: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
+			grpcServer := grpc.NewServer()
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen failed: %v", err)
+			}
+			pb.RegisterExternalScalerServer(grpcServer, &erroringStreamMetricSpecServer{
+				specsBeforeError: tt.specsBeforeError,
+			})
+			go func() {
+				if err := grpcServer.Serve(lis); err != nil {
+					t.Error(err)
+				}
+			}()
+			defer grpcServer.GracefulStop()
+
+			pushScaler, err := NewExternalPushScaler(&scalersconfig.ScalerConfig{
+				ScalableObjectName:      "app",
+				ScalableObjectNamespace: "namespace",
+				TriggerMetadata:         map[string]string{"scalerAddress": lis.Addr().String()},
+				ResolvedEnv:             map[string]string{},
+			})
+			if err != nil {
+				t.Fatalf("NewExternalPushScaler: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			shouldStop, resetRetry := pushScaler.(*externalPushScaler).streamMetricSpecOnce(ctx)
+			if shouldStop {
+				t.Fatal("streamMetricSpecOnce should not request stop on a stream error")
+			}
+			if resetRetry != tt.wantResetRetry {
+				t.Fatalf("expected resetRetry=%v, got %v", tt.wantResetRetry, resetRetry)
+			}
+		})
+	}
+}
+
+func TestConvertMetricSpecResponse(t *testing.T) {
+	s := &externalPushScaler{
+		externalScaler: externalScaler{
+			metricType: "AverageValue",
+			metadata:   externalScalerMetadata{triggerIndex: 0},
+		},
+	}
+
+	resp := &pb.GetMetricSpecResponse{
+		MetricSpecs: []*pb.MetricSpec{
+			{MetricName: "metric-a", TargetSize: 50},
+			{MetricName: "metric-b", TargetSizeFloat: 1.5},
+		},
+	}
+
+	specs := s.buildMetricSpecs(resp)
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 specs, got %d", len(specs))
+	}
+	if specs[0].External.Metric.Name != "s0-metric-a" {
+		t.Errorf("expected s0-metric-a, got %s", specs[0].External.Metric.Name)
+	}
+	if specs[1].External.Metric.Name != "s0-metric-b" {
+		t.Errorf("expected s0-metric-b, got %s", specs[1].External.Metric.Name)
+	}
+	// First spec uses integer target
+	if specs[0].External.Target.AverageValue.Value() != 50 {
+		t.Errorf("expected target 50, got %d", specs[0].External.Target.AverageValue.Value())
 	}
 }

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -448,6 +448,7 @@ func TestExternalPushScaler_StreamMetricSpec(t *testing.T) {
 	metricSpecsCh := make(chan *pb.GetMetricSpecResponse, 1)
 	activeCh := make(chan bool, 1)
 
+	// nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
 	grpcServer := grpc.NewServer()
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -516,6 +517,7 @@ func TestExternalPushScaler_StreamMetricSpec(t *testing.T) {
 func TestExternalPushScaler_StreamMetricSpecUnimplemented(t *testing.T) {
 	activeCh := make(chan bool, 1)
 
+	// nosemgrep: go.grpc.security.grpc-server-insecure-connection.grpc-server-insecure-connection
 	grpcServer := grpc.NewServer()
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/pkg/scalers/externalscaler/externalscaler.pb.go
+++ b/pkg/scalers/externalscaler/externalscaler.pb.go
@@ -424,13 +424,14 @@ const file_externalscaler_proto_rawDesc = "" +
 	"metricName\x18\x01 \x01(\tR\n" +
 	"metricName\x12 \n" +
 	"\vmetricValue\x18\x02 \x01(\x03R\vmetricValue\x12*\n" +
-	"\x10metricValueFloat\x18\x03 \x01(\x01R\x10metricValueFloat2\xec\x02\n" +
+	"\x10metricValueFloat\x18\x03 \x01(\x01R\x10metricValueFloat2\xcc\x03\n" +
 	"\x0eExternalScaler\x12O\n" +
 	"\bIsActive\x12\x1f.externalscaler.ScaledObjectRef\x1a .externalscaler.IsActiveResponse\"\x00\x12W\n" +
 	"\x0eStreamIsActive\x12\x1f.externalscaler.ScaledObjectRef\x1a .externalscaler.IsActiveResponse\"\x000\x01\x12Y\n" +
 	"\rGetMetricSpec\x12\x1f.externalscaler.ScaledObjectRef\x1a%.externalscaler.GetMetricSpecResponse\"\x00\x12U\n" +
 	"\n" +
-	"GetMetrics\x12!.externalscaler.GetMetricsRequest\x1a\".externalscaler.GetMetricsResponse\"\x00B\x12Z\x10.;externalscalerb\x06proto3"
+	"GetMetrics\x12!.externalscaler.GetMetricsRequest\x1a\".externalscaler.GetMetricsResponse\"\x00\x12^\n" +
+	"\x10StreamMetricSpec\x12\x1f.externalscaler.ScaledObjectRef\x1a%.externalscaler.GetMetricSpecResponse\"\x000\x01B\x12Z\x10.;externalscalerb\x06proto3"
 
 var (
 	file_externalscaler_proto_rawDescOnce sync.Once
@@ -464,12 +465,14 @@ var file_externalscaler_proto_depIdxs = []int32{
 	0, // 5: externalscaler.ExternalScaler.StreamIsActive:input_type -> externalscaler.ScaledObjectRef
 	0, // 6: externalscaler.ExternalScaler.GetMetricSpec:input_type -> externalscaler.ScaledObjectRef
 	4, // 7: externalscaler.ExternalScaler.GetMetrics:input_type -> externalscaler.GetMetricsRequest
-	1, // 8: externalscaler.ExternalScaler.IsActive:output_type -> externalscaler.IsActiveResponse
-	1, // 9: externalscaler.ExternalScaler.StreamIsActive:output_type -> externalscaler.IsActiveResponse
-	2, // 10: externalscaler.ExternalScaler.GetMetricSpec:output_type -> externalscaler.GetMetricSpecResponse
-	5, // 11: externalscaler.ExternalScaler.GetMetrics:output_type -> externalscaler.GetMetricsResponse
-	8, // [8:12] is the sub-list for method output_type
-	4, // [4:8] is the sub-list for method input_type
+	0, // 8: externalscaler.ExternalScaler.StreamMetricSpec:input_type -> externalscaler.ScaledObjectRef
+	1, // 9: externalscaler.ExternalScaler.IsActive:output_type -> externalscaler.IsActiveResponse
+	1, // 10: externalscaler.ExternalScaler.StreamIsActive:output_type -> externalscaler.IsActiveResponse
+	2, // 11: externalscaler.ExternalScaler.GetMetricSpec:output_type -> externalscaler.GetMetricSpecResponse
+	5, // 12: externalscaler.ExternalScaler.GetMetrics:output_type -> externalscaler.GetMetricsResponse
+	2, // 13: externalscaler.ExternalScaler.StreamMetricSpec:output_type -> externalscaler.GetMetricSpecResponse
+	9, // [9:14] is the sub-list for method output_type
+	4, // [4:9] is the sub-list for method input_type
 	4, // [4:4] is the sub-list for extension type_name
 	4, // [4:4] is the sub-list for extension extendee
 	0, // [0:4] is the sub-list for field type_name

--- a/pkg/scalers/externalscaler/externalscaler.proto
+++ b/pkg/scalers/externalscaler/externalscaler.proto
@@ -8,6 +8,21 @@ service ExternalScaler {
     rpc StreamIsActive(ScaledObjectRef) returns (stream IsActiveResponse) {}
     rpc GetMetricSpec(ScaledObjectRef) returns (GetMetricSpecResponse) {}
     rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse) {}
+
+    // Optional. When implemented, the scaler pushes updated metric specs
+    // whenever HPA target values change. KEDA updates the cached specs and
+    // syncs the HPA accordingly. If unimplemented (returns Unimplemented),
+    // KEDA silently falls back to the existing pull-based behavior.
+    //
+    // Servers implementing this RPC must follow two rules:
+    //   1. Send the current metric specs immediately when the stream is
+    //      opened (like StreamIsActive), not only when values change.
+    //   2. Keep GetMetricSpec returning the same current values as the
+    //      latest streamed update. KEDA may rebuild its internal scaler
+    //      state (e.g. after a scaler error) and falls back to
+    //      GetMetricSpec until the next streamed update; if the two
+    //      diverge, HPA targets can temporarily revert to stale values.
+    rpc StreamMetricSpec(ScaledObjectRef) returns (stream GetMetricSpecResponse) {}
 }
 
 message ScaledObjectRef {

--- a/pkg/scalers/externalscaler/externalscaler_grpc.pb.go
+++ b/pkg/scalers/externalscaler/externalscaler_grpc.pb.go
@@ -19,10 +19,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ExternalScaler_IsActive_FullMethodName       = "/externalscaler.ExternalScaler/IsActive"
-	ExternalScaler_StreamIsActive_FullMethodName = "/externalscaler.ExternalScaler/StreamIsActive"
-	ExternalScaler_GetMetricSpec_FullMethodName  = "/externalscaler.ExternalScaler/GetMetricSpec"
-	ExternalScaler_GetMetrics_FullMethodName     = "/externalscaler.ExternalScaler/GetMetrics"
+	ExternalScaler_IsActive_FullMethodName         = "/externalscaler.ExternalScaler/IsActive"
+	ExternalScaler_StreamIsActive_FullMethodName   = "/externalscaler.ExternalScaler/StreamIsActive"
+	ExternalScaler_GetMetricSpec_FullMethodName    = "/externalscaler.ExternalScaler/GetMetricSpec"
+	ExternalScaler_GetMetrics_FullMethodName       = "/externalscaler.ExternalScaler/GetMetrics"
+	ExternalScaler_StreamMetricSpec_FullMethodName = "/externalscaler.ExternalScaler/StreamMetricSpec"
 )
 
 // ExternalScalerClient is the client API for ExternalScaler service.
@@ -33,6 +34,20 @@ type ExternalScalerClient interface {
 	StreamIsActive(ctx context.Context, in *ScaledObjectRef, opts ...grpc.CallOption) (grpc.ServerStreamingClient[IsActiveResponse], error)
 	GetMetricSpec(ctx context.Context, in *ScaledObjectRef, opts ...grpc.CallOption) (*GetMetricSpecResponse, error)
 	GetMetrics(ctx context.Context, in *GetMetricsRequest, opts ...grpc.CallOption) (*GetMetricsResponse, error)
+	// Optional. When implemented, the scaler pushes updated metric specs
+	// whenever HPA target values change. KEDA updates the cached specs and
+	// syncs the HPA accordingly. If unimplemented (returns Unimplemented),
+	// KEDA silently falls back to the existing pull-based behavior.
+	//
+	// Servers implementing this RPC must follow two rules:
+	//  1. Send the current metric specs immediately when the stream is
+	//     opened (like StreamIsActive), not only when values change.
+	//  2. Keep GetMetricSpec returning the same current values as the
+	//     latest streamed update. KEDA may rebuild its internal scaler
+	//     state (e.g. after a scaler error) and falls back to
+	//     GetMetricSpec until the next streamed update; if the two
+	//     diverge, HPA targets can temporarily revert to stale values.
+	StreamMetricSpec(ctx context.Context, in *ScaledObjectRef, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetMetricSpecResponse], error)
 }
 
 type externalScalerClient struct {
@@ -92,6 +107,25 @@ func (c *externalScalerClient) GetMetrics(ctx context.Context, in *GetMetricsReq
 	return out, nil
 }
 
+func (c *externalScalerClient) StreamMetricSpec(ctx context.Context, in *ScaledObjectRef, opts ...grpc.CallOption) (grpc.ServerStreamingClient[GetMetricSpecResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &ExternalScaler_ServiceDesc.Streams[1], ExternalScaler_StreamMetricSpec_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[ScaledObjectRef, GetMetricSpecResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type ExternalScaler_StreamMetricSpecClient = grpc.ServerStreamingClient[GetMetricSpecResponse]
+
 // ExternalScalerServer is the server API for ExternalScaler service.
 // All implementations must embed UnimplementedExternalScalerServer
 // for forward compatibility.
@@ -100,6 +134,20 @@ type ExternalScalerServer interface {
 	StreamIsActive(*ScaledObjectRef, grpc.ServerStreamingServer[IsActiveResponse]) error
 	GetMetricSpec(context.Context, *ScaledObjectRef) (*GetMetricSpecResponse, error)
 	GetMetrics(context.Context, *GetMetricsRequest) (*GetMetricsResponse, error)
+	// Optional. When implemented, the scaler pushes updated metric specs
+	// whenever HPA target values change. KEDA updates the cached specs and
+	// syncs the HPA accordingly. If unimplemented (returns Unimplemented),
+	// KEDA silently falls back to the existing pull-based behavior.
+	//
+	// Servers implementing this RPC must follow two rules:
+	//  1. Send the current metric specs immediately when the stream is
+	//     opened (like StreamIsActive), not only when values change.
+	//  2. Keep GetMetricSpec returning the same current values as the
+	//     latest streamed update. KEDA may rebuild its internal scaler
+	//     state (e.g. after a scaler error) and falls back to
+	//     GetMetricSpec until the next streamed update; if the two
+	//     diverge, HPA targets can temporarily revert to stale values.
+	StreamMetricSpec(*ScaledObjectRef, grpc.ServerStreamingServer[GetMetricSpecResponse]) error
 	mustEmbedUnimplementedExternalScalerServer()
 }
 
@@ -121,6 +169,9 @@ func (UnimplementedExternalScalerServer) GetMetricSpec(context.Context, *ScaledO
 }
 func (UnimplementedExternalScalerServer) GetMetrics(context.Context, *GetMetricsRequest) (*GetMetricsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMetrics not implemented")
+}
+func (UnimplementedExternalScalerServer) StreamMetricSpec(*ScaledObjectRef, grpc.ServerStreamingServer[GetMetricSpecResponse]) error {
+	return status.Error(codes.Unimplemented, "method StreamMetricSpec not implemented")
 }
 func (UnimplementedExternalScalerServer) mustEmbedUnimplementedExternalScalerServer() {}
 func (UnimplementedExternalScalerServer) testEmbeddedByValue()                        {}
@@ -208,6 +259,17 @@ func _ExternalScaler_GetMetrics_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ExternalScaler_StreamMetricSpec_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(ScaledObjectRef)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(ExternalScalerServer).StreamMetricSpec(m, &grpc.GenericServerStream[ScaledObjectRef, GetMetricSpecResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type ExternalScaler_StreamMetricSpecServer = grpc.ServerStreamingServer[GetMetricSpecResponse]
+
 // ExternalScaler_ServiceDesc is the grpc.ServiceDesc for ExternalScaler service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -232,6 +294,11 @@ var ExternalScaler_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamIsActive",
 			Handler:       _ExternalScaler_StreamIsActive_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamMetricSpec",
+			Handler:       _ExternalScaler_StreamMetricSpec_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -61,6 +61,12 @@ type PushScaler interface {
 	Run(ctx context.Context, active chan<- bool)
 }
 
+// MetricSpecStreamer is optionally implemented by PushScalers that support
+// dynamic metric spec updates via server-streaming RPCs.
+type MetricSpecStreamer interface {
+	MetricSpecChan() <-chan []v2.MetricSpec
+}
+
 var (
 	// ErrScalerUnsupportedUtilizationMetricType is returned when v2.UtilizationMetricType
 	// is provided as the metric target type for scaler.

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/expr-lang/expr/vm"
 	v2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -90,9 +91,23 @@ func (c *ScalersCache) acquireReader() (release func(), err error) {
 }
 
 type ScalerBuilder struct {
-	Scaler       scalers.Scaler
-	ScalerConfig scalersconfig.ScalerConfig
-	Factory      func() (scalers.Scaler, *scalersconfig.ScalerConfig, error)
+	Scaler            scalers.Scaler
+	ScalerConfig      scalersconfig.ScalerConfig
+	Factory           func() (scalers.Scaler, *scalersconfig.ScalerConfig, error)
+	CachedMetricSpecs []v2.MetricSpec
+}
+
+func cloneMetricSpecs(specs []v2.MetricSpec) []v2.MetricSpec {
+	if specs == nil {
+		return nil
+	}
+
+	cloned := make([]v2.MetricSpec, 0, len(specs))
+	for i := range specs {
+		spec := specs[i]
+		cloned = append(cloned, *spec.DeepCopy())
+	}
+	return cloned
 }
 
 // GetScalers returns array of scalers and scaler config stored in the cache
@@ -170,18 +185,24 @@ func (c *ScalersCache) Close(ctx context.Context) {
 	}
 }
 
-// GetMetricSpecForScaling returns metrics specs for all scalers in the cache
+// GetMetricSpecForScaling returns metrics specs for all scalers in the cache.
+// If a scaler has cached metric specs from StreamMetricSpec, those take precedence.
 func (c *ScalersCache) GetMetricSpecForScaling(ctx context.Context) []v2.MetricSpec {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	var spec []v2.MetricSpec
 	for _, s := range c.Scalers {
-		spec = append(spec, s.Scaler.GetMetricSpecForScaling(ctx)...)
+		if s.CachedMetricSpecs != nil {
+			spec = append(spec, cloneMetricSpecs(s.CachedMetricSpecs)...)
+		} else {
+			spec = append(spec, s.Scaler.GetMetricSpecForScaling(ctx)...)
+		}
 	}
 	return spec
 }
 
-// GetMetricSpecForScalingForScaler returns metrics spec for a scaler identified by the metric name
+// GetMetricSpecForScalingForScaler returns metrics spec for a scaler identified by the metric name.
+// If the scaler has cached metric specs from StreamMetricSpec, those take precedence.
 func (c *ScalersCache) GetMetricSpecForScalingForScaler(ctx context.Context, index int) ([]v2.MetricSpec, error) {
 	release, err := c.acquireReader()
 	if err != nil {
@@ -192,6 +213,10 @@ func (c *ScalersCache) GetMetricSpecForScalingForScaler(ctx context.Context, ind
 	sb, err := c.getScalerBuilder(index)
 	if err != nil {
 		return nil, err
+	}
+
+	if sb.CachedMetricSpecs != nil {
+		return cloneMetricSpecs(sb.CachedMetricSpecs), nil
 	}
 
 	metricSpecs := sb.Scaler.GetMetricSpecForScaling(ctx)
@@ -247,6 +272,35 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 	return metric, activity, time.Since(startTime), err
 }
 
+// UpdateMetricSpecForScaler replaces the cached metric specs for a given scaler
+// index, but only when the cache still belongs to the ScaledObject identified by
+// uid and generation. The identity guard prevents a stale streaming watcher
+// (bound to an older ScaledObject generation, or to an object that was deleted
+// and recreated under the same name) from overwriting the specs of an unrelated
+// cache. A cache rebuilt for the same UID and generation (e.g. after a scaler
+// error) keeps the same identity, so legitimate cache invalidation still
+// receives streamed updates.
+//
+// The identity check and the write are performed under the same lock so the
+// validated cache cannot silently become stale between the two operations. It
+// reports whether the update was applied (false if the cache is closed, the
+// index is out of range, or the identity does not match).
+func (c *ScalersCache) UpdateMetricSpecForScaler(index int, specs []v2.MetricSpec, uid types.UID, generation int64) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.closed || index < 0 || index >= len(c.Scalers) {
+		return false
+	}
+
+	if c.ScaledObject == nil || c.ScaledObject.UID != uid || c.ScalableObjectGeneration != generation {
+		return false
+	}
+
+	c.Scalers[index].CachedMetricSpecs = cloneMetricSpecs(specs)
+	return true
+}
+
 func (c *ScalersCache) refreshScaler(ctx context.Context, index int) (scalers.Scaler, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -267,9 +321,10 @@ func (c *ScalersCache) refreshScaler(ctx context.Context, index int) (scalers.Sc
 	}
 
 	c.Scalers[index] = ScalerBuilder{
-		Scaler:       newScaler,
-		ScalerConfig: *sConfig,
-		Factory:      oldSb.Factory,
+		Scaler:            newScaler,
+		ScalerConfig:      *sConfig,
+		Factory:           oldSb.Factory,
+		CachedMetricSpecs: cloneMetricSpecs(oldSb.CachedMetricSpecs),
 	}
 
 	oldSb.Scaler.Close(ctx)

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -26,11 +26,19 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/atomic"
 	v2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/scalers"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+)
+
+const (
+	testCacheUID        = types.UID("test-cache-uid")
+	testCacheGeneration = int64(1)
 )
 
 func TestBuildScalerRequestCtx(t *testing.T) {
@@ -133,6 +141,13 @@ func (f *fakeScaler) Close(_ context.Context) error {
 
 func newCacheWithScaler(s scalers.Scaler) *ScalersCache {
 	return &ScalersCache{
+		ScaledObject: &kedav1alpha1.ScaledObject{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:        testCacheUID,
+				Generation: testCacheGeneration,
+			},
+		},
+		ScalableObjectGeneration: testCacheGeneration,
 		Scalers: []ScalerBuilder{{
 			Scaler:       s,
 			ScalerConfig: scalersconfig.ScalerConfig{},
@@ -386,5 +401,116 @@ func TestScalersCache_ConcurrentCloseAndRead(t *testing.T) {
 		if readErr != nil && !errors.Is(readErr, ErrCacheClosed) {
 			t.Fatalf("iteration %d: unexpected error from concurrent read: %v", i, readErr)
 		}
+	}
+}
+
+func TestScalersCache_UpdateMetricSpecForScaler(t *testing.T) {
+	scaler := newFakeScaler(nil)
+	c := newCacheWithScaler(scaler)
+
+	newSpecs := []v2.MetricSpec{{
+		External: &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{
+				Name:     "updated-metric",
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"source": "stream"}},
+			},
+		},
+		Type: "External",
+	}}
+
+	if !c.UpdateMetricSpecForScaler(0, newSpecs, testCacheUID, testCacheGeneration) {
+		t.Fatal("UpdateMetricSpecForScaler should report true for a valid index")
+	}
+
+	// Mutate the caller-owned slice after storing it; the cache must keep its own deep copy.
+	newSpecs[0].External.Metric.Name = "mutated"
+	newSpecs[0].External.Metric.Selector.MatchLabels["source"] = "mutated"
+
+	specs := c.GetMetricSpecForScaling(context.Background())
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(specs))
+	}
+	if specs[0].External.Metric.Name != "updated-metric" {
+		t.Fatalf("expected updated-metric, got %s", specs[0].External.Metric.Name)
+	}
+	if specs[0].External.Metric.Selector.MatchLabels["source"] != "stream" {
+		t.Fatalf("expected selector source=stream, got %q", specs[0].External.Metric.Selector.MatchLabels["source"])
+	}
+}
+
+func TestScalersCache_UpdateMetricSpecForScaler_InvalidIndex(t *testing.T) {
+	scaler := newFakeScaler(nil)
+	c := newCacheWithScaler(scaler)
+
+	if c.UpdateMetricSpecForScaler(-1, []v2.MetricSpec{}, testCacheUID, testCacheGeneration) {
+		t.Fatal("UpdateMetricSpecForScaler should report false for a negative index")
+	}
+	if c.UpdateMetricSpecForScaler(5, []v2.MetricSpec{}, testCacheUID, testCacheGeneration) {
+		t.Fatal("UpdateMetricSpecForScaler should report false for an out-of-range index")
+	}
+}
+
+func TestScalersCache_UpdateMetricSpecForScaler_IdentityMismatch(t *testing.T) {
+	scaler := newFakeScaler(nil)
+	c := newCacheWithScaler(scaler)
+
+	specs := []v2.MetricSpec{{
+		External: &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{Name: "updated-metric"},
+		},
+		Type: "External",
+	}}
+
+	if c.UpdateMetricSpecForScaler(0, specs, types.UID("other-uid"), testCacheGeneration) {
+		t.Fatal("UpdateMetricSpecForScaler should report false for a mismatched UID")
+	}
+	if c.UpdateMetricSpecForScaler(0, specs, testCacheUID, testCacheGeneration+1) {
+		t.Fatal("UpdateMetricSpecForScaler should report false for a mismatched generation")
+	}
+
+	if got := c.GetMetricSpecForScaling(context.Background()); len(got) != 1 || got[0].External.Metric.Name != "fake" {
+		t.Fatalf("cache specs must be untouched on identity mismatch, got %+v", got)
+	}
+}
+
+func TestScalersCache_GetMetricSpecForScalingForScaler_UsesCachedSpecs(t *testing.T) {
+	scaler := newFakeScaler(nil)
+	c := newCacheWithScaler(scaler)
+
+	cachedSpecs := []v2.MetricSpec{{
+		External: &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{
+				Name:     "cached-metric",
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"owner": "cache"}},
+			},
+		},
+		Type: "External",
+	}}
+	c.UpdateMetricSpecForScaler(0, cachedSpecs, testCacheUID, testCacheGeneration)
+
+	specs, err := c.GetMetricSpecForScalingForScaler(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("expected 1 spec, got %d", len(specs))
+	}
+	if specs[0].External.Metric.Name != "cached-metric" {
+		t.Fatalf("expected cached-metric, got %s", specs[0].External.Metric.Name)
+	}
+
+	// Mutating the returned spec must not bleed back into the cache.
+	specs[0].External.Metric.Name = "mutated"
+	specs[0].External.Metric.Selector.MatchLabels["owner"] = "mutated"
+
+	specsAgain, err := c.GetMetricSpecForScalingForScaler(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error on second read: %v", err)
+	}
+	if specsAgain[0].External.Metric.Name != "cached-metric" {
+		t.Fatalf("expected cached-metric on second read, got %s", specsAgain[0].External.Metric.Name)
+	}
+	if specsAgain[0].External.Metric.Selector.MatchLabels["owner"] != "cache" {
+		t.Fatalf("expected selector owner=cache on second read, got %q", specsAgain[0].External.Metric.Selector.MatchLabels["owner"])
 	}
 }

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -74,6 +75,12 @@ type ScaleHandler interface {
 	SubscribeMetric(ctx context.Context, subscriber string, metricMetadata *api.ScaledObjectRef) bool
 	UnsubscribeMetric(ctx context.Context, subscriber string, metadata *api.ScaledObjectRef) bool
 	GetRawMetricsChan(subscriber string) (rawMetrics chan RawMetrics, done chan bool)
+
+	// MetricSpecReconcileChan returns a channel of events that request a
+	// ScaledObject reconcile. It is fed when an external-push scaler streams
+	// updated metric specs (StreamMetricSpec) so the ScaledObject reconciler
+	// can rebuild the HPA from the freshly cached specs.
+	MetricSpecReconcileChan() <-chan event.GenericEvent
 }
 
 type scaleHandler struct {
@@ -91,6 +98,9 @@ type scaleHandler struct {
 	// redundant, but it will speed up the lookups
 	metricToSubscriptions map[metricMeta][]*RawMetricSubscriptions
 	subsLock              *sync.RWMutex
+	// metricSpecReconcileCh delivers reconcile requests for ScaledObjects whose
+	// external-push scalers have streamed updated metric specs.
+	metricSpecReconcileCh chan event.GenericEvent
 }
 
 // NewScaleHandler creates a ScaleHandler object
@@ -109,6 +119,82 @@ func NewScaleHandler(client client.Client, scaleClient scale.ScalesGetter, recon
 		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
 		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
 		subsLock:                 &sync.RWMutex{},
+		metricSpecReconcileCh:    make(chan event.GenericEvent, 1024),
+	}
+}
+
+// MetricSpecReconcileChan returns the channel of reconcile requests triggered
+// by streamed metric spec updates. See the ScaleHandler interface for details.
+func (h *scaleHandler) MetricSpecReconcileChan() <-chan event.GenericEvent {
+	return h.metricSpecReconcileCh
+}
+
+// enqueueMetricSpecReconcile asks the ScaledObject reconciler to reconcile the
+// named ScaledObject. Updates are never dropped because the shared reconcile
+// channel is full; instead this call waits for channel capacity or returns
+// when ctx is cancelled.
+func (h *scaleHandler) enqueueMetricSpecReconcile(ctx context.Context, name, namespace string) {
+	evt := event.GenericEvent{Object: &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}}
+	select {
+	case <-ctx.Done():
+	case h.metricSpecReconcileCh <- evt:
+	}
+}
+
+// watchMetricSpecUpdates forwards streamed metric spec updates into the latest
+// ScalersCache for the ScaledObject. This keeps StreamMetricSpec working across
+// cache invalidations caused by scaler errors, where the original cache
+// instance is closed and replaced but the existing push-scaler stream is still
+// alive.
+//
+// The watcher is bound to the identity (uid and generation) of the ScaledObject
+// that created it. Because cancelling the scale-loop context does not guarantee
+// the watcher stops before it processes a buffered stream response (Go may pick
+// the stream case over ctx.Done() when both are ready), the resolved cache is
+// verified against that identity before applying the update. This prevents a
+// stale watcher from writing an old generation's metric spec into a newer
+// generation's cache, or into a cache belonging to a different object that was
+// recreated under the same namespace and name. Same-identity cache
+// replacements (e.g. after a scaler error) keep the same uid and generation, so
+// legitimate updates still flow.
+func (h *scaleHandler) watchMetricSpecUpdates(ctx context.Context, scaledObjectName, scaledObjectNamespace string, triggerIndex int, streamer scalers.MetricSpecStreamer, uid types.UID, generation int64) {
+	logger := log.WithValues("namespace", scaledObjectNamespace, "name", scaledObjectName, "triggerIndex", triggerIndex)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case specs, ok := <-streamer.MetricSpecChan():
+			if !ok {
+				return
+			}
+
+			// Fast-path: bail out if the scale loop was cancelled while this
+			// response was buffered. This is only an optimization; the identity
+			// check below is the actual guard against applying stale updates.
+			if ctx.Err() != nil {
+				return
+			}
+
+			scalersCache, err := h.getScalersCacheForScaledObject(ctx, scaledObjectName, scaledObjectNamespace)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				logger.Error(err, "error getting scalers cache for metric spec update")
+				continue
+			}
+
+			// UpdateMetricSpecForScaler validates the cache identity (uid and
+			// generation) and applies the update atomically under the cache
+			// lock, so the cache cannot become stale between the check and the
+			// write.
+			if scalersCache.UpdateMetricSpecForScaler(triggerIndex, specs, uid, generation) {
+				h.enqueueMetricSpecReconcile(ctx, scaledObjectName, scaledObjectNamespace)
+			}
+		}
 	}
 }
 
@@ -222,7 +308,13 @@ func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav
 	}
 
 	for i, ps := range scalersCache.GetPushScalers() {
-		go func(s scalers.PushScaler, triggerIndex int) {
+		// Only ScaledObjects own an HPA that can be re-targeted via StreamMetricSpec.
+		if so, isScaledObject := scalableObject.(*kedav1alpha1.ScaledObject); isScaledObject {
+			if streamer, ok := ps.Scaler.(scalers.MetricSpecStreamer); ok {
+				go h.watchMetricSpecUpdates(ctx, so.Name, so.Namespace, ps.TriggerIndex, streamer, so.UID, so.Generation)
+			}
+		}
+		go func(s scalers.PushScaler, triggerIndex, pushScalerIndex int) {
 			activeCh := make(chan bool)
 			go s.Run(ctx, activeCh)
 			for {
@@ -231,12 +323,12 @@ func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav
 					return
 				case active, channelOpen := <-activeCh:
 					if !channelOpen {
-						logger.V(1).Info("Push scaler channel closed", "scalableObject", scalableObject, "pushScalerIndex", i)
+						logger.V(1).Info("Push scaler channel closed", "scalableObject", scalableObject, "pushScalerIndex", pushScalerIndex)
 						return
 					}
 					if !active {
 						// inactivation events are ignored and inactivation happens through the standard metric scaling logic
-						logger.V(4).Info("Push scaler inactivation event received", "scalableObject", scalableObject, "pushScalerIndex", i)
+						logger.V(4).Info("Push scaler inactivation event received", "scalableObject", scalableObject, "pushScalerIndex", pushScalerIndex)
 						continue
 					}
 					switch scalableObject.(type) {
@@ -265,7 +357,7 @@ func (h *scaleHandler) startPushScalers(ctx context.Context, withTriggers *kedav
 					}
 				}
 			}
-		}(ps.Scaler, ps.TriggerIndex)
+		}(ps.Scaler, ps.TriggerIndex, i)
 	}
 }
 

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -1711,4 +1712,292 @@ func TestHandleResult_DeltaDoesNotOverwriteConcurrentChanges(t *testing.T) {
 	// applied to fresh current: trigger-a stays true (concurrent update preserved), trigger-b set to true
 	assert.True(t, patchedObj.Status.TriggersActivity["trigger-a"].IsActive, "concurrent update to trigger-a must be preserved")
 	assert.True(t, patchedObj.Status.TriggersActivity["trigger-b"].IsActive, "trigger-b updated by push scaler")
+}
+
+type metricSpecWatcherTestPushScaler struct {
+	specCh chan []v2.MetricSpec
+}
+
+func (s *metricSpecWatcherTestPushScaler) GetMetricsAndActivity(context.Context, string) ([]external_metrics.ExternalMetricValue, bool, error) {
+	return nil, false, nil
+}
+
+func (s *metricSpecWatcherTestPushScaler) GetMetricSpecForScaling(context.Context) []v2.MetricSpec {
+	return nil
+}
+
+func (s *metricSpecWatcherTestPushScaler) Close(context.Context) error {
+	return nil
+}
+
+func (s *metricSpecWatcherTestPushScaler) Run(context.Context, chan<- bool) {}
+
+func (s *metricSpecWatcherTestPushScaler) MetricSpecChan() <-chan []v2.MetricSpec {
+	return s.specCh
+}
+
+func TestWatchMetricSpecUpdates_UsesLatestCacheAfterInvalidation(t *testing.T) {
+	const generation = int64(3)
+	uid := types.UID("so-uid-1")
+	scaledObject := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testNameGlobal,
+			Namespace:  testNamespaceGlobal,
+			UID:        uid,
+			Generation: generation,
+		},
+	}
+	key := scaledObject.GenerateIdentifier()
+
+	streamer := &metricSpecWatcherTestPushScaler{specCh: make(chan []v2.MetricSpec, 1)}
+	oldCache := &cache.ScalersCache{
+		ScaledObject:             scaledObject,
+		ScalableObjectGeneration: generation,
+		Scalers: []cache.ScalerBuilder{{
+			Scaler:       streamer,
+			ScalerConfig: scalersconfig.ScalerConfig{TriggerIndex: 0},
+		}},
+		Recorder: events.NewFakeRecorder(10),
+	}
+	// A scaler-error invalidation rebuilds the cache for the same object, so the
+	// replacement keeps the same UID and generation.
+	newCache := &cache.ScalersCache{
+		ScaledObject:             scaledObject,
+		ScalableObjectGeneration: generation,
+		Scalers: []cache.ScalerBuilder{{
+			Scaler:       &metricSpecWatcherTestPushScaler{specCh: make(chan []v2.MetricSpec)},
+			ScalerConfig: scalersconfig.ScalerConfig{TriggerIndex: 0},
+		}},
+		Recorder: events.NewFakeRecorder(10),
+	}
+
+	h := &scaleHandler{
+		scalerCaches:          map[string]*cache.ScalersCache{key: oldCache},
+		scalerCachesLock:      &sync.RWMutex{},
+		metricSpecReconcileCh: make(chan event.GenericEvent, 1),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go h.watchMetricSpecUpdates(ctx, scaledObject.Name, scaledObject.Namespace, 0, streamer, uid, generation)
+
+	oldCache.Close(context.Background())
+	h.scalerCachesLock.Lock()
+	h.scalerCaches[key] = newCache
+	h.scalerCachesLock.Unlock()
+
+	expectedSpecs := []v2.MetricSpec{createMetricSpec(42, "s0-updated")}
+	streamer.specCh <- expectedSpecs
+
+	assert.Eventually(t, func() bool {
+		specs := newCache.GetMetricSpecForScaling(context.Background())
+		return len(specs) == 1 && specs[0].External != nil && specs[0].External.Metric.Name == "s0-updated"
+	}, time.Second, 10*time.Millisecond)
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		assert.Equal(t, scaledObject.Name, evt.Object.GetName())
+		assert.Equal(t, scaledObject.Namespace, evt.Object.GetNamespace())
+	case <-time.After(time.Second):
+		t.Fatal("expected a reconcile event for the replacement cache")
+	}
+}
+
+// TestWatchMetricSpecUpdates_IgnoresStaleGeneration verifies that a watcher
+// bound to an old ScaledObject generation cannot overwrite the metric spec of a
+// cache installed for a newer generation, and does not enqueue a reconcile.
+func TestWatchMetricSpecUpdates_IgnoresStaleGeneration(t *testing.T) {
+	uid := types.UID("so-uid-1")
+	scaledObject := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNameGlobal,
+			Namespace: testNamespaceGlobal,
+			UID:       uid,
+		},
+	}
+	key := scaledObject.GenerateIdentifier()
+
+	streamer := &metricSpecWatcherTestPushScaler{specCh: make(chan []v2.MetricSpec, 1)}
+	// The cache in the map belongs to generation 2, but the watcher was created
+	// for generation 1.
+	newGenCache := &cache.ScalersCache{
+		ScaledObject:             scaledObject,
+		ScalableObjectGeneration: 2,
+		Scalers: []cache.ScalerBuilder{{
+			Scaler:       &metricSpecWatcherTestPushScaler{specCh: make(chan []v2.MetricSpec)},
+			ScalerConfig: scalersconfig.ScalerConfig{TriggerIndex: 0},
+		}},
+		Recorder: events.NewFakeRecorder(10),
+	}
+
+	h := &scaleHandler{
+		scalerCaches:          map[string]*cache.ScalersCache{key: newGenCache},
+		scalerCachesLock:      &sync.RWMutex{},
+		metricSpecReconcileCh: make(chan event.GenericEvent, 1),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go h.watchMetricSpecUpdates(ctx, scaledObject.Name, scaledObject.Namespace, 0, streamer, uid, 1)
+
+	streamer.specCh <- []v2.MetricSpec{createMetricSpec(42, "s0-stale")}
+
+	// The generation-2 cache must never receive the generation-1 update, and no
+	// reconcile must be enqueued.
+	assert.Never(t, func() bool {
+		specs := newGenCache.GetMetricSpecForScaling(context.Background())
+		return len(specs) == 1 && specs[0].External != nil && specs[0].External.Metric.Name == "s0-stale"
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		t.Fatalf("unexpected reconcile event for stale generation update: %s/%s", evt.Object.GetNamespace(), evt.Object.GetName())
+	default:
+	}
+}
+
+// TestWatchMetricSpecUpdates_IgnoresRecreatedObject verifies that a watcher for
+// a deleted object cannot update the cache of a new object created under the
+// same namespace and name but with a different UID.
+func TestWatchMetricSpecUpdates_IgnoresRecreatedObject(t *testing.T) {
+	oldUID := types.UID("so-uid-old")
+	newUID := types.UID("so-uid-new")
+	scaledObject := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNameGlobal,
+			Namespace: testNamespaceGlobal,
+			UID:       newUID,
+		},
+	}
+	key := scaledObject.GenerateIdentifier()
+
+	streamer := &metricSpecWatcherTestPushScaler{specCh: make(chan []v2.MetricSpec, 1)}
+	recreatedCache := &cache.ScalersCache{
+		ScaledObject: scaledObject,
+		Scalers: []cache.ScalerBuilder{{
+			Scaler:       &metricSpecWatcherTestPushScaler{specCh: make(chan []v2.MetricSpec)},
+			ScalerConfig: scalersconfig.ScalerConfig{TriggerIndex: 0},
+		}},
+		Recorder: events.NewFakeRecorder(10),
+	}
+
+	h := &scaleHandler{
+		scalerCaches:          map[string]*cache.ScalersCache{key: recreatedCache},
+		scalerCachesLock:      &sync.RWMutex{},
+		metricSpecReconcileCh: make(chan event.GenericEvent, 1),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Watcher was created for the deleted object (oldUID).
+	go h.watchMetricSpecUpdates(ctx, scaledObject.Name, scaledObject.Namespace, 0, streamer, oldUID, 0)
+
+	streamer.specCh <- []v2.MetricSpec{createMetricSpec(42, "s0-stale")}
+
+	assert.Never(t, func() bool {
+		specs := recreatedCache.GetMetricSpecForScaling(context.Background())
+		return len(specs) == 1 && specs[0].External != nil && specs[0].External.Metric.Name == "s0-stale"
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		t.Fatalf("unexpected reconcile event for recreated object update: %s/%s", evt.Object.GetNamespace(), evt.Object.GetName())
+	default:
+	}
+}
+
+func TestEnqueueMetricSpecReconcile(t *testing.T) {
+	h := &scaleHandler{metricSpecReconcileCh: make(chan event.GenericEvent, 1)}
+
+	h.enqueueMetricSpecReconcile(context.Background(), "test-so", "test-ns")
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		assert.Equal(t, "test-so", evt.Object.GetName())
+		assert.Equal(t, "test-ns", evt.Object.GetNamespace())
+	default:
+		t.Fatal("expected a reconcile event to be enqueued")
+	}
+}
+
+func TestEnqueueMetricSpecReconcile_WaitsForRoomWhenFull(t *testing.T) {
+	h := &scaleHandler{metricSpecReconcileCh: make(chan event.GenericEvent, 1)}
+	h.metricSpecReconcileCh <- event.GenericEvent{Object: &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-so", Namespace: "other-ns"},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		h.enqueueMetricSpecReconcile(ctx, "test-so", "test-ns")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("enqueueMetricSpecReconcile returned before channel space was available")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		assert.Equal(t, "other-so", evt.Object.GetName())
+		assert.Equal(t, "other-ns", evt.Object.GetNamespace())
+	case <-time.After(time.Second):
+		t.Fatal("expected the preloaded event to be drained")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("enqueueMetricSpecReconcile did not complete after channel space became available")
+	}
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		assert.Equal(t, "test-so", evt.Object.GetName())
+		assert.Equal(t, "test-ns", evt.Object.GetNamespace())
+	case <-time.After(time.Second):
+		t.Fatal("expected the waiting reconcile event to be enqueued")
+	}
+}
+
+func TestEnqueueMetricSpecReconcile_RespectsContextCancellation(t *testing.T) {
+	h := &scaleHandler{metricSpecReconcileCh: make(chan event.GenericEvent, 1)}
+	h.metricSpecReconcileCh <- event.GenericEvent{Object: &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-so", Namespace: "other-ns"},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		h.enqueueMetricSpecReconcile(ctx, "test-so", "test-ns")
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("enqueueMetricSpecReconcile did not return after context cancellation")
+	}
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		assert.Equal(t, "other-so", evt.Object.GetName())
+	case <-time.After(time.Second):
+		t.Fatal("expected only the preloaded event to remain in the channel")
+	}
+
+	select {
+	case evt := <-h.MetricSpecReconcileChan():
+		t.Fatalf("unexpected reconcile event after cancellation: %s/%s", evt.Object.GetNamespace(), evt.Object.GetName())
+	default:
+	}
 }


### PR DESCRIPTION
Add an optional `StreamMetricSpec` server-streaming RPC to the external scaler gRPC interface so `external-push` scalers can push updated HPA target values to KEDA without requiring changes to the `ScaledObject`.

When KEDA connects to an `external-push` scaler it now opens a `StreamMetricSpec` stream alongside the existing `StreamIsActive` stream. Streamed metric specs are cached and a `ScaledObject` reconcile is requested so the HPA can be rebuilt with the latest targets.

This work also addresses follow-up review feedback around the new flow:
- streamed metric-spec updates continue working after scaler cache invalidation by resolving updates against the latest cache instance
- cached `MetricSpec` values are deep-copied when stored or returned so reconciler selector mutation does not leak into cache state or race with other readers
- metric-spec reconcile requests are no longer dropped when the shared queue is full; enqueue now waits for channel capacity and respects `ctx.Done()`

If the scaler does not implement `StreamMetricSpec` (returns `Unimplemented`), KEDA stops retrying and falls back to the existing pull-based `GetMetricSpec` behavior, keeping the change backward compatible for older external scalers.

Tests cover the new stream handling, cache invalidation recovery, cached `MetricSpec` mutation isolation, and reconcile enqueue backpressure/cancellation. Local verification was done with `go test ./pkg/scaling/...`.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7793

Relates to kedacore/http-add-on#1656