### PR TITLE
Temporal Scaler: add enableTLS parameter to control TLS with API key auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Improvements
 
 - **Kafka Scaler**: Add optional `fullMetadata` trigger metadata field to control Sarama's full cluster metadata refresh, reducing operator memory for topic scoped triggers ([#7453](https://github.com/kedacore/keda/issues/7453))
+- **Temporal Scaler**: Add `enableTLS` parameter to allow disabling TLS when using API key authentication (e.g. plaintext gRPC endpoints) ([#7854](https://github.com/kedacore/keda/pull/7854))
 - **Temporal Scaler**: Add opt-in `includeRunningWorkflowCount` (with optional `workflowTaskQueueForCount`) to block premature scale-down when the backlog is momentarily zero but Workflow workers are still busy. Worker Deployment Version scalers short-circuit on Version status (`DRAINING` stays active, `DRAINED`/`INACTIVE` scale down); other modes issue a scoped `CountWorkflow` visibility query — including `TemporalWorkerDeploymentVersion is null` for unversioned workers. ([#7459](https://github.com/kedacore/keda/issues/7459))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 

--- a/pkg/scalers/temporal_scaler.go
+++ b/pkg/scalers/temporal_scaler.go
@@ -75,6 +75,7 @@ type temporalMetadata struct {
 	WorkflowTaskQueueForCount   string `keda:"name=workflowTaskQueueForCount,   order=triggerMetadata;resolvedEnv, optional"`
 	APIKey                      string `keda:"name=apiKey,                    order=authParams;resolvedEnv, optional"`
 	MinConnectTimeout           int    `keda:"name=minConnectTimeout,         order=triggerMetadata, default=5"`
+	EnableTLS                   bool   `keda:"name=enableTLS,                 order=triggerMetadata, default=true"`
 
 	UnsafeSsl     bool   `keda:"name=unsafeSsl,                 order=triggerMetadata, optional"`
 	Cert          string `keda:"name=cert,                      order=authParams, optional"`
@@ -542,23 +543,13 @@ func getTemporalClient(ctx context.Context, meta *temporalMetadata, log logr.Log
 		},
 	))
 
-	var tlsConfig *tls.Config
-
 	if meta.APIKey != "" {
 		options.Credentials = sdk.NewAPIKeyStaticCredentials(meta.APIKey)
-		tlsConfig = kedautil.CreateTLSClientConfig(meta.UnsafeSsl)
 	}
 
-	if meta.Cert != "" && meta.Key != "" {
-		var err error
-		tlsConfig, err = kedautil.NewTLSConfigWithPassword(meta.Cert, meta.Key, meta.KeyPassword, meta.CA, meta.UnsafeSsl)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if tlsConfig != nil && meta.TLSServerName != "" {
-		tlsConfig.ServerName = meta.TLSServerName
+	tlsConfig, err := buildTemporalTLSConfig(meta, log)
+	if err != nil {
+		return nil, err
 	}
 
 	options.ConnectionOptions = sdk.ConnectionOptions{
@@ -567,6 +558,40 @@ func getTemporalClient(ctx context.Context, meta *temporalMetadata, log logr.Log
 	}
 
 	return sdk.DialContext(ctx, options)
+}
+
+func buildTemporalTLSConfig(meta *temporalMetadata, log logr.Logger) (*tls.Config, error) {
+	// cert+key always uses TLS (mTLS); enableTLS only controls apiKey-only connections.
+	// When both apiKey and cert+key are set (e.g. Temporal Cloud), the client certificate
+	// is included - restoring the layered behavior from before this function was extracted.
+	if meta.Cert != "" && meta.Key != "" {
+		if !meta.EnableTLS {
+			log.V(0).Info("enableTLS is ignored when cert/key are provided; mTLS requires TLS")
+		}
+		tlsConfig, err := kedautil.NewTLSConfigWithPassword(meta.Cert, meta.Key, meta.KeyPassword, meta.CA, meta.UnsafeSsl)
+		if err != nil {
+			return nil, err
+		}
+		if meta.TLSServerName != "" {
+			tlsConfig.ServerName = meta.TLSServerName
+		}
+		return tlsConfig, nil
+	}
+
+	// apiKey without cert+key: TLS gated by enableTLS
+	if meta.APIKey != "" {
+		if !meta.EnableTLS {
+			log.V(0).Info("WARNING: enableTLS is false while apiKey is set; API key will be transmitted in cleartext - only use this in trusted network environments")
+			return nil, nil
+		}
+		tlsConfig := kedautil.CreateTLSClientConfig(meta.UnsafeSsl)
+		if meta.TLSServerName != "" {
+			tlsConfig.ServerName = meta.TLSServerName
+		}
+		return tlsConfig, nil
+	}
+
+	return nil, nil
 }
 
 func parseTemporalMetadata(config *scalersconfig.ScalerConfig, _ logr.Logger) (*temporalMetadata, error) {

--- a/pkg/scalers/temporal_scaler_test.go
+++ b/pkg/scalers/temporal_scaler_test.go
@@ -2,10 +2,19 @@ package scalers
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -138,6 +147,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				AllActive:                 false,
 				Unversioned:               false,
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 			},
 			wantErr: true,
 		},
@@ -156,6 +166,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				AllActive:                 false,
 				Unversioned:               false,
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 			},
 			wantErr: false,
 		},
@@ -176,6 +187,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				AllActive:                 false,
 				Unversioned:               false,
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 			},
 			wantErr: false,
 		},
@@ -196,6 +208,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				Unversioned:               false,
 				APIKey:                    "test01",
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 			},
 			authParams: map[string]string{
 				"apiKey": "test01",
@@ -220,6 +233,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				Unversioned:               false,
 				QueueTypes:                []string{"workflow", "activity"},
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 			},
 			wantErr: false,
 		},
@@ -245,6 +259,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				Unversioned:               false,
 				APIKey:                    "test01",
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 			},
 			authParams: map[string]string{
 				"apiKey": "test01",
@@ -269,9 +284,35 @@ func TestParseTemporalMetadata(t *testing.T) {
 				Unversioned:               false,
 				APIKey:                    "test-api-key",
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 			},
 			authParams: map[string]string{
 				"apiKey": "test-api-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "apiKey with enableTLS false (plaintext gRPC)",
+			metadata: map[string]string{
+				"endpoint":  "test:7233",
+				"namespace": "default",
+				"taskQueue": "testxx",
+				"enableTLS": "false",
+			},
+			authParams: map[string]string{
+				"apiKey": "test-api-key",
+			},
+			wantMeta: &temporalMetadata{
+				Endpoint:                  "test:7233",
+				Namespace:                 "default",
+				TaskQueue:                 "testxx",
+				TargetQueueSize:           5,
+				ActivationTargetQueueSize: 0,
+				AllActive:                 false,
+				Unversioned:               false,
+				APIKey:                    "test-api-key",
+				MinConnectTimeout:         5,
+				EnableTLS:                 false,
 			},
 			wantErr: false,
 		},
@@ -292,6 +333,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				AllActive:                 false,
 				Unversioned:               false,
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 				TLSServerName:             "my-namespace.tmpr.cloud",
 			},
 			wantErr: false,
@@ -317,6 +359,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				Unversioned:               false,
 				APIKey:                    "test01",
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 				TLSServerName:             "my-namespace.tmpr.cloud",
 			},
 			wantErr: false,
@@ -348,6 +391,7 @@ func TestParseTemporalMetadata(t *testing.T) {
 				KeyPassword:               "password",
 				CA:                        "ca-data",
 				MinConnectTimeout:         5,
+				EnableTLS:                 true,
 				TLSServerName:             "my-namespace.tmpr.cloud",
 			},
 			wantErr: false,
@@ -564,6 +608,55 @@ func TestIsActiveWithoutBacklogVersionStatus(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func generateTemporalTestCertAndKey(t *testing.T) (string, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return string(certPEM), string(keyPEM)
+}
+
+func TestBuildTemporalTLSConfig(t *testing.T) {
+	t.Run("apiKey + enableTLS=true produces non-nil TLS config", func(t *testing.T) {
+		meta := &temporalMetadata{APIKey: "secret", EnableTLS: true}
+		tlsCfg, err := buildTemporalTLSConfig(meta, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, tlsCfg)
+	})
+	t.Run("apiKey + enableTLS=false produces nil TLS config (plaintext)", func(t *testing.T) {
+		meta := &temporalMetadata{APIKey: "secret", EnableTLS: false}
+		tlsCfg, err := buildTemporalTLSConfig(meta, logger)
+		assert.NoError(t, err)
+		assert.Nil(t, tlsCfg)
+	})
+	t.Run("cert+key without apiKey always produces non-nil TLS config", func(t *testing.T) {
+		certPEM, keyPEM := generateTemporalTestCertAndKey(t)
+		meta := &temporalMetadata{Cert: certPEM, Key: keyPEM}
+		tlsCfg, err := buildTemporalTLSConfig(meta, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, tlsCfg)
+	})
+	t.Run("apiKey + cert+key produces non-nil TLS config with client cert (mTLS + apiKey)", func(t *testing.T) {
+		certPEM, keyPEM := generateTemporalTestCertAndKey(t)
+		meta := &temporalMetadata{APIKey: "secret", EnableTLS: true, Cert: certPEM, Key: keyPEM}
+		tlsCfg, err := buildTemporalTLSConfig(meta, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, tlsCfg)
+		assert.NotEmpty(t, tlsCfg.Certificates, "client certificate must be present in TLS config")
+	})
 }
 
 func TestAuthType(t *testing.T) {

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -6048,6 +6048,12 @@
                     "metadataVariableReadable": true
                 },
                 {
+                    "name": "enableTLS",
+                    "type": "string",
+                    "default": "true",
+                    "metadataVariableReadable": true
+                },
+                {
                     "name": "unsafeSsl",
                     "type": "string",
                     "optional": true,

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -3971,6 +3971,10 @@ scalers:
           type: string
           default: "5"
           metadataVariableReadable: true
+        - name: enableTLS
+          type: string
+          default: "true"
+          metadataVariableReadable: true
         - name: unsafeSsl
           type: string
           optional: true


### PR DESCRIPTION
## Problem

When using API key / bearer token authentication with a Temporal server that serves **plaintext gRPC** (no TLS), the Temporal scaler forced a TLS connection:

```go
if meta.APIKey != "" {
    options.Credentials = sdk.NewAPIKeyStaticCredentials(meta.APIKey)
    tlsConfig = kedautil.CreateTLSClientConfig(meta.UnsafeSsl)  // always forced TLS
}
```

This causes every scaling poll to fail with `context canceled` (underlying: `tls: first record does not look like a TLS handshake`).

`sdk.NewAPIKeyStaticCredentials` injects the `Authorization: Bearer <token>` header via a Temporal SDK interceptor — not via gRPC transport credentials. TLS is not required by the auth mechanism itself; it was being forced unconditionally.

## Fix

Add an optional `enableTLS` metadata parameter (default: `true`). When set to `"false"`, TLS is skipped, allowing API key auth over plaintext gRPC. A warning is logged when this combination is in effect.

Backward compatible: existing users (Temporal Cloud) are unaffected — `enableTLS` defaults to `true`.

## Example

```yaml
triggers:
- type: temporal
  metadata:
    endpoint: temporal-frontend.example.com:7233
    namespace: my-namespace
    taskQueue: my-task-queue
    enableTLS: "false"   # only needed for self-hosted plaintext gRPC
  authenticationRef:
    name: temporal-trigger-auth
```

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Docs: https://github.com/kedacore/keda-docs/pull/1791