### PR TITLE
CI: enhance forgejo scale-in diagnostics

### DIFF
--- a/tests/scalers/forgejo_runner/forgejo_runner_test.go
+++ b/tests/scalers/forgejo_runner/forgejo_runner_test.go
@@ -4,15 +4,18 @@
 package forgejo_runner_test
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/kedacore/keda/v2/tests/helper" // For helper methods
@@ -290,5 +293,67 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale in ---")
 
-	assert.True(t, WaitForPodsCompleted(t, kc, "app=forgejo-job", testNamespace, 60, 1), "pods count should be 1 after 1 minute")
+	if !assert.True(t, WaitForPodsCompleted(t, kc, "app=forgejo-job", testNamespace, 60, 1), "pods count should be 1 after 1 minute") {
+		dumpScaleInDiagnostics(t, kc)
+	}
+}
+
+// dumpScaleInDiagnostics prints the state of the runner job and its pods when the scale-in check fails
+func dumpScaleInDiagnostics(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- scale-in failure diagnostics ---")
+	ctx := context.Background()
+
+	jobs, err := kc.BatchV1().Jobs(testNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("diagnostics: cannot list jobs: %s", err)
+	}
+	for _, job := range jobs.Items {
+		t.Logf("job %s: active=%d succeeded=%d failed=%d", job.Name, job.Status.Active, job.Status.Succeeded, job.Status.Failed)
+		for _, cond := range job.Status.Conditions {
+			t.Logf("job %s condition: type=%s status=%s reason=%q message=%q", job.Name, cond.Type, cond.Status, cond.Reason, cond.Message)
+		}
+	}
+
+	pods, err := kc.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("diagnostics: cannot list pods: %s", err)
+	}
+	for _, pod := range pods.Items {
+		t.Logf("pod %s: phase=%s reason=%q message=%q", pod.Name, pod.Status.Phase, pod.Status.Reason, pod.Status.Message)
+		for _, cs := range pod.Status.ContainerStatuses {
+			state := "unknown"
+			detail := ""
+			switch {
+			case cs.State.Waiting != nil:
+				state = "waiting"
+				detail = fmt.Sprintf("reason=%q message=%q", cs.State.Waiting.Reason, cs.State.Waiting.Message)
+			case cs.State.Running != nil:
+				state = "running"
+				detail = fmt.Sprintf("startedAt=%s", cs.State.Running.StartedAt.Format(time.RFC3339))
+			case cs.State.Terminated != nil:
+				state = "terminated"
+				detail = fmt.Sprintf("exitCode=%d reason=%q message=%q startedAt=%s finishedAt=%s",
+					cs.State.Terminated.ExitCode, cs.State.Terminated.Reason, cs.State.Terminated.Message,
+					cs.State.Terminated.StartedAt.Format(time.RFC3339), cs.State.Terminated.FinishedAt.Format(time.RFC3339))
+			}
+			t.Logf("pod %s container %s: restarts=%d state=%s %s", pod.Name, cs.Name, cs.RestartCount, state, detail)
+		}
+	}
+
+	events, err := kc.CoreV1().Events(testNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("diagnostics: cannot list events: %s", err)
+	}
+	for _, ev := range events.Items {
+		t.Logf("event %s/%s: type=%s reason=%s count=%d message=%q", ev.InvolvedObject.Kind, ev.InvolvedObject.Name, ev.Type, ev.Reason, ev.Count, ev.Message)
+	}
+
+	for _, label := range []string{"app=forgejo-job", "app=forgejo"} {
+		logs, err := FindPodLogs(kc, testNamespace, label, true)
+		if err != nil {
+			t.Logf("diagnostics: cannot get logs for %s pods: %s", label, err)
+			continue
+		}
+		t.Logf("--- logs of %s pods ---\n%s", label, strings.Join(logs, ""))
+	}
 }


### PR DESCRIPTION
The e2e test for the forgejo scaler flakes very frequently. It fails usually in one part of the test - scaling in.

```
SUITE                                               07-20  07-19  07-15  07-14  07-13  07-11  07-07  07-06
tests/scalers/forgejo_runner/forgejo_runner_test.go    ❌     ❌     ❌     ✅     ✅     ✅     ✅     ❌
```

But unfortunately, the logs provide very little insight into why scale-in failed, only the fact the expected scale-in count doesn't match the reality
```
 10715 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8308456Z     forgejo_runner_test.go:***9***: --- testing scale in ---
 10716 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8308823Z     helper.go:47***: Waiting for pods with label app=forgejo-job to complete
 10717 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8309176Z     helper.go:47***: Waiting for pods with label app=forgejo-job to complete
...
 10774 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8330136Z     helper.go:47***: Waiting for pods with label app=forgejo-job to complete
 10775 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8330484Z     helper.go:47***: Waiting for pods with label app=forgejo-job to complete
 10776 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8330726Z     forgejo_runner_test.go:***9***:
 10777 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8331145Z            Error Trace:    /__w/keda/keda/tests/scalers/forgejo_runner/forgejo_runner_test.go:***9***
 10778 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8331541Z                                        /__w/keda/keda/tests/scalers/forgejo_runner/forgejo_runner_test.go:***
 10779 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8331785Z            Error:          Should be true
 10780 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8332021Z            Test:           TestForgejoScaler
 10781 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8332327Z            Messages:       pods count should be *** after *** minute
 10782 validate / Run e2e test UNKNOWN STEP    2026-07-20T01:30:18.8332646Z     helper.go:857: Deleting template: forgejoServiceTemplate
```

This PR adds diagnostics dump recording Pod statuses, Job statuses and logs from forgejo pods.