### PR TITLE
docs: update roadmap for v2.20.0 release

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,14 +16,15 @@ Here is an overview of our current release estimations:
 
 | Version | Estimated Release Date                               |
 |:--------|:-----------------------------------------------------|
-| v2.20   | 2nd week of May 2026                                |
 | v2.21   | 2nd week of September 2026                          |
 | v2.22   | 2nd week of January 2027                            |
+| v2.23   | 2nd week of May 2027                                |
 
 Here is an overview of our previous releases:
 
 | Version | Release Date      | Links                                                                  |
 |:--------|:------------------|:-----------------------------------------------------------------------|
+| v2.20   | Jun 1st, 2026     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.20.0) |
 | v2.19   | Feb 2nd, 2026     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.19.0) |
 | v2.18   | Oct 19th, 2025    | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.18.0) |
 | v2.17   | Apr 7th, 2025     | [Release Notes](https://github.com/kedacore/keda/releases/tag/v2.17.0) |


### PR DESCRIPTION
I forgot to update roadmap as part of https://github.com/kedacore/keda/issues/7435
