### PR TITLE
General: clamp ceilToInt64 to prevent float-to-int truncation overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Fix `ceilToInt64` float-to-int truncation overflow that silently wraps to `MinInt64` for values >= 2^63 ([#7796](https://github.com/kedacore/keda/issues/7796))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Add controller-runtime cache field indexes for ScaledObject admission validation so `verifyScaledObjects` and `verifyHpas` look up duplicate scaleTargetRef and HPA-name conflicts via indexed Lists rather than full-namespace scans, eliminating the webhook OOM under high-scale creation bursts ([#7681](https://github.com/kedacore/keda/pull/7681))
+- **General**: Fix `ceilToInt64` float-to-int truncation overflow that silently wraps to `MinInt64` for values >= 2^63 ([#7796](https://github.com/kedacore/keda/issues/7796))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix `pollingInterval` and `cooldownPeriod` relevance warnings incorrectly firing when `idleReplicaCount` is set to a value greater than 0, since idle mode keeps both settings relevant ([#7984](https://github.com/kedacore/keda/pull/7984))
 - **General**: Fix `ScaledJob` removal event using `namespace/name` in place of the namespace, which malformed the emitted CloudEvent's subject and the `namespace` label on the CloudEventSource metrics ([#7967](https://github.com/kedacore/keda/issues/7967))

--- a/pkg/scaling/scaledjob/metrics.go
+++ b/pkg/scaling/scaledjob/metrics.go
@@ -107,8 +107,16 @@ func IsScaledJobActive(scalersMetrics []ScalerMetrics, multipleScalersCalculatio
 	return isActive, ceilToInt64(queueLength), ceilToInt64(maxValue), maxValue
 }
 
-// ceilToInt64 returns the int64 ceil value for the float64 input
+// ceilToInt64 returns the int64 ceil value for the float64 input.
+// Out-of-range values are clamped to math.MaxInt64 / math.MinInt64 to avoid
+// silent truncation overflow (IEEE 754 → CVTTSD2SI returns "integer indefinite").
 func ceilToInt64(x float64) int64 {
+	if x >= float64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	if x < float64(math.MinInt64) {
+		return math.MinInt64
+	}
 	return int64(math.Ceil(x))
 }
 

--- a/pkg/scaling/scaledjob/metrics_test.go
+++ b/pkg/scaling/scaledjob/metrics_test.go
@@ -1,6 +1,7 @@
 package scaledjob
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,30 @@ func TestTargetAverageValue(t *testing.T) {
 
 	targetAverageValue = getTargetAverageValue(specs)
 	assert.Equal(t, 4.666666666666667, targetAverageValue)
+}
+
+func TestCeilToInt64(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected int64
+	}{
+		{name: "positive integer", input: 5.0, expected: 5},
+		{name: "positive ceil", input: 4.2, expected: 5},
+		{name: "zero", input: 0.0, expected: 0},
+		{name: "negative value", input: -2.5, expected: -2},
+		{name: "max int64 boundary", input: float64(math.MaxInt64), expected: math.MaxInt64},
+		{name: "above max int64", input: 1e19, expected: math.MaxInt64},
+		{name: "2^63 exactly", input: math.Float64frombits(0x43e0000000000000), expected: math.MaxInt64},
+		{name: "below min int64", input: -1e19, expected: math.MinInt64},
+		{name: "positive infinity", input: math.Inf(1), expected: math.MaxInt64},
+		{name: "negative infinity", input: math.Inf(-1), expected: math.MinInt64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ceilToInt64(tt.input))
+		})
+	}
 }
 
 // createMetricSpec creates MetricSpec for given metric name and target value.


### PR DESCRIPTION
`ceilToInt64` in `pkg/scaling/scaledjob/metrics.go` silently wraps to `math.MinInt64` instead of returning `math.MaxInt64` when the input `float64` is >= 2^63 (≈ 9.22 × 10^18). The conversion `int64(math.Ceil(x))` compiles to a `CVTTSD2SI` instruction on x86-64; IEEE 754 specifies that this instruction returns the "integer indefinite" value (`0x8000000000000000` = `math.MinInt64`) for any out-of-range input — there is no runtime panic and no error, just a silently wrong result.

This adds overflow guards that clamp to `math.MaxInt64` / `math.MinInt64` before the float-to-int conversion, along with regression tests covering normal values, boundary values (2^63 exactly), large positive/negative values, and ±Inf.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7796