### PR TITLE
CI: Add e2e coverage for paused annotation precedence

### DIFF
--- a/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
+++ b/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
@@ -133,6 +133,7 @@ func TestScaler(t *testing.T) {
 		testBothPauseAnnotationActive(t, kc)
 		testHPANotExistWhilePaused(t, kc)
 		testHPANotExistWhilePausedReplicas(t, kc)
+		testPausedAnnotationTakesPrecedenceOverPauseScaleIn(t, kc)
 		testChangePausedReplicasValue(t, kc)
 		testSwitchFromPausedReplicasToPaused(t, kc)
 
@@ -177,6 +178,28 @@ func upsertScaledObjectPausedReplicasAnnotation(t assert.TestingT, value int) {
 func removeScaledObjectPausedReplicasAnnotation(t assert.TestingT) {
 	_, err := ExecuteCommand(fmt.Sprintf("kubectl annotate scaledobject/%s -n %s autoscaling.keda.sh/paused-replicas- --overwrite", scaledObjectName, testNamespace))
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+}
+
+func upsertScaledObjectPausedScaleInAnnotation(t assert.TestingT) {
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl annotate scaledobject/%s -n %s autoscaling.keda.sh/paused-scale-in=true --overwrite", scaledObjectName, testNamespace))
+	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+}
+
+func removeScaledObjectPausedScaleInAnnotation(t assert.TestingT) {
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl annotate scaledobject/%s -n %s autoscaling.keda.sh/paused-scale-in- --overwrite", scaledObjectName, testNamespace))
+	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+}
+
+func waitForHPADeleted(t *testing.T, kc *kubernetes.Clientset, message string) {
+	var err error
+	for i := 0; i < 12; i++ {
+		_, err = kc.AutoscalingV2().HorizontalPodAutoscalers(testNamespace).Get(context.Background(), hpaName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return
+		}
+		time.Sleep(5 * time.Second)
+	}
+	assert.True(t, errors.IsNotFound(err), message)
 }
 
 func testPauseWhenScaleOut(t *testing.T, kc *kubernetes.Clientset) {
@@ -306,6 +329,22 @@ func testHPANotExistWhilePausedReplicas(t *testing.T, kc *kubernetes.Clientset) 
 	assert.True(t, errors.IsNotFound(err), "HPA should not exist while paused with paused-replicas")
 
 	removeScaledObjectPausedReplicasAnnotation(t)
+	time.Sleep(5 * time.Second)
+}
+
+func testPausedAnnotationTakesPrecedenceOverPauseScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing paused annotation takes precedence over paused-scale-in ---")
+
+	upsertScaledObjectPausedScaleInAnnotation(t)
+
+	_, err := WaitForHpaCreation(t, kc, hpaName, testNamespace, 12, 5)
+	assert.NoError(t, err, "HPA should exist while only paused-scale-in is set")
+
+	upsertScaledObjectPausedAnnotation(t)
+	waitForHPADeleted(t, kc, "HPA should not exist while paused=true is set with paused-scale-in")
+
+	removeScaledObjectPausedAnnotation(t)
+	removeScaledObjectPausedScaleInAnnotation(t)
 	time.Sleep(5 * time.Second)
 }
 

--- a/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
+++ b/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
@@ -212,7 +212,7 @@ func waitForHPADeleted(t *testing.T, kc *kubernetes.Clientset, message string) {
 		}
 		time.Sleep(5 * time.Second)
 	}
-	assert.True(t, errors.IsNotFound(err), message)
+	assert.Truef(t, errors.IsNotFound(err), "%s: last observed error: %v", message, err)
 }
 
 func testPauseWhenScaleOut(t *testing.T, kc *kubernetes.Clientset) {

--- a/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
+++ b/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
@@ -135,6 +135,8 @@ func TestScaler(t *testing.T) {
 		testHPANotExistWhilePausedReplicas(t, kc)
 		testPausedAnnotationTakesPrecedenceOverPauseScaleIn(t, kc)
 		testPausedAnnotationTakesPrecedenceWhenPauseScaleInIsAdded(t, kc)
+		testPausedAnnotationTakesPrecedenceOverPauseScaleOut(t, kc)
+		testPausedAnnotationTakesPrecedenceWhenPauseScaleOutIsAdded(t, kc)
 		testChangePausedReplicasValue(t, kc)
 		testSwitchFromPausedReplicasToPaused(t, kc)
 
@@ -188,6 +190,16 @@ func upsertScaledObjectPausedScaleInAnnotation(t assert.TestingT) {
 
 func removeScaledObjectPausedScaleInAnnotation(t assert.TestingT) {
 	_, err := ExecuteCommand(fmt.Sprintf("kubectl annotate scaledobject/%s -n %s autoscaling.keda.sh/paused-scale-in- --overwrite", scaledObjectName, testNamespace))
+	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+}
+
+func upsertScaledObjectPausedScaleOutAnnotation(t assert.TestingT) {
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl annotate scaledobject/%s -n %s autoscaling.keda.sh/paused-scale-out=true --overwrite", scaledObjectName, testNamespace))
+	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+}
+
+func removeScaledObjectPausedScaleOutAnnotation(t assert.TestingT) {
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl annotate scaledobject/%s -n %s autoscaling.keda.sh/paused-scale-out- --overwrite", scaledObjectName, testNamespace))
 	assert.NoErrorf(t, err, "cannot execute command - %s", err)
 }
 
@@ -359,6 +371,36 @@ func testPausedAnnotationTakesPrecedenceWhenPauseScaleInIsAdded(t *testing.T, kc
 	waitForHPADeleted(t, kc, "HPA should not exist after adding paused-scale-in while paused=true is set")
 
 	removeScaledObjectPausedScaleInAnnotation(t)
+	removeScaledObjectPausedAnnotation(t)
+	time.Sleep(5 * time.Second)
+}
+
+func testPausedAnnotationTakesPrecedenceOverPauseScaleOut(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing paused annotation takes precedence over paused-scale-out ---")
+
+	upsertScaledObjectPausedScaleOutAnnotation(t)
+
+	_, err := WaitForHpaCreation(t, kc, hpaName, testNamespace, 12, 5)
+	assert.NoError(t, err, "HPA should exist while only paused-scale-out is set")
+
+	upsertScaledObjectPausedAnnotation(t)
+	waitForHPADeleted(t, kc, "HPA should not exist while paused=true is set with paused-scale-out")
+
+	removeScaledObjectPausedAnnotation(t)
+	removeScaledObjectPausedScaleOutAnnotation(t)
+	time.Sleep(5 * time.Second)
+}
+
+func testPausedAnnotationTakesPrecedenceWhenPauseScaleOutIsAdded(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing paused annotation stays in effect when paused-scale-out is added ---")
+
+	upsertScaledObjectPausedAnnotation(t)
+	waitForHPADeleted(t, kc, "HPA should not exist while paused=true is set")
+
+	upsertScaledObjectPausedScaleOutAnnotation(t)
+	waitForHPADeleted(t, kc, "HPA should not exist after adding paused-scale-out while paused=true is set")
+
+	removeScaledObjectPausedScaleOutAnnotation(t)
 	removeScaledObjectPausedAnnotation(t)
 	time.Sleep(5 * time.Second)
 }

--- a/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
+++ b/tests/internals/pause_scaledobject_explicitly/pause_scaledobject_explicitly_test.go
@@ -134,6 +134,7 @@ func TestScaler(t *testing.T) {
 		testHPANotExistWhilePaused(t, kc)
 		testHPANotExistWhilePausedReplicas(t, kc)
 		testPausedAnnotationTakesPrecedenceOverPauseScaleIn(t, kc)
+		testPausedAnnotationTakesPrecedenceWhenPauseScaleInIsAdded(t, kc)
 		testChangePausedReplicasValue(t, kc)
 		testSwitchFromPausedReplicasToPaused(t, kc)
 
@@ -345,6 +346,20 @@ func testPausedAnnotationTakesPrecedenceOverPauseScaleIn(t *testing.T, kc *kuber
 
 	removeScaledObjectPausedAnnotation(t)
 	removeScaledObjectPausedScaleInAnnotation(t)
+	time.Sleep(5 * time.Second)
+}
+
+func testPausedAnnotationTakesPrecedenceWhenPauseScaleInIsAdded(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing paused annotation stays in effect when paused-scale-in is added ---")
+
+	upsertScaledObjectPausedAnnotation(t)
+	waitForHPADeleted(t, kc, "HPA should not exist while paused=true is set")
+
+	upsertScaledObjectPausedScaleInAnnotation(t)
+	waitForHPADeleted(t, kc, "HPA should not exist after adding paused-scale-in while paused=true is set")
+
+	removeScaledObjectPausedScaleInAnnotation(t)
+	removeScaledObjectPausedAnnotation(t)
 	time.Sleep(5 * time.Second)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Adds e2e regression coverage for ScaledObject pause annotation precedence.

The new checks verify both annotation orderings between `autoscaling.keda.sh/paused=true` and the directional pause annotations, `autoscaling.keda.sh/paused-scale-in=true` and `autoscaling.keda.sh/paused-scale-out=true`. When either directional pause annotation is set first, adding `paused=true` deletes the HPA; when `paused=true` is set first, adding either directional pause annotation keeps the HPA deleted. This protects the behavior fixed by #7664 and discussed in #7848.

Validation:

- `go test -tags e2e ./tests/internals/pause_scaledobject_explicitly -run TestScaler -count=0`
- Full e2e workflow against this branch:
  - `IMAGE_REGISTRY=docker.io IMAGE_REPO=aliaqel736 make publish`
  - `IMAGE_REGISTRY=docker.io IMAGE_REPO=aliaqel736 go test -v -tags e2e ./utils/setup_test.go`
  - `IMAGE_REGISTRY=docker.io IMAGE_REPO=aliaqel736 go test -v -tags e2e ./internals/pause_scaledobject_explicitly/`
  - `IMAGE_REGISTRY=docker.io IMAGE_REPO=aliaqel736 go test -v -tags e2e ./utils/cleanup_test.go`

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7848

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #7664
