### PR TITLE
fix: reject non-positive liiklus lagThreshold to prevent divide-by-zero panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **General**: Treat negative external metric values as zero to prevent incorrect HPA scaling ([#7880](https://github.com/kedacore/keda/issues/7880))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
+- **Liiklus Scaler**: Reject a non-positive `lagThreshold` and a negative `activationLagThreshold` at parse time to prevent an integer divide-by-zero panic and invalid activation behavior ([#7917](https://github.com/kedacore/keda/issues/7917))
 - **MongoDB Scaler**: Disconnect the client when the initial `Ping` fails so the background topology-monitoring connections opened by `mongo.Connect` are not leaked ([#5612](https://github.com/kedacore/keda/issues/5612))
 
 ### Deprecations

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -35,6 +35,16 @@ type liiklusMetadata struct {
 	triggerIndex           int
 }
 
+func (m *liiklusMetadata) Validate() error {
+	if m.LagThreshold <= 0 {
+		return fmt.Errorf("%q must be a positive number", "lagThreshold")
+	}
+	if m.ActivationLagThreshold < 0 {
+		return fmt.Errorf("%q must be a non-negative number", "activationLagThreshold")
+	}
+	return nil
+}
+
 const (
 	liiklusMetricType = "External"
 )

--- a/pkg/scalers/liiklus_scaler_test.go
+++ b/pkg/scalers/liiklus_scaler_test.go
@@ -85,6 +85,38 @@ var parseLiiklusMetadataTestDataset = []parseLiiklusMetadataTestData{
 			triggerIndex:           0,
 		},
 	},
+	{
+		name:             "Zero lagThreshold is rejected to avoid a divide-by-zero",
+		metadata:         map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup", "lagThreshold": "0"},
+		ExpectedErr:      fmt.Errorf("error parsing liiklus metadata: %q must be a positive number", "lagThreshold"),
+		ExpectedMetadata: nil,
+	},
+	{
+		name:             "Negative lagThreshold is rejected",
+		metadata:         map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup", "lagThreshold": "-1"},
+		ExpectedErr:      fmt.Errorf("error parsing liiklus metadata: %q must be a positive number", "lagThreshold"),
+		ExpectedMetadata: nil,
+	},
+	{
+		name:             "Negative activationLagThreshold is rejected",
+		metadata:         map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup", "activationLagThreshold": "-1"},
+		ExpectedErr:      fmt.Errorf("error parsing liiklus metadata: %q must be a non-negative number", "activationLagThreshold"),
+		ExpectedMetadata: nil,
+	},
+	{
+		name:        "Minimum valid thresholds are accepted",
+		metadata:    map[string]string{"topic": "foo", "address": "using-mock", "group": "mygroup", "lagThreshold": "1", "activationLagThreshold": "0"},
+		ExpectedErr: nil,
+		ExpectedMetadata: &liiklusMetadata{
+			LagThreshold:           1,
+			ActivationLagThreshold: 0,
+			Address:                "using-mock",
+			Topic:                  "foo",
+			Group:                  "mygroup",
+			GroupVersion:           0,
+			triggerIndex:           0,
+		},
+	},
 }
 
 var liiklusMetricIdentifiers = []liiklusMetricIdentifier{


### PR DESCRIPTION
Fixes #7917

### Description

The liiklus scaler panics with `integer divide by zero` when a liiklus trigger sets `lagThreshold: "0"`. `liiklusMetadata` has no `Validate()`, so the value is used as an unchecked `uint64` divisor in `GetMetricsAndActivity` and the metric evaluation panics. A negative `activationLagThreshold` similarly becomes a huge `uint64` that keeps the scaler from activating.

This adds a `Validate()` to `liiklusMetadata` that rejects a non-positive `lagThreshold` and a negative `activationLagThreshold`, matching Kafka and Apache Kafka for both threshold fields, and Azure Event Hubs for the positive scaling-threshold guard. `TypedConfig` invokes it automatically, so a bad trigger is now rejected at parse time instead of panicking. This is the same class of bug as #3366, which was fixed for the kafka scaler; liiklus was missed.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added (parse-rejection cases for `lagThreshold: "0"`, `lagThreshold: "-1"`, and `activationLagThreshold: "-1"`, plus an accepted minimum-valid case `lagThreshold: "1"` / `activationLagThreshold: "0"`)
- [x] Changelog has been updated, referencing the issue (covering both `lagThreshold` and `activationLagThreshold`)
- [x] A docs PR has been opened: kedacore/keda-docs#1811

Documentation of the valid threshold ranges is in kedacore/keda-docs#1811.
