### PR TITLE
fix: watch Secrets and TriggerAuthentication to invalidate stale scaler cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **General**: Treat negative external metric values as zero to prevent incorrect HPA scaling ([#7880](https://github.com/kedacore/keda/issues/7880))
+- **General**: Watch Secrets and TriggerAuthentication resources so that rotated credentials are picked up without restarting the operator or recreating the ScaledObject ([#7906](https://github.com/kedacore/keda/issues/7906))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
 - **MongoDB Scaler**: Disconnect the client when the initial `Ping` fails so the background topology-monitoring connections opened by `mongo.Connect` are not leaked ([#5612](https://github.com/kedacore/keda/issues/5612))
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -57,6 +59,38 @@ var (
 	scheme   = apimachineryruntime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+// buildCacheOptions configures the manager cache, scoping the Secret informer
+// (metadata-only, backing the Secret watches of the controllers) to the
+// namespaces KEDA is actually allowed and expected to read secrets from.
+func buildCacheOptions(namespaces map[string]ctrlcache.Config, kedaNamespace string) ctrlcache.Options {
+	cacheOptions := ctrlcache.Options{
+		DefaultNamespaces: namespaces,
+		DefaultTransform:  kedautil.CacheObjectTransform,
+	}
+	switch {
+	case kedautil.IsRestrictSecretAccess():
+		// With KEDA_RESTRICT_SECRET_ACCESS=true, secrets are only ever read
+		// from the KEDA namespace and RBAC may not permit list/watch on
+		// secrets anywhere else, so the Secret informer must not be
+		// cluster-wide (it would fail cache sync with Forbidden).
+		cacheOptions.ByObject = map[ctrlclient.Object]ctrlcache.ByObject{
+			&corev1.Secret{}: {Namespaces: map[string]ctrlcache.Config{kedaNamespace: {}}},
+		}
+	case len(namespaces) > 0:
+		// ClusterTriggerAuthentication secret refs are resolved from the KEDA
+		// namespace, which may be outside the configured watch namespaces.
+		secretNamespaces := make(map[string]ctrlcache.Config, len(namespaces)+1)
+		for namespace, config := range namespaces {
+			secretNamespaces[namespace] = config
+		}
+		secretNamespaces[kedaNamespace] = ctrlcache.Config{}
+		cacheOptions.ByObject = map[ctrlclient.Object]ctrlcache.ByObject{
+			&corev1.Secret{}: {Namespaces: secretNamespaces},
+		}
+	}
+	return cacheOptions
+}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -145,6 +179,11 @@ func main() {
 		setupLog.Error(err, "failed to get watch namespace")
 		os.Exit(1)
 	}
+	objectNamespace, err := kedautil.GetClusterObjectNamespace()
+	if err != nil {
+		setupLog.Error(err, "Unable to get cluster object namespace")
+		os.Exit(1)
+	}
 
 	leaseDuration, err := kedautil.ResolveOsEnvDuration("KEDA_OPERATOR_LEADER_ELECTION_LEASE_DURATION")
 	if err != nil {
@@ -186,9 +225,18 @@ func main() {
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port: 9443,
 		}),
-		Cache: ctrlcache.Options{
-			DefaultNamespaces: namespaces,
-			DefaultTransform:  kedautil.CacheObjectTransform,
+		Cache: buildCacheOptions(namespaces, objectNamespace),
+		// Secret events are served by a metadata-only informer (see
+		// WatchesMetadata in the controllers), so structured Secret reads must
+		// bypass the cache. This avoids lazily creating a second, full-object
+		// Secret informer that would retain all Secret data in memory, and it
+		// guarantees that scalers rebuilt after a credential rotation read the
+		// new Secret value directly from the API server instead of racing a
+		// possibly stale structured cache.
+		Client: ctrlclient.Options{
+			Cache: &ctrlclient.CacheOptions{
+				DisableFor: []ctrlclient.Object{&corev1.Secret{}},
+			},
 		},
 		HealthProbeBindAddress:  probeAddr,
 		PprofBindAddress:        profilingAddr,
@@ -235,11 +283,6 @@ func main() {
 	kubeClientset, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		setupLog.Error(err, "Unable to create kube clientset")
-		os.Exit(1)
-	}
-	objectNamespace, err := kedautil.GetClusterObjectNamespace()
-	if err != nil {
-		setupLog.Error(err, "Unable to get cluster object namespace")
 		os.Exit(1)
 	}
 	// the namespaced kubeInformerFactory is used to restrict secret informer to only list/watch secrets in KEDA cluster object namespace,

--- a/controllers/keda/scaledobject_controller.go
+++ b/controllers/keda/scaledobject_controller.go
@@ -38,8 +38,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	eventingv1alpha1 "github.com/kedacore/keda/v2/apis/eventing/v1alpha1"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -77,6 +79,7 @@ type ScaledObjectReconciler struct {
 
 	restMapper               meta.RESTMapper
 	scaledObjectsGenerations *sync.Map
+	pendingAuthInvalidations sync.Map
 }
 
 type scaledObjectMetricsData struct {
@@ -106,6 +109,10 @@ func init() {
 func (r *ScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	r.restMapper = mgr.GetRESTMapper()
 	r.scaledObjectsGenerations = &sync.Map{}
+
+	if err := registerTriggerAuthIndexes(mgr); err != nil {
+		return err
+	}
 
 	if r.ScaleHandler == nil {
 		return fmt.Errorf("ScaledObjectReconciler.ScaleHandler is not initialized")
@@ -148,6 +155,17 @@ func (r *ScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager, options cont
 				predicate.AnnotationChangedPredicate{},
 				kedacontrollerutil.HPASpecChangedPredicate{},
 			))).
+		Watches(&kedav1alpha1.TriggerAuthentication{},
+			handler.EnqueueRequestsFromMapFunc(r.mapTriggerAuthToScaledObjects),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&kedav1alpha1.ClusterTriggerAuthentication{},
+			handler.EnqueueRequestsFromMapFunc(r.mapClusterTriggerAuthToScaledObjects),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		// No predicate on Secrets: Secret.metadata.generation does not
+		// increment on data changes, so GenerationChangedPredicate would
+		// suppress the very updates we need to detect (credential rotation).
+		WatchesMetadata(&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.mapSecretToScaledObjects)).
 		Complete(r)
 }
 
@@ -313,12 +331,27 @@ func (r *ScaledObjectReconciler) reconcileScaledObject(ctx context.Context, logg
 		}
 	}
 
+	soKey := client.ObjectKeyFromObject(scaledObject)
+
 	// Notify ScaleHandler if a new HPA was created or if ScaledObject was updated
 	if newHPACreated || scaleObjectSpecChanged {
 		if err := r.requestScaleLoop(ctx, logger, scaledObject); err != nil {
 			return "failed to start a new scale loop with scaling logic", err
 		}
 		logger.Info("Initializing Scaling logic according to ScaledObject Specification")
+		r.pendingAuthInvalidations.Delete(soKey)
+	} else if _, pending := r.pendingAuthInvalidations.LoadAndDelete(soKey); pending {
+		// An auth dependency (Secret, TriggerAuthentication or
+		// ClusterTriggerAuthentication) changed. A full scale loop restart is
+		// required rather than just clearing the scalers cache: push scalers
+		// are started once per loop (startPushScalers), so a cache clear alone
+		// would leave external-push scalers running with the old credentials.
+		logger.V(1).Info("Restarting scaling logic due to auth dependency change")
+		if err := r.requestScaleLoop(ctx, logger, scaledObject); err != nil {
+			// re-mark the invalidation so the requeued reconcile retries the restart
+			r.pendingAuthInvalidations.Store(soKey, true)
+			return "failed to restart scale loop after auth dependency change", err
+		}
 	}
 	return kedav1alpha1.ScaledObjectConditionReadySuccessMessage, nil
 }
@@ -709,4 +742,36 @@ func (r *ScaledObjectReconciler) updateStatusWithTriggersAndAuthsTypes(ctx conte
 	logger.V(1).Info("Updating ScaledObject status with triggers and authentications types", "triggersTypes", triggersTypes, "authenticationsTypes", authsTypes)
 
 	return kedastatus.UpdateScaledObjectStatus(ctx, r.Client, logger, scaledObject, status)
+}
+
+func (r *ScaledObjectReconciler) markPendingAuthInvalidations(requests []reconcile.Request) {
+	for i := range requests {
+		r.pendingAuthInvalidations.Store(requests[i].NamespacedName, true)
+	}
+}
+
+func (r *ScaledObjectReconciler) mapTriggerAuthToScaledObjects(ctx context.Context, obj client.Object) []reconcile.Request {
+	ta, ok := obj.(*kedav1alpha1.TriggerAuthentication)
+	if !ok {
+		return nil
+	}
+	requests := lookupByTriggerAuth(ctx, r.Client, &kedav1alpha1.ScaledObjectList{}, ta.Name, ta.Namespace)
+	r.markPendingAuthInvalidations(requests)
+	return requests
+}
+
+func (r *ScaledObjectReconciler) mapClusterTriggerAuthToScaledObjects(ctx context.Context, obj client.Object) []reconcile.Request {
+	cta, ok := obj.(*kedav1alpha1.ClusterTriggerAuthentication)
+	if !ok {
+		return nil
+	}
+	requests := lookupByClusterTriggerAuth(ctx, r.Client, &kedav1alpha1.ScaledObjectList{}, cta.Name)
+	r.markPendingAuthInvalidations(requests)
+	return requests
+}
+
+func (r *ScaledObjectReconciler) mapSecretToScaledObjects(ctx context.Context, obj client.Object) []reconcile.Request {
+	requests := mapSecretToScalableObjects(ctx, r.Client, func() client.ObjectList { return &kedav1alpha1.ScaledObjectList{} }, obj.GetName(), obj.GetNamespace())
+	r.markPendingAuthInvalidations(requests)
+	return requests
 }

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -19,6 +19,7 @@ package keda
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync/atomic"
 	"time"
 
@@ -32,7 +33,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
@@ -2140,3 +2143,410 @@ func generateDeployment(name string) *appsv1.Deployment {
 		},
 	}
 }
+
+var _ = Describe("ScaledObjectController mapping functions", func() {
+	var (
+		soReconciler ScaledObjectReconciler
+		mockCl       *mock_client.MockClient
+		mockCtrl     *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(util.GinkgoTestReporter{})
+		mockCl = mock_client.NewMockClient(mockCtrl)
+		soReconciler = ScaledObjectReconciler{
+			Client: mockCl,
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Describe("mapTriggerAuthToScaledObjects", func() {
+		It("should return requests for ScaledObjects referencing the TriggerAuthentication", func() {
+			ta := &kedav1alpha1.TriggerAuthentication{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-ta", Namespace: "ns1"},
+			}
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					soList := list.(*kedav1alpha1.ScaledObjectList)
+					soList.Items = []kedav1alpha1.ScaledObject{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "so-match", Namespace: "ns1"},
+							Spec: kedav1alpha1.ScaledObjectSpec{
+								Triggers: []kedav1alpha1.ScaleTriggers{
+									{Type: "prometheus", AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: "my-ta"}},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			requests := soReconciler.mapTriggerAuthToScaledObjects(context.Background(), ta)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName).To(Equal(types.NamespacedName{Name: "so-match", Namespace: "ns1"}))
+		})
+
+		It("should return empty when no ScaledObjects match", func() {
+			ta := &kedav1alpha1.TriggerAuthentication{
+				ObjectMeta: metav1.ObjectMeta{Name: "unused-ta", Namespace: "ns1"},
+			}
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					soList := list.(*kedav1alpha1.ScaledObjectList)
+					soList.Items = nil
+					return nil
+				})
+
+			requests := soReconciler.mapTriggerAuthToScaledObjects(context.Background(), ta)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Describe("mapClusterTriggerAuthToScaledObjects", func() {
+		It("should return requests for ScaledObjects referencing the ClusterTriggerAuthentication", func() {
+			cta := &kedav1alpha1.ClusterTriggerAuthentication{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cta"},
+			}
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					soList := list.(*kedav1alpha1.ScaledObjectList)
+					soList.Items = []kedav1alpha1.ScaledObject{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "so-cta-match", Namespace: "ns1"},
+							Spec: kedav1alpha1.ScaledObjectSpec{
+								Triggers: []kedav1alpha1.ScaleTriggers{
+									{Type: "prometheus", AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: "my-cta", Kind: "ClusterTriggerAuthentication"}},
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "so-other-ns", Namespace: "ns2"},
+							Spec: kedav1alpha1.ScaledObjectSpec{
+								Triggers: []kedav1alpha1.ScaleTriggers{
+									{Type: "prometheus", AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: "my-cta", Kind: "ClusterTriggerAuthentication"}},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			requests := soReconciler.mapClusterTriggerAuthToScaledObjects(context.Background(), cta)
+			Expect(requests).To(HaveLen(2))
+			Expect(requests).To(ContainElement(reconcile.Request{NamespacedName: types.NamespacedName{Name: "so-cta-match", Namespace: "ns1"}}))
+			Expect(requests).To(ContainElement(reconcile.Request{NamespacedName: types.NamespacedName{Name: "so-other-ns", Namespace: "ns2"}}))
+		})
+	})
+
+	Describe("mapSecretToScaledObjects", func() {
+		It("should map Secret metadata to ScaledObjects using it via TriggerAuthentication", func() {
+			secret := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "ns1"},
+			}
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.TriggerAuthenticationList{}), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					taList := list.(*kedav1alpha1.TriggerAuthenticationList)
+					taList.Items = []kedav1alpha1.TriggerAuthentication{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "ta-with-secret", Namespace: "ns1"},
+							Spec: kedav1alpha1.TriggerAuthenticationSpec{
+								SecretTargetRef: []kedav1alpha1.AuthSecretTargetRef{
+									{Parameter: "bearerToken", Name: "my-secret", Key: "token"},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.ScaledObjectList{}), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					soList := list.(*kedav1alpha1.ScaledObjectList)
+					soList.Items = []kedav1alpha1.ScaledObject{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "so-uses-ta", Namespace: "ns1"},
+							Spec: kedav1alpha1.ScaledObjectSpec{
+								Triggers: []kedav1alpha1.ScaleTriggers{
+									{Type: "prometheus", AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: "ta-with-secret"}},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			requests := soReconciler.mapSecretToScaledObjects(context.Background(), secret)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName).To(Equal(types.NamespacedName{Name: "so-uses-ta", Namespace: "ns1"}))
+		})
+
+		It("should return empty when no TriggerAuthentication references the Secret", func() {
+			secret := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "unreferenced-secret", Namespace: "ns1"},
+			}
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.TriggerAuthenticationList{}), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					taList := list.(*kedav1alpha1.TriggerAuthenticationList)
+					taList.Items = nil
+					return nil
+				})
+
+			requests := soReconciler.mapSecretToScaledObjects(context.Background(), secret)
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should map a KEDA-namespace Secret to TriggerAuthentications cluster-wide when secret access is restricted", func() {
+			os.Setenv("KEDA_CLUSTER_OBJECT_NAMESPACE", "keda")
+			DeferCleanup(os.Unsetenv, "KEDA_CLUSTER_OBJECT_NAMESPACE")
+			os.Setenv(util.RestrictSecretAccessEnvVar, "true")
+			DeferCleanup(os.Unsetenv, util.RestrictSecretAccessEnvVar)
+
+			secret := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "restricted-secret", Namespace: "keda"},
+			}
+
+			// TA lookup must not be limited to the Secret's namespace: with
+			// restricted access TAs in any namespace resolve this Secret.
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.TriggerAuthenticationList{}), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					taList := list.(*kedav1alpha1.TriggerAuthenticationList)
+					taList.Items = []kedav1alpha1.TriggerAuthentication{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "ta-other-ns", Namespace: "ns1"},
+							Spec: kedav1alpha1.TriggerAuthenticationSpec{
+								SecretTargetRef: []kedav1alpha1.AuthSecretTargetRef{
+									{Parameter: "bearerToken", Name: "restricted-secret", Key: "token"},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.ClusterTriggerAuthenticationList{}), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					ctaList := list.(*kedav1alpha1.ClusterTriggerAuthenticationList)
+					ctaList.Items = nil
+					return nil
+				})
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.ScaledObjectList{}), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					soList := list.(*kedav1alpha1.ScaledObjectList)
+					soList.Items = []kedav1alpha1.ScaledObject{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "so-restricted", Namespace: "ns1"},
+							Spec: kedav1alpha1.ScaledObjectSpec{
+								Triggers: []kedav1alpha1.ScaleTriggers{
+									{Type: "prometheus", AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: "ta-other-ns"}},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			requests := soReconciler.mapSecretToScaledObjects(context.Background(), secret)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName).To(Equal(types.NamespacedName{Name: "so-restricted", Namespace: "ns1"}))
+		})
+
+		It("should ignore Secrets outside the KEDA namespace when secret access is restricted", func() {
+			os.Setenv("KEDA_CLUSTER_OBJECT_NAMESPACE", "keda")
+			DeferCleanup(os.Unsetenv, "KEDA_CLUSTER_OBJECT_NAMESPACE")
+			os.Setenv(util.RestrictSecretAccessEnvVar, "true")
+			DeferCleanup(os.Unsetenv, util.RestrictSecretAccessEnvVar)
+
+			secret := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "app-secret", Namespace: "ns1"},
+			}
+
+			// No List calls expected: secrets outside the KEDA namespace are
+			// never resolved when secret access is restricted.
+			requests := soReconciler.mapSecretToScaledObjects(context.Background(), secret)
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should return requests for ScaledObjects using a Secret via ClusterTriggerAuthentication", func() {
+			os.Setenv("KEDA_CLUSTER_OBJECT_NAMESPACE", "keda")
+			DeferCleanup(os.Unsetenv, "KEDA_CLUSTER_OBJECT_NAMESPACE")
+
+			secret := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "cta-secret", Namespace: "keda"},
+			}
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.TriggerAuthenticationList{}), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					taList := list.(*kedav1alpha1.TriggerAuthenticationList)
+					taList.Items = nil
+					return nil
+				})
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.ClusterTriggerAuthenticationList{}), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					ctaList := list.(*kedav1alpha1.ClusterTriggerAuthenticationList)
+					ctaList.Items = []kedav1alpha1.ClusterTriggerAuthentication{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "my-cta"},
+							Spec: kedav1alpha1.TriggerAuthenticationSpec{
+								SecretTargetRef: []kedav1alpha1.AuthSecretTargetRef{
+									{Parameter: "apiKey", Name: "cta-secret", Key: "key"},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			mockCl.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&kedav1alpha1.ScaledObjectList{}), gomock.Any()).DoAndReturn(
+				func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					soList := list.(*kedav1alpha1.ScaledObjectList)
+					soList.Items = []kedav1alpha1.ScaledObject{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "so-via-cta", Namespace: "ns1"},
+							Spec: kedav1alpha1.ScaledObjectSpec{
+								Triggers: []kedav1alpha1.ScaleTriggers{
+									{Type: "prometheus", AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: "my-cta", Kind: "ClusterTriggerAuthentication"}},
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "so-via-cta-ns2", Namespace: "ns2"},
+							Spec: kedav1alpha1.ScaledObjectSpec{
+								Triggers: []kedav1alpha1.ScaleTriggers{
+									{Type: "prometheus", AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: "my-cta", Kind: "ClusterTriggerAuthentication"}},
+								},
+							},
+						},
+					}
+					return nil
+				})
+
+			requests := soReconciler.mapSecretToScaledObjects(context.Background(), secret)
+			Expect(requests).To(HaveLen(2))
+			Expect(requests).To(ContainElement(reconcile.Request{NamespacedName: types.NamespacedName{Name: "so-via-cta", Namespace: "ns1"}}))
+			Expect(requests).To(ContainElement(reconcile.Request{NamespacedName: types.NamespacedName{Name: "so-via-cta-ns2", Namespace: "ns2"}}))
+		})
+	})
+})
+
+// Regression test for https://github.com/kedacore/keda/issues/7906: rotated
+// credentials must be picked up without recreating the ScaledObject or
+// restarting the operator.
+var _ = Describe("ScaledObjectController auth dependency invalidation", func() {
+	It("rebuilds scalers with fresh credentials when the referenced Secret or TriggerAuthentication changes", func() {
+		const namespace = "default"
+		deploymentName := "auth-rotation"
+		soName := "so-" + deploymentName
+		secretName := "auth-rotation-secret"
+		secondSecretName := "auth-rotation-secret-b"
+		taName := "auth-rotation-ta"
+
+		err := k8sClient.Create(context.Background(), generateDeployment(deploymentName))
+		Expect(err).ToNot(HaveOccurred())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: namespace},
+			StringData: map[string]string{"token": "token-v1"},
+		}
+		Expect(k8sClient.Create(context.Background(), secret)).To(Succeed())
+
+		ta := &kedav1alpha1.TriggerAuthentication{
+			ObjectMeta: metav1.ObjectMeta{Name: taName, Namespace: namespace},
+			Spec: kedav1alpha1.TriggerAuthenticationSpec{
+				SecretTargetRef: []kedav1alpha1.AuthSecretTargetRef{
+					{Parameter: "bearerToken", Name: secretName, Key: "token"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), ta)).To(Succeed())
+
+		// A long polling interval ensures the scale loop does not refresh
+		// erroring scalers behind the test's back: a stale credential must
+		// only be replaced through cache invalidation, so the test fails
+		// without the Secret/TriggerAuthentication watches.
+		pollingInterval := int32(3600)
+		so := &kedav1alpha1.ScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: soName, Namespace: namespace},
+			Spec: kedav1alpha1.ScaledObjectSpec{
+				ScaleTargetRef:  &kedav1alpha1.ScaleTarget{Name: deploymentName},
+				PollingInterval: &pollingInterval,
+				Triggers: []kedav1alpha1.ScaleTriggers{
+					{
+						Type: "prometheus",
+						Metadata: map[string]string{
+							"serverAddress": "http://localhost:9090",
+							"query":         "up",
+							"threshold":     "100",
+							"authModes":     "bearer",
+						},
+						AuthenticationRef: &kedav1alpha1.AuthenticationRef{Name: taName},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.Background(), so)).To(Succeed())
+
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+		Eventually(func() error {
+			return k8sClient.Get(context.Background(), types.NamespacedName{Name: "keda-hpa-" + soName, Namespace: namespace}, hpa)
+		}).WithTimeout(30 * time.Second).WithPolling(time.Second).ShouldNot(HaveOccurred())
+
+		cachedBearerToken := func() (string, error) {
+			latestSO := &kedav1alpha1.ScaledObject{}
+			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: soName, Namespace: namespace}, latestSO); err != nil {
+				return "", err
+			}
+			scalersCache, err := testScaleHandler.GetScalersCache(context.Background(), latestSO)
+			if err != nil {
+				return "", err
+			}
+			_, configs := scalersCache.GetScalers()
+			if len(configs) != 1 {
+				return "", fmt.Errorf("expected 1 scaler config, got %d", len(configs))
+			}
+			return configs[0].AuthParams["bearerToken"], nil
+		}
+
+		Eventually(cachedBearerToken).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(Equal("token-v1"))
+
+		// Rotate the Secret: the Secret watch must invalidate the cached scalers.
+		Eventually(func() error {
+			existing := &corev1.Secret{}
+			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: namespace}, existing); err != nil {
+				return err
+			}
+			existing.Data["token"] = []byte("token-v2")
+			return k8sClient.Update(context.Background(), existing)
+		}).WithTimeout(10 * time.Second).WithPolling(time.Second).ShouldNot(HaveOccurred())
+
+		Eventually(cachedBearerToken).WithTimeout(60 * time.Second).WithPolling(time.Second).Should(Equal("token-v2"))
+
+		// Point the TriggerAuthentication at a different Secret: the
+		// TriggerAuthentication watch must invalidate the cached scalers.
+		secretB := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secondSecretName, Namespace: namespace},
+			StringData: map[string]string{"token": "token-b"},
+		}
+		Expect(k8sClient.Create(context.Background(), secretB)).To(Succeed())
+
+		Eventually(func() error {
+			existing := &kedav1alpha1.TriggerAuthentication{}
+			if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: taName, Namespace: namespace}, existing); err != nil {
+				return err
+			}
+			existing.Spec.SecretTargetRef[0].Name = secondSecretName
+			return k8sClient.Update(context.Background(), existing)
+		}).WithTimeout(10 * time.Second).WithPolling(time.Second).ShouldNot(HaveOccurred())
+
+		Eventually(cachedBearerToken).WithTimeout(60 * time.Second).WithPolling(time.Second).Should(Equal("token-b"))
+	})
+})

--- a/controllers/keda/suite_test.go
+++ b/controllers/keda/suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,6 +47,7 @@ import (
 var cfg *rest.Config
 var testEnv *envtest.Environment
 var k8sClient client.Client
+var testScaleHandler scaling.ScaleHandler
 
 var ctx context.Context
 var cancel context.CancelFunc
@@ -85,6 +87,14 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		// Secret reads bypass the cache, mirroring the operator's production
+		// configuration in cmd/operator/main.go (Secret events are served by
+		// a metadata-only informer, structured Secret reads are live).
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Secret{}},
+			},
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -93,10 +103,12 @@ var _ = BeforeSuite(func() {
 
 	authClientSet := &authentication.AuthClientSet{}
 
+	testScaleHandler = scaling.NewScaleHandler(k8sManager.GetClient(), scaleClient, k8sManager.GetScheme(), time.Duration(10), k8sManager.GetEventRecorder("keda-operator"), authClientSet)
+
 	err = (&ScaledObjectReconciler{
 		Client:       k8sManager.GetClient(),
 		Scheme:       k8sManager.GetScheme(),
-		ScaleHandler: scaling.NewScaleHandler(k8sManager.GetClient(), scaleClient, k8sManager.GetScheme(), time.Duration(10), k8sManager.GetEventRecorder("keda-operator"), authClientSet),
+		ScaleHandler: testScaleHandler,
 		ScaleClient:  scaleClient,
 		EventEmitter: eventemitter.NewEventEmitter(k8sManager.GetClient(), k8sManager.GetEventRecorder("keda-operator"), "kubernetes-default", nil),
 	}).SetupWithManager(k8sManager, controller.Options{})

--- a/controllers/keda/triggerauth_index.go
+++ b/controllers/keda/triggerauth_index.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keda
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/util"
+)
+
+const (
+	triggerAuthSecretRefIndex = ".spec.secretTargetRef.name"
+	scalableAuthRefIndex      = ".spec.triggers.authenticationRef"
+
+	authRefTAPrefix  = "ta/"
+	authRefCTAPrefix = "cta/"
+)
+
+var (
+	registerTriggerAuthIndexOnce sync.Once
+	triggerAuthIndexErr          error
+)
+
+// extractAuthRefKeys returns composite index keys for a set of ScaleTriggers.
+// TriggerAuthentication refs produce "ta/<name>", ClusterTriggerAuthentication
+// refs produce "cta/<name>".
+func extractAuthRefKeys(triggers []kedav1alpha1.ScaleTriggers) []string {
+	var keys []string
+	for _, trigger := range triggers {
+		if trigger.AuthenticationRef == nil {
+			continue
+		}
+		if trigger.AuthenticationRef.Kind == "ClusterTriggerAuthentication" {
+			keys = append(keys, authRefCTAPrefix+trigger.AuthenticationRef.Name)
+		} else {
+			keys = append(keys, authRefTAPrefix+trigger.AuthenticationRef.Name)
+		}
+	}
+	return keys
+}
+
+// registerTriggerAuthIndexes creates field indexes so that the
+// Secret→ScaledObject/ScaledJob mapping functions can use indexed lookups
+// instead of listing every object and scanning in-memory.
+//
+// Indexes registered:
+//   - TriggerAuthentication / ClusterTriggerAuthentication by secret ref name
+//   - ScaledObject by trigger authentication ref (composite key)
+func registerTriggerAuthIndexes(mgr ctrl.Manager) error {
+	registerTriggerAuthIndexOnce.Do(func() {
+		ctx := context.Background()
+
+		if err := mgr.GetFieldIndexer().IndexField(ctx,
+			&kedav1alpha1.TriggerAuthentication{},
+			triggerAuthSecretRefIndex,
+			func(obj client.Object) []string {
+				ta := obj.(*kedav1alpha1.TriggerAuthentication)
+				names := make([]string, 0, len(ta.Spec.SecretTargetRef))
+				for _, ref := range ta.Spec.SecretTargetRef {
+					names = append(names, ref.Name)
+				}
+				return names
+			}); err != nil {
+			triggerAuthIndexErr = fmt.Errorf("failed to register TriggerAuthentication index %q: %w",
+				triggerAuthSecretRefIndex, err)
+			return
+		}
+
+		if err := mgr.GetFieldIndexer().IndexField(ctx,
+			&kedav1alpha1.ClusterTriggerAuthentication{},
+			triggerAuthSecretRefIndex,
+			func(obj client.Object) []string {
+				cta := obj.(*kedav1alpha1.ClusterTriggerAuthentication)
+				names := make([]string, 0, len(cta.Spec.SecretTargetRef))
+				for _, ref := range cta.Spec.SecretTargetRef {
+					names = append(names, ref.Name)
+				}
+				return names
+			}); err != nil {
+			triggerAuthIndexErr = fmt.Errorf("failed to register ClusterTriggerAuthentication index %q: %w",
+				triggerAuthSecretRefIndex, err)
+			return
+		}
+
+		if err := mgr.GetFieldIndexer().IndexField(ctx,
+			&kedav1alpha1.ScaledObject{},
+			scalableAuthRefIndex,
+			func(obj client.Object) []string {
+				return extractAuthRefKeys(obj.(*kedav1alpha1.ScaledObject).Spec.Triggers)
+			}); err != nil {
+			triggerAuthIndexErr = fmt.Errorf("failed to register ScaledObject index %q: %w",
+				scalableAuthRefIndex, err)
+			return
+		}
+	})
+	return triggerAuthIndexErr
+}
+
+// objectListToRequests converts any ObjectList to reconcile requests by
+// extracting Name and Namespace from each item's ObjectMeta.
+func objectListToRequests(list client.ObjectList) []reconcile.Request {
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(items))
+	for _, item := range items {
+		o, ok := item.(client.Object)
+		if !ok {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      o.GetName(),
+				Namespace: o.GetNamespace(),
+			},
+		})
+	}
+	return requests
+}
+
+// lookupByTriggerAuth returns reconcile requests for scalable objects in the
+// given namespace that reference the named TriggerAuthentication via the
+// scalableAuthRefIndex.
+func lookupByTriggerAuth(ctx context.Context, c client.Reader, list client.ObjectList, taName, namespace string) []reconcile.Request {
+	if err := c.List(ctx, list,
+		client.InNamespace(namespace),
+		client.MatchingFields{scalableAuthRefIndex: authRefTAPrefix + taName}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list scalable objects by TriggerAuthentication",
+			"triggerAuthentication", taName, "namespace", namespace)
+		return nil
+	}
+	return objectListToRequests(list)
+}
+
+// lookupByClusterTriggerAuth returns reconcile requests for scalable objects
+// (across all namespaces) that reference the named ClusterTriggerAuthentication
+// via the scalableAuthRefIndex.
+func lookupByClusterTriggerAuth(ctx context.Context, c client.Reader, list client.ObjectList, ctaName string) []reconcile.Request {
+	if err := c.List(ctx, list,
+		client.MatchingFields{scalableAuthRefIndex: authRefCTAPrefix + ctaName}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list scalable objects by ClusterTriggerAuthentication",
+			"clusterTriggerAuthentication", ctaName)
+		return nil
+	}
+	return objectListToRequests(list)
+}
+
+// mapSecretToScalableObjects finds TriggerAuthentications and
+// ClusterTriggerAuthentications that reference the given Secret, then returns
+// reconcile requests for all scalable objects that use those auth resources.
+// newList must return a fresh, empty ObjectList of the target type
+// (e.g. &ScaledObjectList{} or &ScaledJobList{}).
+func mapSecretToScalableObjects(ctx context.Context, c client.Reader, newList func() client.ObjectList, secretName, secretNamespace string) []reconcile.Request {
+	logger := log.FromContext(ctx)
+
+	kedaNamespace, kedaNsErr := util.GetClusterObjectNamespace()
+	if kedaNsErr != nil {
+		logger.V(1).Info("Skipping ClusterTriggerAuthentication lookup: cannot determine KEDA namespace",
+			"error", kedaNsErr)
+	}
+
+	restrictedSecretAccess := util.IsRestrictSecretAccess()
+	if restrictedSecretAccess && (kedaNsErr != nil || secretNamespace != kedaNamespace) {
+		// With restricted secret access, secrets are only ever resolved from
+		// the KEDA namespace, so secrets elsewhere cannot affect any auth.
+		return nil
+	}
+
+	taListOpts := []client.ListOption{client.MatchingFields{triggerAuthSecretRefIndex: secretName}}
+	if !restrictedSecretAccess {
+		// Normally a TriggerAuthentication reads secrets from its own
+		// namespace only. With restricted secret access every
+		// TriggerAuthentication resolves secrets from the KEDA namespace
+		// instead, so a KEDA-namespace secret must match TAs cluster-wide.
+		taListOpts = append(taListOpts, client.InNamespace(secretNamespace))
+	}
+	taList := &kedav1alpha1.TriggerAuthenticationList{}
+	if err := c.List(ctx, taList, taListOpts...); err != nil {
+		logger.Error(err, "failed to list TriggerAuthentications for Secret mapping",
+			"secret", secretName, "namespace", secretNamespace)
+		return nil
+	}
+
+	var ctaNames []string
+	if kedaNsErr == nil && secretNamespace == kedaNamespace {
+		ctaList := &kedav1alpha1.ClusterTriggerAuthenticationList{}
+		if err := c.List(ctx, ctaList,
+			client.MatchingFields{triggerAuthSecretRefIndex: secretName}); err == nil {
+			for _, cta := range ctaList.Items {
+				ctaNames = append(ctaNames, cta.Name)
+			}
+		} else {
+			logger.Error(err, "failed to list ClusterTriggerAuthentications for Secret mapping",
+				"secret", secretName, "namespace", secretNamespace)
+		}
+	}
+
+	if len(taList.Items) == 0 && len(ctaNames) == 0 {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	seen := make(map[types.NamespacedName]bool)
+
+	for _, ta := range taList.Items {
+		for _, req := range lookupByTriggerAuth(ctx, c, newList(), ta.Name, ta.Namespace) {
+			if !seen[req.NamespacedName] {
+				requests = append(requests, req)
+				seen[req.NamespacedName] = true
+			}
+		}
+	}
+
+	for _, ctaName := range ctaNames {
+		for _, req := range lookupByClusterTriggerAuth(ctx, c, newList(), ctaName) {
+			if !seen[req.NamespacedName] {
+				requests = append(requests, req)
+				seen[req.NamespacedName] = true
+			}
+		}
+	}
+
+	return requests
+}

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -93,6 +93,17 @@ type scaleHandler struct {
 	subsLock              *sync.RWMutex
 }
 
+// scaleLoopContext identifies one run of a scale loop. Each
+// HandleScalableObject call stores a fresh instance in scaleLoopContexts, and
+// startScaleLoop only clears the scalers cache on shutdown if its own
+// scaleLoopContext is still the stored one. Without this identity check, a
+// superseded loop waking up on its canceled context could clear the cache
+// that the replacement loop had just built (with freshly resolved auth),
+// resurrecting the stale credentials it was restarted to get rid of.
+type scaleLoopContext struct {
+	cancel context.CancelFunc
+}
+
 // NewScaleHandler creates a ScaleHandler object
 func NewScaleHandler(client client.Client, scaleClient scale.ScalesGetter, reconcilerScheme *runtime.Scheme, globalHTTPTimeout time.Duration, recorder events.EventRecorder, authClientSet *authentication.AuthClientSet) ScaleHandler {
 	return &scaleHandler{
@@ -126,15 +137,25 @@ func (h *scaleHandler) HandleScalableObject(ctx context.Context, scalableObject 
 
 	key := withTriggers.GenerateIdentifier()
 	ctx, cancel := context.WithCancel(ctx)
+	loopContext := &scaleLoopContext{cancel: cancel}
 
 	// cancel the outdated ScaleLoop for the same ScaledObject (if exists)
-	value, loaded := h.scaleLoopContexts.LoadOrStore(key, cancel)
+	value, loaded := h.scaleLoopContexts.LoadOrStore(key, loopContext)
 	if loaded {
-		cancelValue, ok := value.(context.CancelFunc)
+		oldLoopContext, ok := value.(*scaleLoopContext)
 		if ok {
-			cancelValue()
+			oldLoopContext.cancel()
 		}
-		h.scaleLoopContexts.Store(key, cancel)
+		// Clear the cache synchronously here: once the new loopContext is
+		// stored below, the identity check in startScaleLoop stops the old
+		// loop from clearing it on shutdown, so the eviction of the scalers
+		// built with the previous configuration/credentials must happen here.
+		if err := h.ClearScalersCache(ctx, scalableObject); err != nil {
+			cancel()
+			h.scaleLoopContexts.Delete(key)
+			return err
+		}
+		h.scaleLoopContexts.Store(key, loopContext)
 	} else {
 		h.recorder.Eventf(withTriggers, nil, corev1.EventTypeNormal, eventreason.KEDAScalersStarted, "ScalersWatchStarted", "%s", message.ScalerStartMsg)
 	}
@@ -144,7 +165,7 @@ func (h *scaleHandler) HandleScalableObject(ctx context.Context, scalableObject 
 
 	// passing deep copy of ScaledObject/ScaledJob to the scaleLoop go routines, it's a precaution to not have global objects shared between threads
 	go h.startPushScalers(ctx, withTriggers, scalableObject.DeepCopyObject().(kedav1alpha1.ScalableObject), scalingMutex)
-	go h.startScaleLoop(ctx, withTriggers, scalableObject.DeepCopyObject().(kedav1alpha1.ScalableObject), scalingMutex)
+	go h.startScaleLoop(ctx, withTriggers, scalableObject.DeepCopyObject().(kedav1alpha1.ScalableObject), scalingMutex, loopContext)
 	return nil
 }
 
@@ -159,9 +180,9 @@ func (h *scaleHandler) DeleteScalableObject(ctx context.Context, scalableObject 
 	key := withTriggers.GenerateIdentifier()
 	result, ok := h.scaleLoopContexts.Load(key)
 	if ok {
-		cancel, ok := result.(context.CancelFunc)
+		loopContext, ok := result.(*scaleLoopContext)
 		if ok {
-			cancel()
+			loopContext.cancel()
 		}
 		h.scaleLoopContexts.Delete(key)
 		err := h.ClearScalersCache(ctx, scalableObject)
@@ -177,7 +198,7 @@ func (h *scaleHandler) DeleteScalableObject(ctx context.Context, scalableObject 
 }
 
 // startScaleLoop blocks forever and checks the scalableObject based on its pollingInterval
-func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, scalableObject kedav1alpha1.ScalableObject, scalingMutex sync.Locker) {
+func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1alpha1.WithTriggers, scalableObject kedav1alpha1.ScalableObject, scalingMutex sync.Locker, loopContext *scaleLoopContext) {
 	logger := log.WithValues("type", withTriggers.Kind, "namespace", withTriggers.Namespace, "name", withTriggers.Name)
 
 	pollingInterval := withTriggers.GetPollingInterval()
@@ -202,9 +223,14 @@ func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1a
 			tmr.Stop()
 		case <-ctx.Done():
 			logger.V(1).Info("Context canceled")
-			err := h.ClearScalersCache(ctx, scalableObject)
-			if err != nil {
-				logger.Error(err, "error clearing scalers cache")
+			// Only clear the scalers cache if this loop is still the one
+			// registered for the object. If it was superseded by a restart
+			// (see HandleScalableObject), the cache may already hold scalers
+			// rebuilt by the new loop and must not be cleared by this stale one.
+			if current, ok := h.scaleLoopContexts.Load(withTriggers.GenerateIdentifier()); ok && current == loopContext {
+				if err := h.ClearScalersCache(ctx, scalableObject); err != nil {
+					logger.Error(err, "error clearing scalers cache")
+				}
 			}
 			tmr.Stop()
 			return

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -1712,3 +1712,182 @@ func TestHandleResult_DeltaDoesNotOverwriteConcurrentChanges(t *testing.T) {
 	assert.True(t, patchedObj.Status.TriggersActivity["trigger-a"].IsActive, "concurrent update to trigger-a must be preserved")
 	assert.True(t, patchedObj.Status.TriggersActivity["trigger-b"].IsActive, "trigger-b updated by push scaler")
 }
+
+// restartTestFixture bundles the mocks and scale handler used by the scale
+// loop restart tests below.
+type restartTestFixture struct {
+	sh           scaleHandler
+	scaledObject kedav1alpha1.ScaledObject
+	scalerCache  *cache.ScalersCache
+	key          string
+	closed       chan struct{}
+}
+
+func newRestartTestFixture(t *testing.T, name string) *restartTestFixture {
+	ctrl := gomock.NewController(t)
+	recorder := events.NewFakeRecorder(10)
+	mockClient := mock_client.NewMockClient(ctrl)
+	mockStatusWriter := mock_client.NewMockStatusWriter(ctrl)
+	mockExecutor := mock_executor.NewMockScaleExecutor(ctrl)
+
+	metricName := name + "-metric"
+	metricsSpecs := []v2.MetricSpec{createMetricSpec(10, metricName)}
+	metricValue := scalers.GenerateMetricInMili(metricName, float64(10))
+
+	longPollingInterval := int32(300)
+	scaledObject := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  testNamespaceGlobal,
+			Generation: 1,
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{
+				Name: "test",
+			},
+			PollingInterval: &longPollingInterval,
+		},
+		Status: kedav1alpha1.ScaledObjectStatus{
+			ScaleTargetGVKR: &kedav1alpha1.GroupVersionKindResource{
+				Group: "apps",
+				Kind:  "Deployment",
+			},
+		},
+	}
+
+	scaler := mock_scalers.NewMockScaler(ctrl)
+	scalerConfig := scalersconfig.ScalerConfig{}
+	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		return scaler, &scalerConfig, nil
+	}
+
+	// the scale loops run asynchronously and may check the scalers a couple of
+	// times before the test finishes, so all expectations are tolerant
+	closed := make(chan struct{})
+	var closeOnce sync.Once
+	scaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Return(metricsSpecs).AnyTimes()
+	scaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).Return([]external_metrics.ExternalMetricValue{metricValue}, true, nil).AnyTimes()
+	scaler.EXPECT().Close(gomock.Any()).DoAndReturn(func(context.Context) error {
+		closeOnce.Do(func() { close(closed) })
+		return nil
+	}).AnyTimes()
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockClient.EXPECT().Status().Return(mockStatusWriter).AnyTimes()
+	mockStatusWriter.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockExecutor.EXPECT().RequestScale(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	scalerCache := &cache.ScalersCache{
+		ScaledObject: &scaledObject,
+		Scalers: []cache.ScalerBuilder{{
+			Scaler:       scaler,
+			ScalerConfig: scalerConfig,
+			Factory:      factory,
+		}},
+		ScalableObjectGeneration: scaledObject.Generation,
+		Recorder:                 recorder,
+	}
+
+	key := scaledObject.GenerateIdentifier()
+
+	return &restartTestFixture{
+		sh: scaleHandler{
+			client:                   mockClient,
+			scaleLoopContexts:        &sync.Map{},
+			scaleExecutor:            mockExecutor,
+			globalHTTPTimeout:        time.Duration(1000),
+			recorder:                 recorder,
+			scalerCaches:             map[string]*cache.ScalersCache{key: scalerCache},
+			scalerCachesLock:         &sync.RWMutex{},
+			scaledObjectsMetricCache: metricscache.NewMetricsCache(),
+			rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+			metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+			subsLock:                 &sync.RWMutex{},
+		},
+		scaledObject: scaledObject,
+		scalerCache:  scalerCache,
+		key:          key,
+		closed:       closed,
+	}
+}
+
+func (f *restartTestFixture) cachedScalersCache() (*cache.ScalersCache, bool) {
+	f.sh.scalerCachesLock.RLock()
+	defer f.sh.scalerCachesLock.RUnlock()
+	c, ok := f.sh.scalerCaches[f.key]
+	return c, ok
+}
+
+func (f *restartTestFixture) waitForScalerClose(t *testing.T) {
+	select {
+	case <-f.closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the previously cached scalers to be closed")
+	}
+}
+
+// TestStaleScaleLoopDoesNotClearActiveScalersCache verifies the loop identity
+// guard in startScaleLoop: a superseded scale loop shutting down must not
+// clear the scalers cache that belongs to the currently active loop, while
+// the loop registered as current still clears the cache on shutdown.
+func TestStaleScaleLoopDoesNotClearActiveScalersCache(t *testing.T) {
+	f := newRestartTestFixture(t, "stale-loop-guard")
+
+	withTriggers, err := kedav1alpha1.AsDuckWithTriggers(&f.scaledObject)
+	assert.NoError(t, err)
+
+	activeLoopContext := &scaleLoopContext{cancel: func() {}}
+	f.sh.scaleLoopContexts.Store(f.key, activeLoopContext)
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// a stale loop (superseded by activeLoopContext) shuts down: it must leave
+	// the cache of the active loop alone
+	staleLoopContext := &scaleLoopContext{cancel: func() {}}
+	f.sh.startScaleLoop(canceledCtx, withTriggers, f.scaledObject.DeepCopy(), &sync.Mutex{}, staleLoopContext)
+
+	_, cached := f.cachedScalersCache()
+	assert.True(t, cached, "stale scale loop must not clear the active scalers cache")
+
+	// the currently registered loop shuts down: now the cache must be cleared
+	f.sh.startScaleLoop(canceledCtx, withTriggers, f.scaledObject.DeepCopy(), &sync.Mutex{}, activeLoopContext)
+
+	_, cached = f.cachedScalersCache()
+	assert.False(t, cached, "current scale loop must clear its scalers cache on shutdown")
+
+	// ClearScalersCache closes the evicted cache asynchronously; wait for it so
+	// the mocks are not used after the test finishes
+	f.waitForScalerClose(t)
+}
+
+// TestHandleScalableObjectRestartClosesCachedScalers verifies that handling an
+// already-handled object again (e.g. after an auth dependency changed) swaps
+// the stored loop context and evicts and closes the previously cached scalers,
+// so the next cache access re-resolves authentication from scratch.
+func TestHandleScalableObjectRestartClosesCachedScalers(t *testing.T) {
+	f := newRestartTestFixture(t, "handle-restart")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NoError(t, f.sh.HandleScalableObject(ctx, &f.scaledObject))
+	firstLoopContext, ok := f.sh.scaleLoopContexts.Load(f.key)
+	assert.True(t, ok)
+
+	assert.NoError(t, f.sh.HandleScalableObject(ctx, &f.scaledObject))
+	secondLoopContext, ok := f.sh.scaleLoopContexts.Load(f.key)
+	assert.True(t, ok)
+	assert.NotSame(t, firstLoopContext, secondLoopContext, "restart must supersede the stored loop context")
+
+	// the pre-populated cache must have been evicted (any cache present now is
+	// a fresh rebuild by the restarted loop) and its scalers closed
+	if current, cached := f.cachedScalersCache(); cached {
+		assert.NotSame(t, f.scalerCache, current, "restart must evict the previously cached scalers")
+	}
+	f.waitForScalerClose(t)
+
+	// stop the running loops and wait for them to observe the cancellation, so
+	// the mocks are not used after the test finishes
+	assert.NoError(t, f.sh.DeleteScalableObject(ctx, &f.scaledObject))
+	time.Sleep(100 * time.Millisecond)
+}

--- a/pkg/util/env_resolver.go
+++ b/pkg/util/env_resolver.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/utils/ptr"
@@ -93,6 +94,12 @@ func GetPodNamespace() string {
 // GetRestrictSecretAccess retrieves the value of the environment variable of KEDA_RESTRICT_SECRET_ACCESS
 func GetRestrictSecretAccess() string {
 	return os.Getenv(RestrictSecretAccessEnvVar)
+}
+
+// IsRestrictSecretAccess returns whether secret access is restricted to the
+// KEDA cluster object namespace (KEDA_RESTRICT_SECRET_ACCESS=true).
+func IsRestrictSecretAccess() bool {
+	return strings.EqualFold(GetRestrictSecretAccess(), strconv.FormatBool(true))
 }
 
 // GetBoundServiceAccountTokenExpiry retrieves the value of the environment variable of KEDA_BOUND_SERVICE_ACCOUNT_TOKEN_EXPIRY


### PR DESCRIPTION
When credentials stored in a Secret (referenced via `TriggerAuthentication` or
`ClusterTriggerAuthentication`) are rotated, the operator keeps using the cached
stale values until the `ScaledObject` is recreated or the operator is restarted.
This causes 401 errors and breaks scaling.

Auth parameters are resolved once at scaler build time and frozen into the
scaler cache, and nothing watched the Secrets / `TriggerAuthentication` /
`ClusterTriggerAuthentication` that back them, so a rotation was never noticed.

This PR watches those auth dependencies and invalidates the affected scalers
when they change, so new credentials are picked up automatically.

## How it works

- **Reverse lookup indexes & watches.** Field indexes are registered on
  `TriggerAuthentication`/`ClusterTriggerAuthentication` (by secret ref name)
  and on `ScaledObject` (by auth ref, using composite `ta/` / `cta/` keys).
  Controller-runtime `Watches` on `TriggerAuthentication` and
  `ClusterTriggerAuthentication` (guarded by `GenerationChangedPredicate`) and a
  metadata-only `WatchesMetadata` on `Secret` map changes back to the affected
  `ScaledObject`s via `EnqueueRequestsFromMapFunc`. Secret changes use a
  two-hop lookup (Secret → TriggerAuth → ScaledObject).
- **Pending invalidation.** A `pendingAuthInvalidations` sync.Map records
  ScaledObjects enqueued due to an auth change. On reconcile, when the spec
  itself hasn't changed (so the normal generation-based restart won't fire), the
  scale loop is restarted to invalidate the cache.
- **Full scale loop restart (not just a cache clear).** Push scalers are started
  once per loop, so merely clearing the scalers cache would leave external-push
  scalers running with the old credentials; the whole loop is restarted instead.
- **Scale loop identity guard.** Each loop run gets a `scaleLoopContext`. A
  superseded loop shutting down no longer clears the cache the replacement loop
  just rebuilt with fresh credentials (this also fixes a pre-existing race); the
  cache is cleared synchronously on restart instead.
- **Live Secret reads.** Structured Secret reads bypass the client cache (the
  metadata-only informer serves the watch), so a rebuild reads the rotated value
  directly from the API server rather than racing a stale structured cache, and
  no second full-object Secret informer is created.
- **`KEDA_RESTRICT_SECRET_ACCESS` support.** In restricted mode the Secret
  informer is scoped to the KEDA namespace (avoiding a crash-loop on missing
  cluster-wide RBAC), and a KEDA-namespace Secret is matched against
  `TriggerAuthentication`s cluster-wide, mirroring how restricted mode resolves
  every `secretTargetRef` from the KEDA namespace.

## Tests

- An envtest regression test rotates a Secret and repoints a
  `TriggerAuthentication`, asserting the cached scalers are rebuilt with the
  fresh credential (verified to fail without the watches).
- Unit tests cover the scale loop identity guard and `HandleScalableObject`
  evicting and closing cached scalers on restart, plus the Secret→ScaledObject
  mapping functions (including restricted-secret-access behavior).

## Known limitations

- **ConfigMap-backed auth not covered.** `TriggerAuthentication` can also
  reference ConfigMaps via `configMapTargetRef`; only `secretTargetRef` is
  watched/indexed here. Can be a follow-up if there is demand.
- **ScaledJob not covered.** The index helpers and mapping functions are generic
  (they accept `client.ObjectList` and a `newList func()`), but this PR wires
  them only into the `ScaledObject` controller. ScaledJob support will come in a
  separate PR.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7906
