### PR TITLE
General: Fix nil pointer dereference in customScalingStrategy when customScalingQueueLengthDeduction is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -465,7 +465,16 @@ type customScalingStrategy struct {
 }
 
 func (s customScalingStrategy) GetEffectiveMaxScale(maxScale, runningJobCount, _, maxReplicaCount, scaleTo int64) (int64, int64) {
-	return min(maxScale-int64(*s.CustomScalingQueueLengthDeduction)-int64(float64(runningJobCount)*(*s.CustomScalingRunningJobPercentage)), maxReplicaCount), scaleTo
+	var deduction int64
+	if s.CustomScalingQueueLengthDeduction != nil {
+		deduction = int64(*s.CustomScalingQueueLengthDeduction)
+	}
+	var runningPercentage float64
+	if s.CustomScalingRunningJobPercentage != nil {
+		runningPercentage = *s.CustomScalingRunningJobPercentage
+	}
+	result := maxScale - deduction - int64(float64(runningJobCount)*runningPercentage)
+	return min(result, maxReplicaCount), scaleTo
 }
 
 type accurateScalingStrategy struct {

--- a/pkg/scaling/executor/scale_jobs_test.go
+++ b/pkg/scaling/executor/scale_jobs_test.go
@@ -128,6 +128,32 @@ func TestCustomScalingStrategy(t *testing.T) {
 	assert.Equal(t, int64(4), maxScaleValue(strategy.GetEffectiveMaxScale(3, 2, 0, 4, 1)))
 }
 
+// TestCustomScalingStrategyNilQueueLengthDeduction is a regression test for
+// issue #7798: a nil CustomScalingQueueLengthDeduction (an omitempty *int32
+// field) must be treated as zero deduction instead of panicking with a nil
+// pointer dereference.
+func TestCustomScalingStrategyNilQueueLengthDeduction(t *testing.T) {
+	// Direct struct construction: deduction is nil, percentage is set.
+	percentage := 0.5
+	strategy := customScalingStrategy{
+		CustomScalingQueueLengthDeduction: nil,
+		CustomScalingRunningJobPercentage: &percentage,
+	}
+	// maxScale(10) - deduction(0) - int64(float64(2)*0.5) = 9
+	assert.Equal(t, int64(9), maxScaleValue(strategy.GetEffectiveMaxScale(10, 2, 0, 100, 1)))
+	// With no running jobs the deduction being nil should yield maxScale.
+	assert.Equal(t, int64(10), maxScaleValue(strategy.GetEffectiveMaxScale(10, 0, 0, 100, 1)))
+
+	// End-to-end via NewScalingStrategy: a ScaledJob that uses the "custom"
+	// strategy with a valid CustomScalingRunningJobPercentage but omits the
+	// optional CustomScalingQueueLengthDeduction field.
+	logger := logf.Log.WithName("ScaledJobTest")
+	scaledJob := getMockScaledJobWithCustomStrategyNilDeduction("custom", "custom", "0.5")
+	strategyFromFactory := NewScalingStrategy(logger, scaledJob)
+	assert.Equal(t, "executor.customScalingStrategy", fmt.Sprintf("%T", strategyFromFactory))
+	assert.Equal(t, int64(9), maxScaleValue(strategyFromFactory.GetEffectiveMaxScale(10, 2, 0, 100, 1)))
+}
+
 func TestAccurateScalingStrategy(t *testing.T) {
 	logger := logf.Log.WithName("ScaledJobTest")
 	strategy := NewScalingStrategy(logger, getMockScaledJobWithStrategy("accurate", "accurate", 0, "0"))
@@ -556,6 +582,19 @@ func getMockScaledJobWithCustomStrategyWithNilParameter(name, scalingStrategy st
 		Spec: kedav1alpha1.ScaledJobSpec{
 			ScalingStrategy: kedav1alpha1.ScalingStrategy{
 				Strategy: scalingStrategy,
+			},
+		},
+	}
+	scaledJob.Name = name
+	return scaledJob
+}
+
+func getMockScaledJobWithCustomStrategyNilDeduction(name, scalingStrategy, customScalingRunningJobPercentage string) *kedav1alpha1.ScaledJob {
+	scaledJob := &kedav1alpha1.ScaledJob{
+		Spec: kedav1alpha1.ScaledJobSpec{
+			ScalingStrategy: kedav1alpha1.ScalingStrategy{
+				Strategy:                          scalingStrategy,
+				CustomScalingRunningJobPercentage: customScalingRunningJobPercentage,
 			},
 		},
 	}


### PR DESCRIPTION
## Description

`customScalingStrategy.GetEffectiveMaxScale` in `pkg/scaling/executor/scale_jobs.go` unconditionally dereferenced `s.CustomScalingQueueLengthDeduction` (a `*int32`) without a nil guard. This field is declared with `omitempty` in the CRD spec, so it is `nil` whenever a `ScaledJob` is created without setting `customScalingQueueLengthDeduction`. When a custom-scaling ScaledJob reached the replica calculation path with this field absent, the controller goroutine panicked with `runtime error: invalid memory address or nil pointer dereference`, interrupting the ScaledJob reconciliation loop indefinitely.

### What changed

- Added nil guards for both pointer fields (`CustomScalingQueueLengthDeduction *int32` and `CustomScalingRunningJobPercentage *float64`) in `customScalingStrategy.GetEffectiveMaxScale`. A nil `CustomScalingQueueLengthDeduction` is now treated as zero deduction, consistent with how the running job percentage is handled. This matches the suggested fix in the issue.
- Added a regression test `TestCustomScalingStrategyNilQueueLengthDeduction` that exercises both the direct struct path and the `NewScalingStrategy` factory path with the deduction omitted. This test panics on the unpatched code and passes with the fix.
- Added a changelog entry under `### Fixes` in `CHANGELOG.md`.

### Why

The field is optional (`omitempty`), so a valid and common ScaledJob configuration that omits `customScalingQueueLengthDeduction` (but sets `customScalingRunningJobPercentage` to enable custom scaling) should not crash the operator.

Fixes #7798

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #