### PR TITLE
fix: forward CloseIdleConnections through InstrumentedRoundTripper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
+- **General**: Fix leaked idle HTTP connections in scaler HTTP clients; the metrics `InstrumentedRoundTripper` did not forward `CloseIdleConnections`, so scaler `Close()`/refresh stopped releasing idle keep-alive connections (e.g. to Prometheus), which could accumulate until the upstream was overwhelmed ([#7898](https://github.com/kedacore/keda/issues/7898))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))

--- a/pkg/metricscollector/http_roundtripper.go
+++ b/pkg/metricscollector/http_roundtripper.go
@@ -96,6 +96,20 @@ func (r *InstrumentedRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	return resp, nil
 }
 
+// CloseIdleConnections forwards to the wrapped RoundTripper so that
+// http.Client.CloseIdleConnections() keeps working through this wrapper.
+// http.Client only closes idle connections when its Transport implements this
+// method; without forwarding, callers such as scaler Close() methods silently
+// fail to release idle keep-alive connections, leaking them to the upstream.
+func (r *InstrumentedRoundTripper) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if tr, ok := r.next.(closeIdler); ok {
+		tr.CloseIdleConnections()
+	}
+}
+
 // BuildScalerRequestCtx attaches scaler metadata used by HTTP client
 // instrumentation to the outbound request context.
 func BuildScalerRequestCtx(ctx context.Context, config scalersconfig.ScalerConfig, metricName string) context.Context {

--- a/pkg/metricscollector/http_roundtripper_test.go
+++ b/pkg/metricscollector/http_roundtripper_test.go
@@ -201,3 +201,46 @@ func TestInstrumentedRoundTripper_ScalerContextKey_Missing(t *testing.T) {
 	Expect(resp).To(Equal(response))
 	defer resp.Body.Close()
 }
+
+// closeIdlerRoundTripper is a RoundTripper that also implements
+// CloseIdleConnections (like *http.Transport), recording how many times it was
+// called so tests can assert the wrapper forwards the call.
+type closeIdlerRoundTripper struct {
+	closeIdleConnectionsCalls int
+}
+
+func (c *closeIdlerRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return fakeResponse(http.StatusOK), nil
+}
+
+func (c *closeIdlerRoundTripper) CloseIdleConnections() {
+	c.closeIdleConnectionsCalls++
+}
+
+func TestInstrumentedRoundTripper_ForwardsCloseIdleConnections(t *testing.T) {
+	RegisterTestingT(t)
+
+	next := &closeIdlerRoundTripper{}
+	rt := NewInstrumentedRoundTripper(next)
+
+	// http.Client.CloseIdleConnections() only reaches the underlying transport
+	// if the client's transport itself exposes CloseIdleConnections(). If the
+	// wrapper does not forward it, the call is a silent no-op and idle
+	// keep-alive connections leak (e.g. to Prometheus) on scaler Close/refresh.
+	client := &http.Client{Transport: rt}
+	client.CloseIdleConnections()
+
+	Expect(next.closeIdleConnectionsCalls).To(Equal(1))
+}
+
+func TestInstrumentedRoundTripper_CloseIdleConnections_NextWithoutCloseIdler(t *testing.T) {
+	RegisterTestingT(t)
+
+	// mockRoundTripper does not implement CloseIdleConnections; forwarding must
+	// be a safe no-op rather than panicking.
+	rt := NewInstrumentedRoundTripper(&mockRoundTripper{})
+
+	Expect(func() {
+		(&http.Client{Transport: rt}).CloseIdleConnections()
+	}).NotTo(Panic())
+}


### PR DESCRIPTION
Since #7644, `kedautil.CreateHTTPClient` wraps the scaler HTTP transport in `metricscollector.InstrumentedRoundTripper`, which implements only `RoundTrip`. Because `http.Client.CloseIdleConnections()` forwards to the transport only when it implements `CloseIdleConnections()`, every scaler's `httpClient.CloseIdleConnections()` call in `Close()` became a silent no-op in v2.20 — idle keep-alive connections from closed/refreshed scaler pools never expire (`IdleConnTimeout == 0`) and accumulate against the upstream (e.g. Prometheus) until it is overwhelmed. v2.19 didn't have this problem because the client's `Transport` was a bare `*http.Transport`, which implements `CloseIdleConnections()`.

This adds a `CloseIdleConnections()` passthrough on `InstrumentedRoundTripper` that forwards to the wrapped transport via the same interface assertion the standard library uses, restoring the pre-v2.20 cleanup behaviour without touching the metrics path.

Tests go through a real `http.Client` so they exercise the stdlib forwarding path: the forwarding test fails on current `main` (verified red) and passes with the fix; a second test pins that wrapping a transport without `CloseIdleConnections` stays a safe no-op.

This is the minimal interim fix described in #7898. #7677 proposes the broader structural fix (one shared, bounded, self-expiring connection pool across scalers); the two are mutually exclusive and should not be combined.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7898

Relates to #7677, #7901
