### PR TITLE
General: Fix concurrent map writes panic in the shared root CA `CertPool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **General**: Treat negative external metric values as zero to prevent incorrect HPA scaling ([#7880](https://github.com/kedacore/keda/issues/7880))
+- **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
 - **MongoDB Scaler**: Disconnect the client when the initial `Ping` fails so the background topology-monitoring connections opened by `mongo.Connect` are not leaked ([#5612](https://github.com/kedacore/keda/issues/5612))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,12 +83,12 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Fixes
 
+- **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **General**: Treat negative external metric values as zero to prevent incorrect HPA scaling ([#7880](https://github.com/kedacore/keda/issues/7880))
-- **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
 - **MongoDB Scaler**: Disconnect the client when the initial `Ping` fails so the background topology-monitoring connections opened by `mongo.Connect` are not leaked ([#5612](https://github.com/kedacore/keda/issues/5612))
 

--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -80,7 +80,9 @@ func NewTLSConfigWithPassword(clientCert, clientKey, clientKeyPassword, caCert s
 	}
 
 	if caCert != "" {
+		rootCAsLock.Lock()
 		config.RootCAs.AppendCertsFromPEM([]byte(caCert))
+		rootCAsLock.Unlock()
 	}
 
 	return config, nil

--- a/pkg/util/tls_config.go
+++ b/pkg/util/tls_config.go
@@ -80,9 +80,11 @@ func NewTLSConfigWithPassword(clientCert, clientKey, clientKeyPassword, caCert s
 	}
 
 	if caCert != "" {
-		rootCAsLock.Lock()
-		config.RootCAs.AppendCertsFromPEM([]byte(caCert))
-		rootCAsLock.Unlock()
+		pool := getRootCAs().Clone()
+		if ok := pool.AppendCertsFromPEM([]byte(caCert)); !ok {
+			return nil, fmt.Errorf("error appending CA certs")
+		}
+		config.RootCAs = pool
 	}
 
 	return config, nil

--- a/pkg/util/tls_config_test.go
+++ b/pkg/util/tls_config_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -250,6 +251,31 @@ func TestNewTLSConfig_WithPassword(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestNewTLSConfig_ConcurrentCACertAppend(t *testing.T) {
+	const goroutines = 50
+
+	cas := []string{randomCACert, rsaCertPEM}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := NewTLSConfig(rsaCertPEM, rsaKeyPEM, cas[i%len(cas)], false)
+			if err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("unexpected error building TLS config: %s", err)
 	}
 }
 

--- a/pkg/util/tls_config_test.go
+++ b/pkg/util/tls_config_test.go
@@ -279,6 +279,28 @@ func TestNewTLSConfig_ConcurrentCACertAppend(t *testing.T) {
 	}
 }
 
+func TestNewTLSConfig_PerObjectCAIsolation(t *testing.T) {
+	before := getRootCAs().Clone()
+
+	configA, err := NewTLSConfig(rsaCertPEM, rsaKeyPEM, randomCACert, false)
+	if err != nil {
+		t.Fatalf("configA: %s", err)
+	}
+	configB, err := NewTLSConfig(rsaCertPEM, rsaKeyPEM, rsaCertPEM, false)
+	if err != nil {
+		t.Fatalf("configB: %s", err)
+	}
+
+	if configA.RootCAs.Equal(configB.RootCAs) {
+		t.Error("per-object CA certs leaked across configs: RootCAs pools are equal")
+	}
+
+	after := getRootCAs()
+	if !before.Equal(after) {
+		t.Error("shared root CA pool was mutated by per-object caCert append")
+	}
+}
+
 type minTLSVersionTestData struct {
 	envValue        string
 	expectedVersion uint16


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Since KEDA reconciles many `ScaledObjects` (each building its own TLS-enabled scaler, e.g. Kafka) concurrently, multiple goroutines call `AppendCertsFromPEM` on the same pool at the same time, causing `fatal error: concurrent map writes` and crashing `keda-operator`. 

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7910
