### PR TITLE
fix(scaling): Add fix to stale scale error and data race in GetScaledObjectMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Check updated status for Fallback condition instead of ScaledObject ([#7488](https://github.com/kedacore/keda/issues/7488))
+- **General**: Clear stale scaler error after partial metric recovery and fix data race in `GetScaledObjectMetrics` ([#7802](https://github.com/kedacore/keda/issues/7802))
 - **General**: Fail fast in `GetMetrics` when the gRPC connection is in Shutdown state instead of waiting for context timeout ([#7251](https://github.com/kedacore/keda/issues/7251))
 - **General**: Fix int64 overflow in milli-quantity conversion for very large metric values ([#7441](https://github.com/kedacore/keda/issues/7441))
 - **General**: Fix misleading namespace in error log when secret access is restricted ([#7739](https://github.com/kedacore/keda/issues/7739))

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -668,9 +668,10 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 
 					// Pair metric values with their trigger names. This is applied only when
 					// ScalingModifiers.Formula is defined in SO.
-					result.metricTriggerPair, err = modifiers.GetPairTriggerAndMetric(scaledObject, metricName, scalerConfig.TriggerName)
-					if err != nil {
-						logger.Error(err, "error pairing triggers & metrics for compositeScaler")
+					pair, pairErr := modifiers.GetPairTriggerAndMetric(scaledObject, metricName, scalerConfig.TriggerName)
+					result.metricTriggerPair = pair
+					if pairErr != nil {
+						logger.Error(pairErr, "error pairing triggers & metrics for compositeScaler")
 					}
 					var rawMetrics []external_metrics.ExternalMetricValue
 					var isMetricActive bool
@@ -997,6 +998,7 @@ func (h *scaleHandler) getScalerState(ctx context.Context, scaler scalers.Scaler
 				scalersCache.Recorder.Eventf(scaledObject, nil, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, eventreason.KEDAScalerFailed, "%s", err.Error())
 			}
 		} else {
+			result.Err = nil
 			result.IsActive = isActiveOrFallback
 			if !scaledObject.IsUsingModifiers() {
 				if result.IsActive {

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/expr-lang/expr"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
@@ -444,6 +445,152 @@ func TestCheckScaledObjectScalersWithError(t *testing.T) {
 	assert.Equal(t, false, isActive)
 	assert.Equal(t, true, isError)
 	assert.Empty(t, activeTriggers)
+}
+
+func TestGetScalerState_ClearsErrorWhenLaterMetricSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	recorder := events.NewFakeRecorder(1)
+
+	metricName1 := "metric-a"
+	metricName2 := "metric-b"
+	metricsSpecs := []v2.MetricSpec{
+		createMetricSpec(1, metricName1),
+		createMetricSpec(1, metricName2),
+	}
+	metricValue2 := scalers.GenerateMetricInMili(metricName2, float64(10))
+
+	metricsAndActivityFn := func(_ context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
+		if metricName == metricName1 {
+			return []external_metrics.ExternalMetricValue{}, false, errors.New("transient error")
+		}
+		return []external_metrics.ExternalMetricValue{metricValue2}, true, nil
+	}
+	newMockScaler := func() *mock_scalers.MockScaler {
+		s := mock_scalers.NewMockScaler(ctrl)
+		s.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).DoAndReturn(metricsAndActivityFn).AnyTimes()
+		s.EXPECT().Close(gomock.Any()).AnyTimes()
+		return s
+	}
+
+	scaler := newMockScaler()
+	scaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Return(metricsSpecs)
+	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		return newMockScaler(), &scalersconfig.ScalerConfig{}, nil
+	}
+
+	scaledObject := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+				Name: "test",
+			},
+		},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			ExternalMetricNames: []string{metricName1, metricName2},
+		},
+	}
+
+	scalerCache := cache.ScalersCache{
+		Scalers: []cache.ScalerBuilder{{
+			Scaler:  scaler,
+			Factory: factory,
+		}},
+		Recorder: recorder,
+	}
+
+	sh := scaleHandler{
+		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
+	}
+
+	result := sh.getScalerState(context.Background(), scaler, 0, scalersconfig.ScalerConfig{}, &scalerCache, logr.Discard(), &scaledObject)
+
+	assert.Nil(t, result.Err)
+	assert.True(t, result.IsActive)
+	assert.Len(t, result.Metrics, 1)
+}
+
+func TestGetScaledObjectState_NoCacheClearWhenLaterMetricSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	recorder := events.NewFakeRecorder(1)
+
+	metricName1 := "metric-a"
+	metricName2 := "metric-b"
+	metricsSpecs := []v2.MetricSpec{
+		createMetricSpec(1, metricName1),
+		createMetricSpec(1, metricName2),
+	}
+	metricValue2 := scalers.GenerateMetricInMili(metricName2, float64(10))
+
+	metricsAndActivityFn := func(_ context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
+		if metricName == metricName1 {
+			return []external_metrics.ExternalMetricValue{}, false, errors.New("transient error")
+		}
+		return []external_metrics.ExternalMetricValue{metricValue2}, true, nil
+	}
+	newMockScaler := func() *mock_scalers.MockScaler {
+		s := mock_scalers.NewMockScaler(ctrl)
+		s.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).DoAndReturn(metricsAndActivityFn).AnyTimes()
+		s.EXPECT().Close(gomock.Any()).AnyTimes()
+		return s
+	}
+
+	scaler := newMockScaler()
+	scaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Return(metricsSpecs)
+	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		return newMockScaler(), &scalersconfig.ScalerConfig{}, nil
+	}
+
+	scaledObject := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+				Name: "test",
+			},
+		},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			ExternalMetricNames: []string{metricName1, metricName2},
+		},
+	}
+
+	scalerCache := cache.ScalersCache{
+		Scalers: []cache.ScalerBuilder{{
+			Scaler:  scaler,
+			Factory: factory,
+		}},
+		Recorder: recorder,
+	}
+
+	caches := map[string]*cache.ScalersCache{}
+	cacheKey := scaledObject.GenerateIdentifier()
+	caches[cacheKey] = &scalerCache
+
+	sh := scaleHandler{
+		scalerCaches:             caches,
+		scalerCachesLock:         &sync.RWMutex{},
+		scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
+	}
+
+	isActive, isError, _, activeTriggers, _, err := sh.getScaledObjectState(context.Background(), &scaledObject)
+	scalerCache.Close(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, isActive)
+	assert.False(t, isError)
+	assert.Contains(t, activeTriggers, metricName2)
+	_, cacheStillPresent := sh.scalerCaches[cacheKey]
+	assert.True(t, cacheStillPresent, "scalers cache should not be cleared when a later metric succeeds")
 }
 
 func TestCheckScaledObjectScalersWithTriggerAuthError(t *testing.T) {


### PR DESCRIPTION
More detail about the problem in the github issue below. I have fixed it by:

-In `getScalerState`, on successful metric fetch: `result.Err = nil` before setting `result.IsActive`.
-In `GetScaledObjectMetrics goroutines`: use `pair, pairErr := modifiers.GetPairTriggerAndMetric(...)` instead of assigning to the outer err.
Added two tests:

-`TestGetScalerState_ClearsErrorWhenLaterMetricSucceeds`
-`TestGetScaledObjectState_NoCacheClearWhenLaterMetricSucceeds`

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes https://github.com/kedacore/keda/issues/7802

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
