### PR TITLE
General: add "default" to ScaledJob scalingStrategy.strategy CRD enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- General: Fix `ScaledJob` CRD validation to include `"default"` as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- General: Fix `ScaledJob` CRD validation to include `"default"` as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
+- **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 
 ### Deprecations
 

--- a/apis/keda/v1alpha1/scaledjob_types.go
+++ b/apis/keda/v1alpha1/scaledjob_types.go
@@ -115,7 +115,7 @@ type ScaledJobList struct {
 // +optional
 type ScalingStrategy struct {
 	// +optional
-	// +kubebuilder:validation:Enum=custom;accurate;eager
+	// +kubebuilder:validation:Enum=default;custom;accurate;eager
 	Strategy string `json:"strategy,omitempty"`
 	// +optional
 	CustomScalingQueueLengthDeduction *int32 `json:"customScalingQueueLengthDeduction,omitempty"`

--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -9059,6 +9059,7 @@ spec:
                     type: array
                   strategy:
                     enum:
+                    - default
                     - custom
                     - accurate
                     - eager


### PR DESCRIPTION
The CRD validation for `ScaledJob.spec.scalingStrategy.strategy` lists only `custom`, `accurate`, and `eager` as valid values. However, the [KEDA docs](https://keda.sh/docs/2.20/reference/scaledjob-spec/#scalingstrategy) explicitly list `"default"` as a valid value, and the runtime already handles it correctly (the `switch` default case returns `defaultScalingStrategy{}`).

This mismatch causes a validation error when users specify `strategy: default` in their ScaledJob manifests, even though it is documented as valid.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7855
Fixes https://github.com/kedacore/charts/issues/875