### PR TITLE
fix(test): unbreak scale_handler_test build after events recorder migration

### DIFF
--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -667,7 +667,7 @@ func TestGetScaledObjectStateRecordsResourceScalerActiveMetric(t *testing.T) {
 	})
 
 	ctrl := gomock.NewController(t)
-	recorder := record.NewFakeRecorder(1)
+	recorder := events.NewFakeRecorder(1)
 	scaler := mock_scalers.NewMockScaler(ctrl)
 
 	metricSpecs := []v2.MetricSpec{{
@@ -744,7 +744,7 @@ func TestGetScaledObjectStateSkipsResourceScalerActiveMetricWithModifiers(t *tes
 	})
 
 	ctrl := gomock.NewController(t)
-	recorder := record.NewFakeRecorder(1)
+	recorder := events.NewFakeRecorder(1)
 	scaler := mock_scalers.NewMockScaler(ctrl)
 
 	metricSpecs := []v2.MetricSpec{{


### PR DESCRIPTION
#7755 added two tests
* `TestGetScaledObjectStateRecordsResourceScalerActiveMetric` 
* `TestGetScaledObjectStateSkipsResourceScalerActiveMetricWithModifiers`

Both using `record.NewFakeRecorder`. In the meantime #7781 migrated this file to the events recorder and dropped the `k8s.io/client-go/tools/record` import, so the merged result fails to compile with `"undefined: record"`, breaking the unit-test build and Static Checks on main.
