### PR TITLE
Azure Blob Scaler: strip leading slash from globPattern before matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
+- **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
 
 ### Deprecations
 

--- a/pkg/scalers/azure_blob_scaler.go
+++ b/pkg/scalers/azure_blob_scaler.go
@@ -19,6 +19,7 @@ package scalers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
@@ -68,7 +69,11 @@ func (m *azureBlobMetadata) Validate() error {
 
 	// Compile glob pattern if provided
 	if m.GlobPattern != "" {
-		compiled, err := glob.Compile(m.GlobPattern)
+		// Blob names returned by the Azure Storage API never have a leading
+		// "/", so a pattern written in path-style (e.g. "/folder/*.json")
+		// would otherwise never match any blob.
+		pattern := strings.TrimPrefix(m.GlobPattern, "/")
+		compiled, err := glob.Compile(pattern)
 		if err != nil {
 			return fmt.Errorf("invalid glob pattern %q: %w", m.GlobPattern, err)
 		}

--- a/pkg/scalers/azure_blob_scaler_test.go
+++ b/pkg/scalers/azure_blob_scaler_test.go
@@ -107,6 +107,44 @@ func TestAzBlobParseMetadata(t *testing.T) {
 	}
 }
 
+func TestAzBlobGlobPatternLeadingSlash(t *testing.T) {
+	tests := []struct {
+		name        string
+		globPattern string
+		blobName    string
+		wantMatch   bool
+	}{
+		{"leading slash pattern matches blob name without leading slash", "/folderA/subFolderA/*.json", "folderA/subFolderA/part-fileA.json", true},
+		{"leading slash pattern with double star matches nested blob name", "/folderA/**", "folderA/subFolderA/part-fileA.json", true},
+		{"pattern without leading slash still matches as before", "folderA/subFolderA/*.json", "folderA/subFolderA/part-fileA.json", true},
+		{"leading slash pattern does not match unrelated blob name", "/folderA/subFolderA/*.json", "folderB/subFolderC/fileE.txt", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, err := parseAzureBlobMetadata(&scalersconfig.ScalerConfig{
+				TriggerMetadata: map[string]string{
+					"connectionFromEnv": "CONNECTION",
+					"blobContainerName": "sample",
+					"blobCount":         "5",
+					"globPattern":       tt.globPattern,
+				},
+				ResolvedEnv: testAzBlobResolvedEnv,
+			}, logr.Discard())
+			if err != nil {
+				t.Fatal("Could not parse metadata:", err)
+			}
+			if meta.compiledGlobPattern == nil {
+				t.Fatal("expected compiledGlobPattern to be set")
+			}
+			match := meta.compiledGlobPattern.Match(tt.blobName)
+			if match != tt.wantMatch {
+				t.Errorf("pattern %q against blob name %q: got match=%v, want match=%v", tt.globPattern, tt.blobName, match, tt.wantMatch)
+			}
+		})
+	}
+}
+
 func TestAzBlobGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range azBlobMetricIdentifiers {
 		ctx := context.Background()


### PR DESCRIPTION
_Strip a leading "/" from `globPattern` before compiling it, since Azure Storage blob names never include one — fixing the reported case where path-style patterns (e.g. `/folderA/subFolderA/*.json`) never matched any blob._

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

## Root cause

`countBlobsWithGlobPattern` matches each listed blob's full name against the compiled `globPattern` using `github.com/gobwas/glob`. Azure Storage blob names returned by the list API never have a leading `/` — but the issue's reported pattern, `/folderA/subFolderA/*.json`, does. `gobwas/glob` treats a leading `/` as a literal character to match, so the pattern can never match any real blob name:

```go
g, _ := glob.Compile("/folderA/subFolderA/*.json")
g.Match("folderA/subFolderA/part-fileA.json") // false
g.Match("/folderA/subFolderA/part-fileA.json") // true, but this is never a real blob name
```

This reproduces with a plain (non-HNS) storage account too — it isn't actually specific to hierarchical namespaces, just that's how the reporter's account happened to be configured. Switching to `**` (as the issue mentions trying) doesn't help, since the mismatch is the leading slash, not the recursion depth.

## Fix

Strip a leading `/` from `GlobPattern` before compiling it in `Validate()`. Patterns without a leading slash are unaffected.

## Testing

Added `TestAzBlobGlobPatternLeadingSlash` covering:
- A leading-slash pattern matching a nested blob name (the reported case)
- A leading-slash pattern with `**` matching a nested blob name
- A pattern without a leading slash still matching as before (no regression)
- A leading-slash pattern correctly *not* matching an unrelated blob name

```
$ go test ./pkg/scalers/... -run TestAzBlobGlobPatternLeadingSlash -v
--- PASS: TestAzBlobGlobPatternLeadingSlash (0.00s)
    --- PASS: TestAzBlobGlobPatternLeadingSlash/leading_slash_pattern_matches_blob_name_without_leading_slash (0.00s)
    --- PASS: TestAzBlobGlobPatternLeadingSlash/leading_slash_pattern_with_double_star_matches_nested_blob_name (0.00s)
    --- PASS: TestAzBlobGlobPatternLeadingSlash/pattern_without_leading_slash_still_matches_as_before (0.00s)
    --- PASS: TestAzBlobGlobPatternLeadingSlash/leading_slash_pattern_does_not_match_unrelated_blob_name (0.00s)
PASS
```

Full `./pkg/scalers/...` suite passes.

Closes #6492
