### PR TITLE
General: Guard against negative metric returned in scaler.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
+- **General**: Treat negative external metric values as zero to prevent incorrect HPA scaling ([#7880](https://github.com/kedacore/keda/issues/7880))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
 
 ### Deprecations

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -129,7 +129,7 @@ func GetMetricTargetMili(metricType v2.MetricTargetType, metricValue float64) v2
 
 	// Construct the target size as a quantity using string parsing to avoid
 	// int64 overflow when metricValue * 1000 exceeds math.MaxInt64 (~9.2e15 threshold).
-	// Treat NaN and Inf as zero to avoid a panic in resource.MustParse.
+	// NaN, Inf, and negative values are treated as zero to prevent panics and incorrect HPA scaling.
 	targetQty := quantityFromFloat64(metricValue)
 	if metricType == v2.AverageValueMetricType {
 		target.AverageValue = &targetQty
@@ -144,7 +144,7 @@ func GetMetricTargetMili(metricType v2.MetricTargetType, metricValue float64) v2
 func GenerateMetricInMili(metricName string, value float64) external_metrics.ExternalMetricValue {
 	// Use string parsing to avoid int64 overflow when value * 1000 exceeds
 	// math.MaxInt64 (~9.2e15 threshold).
-	// Treat NaN and Inf as zero to avoid a panic in resource.MustParse.
+	// NaN, Inf, and negative values are treated as zero to prevent panics and incorrect HPA scaling.
 	qty := quantityFromFloat64(value)
 	return external_metrics.ExternalMetricValue{
 		MetricName: metricName,

--- a/pkg/scalers/scaler.go
+++ b/pkg/scalers/scaler.go
@@ -154,9 +154,9 @@ func GenerateMetricInMili(metricName string, value float64) external_metrics.Ext
 }
 
 // quantityFromFloat64 converts a float64 to a resource.Quantity with milli-precision.
-// NaN and Inf values are treated as zero to prevent panics.
+// NaN, Inf, and negative values are treated as zero to prevent panics and incorrect HPA scaling.
 func quantityFromFloat64(value float64) resource.Quantity {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
 		return resource.MustParse("0")
 	}
 	return resource.MustParse(fmt.Sprintf("%.3f", value))

--- a/pkg/scalers/scaler_test.go
+++ b/pkg/scalers/scaler_test.go
@@ -113,6 +113,14 @@ func TestGetMetricTargetMili(t *testing.T) {
 			name:        "positive Inf treated as zero",
 			metricValue: math.Inf(1),
 		},
+		{
+			name:        "negative value treated as zero",
+			metricValue: -1,
+		},
+		{
+			name:        "large negative value treated as zero",
+			metricValue: -9.3e15,
+		},
 	}
 
 	for _, testCase := range cases {
@@ -121,8 +129,8 @@ func TestGetMetricTargetMili(t *testing.T) {
 			target := GetMetricTargetMili(v2.AverageValueMetricType, c.metricValue)
 			assert.NotNil(t, target.AverageValue)
 
-			if math.IsNaN(c.metricValue) || math.IsInf(c.metricValue, 0) {
-				assert.True(t, target.AverageValue.IsZero(), "expected zero quantity for NaN/Inf, got %v", target.AverageValue)
+			if math.IsNaN(c.metricValue) || math.IsInf(c.metricValue, 0) || c.metricValue < 0 {
+				assert.True(t, target.AverageValue.IsZero(), "expected zero quantity, got %v", target.AverageValue)
 			} else {
 				assert.True(t, target.AverageValue.AsApproximateFloat64() > 0, "expected positive quantity, got %v", target.AverageValue)
 			}
@@ -155,6 +163,14 @@ func TestGenerateMetricInMili(t *testing.T) {
 			name:  "positive Inf treated as zero",
 			value: math.Inf(1),
 		},
+		{
+			name:  "negative value treated as zero",
+			value: -1,
+		},
+		{
+			name:  "large negative value treated as zero",
+			value: -9.3e15,
+		},
 	}
 
 	for _, testCase := range cases {
@@ -163,8 +179,8 @@ func TestGenerateMetricInMili(t *testing.T) {
 			metric := GenerateMetricInMili("test-metric", c.value)
 			assert.Equal(t, "test-metric", metric.MetricName)
 
-			if math.IsNaN(c.value) || math.IsInf(c.value, 0) {
-				assert.True(t, metric.Value.IsZero(), "expected zero quantity for NaN/Inf, got %v", &metric.Value)
+			if math.IsNaN(c.value) || math.IsInf(c.value, 0) || c.value < 0 {
+				assert.True(t, metric.Value.IsZero(), "expected zero quantity, got %v", &metric.Value)
 			} else {
 				assert.True(t, metric.Value.AsApproximateFloat64() > 0, "expected positive quantity, got %v", &metric.Value)
 			}


### PR DESCRIPTION

Creating a guard in `quantityFromFloat64` to return 0 if the metric is negative. This helps when external scalers report negative metrics values


### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7880 

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
