### PR TITLE
Azure Scalers: add unit tests for Azure cloud environment resolution

### DIFF
--- a/pkg/scalers/azure/cloud_config_test.go
+++ b/pkg/scalers/azure/cloud_config_test.go
@@ -58,6 +58,34 @@ func TestEnvironmentFromName(t *testing.T) {
 	}
 }
 
+func TestEnvironmentFromNameAzureStackCloud(t *testing.T) {
+	stackEnv := AzEnvironment{
+		Name:                    "AzureStackCloud",
+		ResourceManagerEndpoint: "https://management.region.stack.example/",
+	}
+	data, err := json.Marshal(stackEnv)
+	if err != nil {
+		t.Fatalf("failed to marshal stack environment: %v", err)
+	}
+	tmpFile := filepath.Join(t.TempDir(), "stack-env.json")
+	if err := os.WriteFile(tmpFile, data, 0600); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	t.Setenv(EnvironmentFilepathName, tmpFile)
+
+	env, err := EnvironmentFromName("AZURESTACKCLOUD")
+	if err != nil {
+		t.Fatalf("EnvironmentFromName(AZURESTACKCLOUD) returned unexpected error: %v", err)
+	}
+	if env.Name != stackEnv.Name {
+		t.Errorf("expected env.Name=%q but got %q", stackEnv.Name, env.Name)
+	}
+	if env.ResourceManagerEndpoint != stackEnv.ResourceManagerEndpoint {
+		t.Errorf("expected ResourceManagerEndpoint=%q but got %q", stackEnv.ResourceManagerEndpoint, env.ResourceManagerEndpoint)
+	}
+}
+
 func TestEnvironmentFromFile(t *testing.T) {
 	expected := AzEnvironment{
 		Name:                    "CustomCloud",
@@ -85,6 +113,9 @@ func TestEnvironmentFromFile(t *testing.T) {
 	}
 	if env.ResourceManagerEndpoint != expected.ResourceManagerEndpoint {
 		t.Errorf("expected ResourceManagerEndpoint=%q but got %q", expected.ResourceManagerEndpoint, env.ResourceManagerEndpoint)
+	}
+	if env.ActiveDirectoryEndpoint != expected.ActiveDirectoryEndpoint {
+		t.Errorf("expected ActiveDirectoryEndpoint=%q but got %q", expected.ActiveDirectoryEndpoint, env.ActiveDirectoryEndpoint)
 	}
 	if env.StorageEndpointSuffix != expected.StorageEndpointSuffix {
 		t.Errorf("expected StorageEndpointSuffix=%q but got %q", expected.StorageEndpointSuffix, env.StorageEndpointSuffix)
@@ -122,5 +153,8 @@ func TestSetEnvironment(t *testing.T) {
 	}
 	if env.Name != customEnv.Name {
 		t.Errorf("expected env.Name=%q but got %q", customEnv.Name, env.Name)
+	}
+	if env.ResourceManagerEndpoint != customEnv.ResourceManagerEndpoint {
+		t.Errorf("expected ResourceManagerEndpoint=%q but got %q", customEnv.ResourceManagerEndpoint, env.ResourceManagerEndpoint)
 	}
 }

--- a/pkg/scalers/azure/cloud_config_test.go
+++ b/pkg/scalers/azure/cloud_config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KEDA Authors
+Copyright 2026 The KEDA Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scalers/azure/cloud_config_test.go
+++ b/pkg/scalers/azure/cloud_config_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 type environmentFromNameTestData struct {
-	name        string
-	expected    AzEnvironment
-	isError     bool
+	name	string
+	expected	AzEnvironment
+	isError	bool
 }
 
 var environmentFromNameTestDataset = []environmentFromNameTestData{
@@ -59,10 +59,10 @@ func TestEnvironmentFromName(t *testing.T) {
 
 func TestEnvironmentFromFile(t *testing.T) {
 	expected := AzEnvironment{
-		Name:                      "CustomCloud",
-		ResourceManagerEndpoint:   "https://management.custom.cloud/",
-		ActiveDirectoryEndpoint:   "https://login.custom.cloud/",
-		StorageEndpointSuffix:     "core.custom.cloud",
+		Name:	"CustomCloud",
+		ResourceManagerEndpoint:	"https://management.custom.cloud/",
+		ActiveDirectoryEndpoint:	"https://login.custom.cloud/",
+		StorageEndpointSuffix:	"core.custom.cloud",
 	}
 
 	data, err := json.Marshal(expected)
@@ -105,8 +105,8 @@ func TestEnvironmentFromFileNotFound(t *testing.T) {
 
 func TestSetEnvironment(t *testing.T) {
 	customEnv := AzEnvironment{
-		Name:                    "TestCustomCloud",
-		ResourceManagerEndpoint: "https://management.test.cloud/",
+		Name:	"TestCustomCloud",
+		ResourceManagerEndpoint:	"https://management.test.cloud/",
 	}
 	SetEnvironment("AzureTestCustomCloud", customEnv)
 

--- a/pkg/scalers/azure/cloud_config_test.go
+++ b/pkg/scalers/azure/cloud_config_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+type environmentFromNameTestData struct {
+	name        string
+	expected    AzEnvironment
+	isError     bool
+}
+
+var environmentFromNameTestDataset = []environmentFromNameTestData{
+	{"AzurePublicCloud", PublicCloud, false},
+	{"AZURECLOUD", PublicCloud, false},
+	{"azurecloud", PublicCloud, false},
+	{"AzureUSGovernmentCloud", USGovernmentCloud, false},
+	{"AZUREUSGOVERNMENT", USGovernmentCloud, false},
+	{"AzureChinaCloud", ChinaCloud, false},
+	{"AzureGermanCloud", GermanCloud, false},
+	{"InvalidCloud", AzEnvironment{}, true},
+	{"", AzEnvironment{}, true},
+}
+
+func TestEnvironmentFromName(t *testing.T) {
+	for _, testData := range environmentFromNameTestDataset {
+		env, err := EnvironmentFromName(testData.name)
+		if testData.isError && err == nil {
+			t.Errorf("For cloud name %q: expected error but got success", testData.name)
+			continue
+		}
+		if !testData.isError && err != nil {
+			t.Errorf("For cloud name %q: expected success but got error: %v", testData.name, err)
+			continue
+		}
+		if !testData.isError && env.Name != testData.expected.Name {
+			t.Errorf("For cloud name %q: expected env.Name=%q but got %q", testData.name, testData.expected.Name, env.Name)
+		}
+	}
+}
+
+func TestEnvironmentFromFile(t *testing.T) {
+	expected := AzEnvironment{
+		Name:                      "CustomCloud",
+		ResourceManagerEndpoint:   "https://management.custom.cloud/",
+		ActiveDirectoryEndpoint:   "https://login.custom.cloud/",
+		StorageEndpointSuffix:     "core.custom.cloud",
+	}
+
+	data, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("failed to marshal test environment: %v", err)
+	}
+
+	f, err := os.CreateTemp("", "azure-env-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+
+	if _, err = f.Write(data); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	f.Close()
+
+	env, err := EnvironmentFromFile(f.Name())
+	if err != nil {
+		t.Fatalf("EnvironmentFromFile returned unexpected error: %v", err)
+	}
+	if env.Name != expected.Name {
+		t.Errorf("expected env.Name=%q but got %q", expected.Name, env.Name)
+	}
+	if env.ResourceManagerEndpoint != expected.ResourceManagerEndpoint {
+		t.Errorf("expected ResourceManagerEndpoint=%q but got %q", expected.ResourceManagerEndpoint, env.ResourceManagerEndpoint)
+	}
+	if env.StorageEndpointSuffix != expected.StorageEndpointSuffix {
+		t.Errorf("expected StorageEndpointSuffix=%q but got %q", expected.StorageEndpointSuffix, env.StorageEndpointSuffix)
+	}
+}
+
+func TestEnvironmentFromFileNotFound(t *testing.T) {
+	_, err := EnvironmentFromFile("/nonexistent/path/env.json")
+	if err == nil {
+		t.Error("expected error for nonexistent file but got success")
+	}
+}
+
+func TestSetEnvironment(t *testing.T) {
+	customEnv := AzEnvironment{
+		Name:                    "TestCustomCloud",
+		ResourceManagerEndpoint: "https://management.test.cloud/",
+	}
+	SetEnvironment("AzureTestCustomCloud", customEnv)
+
+	env, err := EnvironmentFromName("AzureTestCustomCloud")
+	if err != nil {
+		t.Fatalf("expected to find registered custom environment but got error: %v", err)
+	}
+	if env.Name != customEnv.Name {
+		t.Errorf("expected env.Name=%q but got %q", customEnv.Name, env.Name)
+	}
+
+	// cleanup
+	delete(environments, "AZURETESTCUSTOMCLOUD")
+}

--- a/pkg/scalers/azure/cloud_config_test.go
+++ b/pkg/scalers/azure/cloud_config_test.go
@@ -19,6 +19,7 @@ package azure
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -70,18 +71,12 @@ func TestEnvironmentFromFile(t *testing.T) {
 		t.Fatalf("failed to marshal test environment: %v", err)
 	}
 
-	f, err := os.CreateTemp("", "azure-env-*.json")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	defer os.Remove(f.Name())
-
-	if _, err = f.Write(data); err != nil {
+	tmpFile := filepath.Join(t.TempDir(), "azure-env.json")
+	if err := os.WriteFile(tmpFile, data, 0600); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
-	f.Close()
 
-	env, err := EnvironmentFromFile(f.Name())
+	env, err := EnvironmentFromFile(tmpFile)
 	if err != nil {
 		t.Fatalf("EnvironmentFromFile returned unexpected error: %v", err)
 	}
@@ -97,13 +92,24 @@ func TestEnvironmentFromFile(t *testing.T) {
 }
 
 func TestEnvironmentFromFileNotFound(t *testing.T) {
-	_, err := EnvironmentFromFile("/nonexistent/path/env.json")
+	missing := filepath.Join(t.TempDir(), "nonexistent.json")
+	_, err := EnvironmentFromFile(missing)
 	if err == nil {
 		t.Error("expected error for nonexistent file but got success")
 	}
 }
 
 func TestSetEnvironment(t *testing.T) {
+	const key = "AZURETESTCUSTOMCLOUD"
+	prev, existed := environments[key]
+	t.Cleanup(func() {
+		if existed {
+			environments[key] = prev
+		} else {
+			delete(environments, key)
+		}
+	})
+
 	customEnv := AzEnvironment{
 		Name:                    "TestCustomCloud",
 		ResourceManagerEndpoint: "https://management.test.cloud/",
@@ -117,7 +123,4 @@ func TestSetEnvironment(t *testing.T) {
 	if env.Name != customEnv.Name {
 		t.Errorf("expected env.Name=%q but got %q", customEnv.Name, env.Name)
 	}
-
-	// cleanup
-	delete(environments, "AZURETESTCUSTOMCLOUD")
 }

--- a/pkg/scalers/azure/cloud_config_test.go
+++ b/pkg/scalers/azure/cloud_config_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 type environmentFromNameTestData struct {
-	name	string
-	expected	AzEnvironment
-	isError	bool
+	name     string
+	expected AzEnvironment
+	isError  bool
 }
 
 var environmentFromNameTestDataset = []environmentFromNameTestData{
@@ -59,10 +59,10 @@ func TestEnvironmentFromName(t *testing.T) {
 
 func TestEnvironmentFromFile(t *testing.T) {
 	expected := AzEnvironment{
-		Name:	"CustomCloud",
-		ResourceManagerEndpoint:	"https://management.custom.cloud/",
-		ActiveDirectoryEndpoint:	"https://login.custom.cloud/",
-		StorageEndpointSuffix:	"core.custom.cloud",
+		Name:                    "CustomCloud",
+		ResourceManagerEndpoint: "https://management.custom.cloud/",
+		ActiveDirectoryEndpoint: "https://login.custom.cloud/",
+		StorageEndpointSuffix:   "core.custom.cloud",
 	}
 
 	data, err := json.Marshal(expected)
@@ -105,8 +105,8 @@ func TestEnvironmentFromFileNotFound(t *testing.T) {
 
 func TestSetEnvironment(t *testing.T) {
 	customEnv := AzEnvironment{
-		Name:	"TestCustomCloud",
-		ResourceManagerEndpoint:	"https://management.test.cloud/",
+		Name:                    "TestCustomCloud",
+		ResourceManagerEndpoint: "https://management.test.cloud/",
 	}
 	SetEnvironment("AzureTestCustomCloud", customEnv)
 


### PR DESCRIPTION
Adds unit test coverage for `EnvironmentFromName`, `EnvironmentFromFile`, and `SetEnvironment` in `pkg/scalers/azure/cloud_config.go`, following the same pattern established by the recently added AWS (`pkg/scalers/aws/`) and GCP (`pkg/scalers/gcp/`) authorization unit tests.

**Coverage added:**
- `TestEnvironmentFromName` — verifies all known cloud names (public, US government, China, Germany), case-insensitive matching, and rejects unknown names
- `TestEnvironmentFromFile` — verifies loading a custom cloud environment from a JSON file
- `TestEnvironmentFromFileNotFound` — verifies error is returned for a missing file
- `TestSetEnvironment` — verifies a custom environment registered via `SetEnvironment` is resolvable by `EnvironmentFromName`

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))