### PR TITLE
General: Fix nil ptr dereference on uninitialized Deployment spec replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
+- **General**: Fix nil pointer dereference in `GetCurrentReplicas` when a Deployment/StatefulSet/ReplicaSet is returned from the informer cache with an undefaulted `spec.replicas`; a nil value is now treated as the Kubernetes default of 1 instead of panicking ([#7863](https://github.com/kedacore/keda/issues/7863))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **General**: Treat negative external metric values as zero to prevent incorrect HPA scaling ([#7880](https://github.com/kedacore/keda/issues/7880))

--- a/pkg/scaling/resolver/scale_resolvers.go
+++ b/pkg/scaling/resolver/scale_resolvers.go
@@ -814,21 +814,21 @@ func GetCurrentReplicas(ctx context.Context, client client.Client, scaleClient s
 			logger.Error(err, "target deployment doesn't exist")
 			return 0, err
 		}
-		return *deployment.Spec.Replicas, nil
+		return ptr.Deref(deployment.Spec.Replicas, 1), nil
 	case targetGVKR.Group == appsGroup && targetGVKR.Kind == statefulSetKind:
 		statefulSet := &appsv1.StatefulSet{}
 		if err := client.Get(ctx, types.NamespacedName{Name: targetName, Namespace: scaledObject.Namespace}, statefulSet); err != nil {
 			logger.Error(err, "target statefulset doesn't exist")
 			return 0, err
 		}
-		return *statefulSet.Spec.Replicas, nil
+		return ptr.Deref(statefulSet.Spec.Replicas, 1), nil
 	case targetGVKR.Group == appsGroup && targetGVKR.Kind == replicaSetKind:
 		replicaSet := &appsv1.ReplicaSet{}
 		if err := client.Get(ctx, types.NamespacedName{Name: targetName, Namespace: scaledObject.Namespace}, replicaSet); err != nil {
 			logger.Error(err, "target replicaset doesn't exist")
 			return 0, err
 		}
-		return *replicaSet.Spec.Replicas, nil
+		return ptr.Deref(replicaSet.Spec.Replicas, 1), nil
 	default:
 		// Try reading from the informer cache via Unstructured to avoid an API call.
 		unstruct := &unstructured.Unstructured{}

--- a/pkg/scaling/resolver/scale_resolvers_test.go
+++ b/pkg/scaling/resolver/scale_resolvers_test.go
@@ -1142,12 +1142,24 @@ func TestGetCurrentReplicas_NilScaleTargetGVKR(t *testing.T) {
 	const soName = "so-nil-gvkr"
 	const soNamespace = "test-ns"
 	const deploymentName = "target-dep"
+	const stsName = "target-sts"
+	const rsName = "target-rs"
 	replicas := int32(3)
 
 	populatedGVKR := &kedav1alpha1.GroupVersionKindResource{
 		Group:   "apps",
 		Version: "v1",
 		Kind:    "Deployment",
+	}
+	populatedGVKRSts := &kedav1alpha1.GroupVersionKindResource{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "StatefulSet",
+	}
+	populatedGVKRRs := &kedav1alpha1.GroupVersionKindResource{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "ReplicaSet",
 	}
 
 	tests := []struct {
@@ -1173,6 +1185,57 @@ func TestGetCurrentReplicas_NilScaleTargetGVKR(t *testing.T) {
 				},
 			},
 			wantReplicas: replicas,
+		},
+		{
+			name: "deployment with nil spec.replicas defaults to 1",
+			existing: []runtime.Object{
+				&kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{Name: soName, Namespace: soNamespace},
+					Spec: kedav1alpha1.ScaledObjectSpec{
+						ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: deploymentName},
+					},
+					Status: kedav1alpha1.ScaledObjectStatus{ScaleTargetGVKR: populatedGVKR},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: deploymentName, Namespace: soNamespace},
+					Spec:       appsv1.DeploymentSpec{Replicas: nil},
+				},
+			},
+			wantReplicas: 1,
+		},
+		{
+			name: "statefulset with nil spec.replicas defaults to 1",
+			existing: []runtime.Object{
+				&kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{Name: soName, Namespace: soNamespace},
+					Spec: kedav1alpha1.ScaledObjectSpec{
+						ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: stsName},
+					},
+					Status: kedav1alpha1.ScaledObjectStatus{ScaleTargetGVKR: populatedGVKRSts},
+				},
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: soNamespace},
+					Spec:       appsv1.StatefulSetSpec{Replicas: nil},
+				},
+			},
+			wantReplicas: 1,
+		},
+		{
+			name: "replicaset with nil spec.replicas defaults to 1",
+			existing: []runtime.Object{
+				&kedav1alpha1.ScaledObject{
+					ObjectMeta: metav1.ObjectMeta{Name: soName, Namespace: soNamespace},
+					Spec: kedav1alpha1.ScaledObjectSpec{
+						ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: rsName},
+					},
+					Status: kedav1alpha1.ScaledObjectStatus{ScaleTargetGVKR: populatedGVKRRs},
+				},
+				&appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{Name: rsName, Namespace: soNamespace},
+					Spec:       appsv1.ReplicaSetSpec{Replicas: nil},
+				},
+			},
+			wantReplicas: 1,
 		},
 		{
 			name: "nil GVKR on input, refetch also has nil GVKR",


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

Followup to https://github.com/kedacore/keda/pull/7661, the nil ptr dereference with 2.5k SOs can still happen but on a different field few lines lower. That is because `Deployment` (and other resources) can have `spec.replicas` set to `nil` before the control-plane controllers initialize this to 1. This rarely happens on small clusters because control-plane is very fast, but on big clusters where there is a lot of churn, KEDA informer can pick up uninitialized resource fairly often and nil ptr dereferences result in keda-operator crashes.

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda/issues/7863
