### PR TITLE
fix(api): add "default" to ScaledJob rollout strategy CRD enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
+- **General**: Add `default` to `ScaledJob` `rollout.strategy` CRD enum to match documented values ([#7864](https://github.com/kedacore/keda/issues/7864))
 
 ### Deprecations
 

--- a/apis/keda/v1alpha1/scaledjob_types.go
+++ b/apis/keda/v1alpha1/scaledjob_types.go
@@ -66,7 +66,7 @@ type ScaledJobSpec struct {
 	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty"`
 	// Deprecated: Use Rollout.Strategy instead (see https://github.com/kedacore/keda/issues/3596).
 	// +optional
-	// +kubebuilder:validation:Enum=gradual;immediate
+	// +kubebuilder:validation:Enum=default;gradual;immediate
 	RolloutStrategy string `json:"rolloutStrategy,omitempty"`
 	// +optional
 	Rollout Rollout `json:"rollout,omitempty"`
@@ -132,7 +132,7 @@ type ScalingStrategy struct {
 // +optional
 type Rollout struct {
 	// +optional
-	// +kubebuilder:validation:Enum=gradual;immediate
+	// +kubebuilder:validation:Enum=default;gradual;immediate
 	Strategy string `json:"strategy,omitempty"`
 	// +optional
 	// +kubebuilder:validation:Enum=foreground;background

--- a/config/crd/bases/keda.sh_scaledjobs.yaml
+++ b/config/crd/bases/keda.sh_scaledjobs.yaml
@@ -9028,6 +9028,7 @@ spec:
                     type: string
                   strategy:
                     enum:
+                    - default
                     - gradual
                     - immediate
                     type: string
@@ -9035,6 +9036,7 @@ spec:
               rolloutStrategy:
                 description: 'Deprecated: Use Rollout.Strategy instead (see https://github.com/kedacore/keda/issues/3596).'
                 enum:
+                - default
                 - gradual
                 - immediate
                 type: string


### PR DESCRIPTION
## Summary

Add `"default"` to the kubebuilder validation enum for `ScaledJob` rollout strategy fields, aligning the CRD with [documented values](https://keda.sh/docs/2.20/reference/scaledjob-spec/#rollout).

## Changes

- Add `default` to `+kubebuilder:validation:Enum` on `Rollout.Strategy` field
- Add `default` to `+kubebuilder:validation:Enum` on deprecated `RolloutStrategy` field  
- Regenerate CRD YAML via `controller-gen`
- Add CHANGELOG entry

## Why

The controller already handles `"default"` correctly via its `switch` statement `default:` case (same behavior as `"immediate"`). The CRD enum was the only thing rejecting the value.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7864