### PR TITLE
fix(metricsservice): continuously monitor gRPC connection for reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,8 +84,8 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
-- **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
 - **General**: Continuously monitor and re-establish the metrics service gRPC connection in the background, instead of relying solely on incoming metric requests to trigger reconnection after the connection is lost ([#7874](https://github.com/kedacore/keda/issues/7874))
+- **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
+- **General**: Continuously monitor and re-establish the metrics service gRPC connection in the background, instead of relying solely on incoming metric requests to trigger reconnection after the connection is lost ([#7874](https://github.com/kedacore/keda/issues/7874))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))

--- a/pkg/metricsservice/client.go
+++ b/pkg/metricsservice/client.go
@@ -259,6 +259,26 @@ func (c *GrpcClient) WaitForConnectionReady(ctx context.Context, logger logr.Log
 	}
 }
 
+// WaitWhileConnectionReady blocks while the gRPC connection remains in the Ready
+// state, returning as soon as it transitions away from Ready (e.g. because the
+// connection was lost) or the context is cancelled.
+// Returns true if the connection left the Ready state, false if the context is cancelled.
+func (c *GrpcClient) WaitWhileConnectionReady(ctx context.Context, logger logr.Logger) bool {
+	for {
+		currentState := c.connection.GetState()
+		if currentState != connectivity.Ready {
+			return true
+		}
+
+		if !c.connection.WaitForStateChange(ctx, currentState) {
+			// Context was cancelled
+			return false
+		}
+
+		logger.V(1).Info("gRPC connection state changed away from ready", "currentState", c.connection.GetState().String())
+	}
+}
+
 // GetServerURL returns url of the gRPC server this client is connected to
 func (c *GrpcClient) GetServerURL() string {
 	return c.connection.Target()

--- a/pkg/metricsservice/client_test.go
+++ b/pkg/metricsservice/client_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsservice
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// newTLSTestServerAndClientConn starts a gRPC server on a random local port secured
+// with a self-signed certificate for 127.0.0.1, and returns a gRPC client connection
+// trusting that certificate.
+func newTLSTestServerAndClientConn(t *testing.T) (*grpc.Server, net.Listener, *grpc.ClientConn) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  priv,
+	}
+
+	certPool := x509.NewCertPool()
+	certPool.AddCert(cert)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	serverCreds := credentials.NewTLS(&tls.Config{Certificates: []tls.Certificate{tlsCert}, MinVersion: tls.VersionTLS13})
+	server := grpc.NewServer(grpc.Creds(serverCreds))
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	clientCreds := credentials.NewTLS(&tls.Config{RootCAs: certPool, ServerName: "127.0.0.1", MinVersion: tls.VersionTLS13})
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(clientCreds))
+	require.NoError(t, err)
+
+	return server, lis, conn
+}
+
+func TestWaitWhileConnectionReady(t *testing.T) {
+	server, lis, conn := newTLSTestServerAndClientConn(t)
+	defer server.Stop()
+	defer conn.Close()
+
+	client := &GrpcClient{connection: conn}
+	logger := logr.Discard()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	require.True(t, client.WaitForConnectionReady(ctx, logger), "connection should become ready")
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- client.WaitWhileConnectionReady(ctx, logger)
+	}()
+
+	// Stop the server to force the connection out of the Ready state.
+	server.Stop()
+	_ = lis.Close()
+
+	select {
+	case result := <-done:
+		require.True(t, result, "WaitWhileConnectionReady should return true once the connection leaves the Ready state")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for WaitWhileConnectionReady to detect the connection leaving the Ready state")
+	}
+}
+
+func TestWaitWhileConnectionReadyContextCancelled(t *testing.T) {
+	server, lis, conn := newTLSTestServerAndClientConn(t)
+	defer server.Stop()
+	defer lis.Close()
+	defer conn.Close()
+
+	client := &GrpcClient{connection: conn}
+	logger := logr.Discard()
+
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer readyCancel()
+	require.True(t, client.WaitForConnectionReady(readyCtx, logger), "connection should become ready")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.False(t, client.WaitWhileConnectionReady(ctx, logger), "should return false when context is already cancelled")
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -55,13 +55,25 @@ func NewProvider(ctx context.Context, adapterLogger logr.Logger, client client.C
 	logger = adapterLogger.WithName("provider")
 	logger.Info("starting")
 
+	// Continuously monitor the gRPC connection so that reconnection is actively
+	// driven in the background, instead of depending solely on incoming
+	// GetExternalMetric requests (whose request-scoped contexts may not leave
+	// enough time for the connection to recover) to trigger it.
 	go func() {
-		if !grpcClient.WaitForConnectionReady(ctx, logger) {
-			grpcClientConnected = false
-			logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", grpcClient.GetServerURL())
-		} else if !grpcClientConnected {
+		for {
+			if !grpcClient.WaitForConnectionReady(ctx, logger) {
+				grpcClientConnected = false
+				logger.Error(fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server"), "timeout", "server", grpcClient.GetServerURL())
+				return
+			}
 			grpcClientConnected = true
 			logger.Info("Connection to KEDA Metrics Service gRPC server has been successfully established", "server", grpcClient.GetServerURL())
+
+			if !grpcClient.WaitWhileConnectionReady(ctx, logger) {
+				return
+			}
+			grpcClientConnected = false
+			logger.Info("Connection to KEDA Metrics Service gRPC server was lost, attempting to reconnect", "server", grpcClient.GetServerURL())
 		}
 	}()
 


### PR DESCRIPTION
_Continuously monitor the metrics service gRPC connection in the background so reconnection is actively driven after a connection loss, instead of depending solely on whichever metric request happens to be in flight at the time._

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

## Problem

`pkg/provider/provider.go`'s `NewProvider` previously launched a one-shot goroutine that called `WaitForConnectionReady` exactly once at startup, then exited regardless of the outcome. After that, the only thing capable of re-driving reconnection was whichever `GetExternalMetric` request happened to call `WaitForConnectionReady` next — and that call uses the request's own (typically short) context deadline.

When the keda-operator pod's IP changes (e.g. after a rescheduling event) while the metrics-apiserver's gRPC client still has the old address resolved, recovery depends on a new DNS resolution happening within the lifetime of some incoming request's context. If that doesn't line up favorably, the connection can sit unrecovered for longer than necessary, and the only signal is each individual request failing with a connection error.

## Change

- Added `WaitWhileConnectionReady` to `GrpcClient`, which blocks while the connection stays in the `Ready` state and returns as soon as it transitions away (mirroring the existing `WaitForConnectionReady`'s use of `WaitForStateChange` instead of busy-polling).
- Changed the startup goroutine in `NewProvider` to loop: wait for ready → wait while ready → on disconnect, immediately loop back into `WaitForConnectionReady` with a long-lived context (not tied to any single request), so reconnection is driven independently of incoming traffic.
- No changes to the per-request path in `GetExternalMetric` — it's unaffected.

## Testing

Added `pkg/metricsservice/client_test.go` covering `WaitWhileConnectionReady`:
- Returns `true` once a real local gRPC server is stopped and the connection leaves `Ready`.
- Returns `false` immediately when the context is already cancelled.

```
$ go test ./pkg/metricsservice/... -run TestWaitWhileConnectionReady -v
=== RUN   TestWaitWhileConnectionReady
--- PASS: TestWaitWhileConnectionReady (0.00s)
=== RUN   TestWaitWhileConnectionReadyContextCancelled
--- PASS: TestWaitWhileConnectionReadyContextCancelled (0.00s)
PASS
ok  	github.com/kedacore/keda/v2/pkg/metricsservice	1.636s
```

Full package suite (`./pkg/metricsservice/...`, `./pkg/provider/...`) passes.

Note: I wasn't able to reproduce the exact pod-IP-rotation scenario from the issue in a live cluster, so I can't claim this fully resolves every angle of it — but the previous "watch once, then never again" behavior was clearly insufficient for a long-running server regardless of the precise DNS/grpc-internals timing, so this should be a meaningful improvement either way. Happy to iterate based on feedback.

Closes #7874
