### PR TITLE
fix: guard nil pointer dereference in customScalingStrategy.GetEffectiveMaxScale

### DIFF
--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -465,7 +465,16 @@ type customScalingStrategy struct {
 }
 
 func (s customScalingStrategy) GetEffectiveMaxScale(maxScale, runningJobCount, _, maxReplicaCount, scaleTo int64) (int64, int64) {
-	return min(maxScale-int64(*s.CustomScalingQueueLengthDeduction)-int64(float64(runningJobCount)*(*s.CustomScalingRunningJobPercentage)), maxReplicaCount), scaleTo
+	var deduction int64
+	if s.CustomScalingQueueLengthDeduction != nil {
+		deduction = int64(*s.CustomScalingQueueLengthDeduction)
+	}
+	var runningPercentage float64
+	if s.CustomScalingRunningJobPercentage != nil {
+		runningPercentage = *s.CustomScalingRunningJobPercentage
+	}
+	result := maxScale - deduction - int64(float64(runningJobCount)*runningPercentage)
+	return min(result, maxReplicaCount), scaleTo
 }
 
 type accurateScalingStrategy struct {

--- a/pkg/scaling/executor/scale_jobs_test.go
+++ b/pkg/scaling/executor/scale_jobs_test.go
@@ -128,6 +128,26 @@ func TestCustomScalingStrategy(t *testing.T) {
 	assert.Equal(t, int64(4), maxScaleValue(strategy.GetEffectiveMaxScale(3, 2, 0, 4, 1)))
 }
 
+func TestCustomScalingStrategyNilQueueLengthDeduction(t *testing.T) {
+	logger := logf.Log.WithName("ScaledJobTest")
+	scaledJob := &kedav1alpha1.ScaledJob{
+		Spec: kedav1alpha1.ScaledJobSpec{
+			ScalingStrategy: kedav1alpha1.ScalingStrategy{
+				Strategy:                          "custom",
+				CustomScalingQueueLengthDeduction: nil,
+				CustomScalingRunningJobPercentage: "0.5",
+			},
+		},
+	}
+	scaledJob.Name = "custom"
+	strategy := NewScalingStrategy(logger, scaledJob)
+
+	assert.Equal(t, "executor.customScalingStrategy", fmt.Sprintf("%T", strategy))
+	// nil deduction should behave as zero deduction
+	assert.Equal(t, int64(2), maxScaleValue(strategy.GetEffectiveMaxScale(3, 2, 0, 5, 1)))
+	assert.Equal(t, int64(10), maxScaleValue(strategy.GetEffectiveMaxScale(10, 0, 0, 10, 1)))
+}
+
 func TestAccurateScalingStrategy(t *testing.T) {
 	logger := logf.Log.WithName("ScaledJobTest")
 	strategy := NewScalingStrategy(logger, getMockScaledJobWithStrategy("accurate", "accurate", 0, "0"))


### PR DESCRIPTION
`customScalingStrategy.GetEffectiveMaxScale` unconditionally dereferences `CustomScalingQueueLengthDeduction` (`*int32`) without a nil guard. The field is declared with `omitempty` in the CRD spec, so it is `nil` whenever a `ScaledJob` is created with `scalingStrategy.strategy: custom` and `customScalingRunningJobPercentage` set, but `customScalingQueueLengthDeduction` omitted. When the controller reaches the replica calculation path, it panics.

This PR adds nil guards for both pointer fields in `GetEffectiveMaxScale`, treating `nil` as zero (consistent with how other optional fields are handled). A regression test is included that exercises the exact configuration that triggers the panic.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7798

Relates to #