### PR TITLE
fix(e2e): address flakiness for internal/events test

### DIFF
--- a/tests/internals/events/events_test.go
+++ b/tests/internals/events/events_test.go
@@ -4,6 +4,7 @@
 package events_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -325,11 +326,10 @@ func getTemplateData() (templateData, []Template) {
 	}, []Template{}
 }
 
-func checkingEvent(t *testing.T, namespace, kind, name string, index int, eventReason, msg string) {
-	// Scope the query to the current resource's UID so that orphaned events from
-	// a previous attempt (run-all.go retries failed tests) don't pollute the
+func checkingEvent(t *testing.T, namespace, kind, name string, eventReason, msg string) {
 	// regarding.name-only selector.
 	var uid string
+	want := eventReason + ":" + msg
 	assert.Eventually(t, func() bool {
 		if uid == "" {
 			out, err := ExecuteCommand(fmt.Sprintf("kubectl get %s %s -n %s --ignore-not-found -o jsonpath={.metadata.uid}", kind, name, namespace))
@@ -341,13 +341,26 @@ func checkingEvent(t *testing.T, namespace, kind, name string, index int, eventR
 		if uid != "" {
 			selector = fmt.Sprintf("regarding.name=%s,regarding.uid=%s", name, uid)
 		}
-		result, err := ExecuteCommand(fmt.Sprintf("kubectl get events.events.k8s.io -n %s --field-selector %s --sort-by=.metadata.creationTimestamp -o jsonpath=\"{.items[%d].reason}:{.items[%d].note}\"", namespace, selector, index, index))
+		out, err := ExecuteCommand(fmt.Sprintf("kubectl get events.events.k8s.io -n %s --field-selector %s -o json", namespace, selector))
 		if err != nil {
 			return false
 		}
-		lastEventMessage := strings.Trim(string(result), "\"")
-		return strings.Contains(lastEventMessage, eventReason+":"+msg)
-	}, 60*time.Second, 2*time.Second, "expected event %s:%s for %s/%s[%d]", eventReason, msg, namespace, name, index)
+		var events struct {
+			Items []struct {
+				Reason string `json:"reason"`
+				Note   string `json:"note"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(out, &events); err != nil {
+			return false
+		}
+		for _, e := range events.Items {
+			if strings.Contains(e.Reason+":"+e.Note, want) {
+				return true
+			}
+		}
+		return false
+	}, 60*time.Second, 2*time.Second, "expected event %s:%s for %s/%s", eventReason, msg, namespace, name)
 }
 
 func testNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {
@@ -361,9 +374,9 @@ func testNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) 
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 2, testNamespace)
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 1),
 		"replica count should be 2 after 1 minute")
-	checkingEvent(t, testNamespace, "scaledobject", scaledObjectName, 0, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
-	checkingEvent(t, testNamespace, "scaledobject", scaledObjectName, 1, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
-	checkingEvent(t, testNamespace, "scaledobject", scaledObjectName, 2, eventreason.ScaledObjectReady, message.ScalerReadyMsg)
+	checkingEvent(t, testNamespace, "scaledobject", scaledObjectName, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
+	checkingEvent(t, testNamespace, "scaledobject", scaledObjectName, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
+	checkingEvent(t, testNamespace, "scaledobject", scaledObjectName, eventreason.ScaledObjectReady, message.ScalerReadyMsg)
 
 	KubectlDeleteWithTemplate(t, data, "deploymentTemplate", deploymentTemplate)
 	KubectlDeleteWithTemplate(t, data, "monitoredDeploymentName", monitoredDeploymentTemplate)
@@ -374,8 +387,8 @@ func testTargetNotFoundErr(t *testing.T, _ *kubernetes.Clientset, data templateD
 	t.Log("--- testing target not found error event ---")
 
 	KubectlApplyWithTemplate(t, data, "scaledObjectTargetErrTemplate", scaledObjectTargetErrTemplate)
-	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNotFoundName, -2, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNotFoundMsg)
-	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNotFoundName, -1, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
+	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNotFoundName, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNotFoundMsg)
+	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNotFoundName, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
 }
 
 func testTargetNotSupportEventErr(t *testing.T, _ *kubernetes.Clientset, data templateData) {
@@ -383,8 +396,8 @@ func testTargetNotSupportEventErr(t *testing.T, _ *kubernetes.Clientset, data te
 
 	KubectlApplyWithTemplate(t, data, "daemonSetTemplate", daemonSetTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTargetNotSupportTemplate", scaledObjectTargetNotSupportTemplate)
-	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNoSubresourceName, -2, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNoSubresourceMsg)
-	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNoSubresourceName, -1, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
+	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNoSubresourceName, eventreason.ScaledObjectCheckFailed, message.ScaleTargetNoSubresourceMsg)
+	checkingEvent(t, testNamespace, "scaledobject", scaledObjectTargetNoSubresourceName, eventreason.ScaledObjectCheckFailed, message.ScaleTargetErrMsg)
 }
 
 func testScaledJobNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templateData) {
@@ -397,9 +410,9 @@ func testScaledJobNormalEvent(t *testing.T, kc *kubernetes.Clientset, data templ
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 2, testNamespace)
 	assert.True(t, WaitForJobCount(t, kc, testNamespace, 2, 60, 1),
 		"replica count should be 2 after 1 minute")
-	checkingEvent(t, testNamespace, "scaledjob", scaledJobName, 0, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
-	checkingEvent(t, testNamespace, "scaledjob", scaledJobName, 1, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
-	checkingEvent(t, testNamespace, "scaledjob", scaledJobName, 2, eventreason.ScaledJobReady, message.ScaledJobReadyMsg)
+	checkingEvent(t, testNamespace, "scaledjob", scaledJobName, eventreason.KEDAScalersStarted, fmt.Sprintf(message.ScalerIsBuiltMsg, "kubernetes-workload"))
+	checkingEvent(t, testNamespace, "scaledjob", scaledJobName, eventreason.KEDAScalersStarted, message.ScalerStartMsg)
+	checkingEvent(t, testNamespace, "scaledjob", scaledJobName, eventreason.ScaledJobReady, message.ScaledJobReadyMsg)
 
 	KubectlDeleteWithTemplate(t, data, "deploymentTemplate", deploymentTemplate)
 	KubectlDeleteWithTemplate(t, data, "monitoredDeploymentName", monitoredDeploymentTemplate)
@@ -410,7 +423,7 @@ func testScaledJobTargetNotSupportEventErr(t *testing.T, _ *kubernetes.Clientset
 	t.Log("--- testing target not support error event ---")
 
 	KubectlApplyWithTemplate(t, data, "scaledJobErrTemplate", scaledJobErrTemplate)
-	checkingEvent(t, testNamespace, "scaledjob", scaledJobErrName, -1, eventreason.ScaledJobCheckFailed, "Failed to ensure ScaledJob is correctly created")
+	checkingEvent(t, testNamespace, "scaledjob", scaledJobErrName, eventreason.ScaledJobCheckFailed, "Failed to ensure ScaledJob is correctly created")
 }
 
 func testTriggerAuthenticationEvent(t *testing.T, _ *kubernetes.Clientset, data templateData) {
@@ -422,19 +435,19 @@ func testTriggerAuthenticationEvent(t *testing.T, _ *kubernetes.Clientset, data 
 	data.SecretTargetName = secretName
 	KubectlApplyWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
 
-	checkingEvent(t, testNamespace, "triggerauthentication", triggerAuthName, 0, eventreason.TriggerAuthenticationAdded, message.TriggerAuthenticationCreatedMsg)
+	checkingEvent(t, testNamespace, "triggerauthentication", triggerAuthName, eventreason.TriggerAuthenticationAdded, message.TriggerAuthenticationCreatedMsg)
 
 	KubectlApplyWithTemplate(t, data, "clusterTriggerAuthenticationTemplate", clusterTriggerAuthenticationTemplate)
 
-	checkingEvent(t, "default", "clustertriggerauthentication", clusterTriggerAuthName, 0, eventreason.ClusterTriggerAuthenticationAdded, message.ClusterTriggerAuthenticationCreatedMsg)
+	checkingEvent(t, "default", "clustertriggerauthentication", clusterTriggerAuthName, eventreason.ClusterTriggerAuthenticationAdded, message.ClusterTriggerAuthenticationCreatedMsg)
 
 	data.SecretTargetName = secretName2
 	KubectlApplyWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)
 
-	checkingEvent(t, testNamespace, "triggerauthentication", triggerAuthName, -1, eventreason.TriggerAuthenticationUpdated, fmt.Sprintf(message.TriggerAuthenticationUpdatedMsg, triggerAuthName))
+	checkingEvent(t, testNamespace, "triggerauthentication", triggerAuthName, eventreason.TriggerAuthenticationUpdated, fmt.Sprintf(message.TriggerAuthenticationUpdatedMsg, triggerAuthName))
 	KubectlApplyWithTemplate(t, data, "clusterTriggerAuthenticationTemplate", clusterTriggerAuthenticationTemplate)
 
-	checkingEvent(t, "default", "clustertriggerauthentication", clusterTriggerAuthName, -1, eventreason.ClusterTriggerAuthenticationUpdated, fmt.Sprintf(message.ClusterTriggerAuthenticationUpdatedMsg, clusterTriggerAuthName))
+	checkingEvent(t, "default", "clustertriggerauthentication", clusterTriggerAuthName, eventreason.ClusterTriggerAuthenticationUpdated, fmt.Sprintf(message.ClusterTriggerAuthenticationUpdatedMsg, clusterTriggerAuthName))
 	KubectlDeleteWithTemplate(t, data, "secretTemplate", secretTemplate)
 	KubectlDeleteWithTemplate(t, data, "secret2Template", secret2Template)
 	KubectlDeleteWithTemplate(t, data, "triggerAuthenticationTemplate", triggerAuthenticationTemplate)


### PR DESCRIPTION
The events e2e test asserted events at fixed positions in a list sorted by `.metadata.creationTimestamp`. KEDA emits several events for a single `ScaledObject`/`ScaledJob` within the same second, and `events.k8s.io` `creationTimestamp` only has 1s granularity, so same-second events sort non-deterministically. After #7781 migrated event recording to `events.k8s.io`, the already flaky test became failing almost always.

Match the expected reason/note pair against any event emitted for the resource instead of a fixed index, removing the ordering dependency.