### PR TITLE
Azure Pipelines Scaler: auto-use accurate strategy with default scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
+- **Azure Pipelines Scaler**: Auto-use accurate scaling strategy for ScaledJobs with default strategy to fix scale-out regression after 2.20 ([#7878](https://github.com/kedacore/keda/issues/7878))
 
 ### Deprecations
 

--- a/pkg/scaling/executor/scale_jobs.go
+++ b/pkg/scaling/executor/scale_jobs.go
@@ -442,9 +442,22 @@ func NewScalingStrategy(logger logr.Logger, scaledJob *kedav1alpha1.ScaledJob) S
 		logger.V(1).Info("Selecting Scale Strategy", "specified", scaledJob.Spec.ScalingStrategy.Strategy, "selected", "eager")
 		return eagerScalingStrategy{}
 	default:
+		if usesAzurePipelinesTrigger(scaledJob) {
+			logger.V(1).Info("Selecting Scale Strategy", "specified", scaledJob.Spec.ScalingStrategy.Strategy, "selected", "accurate", "reason", "azure-pipelines compatibility")
+			return accurateScalingStrategy{}
+		}
 		logger.V(1).Info("Selecting Scale Strategy", "specified", scaledJob.Spec.ScalingStrategy.Strategy, "selected", "default")
 		return defaultScalingStrategy{}
 	}
+}
+
+func usesAzurePipelinesTrigger(scaledJob *kedav1alpha1.ScaledJob) bool {
+	for _, trigger := range scaledJob.Spec.Triggers {
+		if trigger.Type == "azure-pipelines" {
+			return true
+		}
+	}
+	return false
 }
 
 // ScalingStrategy is an interface for switching scaling algorithm

--- a/pkg/scaling/executor/scale_jobs_test.go
+++ b/pkg/scaling/executor/scale_jobs_test.go
@@ -85,6 +85,21 @@ func maxScaleValue(maxValue, _ int64) int64 {
 	return maxValue
 }
 
+func TestDefaultScalingStrategyAzurePipelinesAutoAccurate(t *testing.T) {
+	logger := logf.Log.WithName("ScaledJobTest")
+
+	scaledJob := getMockScaledJobWithTriggerType("default", "azure-pipelines")
+	strategy := NewScalingStrategy(logger, scaledJob)
+	assert.Equal(t, "executor.accurateScalingStrategy", fmt.Sprintf("%T", strategy))
+	// Issue scenario: 4 unassigned ADO jobs, 4 running K8s agents, 0 pending pods.
+	assert.Equal(t, int64(4), maxScaleValue(strategy.GetEffectiveMaxScale(4, 4, 0, 100, 4)))
+
+	scaledJobSQS := getMockScaledJobWithTriggerType("default", "aws-sqs-queue")
+	strategySQS := NewScalingStrategy(logger, scaledJobSQS)
+	assert.Equal(t, "executor.defaultScalingStrategy", fmt.Sprintf("%T", strategySQS))
+	assert.Equal(t, int64(0), maxScaleValue(strategySQS.GetEffectiveMaxScale(4, 4, 0, 100, 4)))
+}
+
 func TestDefaultScalingStrategy(t *testing.T) {
 	logger := logf.Log.WithName("ScaledJobTest")
 	strategy := NewScalingStrategy(logger, getMockScaledJobWithDefaultStrategy("default"))
@@ -609,6 +624,15 @@ func getMockScaledJobWithDefaultStrategy(name string) *kedav1alpha1.ScaledJob {
 		},
 	}
 	scaledJob.Name = name
+	return scaledJob
+}
+
+func getMockScaledJobWithTriggerType(name, triggerType string) *kedav1alpha1.ScaledJob {
+	scaledJob := getMockScaledJobWithDefaultStrategy(name)
+	scaledJob.Spec.ScalingStrategy.Strategy = "default"
+	scaledJob.Spec.Triggers = []kedav1alpha1.ScaleTriggers{
+		{Type: triggerType, Metadata: map[string]string{}},
+	}
 	return scaledJob
 }
 


### PR DESCRIPTION
After upgrading to KEDA 2.20, Azure Pipelines ScaledJobs using `scalingStrategy.strategy: default` (or leaving strategy unset) stopped scaling out correctly when agents were already running. With 4 running agents and 4 newly queued pipeline jobs, KEDA created 0 new jobs instead of 4.

PR [#7757](https://github.com/kedacore/keda/pull/7757) (fix for #7747) changed the Azure Pipelines scaler so `stripDeadJobs` excludes ADO jobs that already have `ReceiveTime` set (assigned to an agent). The metric now counts only **unassigned** pipeline jobs.

The `default` scaling strategy still subtracts **running Kubernetes jobs** from `maxScale` (`maxScale - runningJobCount`).
https://github.com/kedacore/keda/blob/3f63bf59e11980e0d99c2ba80000cb06a9b46da6/pkg/scaling/executor/scale_jobs.go#L458-L460
 This double-penalizes Azure Pipelines workloads: running K8s agents serve assigned ADO work that is no longer included in the metric, so subtracting them again drives `effectiveMaxScale` to zero.

Example from the issue:

| Input | Value |
|-------|-------|
| Unassigned ADO jobs (scaler metric) | 4 → `maxScale = 4` |
| Running K8s agent jobs | 4 |
| Pending K8s jobs | 0 |

- **Before fix (`default`)**: `4 - 4 = 0` → no jobs created
- **With `accurate`**: `4 - 0 = 4` → 4 jobs created (reporter's workaround)

Auto-select `accurateScalingStrategy` in `NewScalingStrategy` when the ScaledJob uses the default/empty strategy **and** has an `azure-pipelines` trigger. This restores pre-2.20 scale-out behavior without changing `default` globally (which remains correct for queue-based scalers like SQS and Azure Storage Queue).

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7878
Fixes #8185

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #