### PR TITLE
feat(webhook): validate customScalingRunningJobPercentage is a valid float

### DIFF
--- a/apis/keda/v1alpha1/scaledjob_webhook.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -96,7 +97,8 @@ func verifyScaledJobScalingStrategy(s *ScaledJob) error {
 	if p == "" {
 		return nil
 	}
-	if _, err := strconv.ParseFloat(p, 64); err != nil {
+	v, err := strconv.ParseFloat(p, 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
 		return fmt.Errorf("ScaledJob.spec.scalingStrategy.customScalingRunningJobPercentage must be a valid floating-point number, got %q", p)
 	}
 	return nil

--- a/apis/keda/v1alpha1/scaledjob_webhook.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook.go
@@ -18,6 +18,8 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,6 +71,9 @@ var _ admission.Validator[*ScaledJob] = &ScaledJobCustomValidator{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (s *ScaledJob) ValidateCreate(dryRun *bool) (admission.Warnings, error) {
 	scaledjoblog.Info("validating scaledjob creation", "namespace", s.Namespace, "name", s.Name, "scaledjob", s)
+	if err := verifyScaledJobScalingStrategy(s); err != nil {
+		return nil, err
+	}
 	return nil, verifyTriggers(s, "create", *dryRun)
 }
 
@@ -80,7 +85,21 @@ func (s *ScaledJob) ValidateUpdate(old runtime.Object, dryRun *bool) (admission.
 		scaledjoblog.V(1).Info("finalizer removal, skipping validation", "namespace", s.Namespace, "name", s.Name)
 		return nil, nil
 	}
+	if err := verifyScaledJobScalingStrategy(s); err != nil {
+		return nil, err
+	}
 	return nil, verifyTriggers(s, "update", *dryRun)
+}
+
+func verifyScaledJobScalingStrategy(s *ScaledJob) error {
+	p := s.Spec.ScalingStrategy.CustomScalingRunningJobPercentage
+	if p == "" {
+		return nil
+	}
+	if _, err := strconv.ParseFloat(p, 64); err != nil {
+		return fmt.Errorf("ScaledJob.spec.scalingStrategy.customScalingRunningJobPercentage must be a valid floating-point number, got %q", p)
+	}
+	return nil
 }
 
 func (s *ScaledJob) ValidateDelete(_ *bool) (admission.Warnings, error) {

--- a/apis/keda/v1alpha1/scaledjob_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook_test.go
@@ -55,6 +55,9 @@ func TestVerifyScaledJobScalingStrategy(t *testing.T) {
 		{"valid float 0.0", "0.0", false},
 		{"not a float", "abc", true},
 		{"partially numeric", "1.5abc", true},
+		{"NaN", "NaN", true},
+		{"positive infinity", "+Inf", true},
+		{"negative infinity", "-Inf", true},
 	}
 
 	for _, tt := range tests {

--- a/apis/keda/v1alpha1/scaledjob_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook_test.go
@@ -44,9 +44,9 @@ var _ = It("should validate empty triggers in ScaledJob", func() {
 
 func TestVerifyScaledJobScalingStrategy(t *testing.T) {
 	tests := []struct {
-		name      string
+		name       string
 		percentage string
-		wantErr   bool
+		wantErr    bool
 	}{
 		{"empty percentage is valid", "", false},
 		{"valid float 0.5", "0.5", false},

--- a/apis/keda/v1alpha1/scaledjob_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledjob_webhook_test.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,6 +41,41 @@ var _ = It("should validate empty triggers in ScaledJob", func() {
 		return k8sClient.Create(context.Background(), sj)
 	}).Should(HaveOccurred())
 })
+
+func TestVerifyScaledJobScalingStrategy(t *testing.T) {
+	tests := []struct {
+		name      string
+		percentage string
+		wantErr   bool
+	}{
+		{"empty percentage is valid", "", false},
+		{"valid float 0.5", "0.5", false},
+		{"valid float 1.0", "1.0", false},
+		{"valid float 0", "0", false},
+		{"valid float 0.0", "0.0", false},
+		{"not a float", "abc", true},
+		{"partially numeric", "1.5abc", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sj := &ScaledJob{
+				Spec: ScaledJobSpec{
+					ScalingStrategy: ScalingStrategy{
+						CustomScalingRunningJobPercentage: tt.percentage,
+					},
+				},
+			}
+			err := verifyScaledJobScalingStrategy(sj)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
 
 // -------------------------------------------------------------------------- //
 // ----------------------------- HELP FUNCTIONS ----------------------------- //


### PR DESCRIPTION
When `ScaledJob.spec.scalingStrategy.customScalingRunningJobPercentage` is set to a non-numeric string, the operator silently falls back to the default scaling strategy at runtime (see `pkg/scaling/executor/scale_jobs.go:434-436`). This gives users no feedback that their configuration is invalid.

This change adds admission webhook validation so ScaledJobs with a non-parseable `customScalingRunningJobPercentage` are rejected at creation/update time with a clear error message, rather than silently misbehaving at runtime.

**Example error:**
```
ScaledJob.spec.scalingStrategy.customScalingRunningJobPercentage must be a valid floating-point number, got "not-a-float"
```

CONTRIBUTING.md explicitly calls out improving webhook validations as "another easy way to contribute".

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))