### PR TITLE
fix: guard against nil ScaleTargetGVKR in GetCurrentReplicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Fix nil pointer panic in `GetCurrentReplicas` when `ScaleTargetGVKR` status is not yet populated during heavy ScaledObject churn ([#7863](https://github.com/kedacore/keda/issues/7863))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 
 ### Deprecations

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -775,6 +775,26 @@ func resolveServiceAccountAnnotation(ctx context.Context, client client.Client, 
 
 // GetCurrentReplicas returns the current replica count for a ScaledObject
 func GetCurrentReplicas(ctx context.Context, client client.Client, scaleClient scale.ScalesGetter, scaledObject *kedav1alpha1.ScaledObject) (int32, error) {
+	// Due to a race condition the informer cache may have a ScaledObject whose
+	// Status.ScaleTargetGVKR has not been populated yet. Re-read from the cache
+	// in case the informer has received an update since the caller's copy was
+	// captured, and if still nil, return an error instead of panicking.
+	// See https://github.com/kedacore/keda/issues/4389
+	// See https://github.com/kedacore/keda/issues/7863
+	if scaledObject.Status.ScaleTargetGVKR == nil {
+		freshObj := &kedav1alpha1.ScaledObject{}
+		if err := client.Get(ctx, types.NamespacedName{Name: scaledObject.Name, Namespace: scaledObject.Namespace}, freshObj); err != nil {
+			log.Error(err, "failed to get ScaledObject", "name", scaledObject.Name, "namespace", scaledObject.Namespace)
+			return 0, err
+		}
+		scaledObject = freshObj
+	}
+	if scaledObject.Status.ScaleTargetGVKR == nil {
+		err := fmt.Errorf("failed to get ScaledObject.Status.ScaleTargetGVKR, probably invalid ScaledObject cache")
+		log.Error(err, "ScaleTargetGVKR is nil, scaledObject status may not be initialized yet", "scaledObject.Name", scaledObject.Name, "scaledObject.Namespace", scaledObject.Namespace)
+		return 0, err
+	}
+
 	targetName := scaledObject.Spec.ScaleTargetRef.Name
 	targetGVKR := scaledObject.Status.ScaleTargetGVKR
 

--- a/pkg/scaling/resolver/scale_resolvers_test.go
+++ b/pkg/scaling/resolver/scale_resolvers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1234,4 +1235,65 @@ func TestResolveAuthSecret_UnrestrictedAccess_UsesOriginalNamespace(t *testing.T
 	)
 
 	assert.Equal(t, secretData, result)
+}
+
+func TestGetCurrentReplicas_NilScaleTargetGVKR_RefreshFindsIt(t *testing.T) {
+	if err := kedav1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	replicas := int32(3)
+	storedSO := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-so",
+			Namespace: namespace,
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "my-deploy"},
+		},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			ScaleTargetGVKR: &kedav1alpha1.GroupVersionKindResource{
+				Group:    "apps",
+				Version:  "v1",
+				Kind:     "Deployment",
+				Resource: "deployments",
+			},
+		},
+	}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-deploy", Namespace: namespace},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(storedSO, deploy).Build()
+
+	callerSO := storedSO.DeepCopy()
+	callerSO.Status.ScaleTargetGVKR = nil
+
+	got, err := GetCurrentReplicas(context.Background(), fakeClient, nil, callerSO)
+	assert.NoError(t, err)
+	assert.Equal(t, replicas, got)
+}
+
+func TestGetCurrentReplicas_NilScaleTargetGVKR_StillNilAfterRefresh(t *testing.T) {
+	if err := kedav1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	storedSO := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-so",
+			Namespace: namespace,
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "my-deploy"},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(storedSO).Build()
+
+	callerSO := storedSO.DeepCopy()
+
+	got, err := GetCurrentReplicas(context.Background(), fakeClient, nil, callerSO)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ScaleTargetGVKR")
+	assert.Equal(t, int32(0), got)
 }


### PR DESCRIPTION
During heavy ScaledObject churn (create/delete/update/pause cycles), the
informer cache can contain a ScaledObject whose `Status.ScaleTargetGVKR`
has not been populated yet by the controller. `GetCurrentReplicas`
dereferences this pointer without a nil check when building the logger,
causing a nil pointer panic that crashes the operator.

This applies the same defensive re-read-and-check pattern already used
in `ResolveScaleTargetPodSpec` (added for #4389 / #4955): if
`ScaleTargetGVKR` is nil, re-read the object from the cache in case the
informer has received an update, and if still nil, return an error
instead of panicking.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7863