### PR TITLE
General: Fix concurrent map iteration and map write in pkg/fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Fix concurrent map read/write data race in fallback `updateStatus` that caused panics when multiple triggers were scaling simultaneously ([#7838](https://github.com/kedacore/keda/issues/7838))
 - **General**: Fix `KEDAScalersStarted` "Started scalers watch" event not being emitted for ScaledJobs because it shared an events.k8s.io aggregation key with the per-scaler "scaler is built" event ([#7820](https://github.com/kedacore/keda/pull/7820))
 
 ### Deprecations

--- a/pkg/fallback/fallback.go
+++ b/pkg/fallback/fallback.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 
 	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
@@ -38,11 +39,18 @@ import (
 
 var log = logf.Log.WithName("fallback")
 
+// scaledObjectMu holds one mutex per ScaledObject to prevent concurrent map read/write in updateStatus.
+var scaledObjectMu sync.Map
+
 func isFallbackEnabled(scaledObject *kedav1alpha1.ScaledObject) bool {
 	return scaledObject.Spec.Fallback != nil
 }
 
 func GetMetricsWithFallback(ctx context.Context, client runtimeclient.Client, scaleClient scale.ScalesGetter, metrics []external_metrics.ExternalMetricValue, suppressedError error, metricName string, scaledObject *kedav1alpha1.ScaledObject, metricSpec v2.MetricSpec) ([]external_metrics.ExternalMetricValue, bool, error) {
+	mu, _ := scaledObjectMu.LoadOrStore(scaledObject.Namespace+"/"+scaledObject.Name, &sync.Mutex{})
+	mu.(*sync.Mutex).Lock()
+	defer mu.(*sync.Mutex).Unlock()
+
 	status := scaledObject.Status.DeepCopy()
 
 	initHealthStatus(status)

--- a/pkg/fallback/fallback.go
+++ b/pkg/fallback/fallback.go
@@ -19,17 +19,18 @@ package fallback
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"sync"
 
 	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/scale"
 	"k8s.io/metrics/pkg/apis/external_metrics"
+	"k8s.io/utils/ptr"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -39,39 +40,96 @@ import (
 
 var log = logf.Log.WithName("fallback")
 
-// scaledObjectMu holds one mutex per ScaledObject to prevent concurrent map read/write in updateStatus.
-var scaledObjectMu sync.Map
+// ScaledObjectHandler encapsulates ScaledObject with necessary clients and locks for performing fallback operations safely in concurrent code
+type ScaledObjectHandler struct {
+	Ctx          context.Context
+	KubeClient   runtimeclient.Client
+	ScaleClient  scale.ScalesGetter
+	UpdateLock   *sync.RWMutex
+	ScaledObject *kedav1alpha1.ScaledObject
+}
+
+// UpdateHealthStatus safely serializes updates to ScaledObject's health status and ships them to kube-api
+func (h *ScaledObjectHandler) UpdateHealthStatus(metricName string, healthStatus kedav1alpha1.HealthStatus) {
+	h.UpdateLock.Lock()
+	defer h.UpdateLock.Unlock()
+
+	original := h.ScaledObject.DeepCopy()
+	if h.ScaledObject.Status.Health == nil {
+		h.ScaledObject.Status.Health = make(map[string]kedav1alpha1.HealthStatus)
+	}
+	h.ScaledObject.Status.Health[metricName] = healthStatus
+	h.updateStatus(original)
+}
+
+// IncrementFailure increments the failure count for a specific metric in the ScaledObject's status and persists the change to kube-api
+func (h *ScaledObjectHandler) IncrementFailure(metricName string) kedav1alpha1.HealthStatus {
+	h.UpdateLock.Lock()
+	defer h.UpdateLock.Unlock()
+
+	original := h.ScaledObject.DeepCopy()
+	if h.ScaledObject.Status.Health == nil {
+		h.ScaledObject.Status.Health = make(map[string]kedav1alpha1.HealthStatus)
+	}
+	healthStatus := h.ScaledObject.Status.Health[metricName]
+	if healthStatus.NumberOfFailures == nil {
+		healthStatus.NumberOfFailures = ptr.To(int32(0))
+	}
+	*healthStatus.NumberOfFailures++
+	healthStatus.Status = kedav1alpha1.HealthStatusFailing
+	h.ScaledObject.Status.Health[metricName] = healthStatus
+	h.updateStatus(original)
+	return healthStatus
+}
+
+// updateStatus recomputes the fallback condition and patches the status to kube-api if it changed.
+// It must be called with h.UpdateLock held; original is a snapshot taken before the health mutation
+// so the merge patch carries both the health and condition diffs.
+func (h *ScaledObjectHandler) updateStatus(original *kedav1alpha1.ScaledObject) {
+	if !isFallbackEnabled(h.ScaledObject) || !HasValidFallback(h.ScaledObject) {
+		log.V(1).Info("Fallback is not enabled, hence skipping the health update to the scaledobject", "scaledObject.Namespace", h.ScaledObject.Namespace, "scaledObject.Name", h.ScaledObject.Name)
+		return
+	}
+
+	if fallbackExceededThreshold(h.ScaledObject.Status, h.ScaledObject.Spec.Fallback.FailureThreshold) {
+		h.ScaledObject.Status.Conditions.SetFallbackCondition(metav1.ConditionTrue, "FallbackExists", "At least one trigger is falling back on this scaled object")
+	} else {
+		h.ScaledObject.Status.Conditions.SetFallbackCondition(metav1.ConditionFalse, "NoFallbackFound", "No fallbacks are active on this scaled object")
+	}
+
+	// Update status only if it has changed
+	if equality.Semantic.DeepEqual(original.Status, h.ScaledObject.Status) {
+		return
+	}
+
+	patch := runtimeclient.MergeFrom(original)
+	if err := h.KubeClient.Status().Patch(h.Ctx, h.ScaledObject, patch); err != nil {
+		log.Error(err, "failed to patch ScaledObjects Status", "scaledObject.Namespace", h.ScaledObject.Namespace, "scaledObject.Name", h.ScaledObject.Name)
+	}
+}
 
 func isFallbackEnabled(scaledObject *kedav1alpha1.ScaledObject) bool {
 	return scaledObject.Spec.Fallback != nil
 }
 
-func GetMetricsWithFallback(ctx context.Context, client runtimeclient.Client, scaleClient scale.ScalesGetter, metrics []external_metrics.ExternalMetricValue, suppressedError error, metricName string, scaledObject *kedav1alpha1.ScaledObject, metricSpec v2.MetricSpec) ([]external_metrics.ExternalMetricValue, bool, error) {
-	mu, _ := scaledObjectMu.LoadOrStore(scaledObject.Namespace+"/"+scaledObject.Name, &sync.Mutex{})
-	mu.(*sync.Mutex).Lock()
-	defer mu.(*sync.Mutex).Unlock()
+func GetMetricsWithFallback(soh ScaledObjectHandler, metrics []external_metrics.ExternalMetricValue, suppressedError error, metricName string, metricSpec v2.MetricSpec) ([]external_metrics.ExternalMetricValue, bool, error) {
+	soh.UpdateLock.RLock()
+	scaledObject := soh.ScaledObject.DeepCopy()
+	soh.UpdateLock.RUnlock()
 
-	status := scaledObject.Status.DeepCopy()
-
-	initHealthStatus(status)
-	healthStatus := getHealthStatus(status, metricName)
+	// Health is only tracked for ScaledObjects with a valid fallback configured. For all others we
+	// must leave the status untouched, so the enabled/valid checks have to happen before any mutation.
+	fallbackConfigured := isFallbackEnabled(scaledObject) && HasValidFallback(scaledObject)
 
 	if suppressedError == nil {
-		zero := int32(0)
-		healthStatus.NumberOfFailures = &zero
-		healthStatus.Status = kedav1alpha1.HealthStatusHappy
-		status.Health[metricName] = *healthStatus
-
-		updateStatus(ctx, client, scaledObject, status)
-
+		if fallbackConfigured {
+			soh.UpdateHealthStatus(metricName, kedav1alpha1.HealthStatus{
+				NumberOfFailures: ptr.To(int32(0)),
+				Status:           kedav1alpha1.HealthStatusHappy,
+			})
+		}
 		return metrics, false, nil
 	}
-
-	healthStatus.Status = kedav1alpha1.HealthStatusFailing
-	*healthStatus.NumberOfFailures++
-	status.Health[metricName] = *healthStatus
-
-	updateStatus(ctx, client, scaledObject, status)
 
 	switch {
 	case !isFallbackEnabled(scaledObject):
@@ -79,6 +137,11 @@ func GetMetricsWithFallback(ctx context.Context, client runtimeclient.Client, sc
 	case !HasValidFallback(scaledObject):
 		log.Info("Failed to validate ScaledObject Spec. Please check that parameters are positive integers", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
 		return nil, false, suppressedError
+	}
+
+	healthStatus := soh.IncrementFailure(metricName)
+
+	switch {
 	case *healthStatus.NumberOfFailures > scaledObject.Spec.Fallback.FailureThreshold:
 		if scaledObject.Spec.Fallback.Behavior == kedav1alpha1.FallbackBehaviorScalingModifiers {
 			// scaling modifier expression engine will treat this as "nil" for the "??" operator
@@ -94,13 +157,13 @@ func GetMetricsWithFallback(ctx context.Context, client runtimeclient.Client, sc
 		var err error
 
 		if scaledObject.Spec.Fallback.Behavior != kedav1alpha1.FallbackBehaviorStatic {
-			currentReplicas, err = resolver.GetCurrentReplicas(ctx, client, scaleClient, scaledObject)
+			currentReplicas, err = resolver.GetCurrentReplicas(soh.Ctx, soh.KubeClient, soh.ScaleClient, soh.ScaledObject)
 			if err != nil {
 				return nil, false, suppressedError
 			}
 		}
 
-		l := doFallback(ctx, client, scaleClient, scaledObject, metricSpec, metricName, currentReplicas, suppressedError)
+		l := doFallback(soh, metricSpec, metricName, currentReplicas, suppressedError)
 		if l == nil {
 			return l, false, fmt.Errorf("error performing fallback")
 		}
@@ -111,9 +174,9 @@ func GetMetricsWithFallback(ctx context.Context, client runtimeclient.Client, sc
 	}
 }
 
-func fallbackExistsInStatus(scaledObject *kedav1alpha1.ScaledObject, status *kedav1alpha1.ScaledObjectStatus) bool {
+func fallbackExceededThreshold(status kedav1alpha1.ScaledObjectStatus, failureThreshold int32) bool {
 	for _, element := range status.Health {
-		if element.Status == kedav1alpha1.HealthStatusFailing && *element.NumberOfFailures > scaledObject.Spec.Fallback.FailureThreshold {
+		if element.Status == kedav1alpha1.HealthStatusFailing && *element.NumberOfFailures > failureThreshold {
 			return true
 		}
 	}
@@ -145,12 +208,13 @@ func IsPodReady(pod *v1.Pod) bool {
 }
 
 // Similar to how it's done in HPA's code: https://github.com/kubernetes/kubernetes/blob/091f87c10bc3532041b77a783a5f832de5506dc8/pkg/controller/podautoscaler/replica_calculator.go#L323
-func getReadyReplicasCount(ctx context.Context, client runtimeclient.Client, scaleClient scale.ScalesGetter, scaledObject *kedav1alpha1.ScaledObject) (int32, error) {
+func getReadyReplicasCount(soh ScaledObjectHandler) (int32, error) {
+	scaledObject := soh.ScaledObject
 	if scaledObject == nil || scaledObject.Spec.ScaleTargetRef == nil || scaledObject.Status.ScaleTargetGVKR == nil {
 		return -1, fmt.Errorf("")
 	}
 
-	scale, err := scaleClient.Scales(scaledObject.Namespace).Get(ctx, scaledObject.Status.ScaleTargetGVKR.GroupResource(), scaledObject.Spec.ScaleTargetRef.Name, metav1.GetOptions{})
+	scale, err := soh.ScaleClient.Scales(scaledObject.Namespace).Get(soh.Ctx, scaledObject.Status.ScaleTargetGVKR.GroupResource(), scaledObject.Spec.ScaleTargetRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return -1, err
 	}
@@ -161,7 +225,7 @@ func getReadyReplicasCount(ctx context.Context, client runtimeclient.Client, sca
 	}
 
 	podList := v1.PodList{}
-	err = client.List(ctx, &podList, runtimeclient.InNamespace(scaledObject.Namespace), runtimeclient.MatchingLabelsSelector{Selector: parsedSelector})
+	err = soh.KubeClient.List(soh.Ctx, &podList, runtimeclient.InNamespace(scaledObject.Namespace), runtimeclient.MatchingLabelsSelector{Selector: parsedSelector})
 	if err != nil {
 		return -1, err
 	}
@@ -176,7 +240,8 @@ func getReadyReplicasCount(ctx context.Context, client runtimeclient.Client, sca
 	return readyPodCount, nil
 }
 
-func doFallback(ctx context.Context, client runtimeclient.Client, scaleClient scale.ScalesGetter, scaledObject *kedav1alpha1.ScaledObject, metricSpec v2.MetricSpec, metricName string, currentReplicas int32, suppressedError error) []external_metrics.ExternalMetricValue {
+func doFallback(soh ScaledObjectHandler, metricSpec v2.MetricSpec, metricName string, currentReplicas int32, suppressedError error) []external_metrics.ExternalMetricValue {
+	scaledObject := soh.ScaledObject
 	fallbackBehavior := scaledObject.Spec.Fallback.Behavior
 	fallbackReplicas := int64(scaledObject.Spec.Fallback.Replicas)
 	var replicas float64
@@ -209,7 +274,7 @@ func doFallback(ctx context.Context, client runtimeclient.Client, scaleClient sc
 	// If the metricType is Value, we get the number of readyReplicas, and divide replicas by it.
 	if (!scaledObject.IsUsingModifiers() && metricSpec.External.Target.Type == v2.ValueMetricType) ||
 		(scaledObject.IsUsingModifiers() && scaledObject.Spec.Advanced.ScalingModifiers.MetricType == v2.ValueMetricType) {
-		readyReplicas, err := getReadyReplicasCount(ctx, client, scaleClient, scaledObject)
+		readyReplicas, err := getReadyReplicasCount(soh)
 		if err != nil {
 			log.Error(err, "failed to do fallback for metric of type Value", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name, "metricName", metricName)
 			return nil
@@ -250,50 +315,4 @@ func doFallback(ctx context.Context, client runtimeclient.Client, scaleClient sc
 		"fallback.replicas", fallbackReplicas,
 		"workload.currentReplicas", currentReplicas)
 	return fallbackMetrics
-}
-
-func updateStatus(ctx context.Context, client runtimeclient.Client, scaledObject *kedav1alpha1.ScaledObject, status *kedav1alpha1.ScaledObjectStatus) {
-	patch := runtimeclient.MergeFrom(scaledObject.DeepCopy())
-
-	if !isFallbackEnabled(scaledObject) || !HasValidFallback(scaledObject) {
-		log.V(1).Info("Fallback is not enabled, hence skipping the health update to the scaledobject", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
-		return
-	}
-
-	if fallbackExistsInStatus(scaledObject, status) {
-		status.Conditions.SetFallbackCondition(metav1.ConditionTrue, "FallbackExists", "At least one trigger is falling back on this scaled object")
-	} else {
-		status.Conditions.SetFallbackCondition(metav1.ConditionFalse, "NoFallbackFound", "No fallbacks are active on this scaled object")
-	}
-
-	// Update status only if it has changed
-	if !reflect.DeepEqual(scaledObject.Status, *status) {
-		scaledObject.Status = *status
-		err := client.Status().Patch(ctx, scaledObject, patch)
-		if err != nil {
-			log.Error(err, "failed to patch ScaledObjects Status", "scaledObject.Namespace", scaledObject.Namespace, "scaledObject.Name", scaledObject.Name)
-		}
-	}
-}
-
-func getHealthStatus(status *kedav1alpha1.ScaledObjectStatus, metricName string) *kedav1alpha1.HealthStatus {
-	// Get health status for a specific metric
-	_, healthStatusExists := status.Health[metricName]
-	if !healthStatusExists {
-		zero := int32(0)
-		healthStatus := kedav1alpha1.HealthStatus{
-			NumberOfFailures: &zero,
-			Status:           kedav1alpha1.HealthStatusHappy,
-		}
-		status.Health[metricName] = healthStatus
-	}
-	healthStatus := status.Health[metricName]
-	return &healthStatus
-}
-
-func initHealthStatus(status *kedav1alpha1.ScaledObjectStatus) {
-	// Init health status if missing
-	if status.Health == nil {
-		status.Health = make(map[string]kedav1alpha1.HealthStatus)
-	}
 }

--- a/pkg/fallback/fallback_test.go
+++ b/pkg/fallback/fallback_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -601,4 +602,56 @@ func createMetricSpec(averageValue int) v2.MetricSpec {
 			},
 		},
 	}
+}
+
+// TestUpdateStatusConcurrency verifies that concurrent calls to GetMetricsWithFallback
+// for different metrics of the same ScaledObject do not cause a
+// "fatal error: concurrent map iteration and map write" panic. Run this test with -race.
+func TestUpdateStatusConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := mock_client.NewMockClient(ctrl)
+	statusWriter := mock_client.NewMockStatusWriter(ctrl)
+	statusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockClient.EXPECT().Status().Return(statusWriter).AnyTimes()
+
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-concurrent",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"anno1": "val1", "anno2": "val2", "anno3": "val3",
+			},
+			Labels: map[string]string{
+				"label1": "val1", "label2": "val2",
+			},
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "myapp"},
+			Fallback: &kedav1alpha1.Fallback{
+				FailureThreshold: 3,
+				Replicas:         10,
+			},
+		},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			Health:     map[string]kedav1alpha1.HealthStatus{},
+			Conditions: *kedav1alpha1.GetInitializedConditions(),
+		},
+	}
+
+	suppressedErr := errors.New("scaler error")
+	metricSpec := createMetricSpec(3)
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			mn := fmt.Sprintf("metric_%d", i)
+			_, _, _ = GetMetricsWithFallback(context.Background(), mockClient, nil, nil, suppressedErr, mn, so, metricSpec)
+		}(i)
+	}
+	wg.Wait()
 }

--- a/pkg/fallback/fallback_test.go
+++ b/pkg/fallback/fallback_test.go
@@ -74,11 +74,36 @@ var _ = Describe("fallback", func() {
 		metricSpec := createMetricSpec(3)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
 		Expect(value).Should(Equal(expectedMetricValue))
+	})
+
+	It("should initialise the health status on success when fallback is enabled and status is empty", func() {
+		expectedMetricValue := float64(6)
+		primeGetMetrics(scaler, expectedMetricValue)
+
+		// nil Health map: a freshly created fallback ScaledObject whose first poll succeeds
+		so := buildScaledObject(
+			&kedav1alpha1.Fallback{
+				FailureThreshold: int32(3),
+				Replicas:         int32(10),
+			},
+			nil,
+		)
+
+		metricSpec := createMetricSpec(3)
+		expectStatusPatch(ctrl, client)
+
+		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
+
+		Expect(err).ToNot(HaveOccurred())
+		value := metrics[0].Value.AsApproximateFloat64()
+		Expect(value).Should(Equal(expectedMetricValue))
+		Expect(so.Status.Health[metricName]).To(haveFailureAndStatus(0, kedav1alpha1.HealthStatusHappy))
 	})
 
 	It("should reset the health status when scaler metrics are available when fallback is enabled", func() {
@@ -105,7 +130,7 @@ var _ = Describe("fallback", func() {
 		expectStatusPatch(ctrl, client)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
@@ -134,7 +159,7 @@ var _ = Describe("fallback", func() {
 		expectNoStatusPatch(ctrl)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
@@ -150,7 +175,7 @@ var _ = Describe("fallback", func() {
 		expectNoStatusPatch(ctrl)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		_, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		_, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(Equal("some error"))
@@ -179,7 +204,7 @@ var _ = Describe("fallback", func() {
 		expectStatusPatch(ctrl, client)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		_, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		_, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(Equal("some error"))
@@ -211,7 +236,7 @@ var _ = Describe("fallback", func() {
 		mockScaleAndDeployment(ctrl, client, scaleClient, 5)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
@@ -247,7 +272,7 @@ var _ = Describe("fallback", func() {
 		mockScaleAndDeployment(ctrl, client, scaleClient, 5)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
@@ -276,7 +301,7 @@ var _ = Describe("fallback", func() {
 		metricSpec := createMetricSpec(10)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		_, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		_, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(Equal("some error"))
@@ -312,7 +337,7 @@ var _ = Describe("fallback", func() {
 		mockScaleAndDeployment(ctrl, client, scaleClient, 5)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		_, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		_, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		condition := so.Status.Conditions.GetFallbackCondition()
@@ -346,7 +371,7 @@ var _ = Describe("fallback", func() {
 		metricSpec := createMetricSpec(10)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		_, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		_, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ShouldNot(BeNil())
 		Expect(err.Error()).Should(Equal("some error"))
@@ -380,7 +405,7 @@ var _ = Describe("fallback", func() {
 		mockScaleAndDeployment(ctrl, client, scaleClient, 4)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
@@ -414,7 +439,7 @@ var _ = Describe("fallback", func() {
 		mockScaleAndDeployment(ctrl, client, scaleClient, 6)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
@@ -446,7 +471,7 @@ var _ = Describe("fallback", func() {
 		expectStatusPatch(ctrl, client)
 
 		metrics, _, err := scaler.GetMetricsAndActivity(context.Background(), metricName)
-		metrics, _, err = GetMetricsWithFallback(context.Background(), client, scaleClient, metrics, err, metricName, so, metricSpec)
+		metrics, _, err = GetMetricsWithFallback(newHandler(client, scaleClient, so), metrics, err, metricName, metricSpec)
 
 		Expect(err).ToNot(HaveOccurred())
 		value := metrics[0].Value.AsApproximateFloat64()
@@ -643,6 +668,9 @@ func TestUpdateStatusConcurrency(t *testing.T) {
 	suppressedErr := errors.New("scaler error")
 	metricSpec := createMetricSpec(3)
 
+	// lock from ScalersCache
+	updateLock := &sync.RWMutex{}
+
 	const concurrency = 20
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
@@ -650,8 +678,25 @@ func TestUpdateStatusConcurrency(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			mn := fmt.Sprintf("metric_%d", i)
-			_, _, _ = GetMetricsWithFallback(context.Background(), mockClient, nil, nil, suppressedErr, mn, so, metricSpec)
+			soh := ScaledObjectHandler{
+				Ctx:          context.Background(),
+				KubeClient:   mockClient,
+				UpdateLock:   updateLock,
+				ScaledObject: so,
+			}
+			_, _, _ = GetMetricsWithFallback(soh, nil, suppressedErr, mn, metricSpec)
 		}(i)
 	}
 	wg.Wait()
+}
+
+// newHandler builds a ScaledObjectHandler for tests with a fresh per-ScaledObject lock.
+func newHandler(client *mock_client.MockClient, scaleClient *mock_scale.MockScalesGetter, so *kedav1alpha1.ScaledObject) ScaledObjectHandler {
+	return ScaledObjectHandler{
+		Ctx:          context.Background(),
+		KubeClient:   client,
+		ScaleClient:  scaleClient,
+		UpdateLock:   &sync.RWMutex{},
+		ScaledObject: so,
+	}
 }

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -41,6 +41,7 @@ var log = logf.Log.WithName("scalers_cache")
 var ErrCacheClosed = errors.New("scalers cache is closed")
 
 type ScalersCache struct {
+	ScaledObjectUpdateLock   sync.RWMutex // serializes updates to the ScaledObject
 	ScaledObject             *kedav1alpha1.ScaledObject
 	Scalers                  []ScalerBuilder
 	ScalableObjectGeneration int64

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -557,9 +557,10 @@ func (h *scaleHandler) ClearScalersCache(ctx context.Context, scalableObject ked
 /// --------------------------------------------------------------------------- ///
 
 // processMetricsWithFallback processes metrics with fallback support and handles metric recording
-func (h *scaleHandler) processMetricsWithFallback(ctx context.Context, rawMetrics []external_metrics.ExternalMetricValue, rawErr error, metricName string, triggerName string, triggerIndex int, scaledObject *kedav1alpha1.ScaledObject, metricSpec v2.MetricSpec, sendRawMetricsCondition bool, isMetricActive bool, logger logr.Logger) ([]external_metrics.ExternalMetricValue, bool, error) {
+func (h *scaleHandler) processMetricsWithFallback(soh fallback.ScaledObjectHandler, rawMetrics []external_metrics.ExternalMetricValue, rawErr error, metricName string, triggerName string, triggerIndex int, metricSpec v2.MetricSpec, sendRawMetricsCondition bool, isMetricActive bool, logger logr.Logger) ([]external_metrics.ExternalMetricValue, bool, error) {
 	// check if we need to set a fallback
-	metrics, fallbackActive, err := fallback.GetMetricsWithFallback(ctx, h.client, h.scaleClient, rawMetrics, rawErr, metricName, scaledObject, metricSpec)
+	metrics, fallbackActive, err := fallback.GetMetricsWithFallback(soh, rawMetrics, rawErr, metricName, metricSpec)
+	so := soh.ScaledObject
 
 	if err != nil {
 		logger.Error(err, "error getting metric for trigger", "trigger", triggerName)
@@ -567,12 +568,12 @@ func (h *scaleHandler) processMetricsWithFallback(ctx context.Context, rawMetric
 		// Record metrics
 		for _, metric := range metrics {
 			metricValue := metric.Value.AsApproximateFloat64()
-			metricscollector.RecordScalerMetric(scaledObject.Namespace, scaledObject.Name, triggerName, triggerIndex, metric.MetricName, true, metricValue)
+			metricscollector.RecordScalerMetric(so.Namespace, so.Name, triggerName, triggerIndex, metric.MetricName, true, metricValue)
 		}
 
 		// Send raw metrics if conditions are met
 		if sendRawMetricsCondition {
-			go h.sendWhenSubscribed(scaledObject.Name, scaledObject.Namespace, triggerName, isMetricActive, metrics)
+			go h.sendWhenSubscribed(so.Name, so.Namespace, triggerName, isMetricActive, metrics)
 		}
 	}
 
@@ -708,7 +709,14 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 					}
 
 					// Use the helper function to process metrics with fallback
-					metrics, fallbackActive, err := h.processMetricsWithFallback(ctx, rawMetrics, rawErr, metricName, triggerName, triggerIndex, scaledObject, spec, shouldSendRawMetrics(RawMetricsHPA), isMetricActive, logger)
+					soh := fallback.ScaledObjectHandler{
+						Ctx:          ctx,
+						KubeClient:   h.client,
+						ScaleClient:  h.scaleClient,
+						UpdateLock:   &scalersCache.ScaledObjectUpdateLock,
+						ScaledObject: scaledObject,
+					}
+					metrics, fallbackActive, err := h.processMetricsWithFallback(soh, rawMetrics, rawErr, metricName, triggerName, triggerIndex, spec, shouldSendRawMetrics(RawMetricsHPA), isMetricActive, logger)
 
 					result.metricName = metricName
 					result.triggerName = triggerName
@@ -974,7 +982,14 @@ func (h *scaleHandler) getScalerState(ctx context.Context, scaler scalers.Scaler
 		logger.V(1).Info("Getting metrics and activity from scaler", "scaler", result.TriggerName, "metricName", metricName, "metrics", rawMetrics, "activity", isMetricActive, "scalerError", rawErr)
 
 		// Use the helper function to process metrics with fallback
-		metrics, fallbackActive, err := h.processMetricsWithFallback(ctx, rawMetrics, rawErr, metricName, result.TriggerName, triggerIndex, scaledObject, spec, shouldSendRawMetrics(RawMetricsPollingInterval), isMetricActive, logger)
+		soh := fallback.ScaledObjectHandler{
+			Ctx:          ctx,
+			KubeClient:   h.client,
+			ScaleClient:  h.scaleClient,
+			UpdateLock:   &scalersCache.ScaledObjectUpdateLock,
+			ScaledObject: scaledObject,
+		}
+		metrics, fallbackActive, err := h.processMetricsWithFallback(soh, rawMetrics, rawErr, metricName, result.TriggerName, triggerIndex, spec, shouldSendRawMetrics(RawMetricsPollingInterval), isMetricActive, logger)
 
 		// Store fallback information
 		if fallbackActive {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

Bug: Previously GetScaledObjectMetrics spawns one goroutine per trigger, and all goroutines share the same *ScaledObject pointer. The original updateStatus [wrote directly to that shared object (scaledObject.Status = *status)](https://github.com/kedacore/keda/blob/v2.18.3/pkg/fallback/fallback.go#L251). Concurrently, [other goroutines call scaledObject.DeepCopy()](https://github.com/kedacore/keda/blob/v2.18.3/pkg/fallback/fallback.go#L236), which causes concurrent map read/write data race that causes panics.

This PR fixes this by adding a mutex in `GetMetricsWithFallback` (`updateStatus`'s caller), keyed by namespace + scaledobject name.

We also tried the local copy method which did not work, as we rely on reading from the shared scaled object in some cases (see the e2e test failures in the comments below). So writing back to the local copy will break this usecase.
  
<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Added a unit test to verify the fix; without the fix, the test fails with:

```
root@48d5f2c92366:/workspaces/keda#   go test ./pkg/fallback/... -run TestUpdateStatusConcurrency -v -race -count=1                                                                
=== RUN   TestUpdateStatusConcurrency
==================
WARNING: DATA RACE
Read at 0x00c0001c6a00 by goroutine 62:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:392 +0x0
  github.com/kedacore/keda/v2/apis/keda/v1alpha1.(*ScaledObjectStatus).DeepCopyInto()
      /workspaces/keda/apis/keda/v1alpha1/zz_generated.deepcopy.go:1118 +0x5b4
  github.com/kedacore/keda/v2/apis/keda/v1alpha1.(*ScaledObject).DeepCopyInto()
      /workspaces/keda/apis/keda/v1alpha1/zz_generated.deepcopy.go:953 +0x154
  github.com/kedacore/keda/v2/apis/keda/v1alpha1.(*ScaledObject).DeepCopy()
      /workspaces/keda/apis/keda/v1alpha1/zz_generated.deepcopy.go:962 +0x68
  github.com/kedacore/keda/v2/pkg/fallback.updateStatus()
      /workspaces/keda/pkg/fallback/fallback.go:248 +0x48
  github.com/kedacore/keda/v2/pkg/fallback.GetMetricsWithFallback()
      /workspaces/keda/pkg/fallback/fallback.go:66 +0x31c
  github.com/kedacore/keda/v2/pkg/fallback.TestUpdateStatusConcurrency.func1()
      /workspaces/keda/pkg/fallback/fallback_test.go:654 +0x174
  github.com/kedacore/keda/v2/pkg/fallback.TestUpdateStatusConcurrency.gowrap2()
      /workspaces/keda/pkg/fallback/fallback_test.go:655 +0x38

Previous write at 0x00c0001c6a00 by goroutine 78:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:392 +0x0
  github.com/kedacore/keda/v2/apis/keda/v1alpha1.(*ScaledObjectStatus).DeepCopyInto()
      /workspaces/keda/apis/keda/v1alpha1/zz_generated.deepcopy.go:1118 +0x5b4
  github.com/kedacore/keda/v2/apis/keda/v1alpha1.(*ScaledObjectStatus).DeepCopy()
      /workspaces/keda/apis/keda/v1alpha1/zz_generated.deepcopy.go:1157 +0xa0
  github.com/kedacore/keda/v2/pkg/fallback.GetMetricsWithFallback()
      /workspaces/keda/pkg/fallback/fallback.go:46 +0x60
  github.com/kedacore/keda/v2/pkg/fallback.TestUpdateStatusConcurrency.func1()
      /workspaces/keda/pkg/fallback/fallback_test.go:654 +0x174
  github.com/kedacore/keda/v2/pkg/fallback.TestUpdateStatusConcurrency.gowrap2()
      /workspaces/keda/pkg/fallback/fallback_test.go:655 +0x38

Goroutine 62 (running) created at:
  github.com/kedacore/keda/v2/pkg/fallback.TestUpdateStatusConcurrency()
      /workspaces/keda/pkg/fallback/fallback_test.go:651 +0xd44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x34

Goroutine 78 (running) created at:
  github.com/kedacore/keda/v2/pkg/fallback.TestUpdateStatusConcurrency()
      /workspaces/keda/pkg/fallback/fallback_test.go:651 +0xd44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:2101 +0x34
==================
...
    testing.go:1712: race detected during execution of test
--- FAIL: TestUpdateStatusConcurrency (0.00s)
FAIL
FAIL    github.com/kedacore/keda/v2/pkg/fallback        0.049s
FAIL
```

With the fix:

```
root@48d5f2c92366:/workspaces/keda#   go test ./pkg/fallback/... -run TestUpdateStatusConcurrency -v -race -count=1                                                                
=== RUN   TestUpdateStatusConcurrency
--- PASS: TestUpdateStatusConcurrency (0.00s)
PASS
ok      github.com/kedacore/keda/v2/pkg/fallback        1.058s
```

Also, ran the e2e tests from a dev container with `IMAGE_REGISTRY=docker.io IMAGE_REPO="$DOCKER_USER" go test -v -tags e2e ./internals/fallback/...`, showing all tests pass.

<img width="849" height="271" alt="Screenshot 2026-06-04 at 3 31 39 PM" src="https://github.com/user-attachments/assets/4cd565ce-7082-4dfe-ba4a-0626d82b1cda" />

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7838

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
