### PR TITLE
ci: bump e2e node-pool from 3 to 5

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Scale cluster
         run: make scale-node-pool
         env:
-          NODE_POOL_SIZE: 3
+          NODE_POOL_SIZE: 5
           TEST_CLUSTER_NAME: keda-e2e-cluster-pr
 
       - name: Run end to end tests

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Scale cluster
         run: make scale-node-pool
         env:
-          NODE_POOL_SIZE: 3
+          NODE_POOL_SIZE: 5
 
       - name: Run end to end tests
         env:


### PR DESCRIPTION
I have been paying closer attention to our e2e test infra since the nightly e2e runs as well as PR e2e runs that execute the full suite have a very high rate of flakiness. Couple of issues were addressed separately but there is this one that happens frequently too, nodes getting temporarily overloaded and pods evicted mid test execution.

```
$ k describe po -n aws-identity-assume-role-test-ns aws-identity-assume-role-test-deployment-6669c79449-hsfsg
...
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  31s   default-scheduler  Successfully assigned aws-identity-assume-role-test-ns/aws-identity-assume-role-test-deployment-6669c79449-hsfsg to aks-default-24092150-vmss0001wd
  Warning  Evicted    32s   kubelet            The node had condition: [MemoryPressure].

$ k get po -A | grep Evicted | wc -l
73
```

I would like to propose increasing node number to 5 so the load from e2e tests can comfortably run on the infra. Constantly retriggering tests flaking due to insufficient node count might cost more than provisioning 2 extra nodes per execution.