### PR TITLE
e2e: disable flaky accurate_scaling_strategy test

### DIFF
--- a/tests/internals/scaling_strategies/accurate_scaling_strategy/accurate_scaling_strategy_test.go
+++ b/tests/internals/scaling_strategies/accurate_scaling_strategy/accurate_scaling_strategy_test.go
@@ -92,6 +92,9 @@ type templateData struct {
 
 func TestScalingStrategy(t *testing.T) {
 	// Setup
+
+	// FIXME: the busybox jobs never consume the queue, so the 'accurate' strategy scales to maxReplicaCount instead of the expected per-message counts; needs a redesign where jobs drain the queue.
+	t.Skip("flaky/broken since #7607: see also https://github.com/kedacore/keda/issues/7806")
 	ctx := context.Background()
 	t.Log("--- setting up ---")
 	require.NotEmpty(t, connectionString, "TF_AZURE_STORAGE_CONNECTION_STRING env variable is required for azure queue test")


### PR DESCRIPTION
Ever since https://github.com/kedacore/keda/pull/7607 merged, the test has always failed the nightly e2e runs. The "accurate" tests are very much "inaccurate".

Failed nightly runs
    - 2026-06-01: run 26729697815 (https://github.com/kedacore/keda/actions/runs/26729697815)
    - 2026-05-31: run 26699411222 (https://github.com/kedacore/keda/actions/runs/26699411222)
    - 2026-05-30: run 26669785234 (https://github.com/kedacore/keda/actions/runs/26669785234)
    - 2026-05-29: run 26611402590 (https://github.com/kedacore/keda/actions/runs/26611402590)



see also: https://github.com/kedacore/keda/issues/7806