### PR TITLE
Mongo Scaler: Disconnect client when initial Ping fails to avoid leaking connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
+- **MongoDB Scaler**: Disconnect the client when the initial `Ping` fails so the background topology-monitoring connections opened by `mongo.Connect` are not leaked ([#5612](https://github.com/kedacore/keda/issues/5612))
 
 ### Deprecations
 

--- a/pkg/scalers/mongo_scaler.go
+++ b/pkg/scalers/mongo_scaler.go
@@ -93,7 +93,9 @@ func NewMongoDBScaler(ctx context.Context, config *scalersconfig.ScalerConfig) (
 		return nil, fmt.Errorf("error parsing mongodb metadata: %w", err)
 	}
 
-	client, err := createMongoDBClient(ctx, meta)
+	logger := InitializeLogger(config, "mongodb_scaler")
+
+	client, err := createMongoDBClient(ctx, meta, logger)
 	if err != nil {
 		return nil, fmt.Errorf("error creating mongodb client: %w", err)
 	}
@@ -102,7 +104,7 @@ func NewMongoDBScaler(ctx context.Context, config *scalersconfig.ScalerConfig) (
 		metricType: metricType,
 		metadata:   meta,
 		client:     client,
-		logger:     InitializeLogger(config, "mongodb_scaler"),
+		logger:     logger,
 	}, nil
 }
 
@@ -117,7 +119,7 @@ func parseMongoDBMetadata(config *scalersconfig.ScalerConfig) (mongoDBMetadata, 
 	return meta, nil
 }
 
-func createMongoDBClient(ctx context.Context, meta mongoDBMetadata) (*mongo.Client, error) {
+func createMongoDBClient(ctx context.Context, meta mongoDBMetadata, logger logr.Logger) (*mongo.Client, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -155,6 +157,11 @@ func createMongoDBClient(ctx context.Context, meta mongoDBMetadata) (*mongo.Clie
 
 	err = client.Ping(ctx, readpref.Primary())
 	if err != nil {
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer disconnectCancel()
+		if disconnectErr := client.Disconnect(disconnectCtx); disconnectErr != nil {
+			logger.Error(disconnectErr, "failed to disconnect mongodb client after ping failure, connection may be leaked")
+		}
 		return nil, fmt.Errorf("failed to ping mongodb: %w", err)
 	}
 


### PR DESCRIPTION
### Provide a description of what has been changed

`createMongoDBClient` (`pkg/scalers/mongo_scaler.go`) calls `mongo.Connect` and then `client.Ping`. `mongo.Connect` immediately starts background topology-monitoring connections to the replica-set members **before** `Ping` runs. When `Ping` fails, the function returned the error while the freshly-created `client` was only a local variable — nothing ever called `Disconnect` on it, so those background connections were leaked and ran forever.

Because a scaler is refreshed on every failed poll, each failure (a transient network blip, an Atlas maintenance event, or the cluster already being loaded by earlier leaks) permanently leaked one more client, with no backoff and no cap. The behaviour is self-reinforcing: more leaked clients → more background connection load → more likely the next poll fails.

We hit this in production against MongoDB Atlas: a `keda-operator` that had been up for 76 days accumulated ~1,000 leaked connections on the cluster (roughly half of every node's total), driving sustained CPU high enough to trigger an Atlas tier auto-scale. Restarting the operator dropped connections ~50% instantly, confirming the source.

The fix disconnects the client on the `Ping` error path:

```go
err = client.Ping(ctx, readpref.Primary())
if err != nil {
    _ = client.Disconnect(ctx)
    return nil, fmt.Errorf("failed to ping mongodb: %w", err)
}
```

This is the same `Disconnect(ctx)` call the scaler's existing `Close` method already uses.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] I have verified that my change does not break any existing tests

**A note on tests:** there is currently no unit harness that exercises `createMongoDBClient` — the existing `mongo_scaler_test.go` covers only metadata/connection-string parsing, and the created client is a local variable (not returned) so a test cannot observe the `Disconnect` call without introducing a mock cluster (e.g. `mtest`). I opted not to add a slow/flaky test against an unreachable host. Happy to add one if a maintainer prefers a specific approach.

Relates to #5612

### Relates to

#5612
