### PR TITLE
fix: forward CloseIdleConnections through InstrumentedRoundTripper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
+- **General**: Fix idle HTTP connection leak in scaler HTTP clients; `InstrumentedRoundTripper` now forwards `CloseIdleConnections()` to the wrapped transport, so scaler `Close()` cleanup works again as it did before v2.20 ([#7898](https://github.com/kedacore/keda/issues/7898))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))

--- a/pkg/metricscollector/http_roundtripper.go
+++ b/pkg/metricscollector/http_roundtripper.go
@@ -96,6 +96,17 @@ func (r *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	return resp, nil
 }
 
+// CloseIdleConnections forwards to the wrapped transport so that
+// http.Client.CloseIdleConnections() keeps working when the client's
+// transport is wrapped for instrumentation. Without this method the
+// stdlib's interface assertion fails silently and idle keep-alive
+// connections are never closed (see #7898).
+func (r *InstrumentedRoundTripper) CloseIdleConnections() {
+	if ci, ok := r.next.(interface{ CloseIdleConnections() }); ok {
+		ci.CloseIdleConnections()
+	}
+}
+
 // BuildScalerRequestCtx attaches scaler metadata used by HTTP client
 // instrumentation to the outbound request context.
 func BuildScalerRequestCtx(ctx context.Context, config scalersconfig.ScalerConfig, metricName string) context.Context {

--- a/pkg/metricscollector/http_roundtripper_test.go
+++ b/pkg/metricscollector/http_roundtripper_test.go
@@ -187,6 +187,36 @@ func TestInstrumentedRoundTripper_NilNextUsesDefault(t *testing.T) {
 	Expect(fmt.Sprintf("%T", rt)).To(Equal("*metricscollector.InstrumentedRoundTripper"))
 }
 
+type mockClosableRoundTripper struct {
+	mockRoundTripper
+	closeIdleCalled bool
+}
+
+func (m *mockClosableRoundTripper) CloseIdleConnections() {
+	m.closeIdleCalled = true
+}
+
+func TestInstrumentedRoundTripper_CloseIdleConnectionsForwarded(t *testing.T) {
+	RegisterTestingT(t)
+
+	inner := &mockClosableRoundTripper{}
+	client := &http.Client{Transport: NewInstrumentedRoundTripper(inner)}
+
+	// http.Client.CloseIdleConnections forwards to the transport only if it
+	// implements CloseIdleConnections; before the fix this was a silent no-op.
+	client.CloseIdleConnections()
+	Expect(inner.closeIdleCalled).To(BeTrue())
+}
+
+func TestInstrumentedRoundTripper_CloseIdleConnectionsWithoutSupport(t *testing.T) {
+	RegisterTestingT(t)
+
+	client := &http.Client{Transport: NewInstrumentedRoundTripper(&mockRoundTripper{})}
+
+	// Must not panic when the wrapped transport has no CloseIdleConnections.
+	client.CloseIdleConnections()
+}
+
 func TestInstrumentedRoundTripper_ScalerContextKey_Missing(t *testing.T) {
 	RegisterTestingT(t)
 	response := fakeResponse(200)


### PR DESCRIPTION
Since #7644, `kedautil.CreateHTTPClient` wraps the scaler HTTP transport in `metricscollector.InstrumentedRoundTripper`, which only implements `RoundTrip`. `http.Client.CloseIdleConnections()` forwards to the transport only when it implements `CloseIdleConnections()`, so since v2.20 every scaler cleanup call (`httpClient.CloseIdleConnections()` in `Close()`, the pattern called out as canonical in #7756) has been a silent no-op. With the default transport (keep-alive on, `IdleConnTimeout == 0`), idle connections from closed scaler pools never expire and accumulate against the upstream (e.g. Prometheus) on every scaler `Close()` / `ScalersCache.refreshScaler`.

This PR adds a `CloseIdleConnections()` passthrough on `InstrumentedRoundTripper` using the same interface assertion the standard library uses, restoring the pre-v2.20 cleanup behaviour without touching the metrics path.

Tests: `TestInstrumentedRoundTripper_CloseIdleConnectionsForwarded` goes through a real `http.Client` so it exercises the stdlib forwarding path — it fails on the current code (verified) and passes with the fix. A second test pins that wrapping a transport without `CloseIdleConnections` stays safe.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7898