### PR TITLE
fix: prevent stale scale-loop result from clobbering fresh unpause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
+- **General**: Fix `Paused` condition being incorrectly flipped back to `true` shortly after a `ScaledObject` is unpaused, caused by a concurrent scale loop iteration applying a stale paused decision computed before the unpause was observed ([#6421](https://github.com/kedacore/keda/issues/6421))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -319,6 +319,23 @@ func (h *scaleHandler) handleResult(ctx context.Context, obj kedav1alpha1.Scalab
 		// apply conditions from the result
 		conds := current.GetStatusConditions()
 		for _, cond := range result.Conditions {
+			if cond.Type == kedav1alpha1.ConditionPaused && cond.Status == metav1.ConditionTrue {
+				// result.Conditions was computed against a possibly-stale cached read of
+				// the object. Re-validate the Paused condition against the freshly
+				// fetched current object before applying it, so a stale "still paused"
+				// decision from this scale loop iteration can't clobber a more recent
+				// unpause already persisted by the reconciler (#6421).
+				var needsPause bool
+				switch typedCurrent := current.(type) {
+				case *kedav1alpha1.ScaledObject:
+					needsPause = typedCurrent.NeedToBePausedByAnnotation()
+				case *kedav1alpha1.ScaledJob:
+					needsPause = typedCurrent.NeedToBePausedByAnnotation()
+				}
+				if !needsPause {
+					continue
+				}
+			}
 			conds.SetCondition(cond.Type, cond.Status, cond.Reason, cond.Message)
 		}
 

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -1712,3 +1712,67 @@ func TestHandleResult_DeltaDoesNotOverwriteConcurrentChanges(t *testing.T) {
 	assert.True(t, patchedObj.Status.TriggersActivity["trigger-a"].IsActive, "concurrent update to trigger-a must be preserved")
 	assert.True(t, patchedObj.Status.TriggersActivity["trigger-b"].IsActive, "trigger-b updated by push scaler")
 }
+
+func TestHandleResult_DoesNotClobberFreshUnpauseWithStalePausedResult(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	statusWriter := mock_client.NewMockStatusWriter(ctrl)
+
+	sh := scaleHandler{client: mockClient}
+
+	// stale object the executor computed its result against: pause annotation
+	// still present, status already reflects Paused=true.
+	staleSO := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "ns",
+			Annotations: map[string]string{"autoscaling.keda.sh/paused": "true"},
+		},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			Conditions: kedav1alpha1.Conditions{
+				{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	// fresh object returned by Get: the pause annotation has since been removed
+	// and the reconciler has already persisted Paused=false.
+	freshSO := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			Conditions: kedav1alpha1.Conditions{
+				{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionFalse},
+			},
+		},
+	}
+
+	var patchedObj *kedav1alpha1.ScaledObject
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "test", Namespace: "ns"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *kedav1alpha1.ScaledObject, _ ...interface{}) error {
+			*obj = *freshSO.DeepCopy()
+			return nil
+		})
+	mockClient.EXPECT().Status().Return(statusWriter).AnyTimes()
+	statusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, obj *kedav1alpha1.ScaledObject, _ interface{}, _ ...interface{}) error {
+			patchedObj = obj
+			return nil
+		}).AnyTimes()
+
+	// executor's result, computed against the stale object: still says Paused=true.
+	// A Ready condition is also included so the delta is non-empty even when the
+	// Paused guard fires, guaranteeing a Patch is issued and the assertion below
+	// is always exercised.
+	result := executor.ScaleResult{
+		Conditions: kedav1alpha1.Conditions{
+			{Type: kedav1alpha1.ConditionPaused, Status: metav1.ConditionTrue, Reason: "ScaledObjectPaused", Message: "ScaledObject is paused"},
+			{Type: kedav1alpha1.ConditionReady, Status: metav1.ConditionTrue, Reason: "ScaledObjectReady", Message: "ScaledObject is defined correctly and is ready for scaling"},
+		},
+	}
+	sh.handleResult(context.Background(), &staleSO, result)
+
+	assert.NotNil(t, patchedObj, "handleResult must issue a status Patch when result contains non-paused conditions")
+	assert.Equal(t, metav1.ConditionFalse, patchedObj.Status.Conditions.GetPausedCondition().Status,
+		"a stale Paused=true result must not clobber the freshly persisted unpause (#6421)")
+}


### PR DESCRIPTION
_Fix the `Paused` condition on `ScaledObject` flipping back to `true` shortly after being unpaused, caused by a race between the controller reconciler and the background scale loop._

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

## Root cause

Two independent writers can both set the `Paused` condition on a `ScaledObject`:

1. `ScaledObjectReconciler.reconcileScaledObject` — watch-event-driven, sets `Paused=false` as soon as it observes the pause annotation removed.
2. The background scale loop (`checkScalers` → `RequestScale` → `handlePaused`) — runs on its own polling interval and re-derives `Paused` from whatever `ScaledObject` it read via `h.client.Get`, which can be a cache read that hasn't yet observed the annotation removal.

`handleResult` already does the right thing for everything else — it re-fetches the object fresh inside a `RetryOnConflict` loop and merges each condition by `Type` rather than replacing the whole array, so concurrent unrelated changes are preserved. But it had no way to know that a `Paused=true` entry in `result.Conditions` was computed against stale data, so it would still apply it on top of the fresh read, clobbering a `Paused=false` the reconciler had just persisted.

## Fix

In `handleResult`, when the result carries `Paused=true`, re-validate it against the freshly fetched object's *current* `NeedToBePausedByAnnotation()` before applying it. If the annotation is no longer present on the fresh object, the stale decision is skipped and the existing (correct) condition is left untouched. `Paused=false` entries, and all other condition types, are unaffected and continue to merge exactly as before.

This was previously discussed in #7563 (closed from inactivity, not rejected) — @rickbrouwer's suggestion there to make it "structurally impossible for the scale loop to overwrite Paused" is exactly what this re-validation achieves, scoped to the one place the race actually occurs.

## Testing

- Added `TestHandleResult_DoesNotClobberFreshUnpauseWithStalePausedResult`, modeled on the existing `TestHandleResult_DeltaDoesNotOverwriteConcurrentChanges` pattern: it feeds `handleResult` a stale paused object (mirroring what the executor would have seen) alongside a `result.Conditions` saying `Paused=true`, while the mocked `Get` returns a freshly-unpaused object. Asserts the persisted/patched state remains `Paused=false`.
- Verified the new test fails without the fix and passes with it (reverted the source change locally, confirmed the test catches the regression, then restored it).
- Full `./pkg/scaling/...`, `./apis/keda/v1alpha1/...`, and `./controllers/keda/...` suites pass (including the envtest-backed integration suite).
- `golangci-lint run ./...`: 0 issues.

Fixes #6421
