### PR TITLE
feat: add metric server performance metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
+- **General**: Add metric server performance metrics for HPA external metric requests and operator GetMetrics gRPC handling ([#3120](https://github.com/kedacore/keda/issues/3120))
 - **Kafka Scaler**: Add optional `fullMetadata` trigger metadata field to control Sarama's full cluster metadata refresh, reducing operator memory for topic scoped triggers ([#7453](https://github.com/kedacore/keda/issues/7453))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/metricsservice"
 	kedaprovider "github.com/kedacore/keda/v2/pkg/provider"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
@@ -65,6 +66,7 @@ var (
 	metricsServiceAddr          string
 	profilingAddr               string
 	metricsServiceGRPCAuthority string
+	enableOpenTelemetryMetrics  bool
 	logToSTDerr                 bool
 	verbosityLevel              int
 	stdErrThreshold             string
@@ -243,6 +245,7 @@ func main() {
 	cmd.Flags().Float32Var(&adapterClientRequestQPS, "kube-api-qps", 20.0, "Set the QPS rate for throttling requests sent to the apiserver")
 	cmd.Flags().IntVar(&adapterClientRequestBurst, "kube-api-burst", 30, "Set the burst for throttling requests sent to the apiserver")
 	cmd.Flags().BoolVar(&disableCompression, "disable-compression", true, "Disable response compression for k8s restAPI in client-go. ")
+	cmd.Flags().BoolVar(&enableOpenTelemetryMetrics, "enable-opentelemetry-metrics", false, "Enable OpenTelemetry export of keda-metrics-apiserver performance metrics.")
 
 	// legacy klogr flags handled for backwards compatibility. Default set to -1 so it doesn't override values set via zap options
 	cmd.Flags().IntVar(&verbosityLevel, "v", -1, "Logging level for Metrics Server. (DEPRECATED)")
@@ -313,6 +316,11 @@ func main() {
 	cmd.WithExternalMetrics(kedaProvider)
 
 	setupLog.Info(cmd.Message)
+
+	metricscollector.RegisterAdapterPerformancePromMetrics(legacyregistry.Registerer())
+	if enableOpenTelemetryMetrics {
+		metricscollector.InitAdapterOtelPerformanceMetrics()
+	}
 
 	RunMetricsServer(ctx)
 

--- a/pkg/metricscollector/export_test.go
+++ b/pkg/metricscollector/export_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricscollector
+
+import (
+	"go.opentelemetry.io/otel/sdk/metric"
+)
+
+// ResetAdapterOtelPerformanceMetricsForTest clears adapter OTEL performance metrics state.
+func ResetAdapterOtelPerformanceMetricsForTest() {
+	adapterOtelMetrics = nil
+}
+
+// InitAdapterOtelPerformanceMetricsForTest initializes adapter OTEL performance metrics with a test reader.
+func InitAdapterOtelPerformanceMetricsForTest(reader metric.Reader) {
+	ResetAdapterOtelPerformanceMetricsForTest()
+	initAdapterOtelPerformanceMetricsWithReader(reader)
+}

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -237,6 +237,11 @@ func RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bo
 	}
 }
 
+// RecordExternalMetricRequest records an HPA external metric request handled by keda-metrics-apiserver.
+func RecordExternalMetricRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string) {
+	RecordAdapterExternalMetricRequest(durationSeconds, err, namespace, scaledObject, metricName)
+}
+
 // RecordMetricsServiceGetMetricsRequest records a GetMetrics gRPC request handled by keda-operator.
 func RecordMetricsServiceGetMetricsRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string) {
 	for _, element := range collectors {

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -89,6 +89,12 @@ type MetricsCollector interface {
 	// namespace, and scaledResource are provided explicitly by the caller; upstream
 	// instrumentation may derive them from context before invoking the collector.
 	RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string)
+
+	// RecordExternalMetricRequest records an HPA external metric request handled by keda-metrics-apiserver.
+	RecordExternalMetricRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string)
+
+	// RecordMetricsServiceGetMetricsRequest records a GetMetrics gRPC request handled by keda-operator.
+	RecordMetricsServiceGetMetricsRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string)
 }
 
 func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool) {
@@ -228,6 +234,13 @@ func RecordEmptyUpstreamResponse(namespace, scaledResource, triggerName, metricN
 func RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string) {
 	for _, element := range collectors {
 		element.RecordHTTPClientRequest(durationSeconds, statusCode, isError, scaler, triggerName, metricName, namespace, scaledResource)
+	}
+}
+
+// RecordMetricsServiceGetMetricsRequest records a GetMetrics gRPC request handled by keda-operator.
+func RecordMetricsServiceGetMetricsRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string) {
+	for _, element := range collectors {
+		element.RecordMetricsServiceGetMetricsRequest(durationSeconds, err, namespace, scaledObject, metricName)
 	}
 }
 

--- a/pkg/metricscollector/metricserver_performance.go
+++ b/pkg/metricscollector/metricserver_performance.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricscollector
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	api "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/metric"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	requestResultSuccess = "success"
+	requestResultError   = "error"
+)
+
+var (
+	adapterExternalMetricRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "external_metrics_provider",
+			Name:      "requests_total",
+			Help:      "Total number of external metric requests served to the Kubernetes HPA, labeled by outcome.",
+		},
+		[]string{"namespace", "scaled_object", "metric", "result"},
+	)
+
+	adapterExternalMetricRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "external_metrics_provider",
+			Name:      "request_duration_seconds",
+			Help:      "Duration in seconds of external metric requests served to the Kubernetes HPA.",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"result"},
+	)
+
+	adapterPerformancePromOnce sync.Once
+
+	adapterOtelMetrics               *adapterOtelPerformanceMetrics
+	adapterOtelPerformanceMetricsLog = logf.Log.WithName("adapter_otel_performance_metrics")
+)
+
+type adapterOtelPerformanceMetrics struct {
+	externalMetricRequests api.Int64Counter
+	externalMetricDuration api.Float64Histogram
+}
+
+// RegisterAdapterPerformancePromMetrics registers HPA-facing performance metrics on the given registerer.
+// Intended for use by keda-metrics-apiserver which exposes metrics through legacyregistry.
+func RegisterAdapterPerformancePromMetrics(registerer prometheus.Registerer) {
+	adapterPerformancePromOnce.Do(func() {
+		registerer.MustRegister(adapterExternalMetricRequestsTotal)
+		registerer.MustRegister(adapterExternalMetricRequestDuration)
+	})
+}
+
+// InitAdapterOtelPerformanceMetrics initializes OpenTelemetry export of HPA-facing performance metrics.
+func InitAdapterOtelPerformanceMetrics() {
+	if adapterOtelMetrics != nil {
+		return
+	}
+
+	protocol := os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+
+	var exporter metric.Exporter
+	var err error
+	switch protocol {
+	case "grpc":
+		adapterOtelPerformanceMetricsLog.V(1).Info("start OTEL grpc client for adapter performance metrics")
+		exporter, err = otlpmetricgrpc.New(context.Background())
+	default:
+		adapterOtelPerformanceMetricsLog.V(1).Info("start OTEL http client for adapter performance metrics")
+		exporter, err = otlpmetrichttp.New(context.Background())
+	}
+
+	if err != nil {
+		adapterOtelPerformanceMetricsLog.Error(err, "failed to initialize adapter OTEL performance metrics")
+		return
+	}
+
+	initAdapterOtelPerformanceMetricsWithReader(metric.NewPeriodicReader(exporter))
+}
+
+func initAdapterOtelPerformanceMetricsWithReader(reader metric.Reader) {
+	if adapterOtelMetrics != nil {
+		return
+	}
+
+	meterProvider := metric.NewMeterProvider(metric.WithReader(reader))
+	otel.SetMeterProvider(meterProvider)
+
+	meter := meterProvider.Meter("keda-adapter-performance-metrics")
+	msg := "failed to create OpenTelemetry instrument for adapter performance metrics"
+
+	externalMetricRequests, err := meter.Int64Counter(
+		"keda.external_metrics_provider.requests.count",
+		api.WithDescription("Total number of external metric requests served to the Kubernetes HPA"),
+	)
+	if err != nil {
+		adapterOtelPerformanceMetricsLog.Error(err, msg)
+		return
+	}
+
+	externalMetricDuration, err := meter.Float64Histogram(
+		"keda.external_metrics_provider.request.duration.seconds",
+		api.WithDescription("Duration in seconds of external metric requests served to the Kubernetes HPA"),
+		api.WithUnit("s"),
+	)
+	if err != nil {
+		adapterOtelPerformanceMetricsLog.Error(err, msg)
+		return
+	}
+
+	adapterOtelMetrics = &adapterOtelPerformanceMetrics{
+		externalMetricRequests: externalMetricRequests,
+		externalMetricDuration: externalMetricDuration,
+	}
+}
+
+// RecordAdapterExternalMetricRequest records an HPA external metric request handled by keda-metrics-apiserver.
+func RecordAdapterExternalMetricRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string) {
+	result := requestResult(err)
+
+	adapterExternalMetricRequestsTotal.WithLabelValues(namespace, scaledObject, metricName, result).Inc()
+	adapterExternalMetricRequestDuration.WithLabelValues(result).Observe(durationSeconds)
+
+	if adapterOtelMetrics != nil {
+		counterOpt := api.WithAttributes(
+			attribute.Key("namespace").String(namespace),
+			attribute.Key("scaled_object").String(scaledObject),
+			attribute.Key("metric").String(metricName),
+			attribute.Key("result").String(result),
+		)
+		histOpt := api.WithAttributes(attribute.Key("result").String(result))
+
+		adapterOtelMetrics.externalMetricRequests.Add(context.Background(), 1, counterOpt)
+		adapterOtelMetrics.externalMetricDuration.Record(context.Background(), durationSeconds, histOpt)
+	}
+}
+
+func requestResult(err error) string {
+	if err != nil {
+		return requestResultError
+	}
+	return requestResultSuccess
+}

--- a/pkg/metricscollector/metricserver_performance.go
+++ b/pkg/metricscollector/metricserver_performance.go
@@ -69,7 +69,8 @@ type adapterOtelPerformanceMetrics struct {
 	externalMetricDuration api.Float64Histogram
 }
 
-// RegisterAdapterPerformancePromMetrics registers HPA-facing performance metrics on the given registerer.
+// RegisterAdapterPerformancePromMetrics registers HPA-facing performance metrics.
+// Registration runs at most once; the first call wins and later calls are no-ops even if a different registerer is passed.
 // Intended for use by keda-metrics-apiserver which exposes metrics through legacyregistry.
 func RegisterAdapterPerformancePromMetrics(registerer prometheus.Registerer) {
 	adapterPerformancePromOnce.Do(func() {

--- a/pkg/metricscollector/metricserver_performance_test.go
+++ b/pkg/metricscollector/metricserver_performance_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricscollector
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestRequestResult(t *testing.T) {
+	assert.Equal(t, requestResultSuccess, requestResult(nil))
+	assert.Equal(t, requestResultError, requestResult(errors.New("boom")))
+}
+
+func TestRecordAdapterExternalMetricRequest(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	RegisterAdapterPerformancePromMetrics(reg)
+
+	namespace := t.Name() + "-ns"
+	scaledObject := t.Name() + "-so"
+	metricName := t.Name() + "-metric"
+
+	RecordAdapterExternalMetricRequest(0.05, nil, namespace, scaledObject, metricName)
+	RecordAdapterExternalMetricRequest(0.1, errors.New("failed"), namespace, scaledObject, metricName)
+
+	m := &dto.Metric{}
+
+	counter, err := adapterExternalMetricRequestsTotal.GetMetricWithLabelValues(namespace, scaledObject, metricName, requestResultSuccess)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
+
+	counter, err = adapterExternalMetricRequestsTotal.GetMetricWithLabelValues(namespace, scaledObject, metricName, requestResultError)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
+
+	hist, err := adapterExternalMetricRequestDuration.GetMetricWithLabelValues(requestResultSuccess)
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.GreaterOrEqual(t, m.Histogram.GetSampleCount(), uint64(1))
+}
+
+func TestRecordAdapterExternalMetricRequest_Otel(t *testing.T) {
+	previousAdapterOtelMetrics := adapterOtelMetrics
+	t.Cleanup(func() {
+		adapterOtelMetrics = previousAdapterOtelMetrics
+	})
+
+	reader := metric.NewManualReader()
+	InitAdapterOtelPerformanceMetricsForTest(reader)
+
+	namespace := t.Name() + "-ns"
+	scaledObject := t.Name() + "-so"
+	metricName := t.Name() + "-metric"
+
+	RecordAdapterExternalMetricRequest(0.05, nil, namespace, scaledObject, metricName)
+	RecordAdapterExternalMetricRequest(0.1, errors.New("failed"), namespace, scaledObject, metricName)
+
+	got := metricdata.ResourceMetrics{}
+	err := reader.Collect(context.Background(), &got)
+	require.NoError(t, err)
+
+	scopeMetrics := got.ScopeMetrics[0]
+	requestCount := retrieveMetric(scopeMetrics.Metrics, "keda.external_metrics_provider.requests.count")
+	require.NotNil(t, requestCount)
+
+	var successCount, errorCount int64
+	for _, dp := range requestCount.Data.(metricdata.Sum[int64]).DataPoints {
+		result, _ := dp.Attributes.Value("result")
+		switch result.AsString() {
+		case requestResultSuccess:
+			successCount = dp.Value
+		case requestResultError:
+			errorCount = dp.Value
+		}
+	}
+	assert.Equal(t, int64(1), successCount)
+	assert.Equal(t, int64(1), errorCount)
+
+	requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.external_metrics_provider.request.duration.seconds")
+	require.NotNil(t, requestDuration)
+	assert.Equal(t, "s", requestDuration.Unit)
+}
+
+func TestRecordMetricsServiceGetMetricsRequest_Collectors(t *testing.T) {
+	withPromCollector(t)
+
+	namespace := t.Name() + "-ns"
+	scaledObject := t.Name() + "-so"
+	metricName := t.Name() + "-metric"
+
+	RecordMetricsServiceGetMetricsRequest(0.05, nil, namespace, scaledObject, metricName)
+	RecordMetricsServiceGetMetricsRequest(0.1, errors.New("failed"), namespace, scaledObject, metricName)
+
+	m := &dto.Metric{}
+
+	counter, err := metricsServiceGetMetricsRequestsTotal.GetMetricWithLabelValues(namespace, scaledObject, metricName, requestResultSuccess)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
+
+	counter, err = metricsServiceGetMetricsRequestsTotal.GetMetricWithLabelValues(namespace, scaledObject, metricName, requestResultError)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
+
+	hist, err := metricsServiceGetMetricsDuration.GetMetricWithLabelValues(requestResultSuccess)
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.GreaterOrEqual(t, m.Histogram.GetSampleCount(), uint64(1))
+}
+
+func TestPromMetrics_RecordMetricsServiceGetMetricsRequest(t *testing.T) {
+	p := &PromMetrics{}
+
+	namespace := t.Name() + "-ns"
+	scaledObject := t.Name() + "-so"
+	metricName := t.Name() + "-metric"
+
+	p.RecordMetricsServiceGetMetricsRequest(0.05, nil, namespace, scaledObject, metricName)
+	p.RecordMetricsServiceGetMetricsRequest(0.1, errors.New("failed"), namespace, scaledObject, metricName)
+
+	m := &dto.Metric{}
+
+	counter, err := metricsServiceGetMetricsRequestsTotal.GetMetricWithLabelValues(namespace, scaledObject, metricName, requestResultSuccess)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
+
+	counter, err = metricsServiceGetMetricsRequestsTotal.GetMetricWithLabelValues(namespace, scaledObject, metricName, requestResultError)
+	require.NoError(t, err)
+	require.NoError(t, counter.Write(m))
+	assert.EqualValues(t, 1, m.Counter.GetValue())
+
+	hist, err := metricsServiceGetMetricsDuration.GetMetricWithLabelValues(requestResultSuccess)
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.GreaterOrEqual(t, m.Histogram.GetSampleCount(), uint64(1))
+}

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -51,6 +51,9 @@ var (
 
 	otHTTPClientRequestsCounter api.Int64Counter
 	otHTTPClientRequestDuration api.Float64Histogram
+
+	otMetricsServiceGetMetricsRequests  api.Int64Counter
+	otMetricsServiceGetMetricsDuration  api.Float64Histogram
 )
 
 type OtelMetrics struct {
@@ -241,6 +244,23 @@ func initMeters() {
 	otHTTPClientRequestDuration, err = meter.Float64Histogram(
 		"keda.scaler.http.request.duration.seconds",
 		api.WithDescription("Duration in seconds of outbound HTTP requests issued during scaler metric collection."),
+		api.WithUnit("s"),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
+	otMetricsServiceGetMetricsRequests, err = meter.Int64Counter(
+		"keda.metricsservice.get_metrics.requests.count",
+		api.WithDescription("Total number of GetMetrics gRPC requests handled by keda-operator for the metrics server"),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
+	otMetricsServiceGetMetricsDuration, err = meter.Float64Histogram(
+		"keda.metricsservice.get_metrics.duration.seconds",
+		api.WithDescription("Duration in seconds of GetMetrics gRPC requests handled by keda-operator for the metrics server"),
 		api.WithUnit("s"),
 	)
 	if err != nil {
@@ -538,6 +558,24 @@ func (o *OtelMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCod
 	)
 	otHTTPClientRequestsCounter.Add(context.Background(), 1, counterOpt)
 	otHTTPClientRequestDuration.Record(context.Background(), durationSeconds, histOpt)
+}
+
+// RecordExternalMetricRequest is a no-op on the operator OpenTelemetry collector.
+func (o *OtelMetrics) RecordExternalMetricRequest(float64, error, string, string, string) {}
+
+// RecordMetricsServiceGetMetricsRequest records a GetMetrics gRPC request handled by keda-operator.
+func (o *OtelMetrics) RecordMetricsServiceGetMetricsRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string) {
+	result := requestResult(err)
+	counterOpt := api.WithAttributes(
+		attribute.Key("namespace").String(namespace),
+		attribute.Key("scaled_object").String(scaledObject),
+		attribute.Key("metric").String(metricName),
+		attribute.Key("result").String(result),
+	)
+	histOpt := api.WithAttributes(attribute.Key("result").String(result))
+
+	otMetricsServiceGetMetricsRequests.Add(context.Background(), 1, counterOpt)
+	otMetricsServiceGetMetricsDuration.Record(context.Background(), durationSeconds, histOpt)
 }
 
 // RecordCloudEventQueueStatus record the number of cloudevents that are waiting for emitting

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -52,8 +52,8 @@ var (
 	otHTTPClientRequestsCounter api.Int64Counter
 	otHTTPClientRequestDuration api.Float64Histogram
 
-	otMetricsServiceGetMetricsRequests  api.Int64Counter
-	otMetricsServiceGetMetricsDuration  api.Float64Histogram
+	otMetricsServiceGetMetricsRequests api.Int64Counter
+	otMetricsServiceGetMetricsDuration api.Float64Histogram
 )
 
 type OtelMetrics struct {

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -2,6 +2,7 @@ package metricscollector
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -154,6 +155,40 @@ func TestRecordHTTPClientRequest(t *testing.T) {
 			assert.Equal(t, "s", requestDuration.Unit)
 		})
 	}
+}
+
+func TestRecordMetricsServiceGetMetricsRequest(t *testing.T) {
+	namespace := t.Name() + "-ns"
+	scaledObject := t.Name() + "-so"
+	metricName := t.Name() + "-metric"
+
+	testOtel.RecordMetricsServiceGetMetricsRequest(0.05, nil, namespace, scaledObject, metricName)
+	testOtel.RecordMetricsServiceGetMetricsRequest(0.1, errors.New("failed"), namespace, scaledObject, metricName)
+
+	got := metricdata.ResourceMetrics{}
+	err := testReader.Collect(context.Background(), &got)
+	assert.Nil(t, err)
+
+	scopeMetrics := got.ScopeMetrics[0]
+	requestCount := retrieveMetric(scopeMetrics.Metrics, "keda.metricsservice.get_metrics.requests.count")
+	assert.NotNil(t, requestCount)
+
+	var successCount, errorCount int64
+	for _, dp := range requestCount.Data.(metricdata.Sum[int64]).DataPoints {
+		result, _ := dp.Attributes.Value("result")
+		switch result.AsString() {
+		case requestResultSuccess:
+			successCount = dp.Value
+		case requestResultError:
+			errorCount = dp.Value
+		}
+	}
+	assert.Equal(t, int64(1), successCount)
+	assert.Equal(t, int64(1), errorCount)
+
+	requestDuration := retrieveMetric(scopeMetrics.Metrics, "keda.metricsservice.get_metrics.duration.seconds")
+	assert.NotNil(t, requestDuration)
+	assert.Equal(t, "s", requestDuration.Unit)
 }
 
 func TestContinuousMetrics(t *testing.T) {

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -182,6 +182,27 @@ var (
 		},
 		[]string{"scaler", "status_code"},
 	)
+
+	metricsServiceGetMetricsRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "metricsservice",
+			Name:      "get_metrics_requests_total",
+			Help:      "Total number of GetMetrics gRPC requests handled by keda-operator for the metrics server, labeled by outcome.",
+		},
+		[]string{"namespace", "scaled_object", "metric", "result"},
+	)
+
+	metricsServiceGetMetricsDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "metricsservice",
+			Name:      "get_metrics_duration_seconds",
+			Help:      "Duration in seconds of GetMetrics gRPC requests handled by keda-operator for the metrics server.",
+			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"result"},
+	)
 )
 
 type PromMetrics struct {
@@ -207,6 +228,9 @@ func NewPromMetrics() *PromMetrics {
 
 	metrics.Registry.MustRegister(httpClientRequestsTotal)
 	metrics.Registry.MustRegister(httpClientRequestDuration)
+
+	metrics.Registry.MustRegister(metricsServiceGetMetricsRequestsTotal)
+	metrics.Registry.MustRegister(metricsServiceGetMetricsDuration)
 
 	RecordBuildInfo()
 	return &PromMetrics{}
@@ -379,6 +403,16 @@ func (p *PromMetrics) RecordHTTPClientRequest(durationSeconds float64, statusCod
 	code := httpStatusCodeLabel(statusCode, isError)
 	httpClientRequestsTotal.WithLabelValues(namespace, scaledResource, scaler, triggerName, metricName, code).Inc()
 	httpClientRequestDuration.WithLabelValues(scaler, code).Observe(durationSeconds)
+}
+
+// RecordExternalMetricRequest is a no-op on the operator Prometheus collector.
+func (p *PromMetrics) RecordExternalMetricRequest(float64, error, string, string, string) {}
+
+// RecordMetricsServiceGetMetricsRequest records a GetMetrics gRPC request handled by keda-operator.
+func (p *PromMetrics) RecordMetricsServiceGetMetricsRequest(durationSeconds float64, err error, namespace, scaledObject, metricName string) {
+	result := requestResult(err)
+	metricsServiceGetMetricsRequestsTotal.WithLabelValues(namespace, scaledObject, metricName, result).Inc()
+	metricsServiceGetMetricsDuration.WithLabelValues(result).Observe(durationSeconds)
 }
 
 // Returns a grpcprom server Metrics object and registers the metrics. The object contains

--- a/pkg/metricsservice/server.go
+++ b/pkg/metricsservice/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -47,6 +48,12 @@ type GrpcServer struct {
 
 // GetMetrics returns metrics values in form of ExternalMetricValueList for specified ScaledObject reference
 func (s *GrpcServer) GetMetrics(ctx context.Context, in *api.ScaledObjectRef) (*api.ExternalMetricValueList, error) {
+	start := time.Now()
+	var err error
+	defer func() {
+		metricscollector.RecordMetricsServiceGetMetricsRequest(time.Since(start).Seconds(), err, in.GetNamespace(), in.GetName(), in.GetMetricName())
+	}()
+
 	extMetrics, err := (*s.scalerHandler).GetScaledObjectMetrics(ctx, in.Name, in.Namespace, in.MetricName)
 	if err != nil {
 		return &api.ExternalMetricValueList{}, fmt.Errorf("error when getting metric values %w", err)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -79,7 +79,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 	var scaledObjectName string
 	var err error
 	defer func() {
-		metricscollector.RecordAdapterExternalMetricRequest(time.Since(start).Seconds(), err, namespace, scaledObjectName, info.Metric)
+		metricscollector.RecordExternalMetricRequest(time.Since(start).Seconds(), err, namespace, scaledObjectName, info.Metric)
 	}()
 
 	// Note:

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/labels"
@@ -28,6 +29,7 @@ import (
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider/defaults"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/metricsservice"
 )
 
@@ -73,6 +75,13 @@ func NewProvider(ctx context.Context, adapterLogger logr.Logger, client client.C
 // implementation how to translate metricSelector to a filter for metric values.
 // Namespace can be used by the implementation for metric identification, access control or ignored.
 func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
+	start := time.Now()
+	var scaledObjectName string
+	var err error
+	defer func() {
+		metricscollector.RecordAdapterExternalMetricRequest(time.Since(start).Seconds(), err, namespace, scaledObjectName, info.Metric)
+	}()
+
 	// Note:
 	//		metric name and namespace is used to lookup for the CRD which contains configuration
 	// 		if not found then ignored and label selector is parsed for all the metrics
@@ -86,7 +95,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 	// Get Metrics from Metrics Service gRPC Server
 	if !p.grpcClient.WaitForConnectionReady(ctx, logger) {
 		grpcClientConnected = false
-		err := fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server")
+		err = fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server")
 		logger.Error(err, "timeout", "server", p.grpcClient.GetServerURL())
 		return nil, err
 	}
@@ -96,15 +105,16 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 	}
 
 	// selector is in form: `scaledobject.keda.sh/name: scaledobject-name`
-	scaledObjectName := selector.Get(kedav1alpha1.ScaledObjectOwnerAnnotation)
+	scaledObjectName = selector.Get(kedav1alpha1.ScaledObjectOwnerAnnotation)
 	if scaledObjectName == "" {
-		err := fmt.Errorf("scaledObject name is not specified")
+		err = fmt.Errorf("scaledObject name is not specified")
 		logger.Error(err, fmt.Sprintf("please specify scaledObject name, it needs to be set as value of label selector %q on the query", kedav1alpha1.ScaledObjectOwnerAnnotation))
 
 		return &external_metrics.ExternalMetricValueList{}, err
 	}
 
-	metrics, err := p.grpcClient.GetMetrics(ctx, scaledObjectName, namespace, info.Metric)
+	var metrics *external_metrics.ExternalMetricValueList
+	metrics, err = p.grpcClient.GetMetrics(ctx, scaledObjectName, namespace, info.Metric)
 	logger.V(1).WithValues("scaledObjectName", scaledObjectName, "scaledObjectNamespace", namespace, "metrics", metrics).Info("Receiving metrics")
 
 	return metrics, err

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -1256,6 +1256,7 @@ func testOperatorMetricValues(t *testing.T, kc *kubernetes.Clientset) {
 	checkTriggerTotalValues(t, families, expectedTriggerTotals)
 	checkCRTotalValues(t, families, expectedCrTotals)
 	checkBuildInfo(t, families)
+	checkMetricsServiceGetMetricsPerformance(t, families)
 }
 
 func checkBuildInfo(t *testing.T, families map[string]*prommodel.MetricFamily) {
@@ -1597,4 +1598,32 @@ func testHTTPClientMetrics(t *testing.T, data templateData) {
 		}
 		assert.True(t, found, "expected keda_scaler_http_request_duration_seconds histogram for prometheus scaler")
 	}
+}
+
+func checkMetricsServiceGetMetricsPerformance(t *testing.T, families map[string]*prommodel.MetricFamily) {
+	t.Log("--- testing metricsservice get metrics performance metrics ---")
+
+	family, ok := families["keda_metricsservice_get_metrics_requests_count_total"]
+	assert.True(t, ok, "keda_metricsservice_get_metrics_requests_count_total not available")
+	if !ok {
+		return
+	}
+
+	metricValue := 0.0
+	for _, metric := range family.GetMetric() {
+		metricValue += *metric.Counter.Value
+	}
+	assert.GreaterOrEqual(t, metricValue, 1.0, "keda_metricsservice_get_metrics_requests_count_total has to be greater than 0")
+
+	family, ok = families["keda_metricsservice_get_metrics_duration_seconds"]
+	assert.True(t, ok, "keda_metricsservice_get_metrics_duration_seconds not available")
+	if !ok {
+		return
+	}
+
+	metricValue = 0.0
+	for _, metric := range family.GetMetric() {
+		metricValue += float64(metric.GetHistogram().GetSampleCount())
+	}
+	assert.Greater(t, metricValue, 0.0, "keda_metricsservice_get_metrics_duration_seconds has to be greater than 0")
 }

--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -1321,6 +1321,8 @@ func checkCRTotalValues(t *testing.T, families map[string]*prommodel.MetricFamil
 func checkGRPCServerMetrics(t *testing.T, families map[string]*prommodel.MetricFamily) {
 	t.Log("--- testing grpc server metrics ---")
 
+	checkMetricsServiceGetMetricsPerformance(t, families)
+
 	family, ok := families["keda_internal_metricsservice_grpc_server_handled_total"]
 	if !ok {
 		t.Errorf("metric keda_internal_metricsservice_grpc_server_handled_total not available")
@@ -1542,6 +1544,8 @@ func checkWebhookValues(t *testing.T, families map[string]*prommodel.MetricFamil
 func checkMetricServerValues(t *testing.T, families map[string]*prommodel.MetricFamily) {
 	t.Log("--- testing metric server metrics ---")
 
+	checkExternalMetricsProviderPerformance(t, families)
+
 	family, ok := families["workqueue_adds_total"]
 	if !ok {
 		t.Errorf("metric workqueue_adds_total not available")
@@ -1572,6 +1576,62 @@ func checkMetricServerValues(t *testing.T, families map[string]*prommodel.Metric
 		}
 	}
 	assert.GreaterOrEqual(t, metricValue, 1.0, "apiserver_request_total has to be greater than 0")
+}
+
+func checkExternalMetricsProviderPerformance(t *testing.T, families map[string]*prommodel.MetricFamily) {
+	t.Log("--- testing external metrics provider performance metrics ---")
+
+	family, ok := families["keda_external_metrics_provider_requests_total"]
+	assert.True(t, ok, "keda_external_metrics_provider_requests_total not available")
+	if !ok {
+		return
+	}
+
+	metricValue := 0.0
+	for _, metric := range family.GetMetric() {
+		metricValue += *metric.Counter.Value
+	}
+	assert.GreaterOrEqual(t, metricValue, 1.0, "keda_external_metrics_provider_requests_total has to be greater than 0")
+
+	family, ok = families["keda_external_metrics_provider_request_duration_seconds"]
+	assert.True(t, ok, "keda_external_metrics_provider_request_duration_seconds not available")
+	if !ok {
+		return
+	}
+
+	metricValue = 0.0
+	for _, metric := range family.GetMetric() {
+		metricValue += float64(metric.GetHistogram().GetSampleCount())
+	}
+	assert.Greater(t, metricValue, 0.0, "keda_external_metrics_provider_request_duration_seconds has to be greater than 0")
+}
+
+func checkMetricsServiceGetMetricsPerformance(t *testing.T, families map[string]*prommodel.MetricFamily) {
+	t.Log("--- testing metricsservice get metrics performance metrics ---")
+
+	family, ok := families["keda_metricsservice_get_metrics_requests_total"]
+	assert.True(t, ok, "keda_metricsservice_get_metrics_requests_total not available")
+	if !ok {
+		return
+	}
+
+	metricValue := 0.0
+	for _, metric := range family.GetMetric() {
+		metricValue += *metric.Counter.Value
+	}
+	assert.GreaterOrEqual(t, metricValue, 1.0, "keda_metricsservice_get_metrics_requests_total has to be greater than 0")
+
+	family, ok = families["keda_metricsservice_get_metrics_duration_seconds"]
+	assert.True(t, ok, "keda_metricsservice_get_metrics_duration_seconds not available")
+	if !ok {
+		return
+	}
+
+	metricValue = 0.0
+	for _, metric := range family.GetMetric() {
+		metricValue += float64(metric.GetHistogram().GetSampleCount())
+	}
+	assert.Greater(t, metricValue, 0.0, "keda_metricsservice_get_metrics_duration_seconds has to be greater than 0")
 }
 
 func testCloudEventEmitted(t *testing.T, data templateData) {


### PR DESCRIPTION
Add Prometheus and OpenTelemetry performance metrics for the HPA external metrics path on keda-metrics-apiserver and GetMetrics gRPC handling on keda-operator.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #3120

Relates to kedacore/keda-docs#1804

## Summary

- **Metrics adapter**: records `keda_external_metrics_provider_*` Prometheus metrics (and optional OTEL via `--enable-opentelemetry-metrics`) for each HPA external metric request
- **Operator**: records `keda_metricsservice_get_metrics_*` Prometheus/OTEL metrics for each GetMetrics gRPC call
- Adds unit tests in `pkg/metricscollector` and e2e assertions in prometheus/opentelemetry metrics tests

## Test plan

- [x] `go test ./pkg/metricscollector/...`
- [x] `make fmt`, `make vet`, `make golangci`, `make test` (CI)
- [x] Sequential e2e: `prometheus_metrics` and `opentelemetry_metrics`

