### PR TITLE
General: Aggregate KEDA CRD permissions into default roles

### DIFF
--- a/config/rbac/aggregate_cluster_roles.yaml
+++ b/config/rbac/aggregate_cluster_roles.yaml
@@ -7,24 +7,14 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
+# Scope a wildcard to KEDA's API groups so that any current or future CRD in
+# these groups is covered automatically, without having to maintain an explicit
+# resource list here as new CRDs are added.
 - apiGroups:
   - keda.sh
-  resources:
-  - clustertriggerauthentications
-  - scaledjobs
-  - scaledobjects
-  - triggerauthentications
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-- apiGroups:
   - eventing.keda.sh
   resources:
-  - cloudeventsources
-  - clustercloudeventsources
+  - "*"
   verbs:
   - create
   - delete
@@ -41,22 +31,14 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
+# Scope a wildcard to KEDA's API groups so that any current or future CRD in
+# these groups is covered automatically, without having to maintain an explicit
+# resource list here as new CRDs are added.
 - apiGroups:
   - keda.sh
-  resources:
-  - clustertriggerauthentications
-  - scaledjobs
-  - scaledobjects
-  - triggerauthentications
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - eventing.keda.sh
   resources:
-  - cloudeventsources
-  - clustercloudeventsources
+  - "*"
   verbs:
   - get
   - list

--- a/config/rbac/aggregate_cluster_roles.yaml
+++ b/config/rbac/aggregate_cluster_roles.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda:edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    app.kubernetes.io/name: keda-operator
+    app.kubernetes.io/part-of: keda-operator
+rules:
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  - scaledjobs
+  - scaledobjects
+  - triggerauthentications
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - eventing.keda.sh
+  resources:
+  - cloudeventsources
+  - clustercloudeventsources
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda:view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    app.kubernetes.io/name: keda-operator
+    app.kubernetes.io/part-of: keda-operator
+rules:
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  - scaledjobs
+  - scaledobjects
+  - triggerauthentications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - eventing.keda.sh
+  resources:
+  - cloudeventsources
+  - clustercloudeventsources
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac/aggregate_cluster_roles.yaml
+++ b/config/rbac/aggregate_cluster_roles.yaml
@@ -6,8 +6,6 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/name: keda-operator
-    app.kubernetes.io/part-of: keda-operator
 rules:
 - apiGroups:
   - keda.sh
@@ -19,6 +17,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - patch
   - update
 - apiGroups:
@@ -29,6 +28,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - patch
   - update
 ---
@@ -40,8 +40,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/name: keda-operator
-    app.kubernetes.io/part-of: keda-operator
 rules:
 - apiGroups:
   - keda.sh

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -10,3 +10,4 @@ labels:
 resources:
 - role.yaml
 - role_binding.yaml
+- aggregate_cluster_roles.yaml


### PR DESCRIPTION
## Summary

Fixes #2723.

Adds `keda:view` and `keda:edit` aggregated ClusterRoles so KEDA CRDs are included in the built-in Kubernetes `view`, `edit`, and `admin` roles.

## Testing

- `kustomize build config/default` includes `keda:view` / `keda:edit` with aggregation labels