### PR TITLE
fix(splunk-observability): poll for pod readiness in e2e test

### DIFF
--- a/tests/scalers/splunk_observability/splunk_observability_test.go
+++ b/tests/scalers/splunk_observability/splunk_observability_test.go
@@ -219,8 +219,8 @@ func TestSplunkObservabilityScaler(t *testing.T) {
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
 	// Ensure nginx deployment is ready
-	assert.True(t, WaitForAllPodRunningInNamespace(t, kc, testNamespace, minReplicaCount, 180),
-		"replica count should be greater than %d after 3 minutes", minReplicaCount)
+	assert.True(t, WaitForAllPodRunningInNamespace(t, kc, testNamespace, 18, 10),
+		"pods should be running after 3 minutes")
 
 	// test scaling
 	testScaleOut(t, kc)


### PR DESCRIPTION
there was a subtle bug in splunk observability e2e tests causing approximatelly 50% flakiness rate. `WaitForAllPodRunningInNamespace(namespace, iterations, intervalSeconds)` was called with `minReplicaCount` (which is 1) as iterations and 180 as the interval, so it checked pod status once immediately after resource creation, slept 180s, and frequently returned false without ever re-checking. The initial readiness assertion then failed whenever the nginx pod was not already `Running` in that single instant, turning the nightly e2e red regardless of scaler behavior.

Swap to 18 iterations x 10s so it actually polls for ~3 minutes, as the message intends.

