### PR TITLE
General: move HPA health signal off Ready into a dedicated HPAActive condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
+- **General**: Introduce a dedicated `HPAActive` condition on `ScaledObject` mirroring the HPA's own `ScalingActive` status, so transient HPA metric gaps no longer flip the `Ready` condition to `False` ([#7914](https://github.com/kedacore/keda/issues/7914))
 - **Kafka Scaler**: Add optional `fullMetadata` trigger metadata field to control Sarama's full cluster metadata refresh, reducing operator memory for topic scoped triggers ([#7453](https://github.com/kedacore/keda/issues/7453))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 

--- a/apis/keda/v1alpha1/condition_types.go
+++ b/apis/keda/v1alpha1/condition_types.go
@@ -34,6 +34,11 @@ const (
 	ConditionFallback ConditionType = "Fallback"
 	// ConditionPaused specifies that the resource is paused.
 	ConditionPaused ConditionType = "Paused"
+	// ConditionHPAActive mirrors the underlying HPA's ScalingActive condition.
+	// It is ScaledObject-specific (ScaledJob has no HPA), so it is intentionally NOT part of
+	// GetInitializedConditions/AreInitialized. It is set lazily by checkHPAHealth once an HPA
+	// exists for the ScaledObject.
+	ConditionHPAActive ConditionType = "HPAActive"
 )
 
 const (
@@ -46,10 +51,18 @@ const (
 	// ScaledObjectConditionPausedMessage defines the default Message for paused ScaledObject
 	ScaledObjectConditionPausedMessage = "ScaledObject is paused"
 
-	// ScaledObjectConditionHPAMetricsUnavailableReason is the Ready condition reason when the HPA cannot fetch metrics
+	// ScaledObjectConditionHPAMetricsUnavailableReason is the HPAActive condition reason when the HPA cannot fetch metrics
 	ScaledObjectConditionHPAMetricsUnavailableReason = "HPAMetricsUnavailable"
-	// ScaledObjectConditionScalingDegradedReason is the Ready condition reason when both scalers and HPA are unhealthy
+	// ScaledObjectConditionScalingDegradedReason was the Ready condition reason when both scalers and HPA were unhealthy.
+	// Since #7914, HPA health no longer affects Ready, so this reason is no longer emitted.
+	// TODO: possibly removable, maintainer decision (#7914)
 	ScaledObjectConditionScalingDegradedReason = "ScalingDegraded"
+	// ScaledObjectConditionHPAActiveReason is the HPAActive condition reason when the HPA is healthy
+	ScaledObjectConditionHPAActiveReason = "HPAActive"
+	// ScaledObjectConditionHPAScalingDisabledReason is the HPAActive condition reason mirroring the HPA's own
+	// ScalingDisabled reason (KEDA-managed scale-to-zero). getHPAHealth currently treats this state as healthy,
+	// so this reason is reserved for callers that want to distinguish it from a generic healthy state.
+	ScaledObjectConditionHPAScalingDisabledReason = "ScalingDisabled"
 )
 
 const (
@@ -184,6 +197,16 @@ func (c *Conditions) SetPausedCondition(status metav1.ConditionStatus, reason st
 	c.SetCondition(ConditionPaused, status, reason, message)
 }
 
+// SetHPAActiveCondition modifies HPAActive Condition according to input parameters.
+// HPAActive is ScaledObject-specific and is set lazily (see ConditionHPAActive); it is not part of
+// GetInitializedConditions, but SetCondition will append it the first time it is set.
+func (c *Conditions) SetHPAActiveCondition(status metav1.ConditionStatus, reason string, message string) {
+	if *c == nil {
+		*c = *GetInitializedConditions()
+	}
+	c.SetCondition(ConditionHPAActive, status, reason, message)
+}
+
 // GetActiveCondition returns Condition of type Active
 func (c *Conditions) GetActiveCondition() Condition {
 	if *c == nil {
@@ -214,6 +237,16 @@ func (c *Conditions) GetPausedCondition() Condition {
 		*c = *GetInitializedConditions()
 	}
 	return c.getCondition(ConditionPaused)
+}
+
+// GetHPAActiveCondition returns Condition of type HPAActive. If it has not been set yet
+// (e.g. no HPA exists for the ScaledObject yet, or this is a ScaledJob), a zero-value Condition
+// is returned.
+func (c *Conditions) GetHPAActiveCondition() Condition {
+	if *c == nil {
+		*c = *GetInitializedConditions()
+	}
+	return c.getCondition(ConditionHPAActive)
 }
 
 func (c Conditions) getCondition(conditionType ConditionType) Condition {

--- a/apis/keda/v1alpha1/condition_types.go
+++ b/apis/keda/v1alpha1/condition_types.go
@@ -60,8 +60,9 @@ const (
 	// ScaledObjectConditionHPAActiveReason is the HPAActive condition reason when the HPA is healthy
 	ScaledObjectConditionHPAActiveReason = "HPAActive"
 	// ScaledObjectConditionHPAScalingDisabledReason is the HPAActive condition reason mirroring the HPA's own
-	// ScalingDisabled reason (KEDA-managed scale-to-zero). getHPAHealth currently treats this state as healthy,
-	// so this reason is reserved for callers that want to distinguish it from a generic healthy state.
+	// ScalingDisabled reason. The HPA sets this when KEDA has scaled the target to zero; HPAActive stays
+	// True (the HPA is not unhealthy, just intentionally idle) but this reason distinguishes it from a
+	// normally-scaling HPA.
 	ScaledObjectConditionHPAScalingDisabledReason = "ScalingDisabled"
 )
 

--- a/apis/keda/v1alpha1/condition_types_test.go
+++ b/apis/keda/v1alpha1/condition_types_test.go
@@ -305,3 +305,100 @@ func TestConditions_getCondition_NotFound(t *testing.T) {
 		t.Errorf("expected empty condition for missing type, got %+v", got)
 	}
 }
+
+// #7914: HPAActive is ScaledObject-specific and set lazily by checkHPAHealth, so it must never be
+// part of the shared GetInitializedConditions/AreInitialized machinery used by ScaledJob too.
+
+func TestGetInitializedConditions_NoHPAActive(t *testing.T) {
+	conditions := GetInitializedConditions()
+
+	if len(*conditions) != 4 {
+		t.Fatalf("expected exactly 4 base conditions (ScaledJob has no HPA), got %d", len(*conditions))
+	}
+	for _, c := range *conditions {
+		if c.Type == ConditionHPAActive {
+			t.Fatal("HPAActive must not be part of the shared default conditions")
+		}
+	}
+}
+
+func TestConditions_AreInitialized_UnaffectedByHPAActive(t *testing.T) {
+	conditions := *GetInitializedConditions()
+
+	if !conditions.AreInitialized() {
+		t.Fatal("the 4 base conditions alone must already count as initialized")
+	}
+
+	// Explicitly setting HPAActive must not change whether the base set is considered initialized.
+	conditions.SetHPAActiveCondition(metav1.ConditionTrue, ScaledObjectConditionHPAActiveReason, "")
+	if !conditions.AreInitialized() {
+		t.Fatal("AreInitialized() must be unaffected by the presence of HPAActive")
+	}
+}
+
+func TestConditions_SetHPAActiveCondition_LazyAppend(t *testing.T) {
+	conditions := *GetInitializedConditions()
+	if len(conditions) != 4 {
+		t.Fatalf("expected 4 base conditions before HPAActive is ever set, got %d", len(conditions))
+	}
+
+	conditions.SetHPAActiveCondition(metav1.ConditionFalse, ScaledObjectConditionHPAMetricsUnavailableReason, "FailedGetExternalMetric: unable to fetch metrics")
+
+	if len(conditions) != 5 {
+		t.Fatalf("expected HPAActive to be appended as a 5th condition, got %d conditions", len(conditions))
+	}
+
+	got := conditions.GetHPAActiveCondition()
+	if got.Type != ConditionHPAActive {
+		t.Errorf("expected type %s, got %s", ConditionHPAActive, got.Type)
+	}
+	if got.Status != metav1.ConditionFalse {
+		t.Errorf("expected status False, got %s", got.Status)
+	}
+	if got.Reason != ScaledObjectConditionHPAMetricsUnavailableReason {
+		t.Errorf("expected reason %s, got %s", ScaledObjectConditionHPAMetricsUnavailableReason, got.Reason)
+	}
+	if got.Message != "FailedGetExternalMetric: unable to fetch metrics" {
+		t.Errorf("expected message to be preserved, got %q", got.Message)
+	}
+}
+
+func TestConditions_SetHPAActiveCondition_UpdatesInPlace(t *testing.T) {
+	conditions := *GetInitializedConditions()
+
+	conditions.SetHPAActiveCondition(metav1.ConditionFalse, ScaledObjectConditionHPAMetricsUnavailableReason, "first message")
+	conditions.SetHPAActiveCondition(metav1.ConditionTrue, ScaledObjectConditionHPAActiveReason, "second message")
+
+	count := 0
+	for _, c := range conditions {
+		if c.Type == ConditionHPAActive {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one HPAActive condition after setting it twice, got %d", count)
+	}
+
+	got := conditions.GetHPAActiveCondition()
+	if got.Status != metav1.ConditionTrue {
+		t.Errorf("expected status to be updated to True, got %s", got.Status)
+	}
+	if got.Reason != ScaledObjectConditionHPAActiveReason {
+		t.Errorf("expected reason to be updated to %s, got %s", ScaledObjectConditionHPAActiveReason, got.Reason)
+	}
+	if got.Message != "second message" {
+		t.Errorf("expected message to be updated to the latest value, got %q", got.Message)
+	}
+}
+
+func TestConditions_GetHPAActiveCondition_ZeroValueWhenUnset(t *testing.T) {
+	conditions := *GetInitializedConditions()
+
+	got := conditions.GetHPAActiveCondition()
+	if got.Type != "" || got.Status != "" || got.Reason != "" || got.Message != "" {
+		t.Errorf("expected zero-value Condition when HPAActive was never set, got %+v", got)
+	}
+	if got.IsTrue() || got.IsFalse() {
+		t.Errorf("a never-set HPAActive condition should be neither True nor False, got %+v", got)
+	}
+}

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -138,9 +138,10 @@ func (e *scaleExecutor) checkHPAHealth(ctx context.Context, logger logr.Logger, 
 //   - metav1.ConditionTrue: the HPA is healthy - either actively scaling (reason
 //     ScaledObjectConditionHPAActiveReason) or intentionally idle because KEDA has scaled the
 //     target to zero (reason ScaledObjectConditionHPAScalingDisabledReason).
-//   - metav1.ConditionFalse: the HPA is unhealthy. The reason is normalized to
-//     ScaledObjectConditionHPAMetricsUnavailableReason; the underlying HPA condition's own reason
-//     and message are preserved in message.
+//   - metav1.ConditionFalse: the HPA is unhealthy. The HPA's own cond.Reason is passed through as-is
+//     so downstream tooling can filter on the specific reason (e.g. FailedGetExternalMetric);
+//     ScaledObjectConditionHPAMetricsUnavailableReason is used as a fallback only when the HPA
+//     reports an empty reason.
 //   - "" (empty status): the HPA could not be observed on this reconcile (no HPA yet, a transient
 //     read error, or the HPA hasn't reported a ScalingActive condition yet). This is distinct from
 //     "healthy" - callers must not treat it as such.
@@ -163,28 +164,24 @@ func (e *scaleExecutor) getHPAHealth(ctx context.Context, logger logr.Logger, sc
 		if cond.Type != autoscalingv2.ScalingActive {
 			continue
 		}
-		if cond.Reason == "ScalingDisabled" {
-			// KEDA-managed scale-to-zero: the HPA is intentionally idle, not unhealthy.
+		switch {
+		case cond.Status == corev1.ConditionTrue:
+			return metav1.ConditionTrue, kedav1alpha1.ScaledObjectConditionHPAActiveReason, "HPA is actively scaling"
+		case cond.Reason == "ScalingDisabled":
+			// KEDA manages scale-to-zero; HPA disables itself at 0 replicas.
 			return metav1.ConditionTrue, kedav1alpha1.ScaledObjectConditionHPAScalingDisabledReason, cond.Message
+		default:
+			hpaReason := cond.Reason
+			if hpaReason == "" {
+				hpaReason = kedav1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason
+			}
+			msg := fmt.Sprintf("HPA is not actively scaling: %s", cond.Message)
+			return metav1.ConditionFalse, hpaReason, msg
 		}
-		if cond.Status == corev1.ConditionTrue {
-			return metav1.ConditionTrue, kedav1alpha1.ScaledObjectConditionHPAActiveReason, cond.Message
-		}
-		return metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaUnhealthyMessage(cond)
 	}
 
 	logger.V(1).Info("HPA has not yet reported a ScalingActive condition, skipping health check")
 	return "", "", ""
-}
-
-// hpaUnhealthyMessage builds the HPAActive message for an unhealthy HPA. Since the Reason field is
-// normalized to ScaledObjectConditionHPAMetricsUnavailableReason, the specific underlying HPA reason
-// is folded into the message alongside the HPA's own message so neither is lost.
-func hpaUnhealthyMessage(cond autoscalingv2.HorizontalPodAutoscalerCondition) string {
-	if cond.Message == "" {
-		return cond.Reason
-	}
-	return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
 }
 
 // An object will be scaled down to 0 only if it's passed its cooldown period

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -34,9 +34,6 @@ import (
 	"github.com/kedacore/keda/v2/pkg/scaling/resolver"
 )
 
-// hpaHealthGracePeriod is the amount of time after HPA creation during which we skip health checks to allow the HPA to initialize and report metrics, avoiding condition flapping.
-const hpaHealthGracePeriod = time.Minute
-
 func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1alpha1.ScaledObject, isActive bool, isError bool, options ScaleExecutorOptions) ScaleResult {
 	logger := e.logger.WithValues("scaledobject.Name", scaledObject.Name, "scaledObject.Namespace", scaledObject.Namespace, "scaleTarget.Name", scaledObject.Spec.ScaleTargetRef.Name)
 	var currentReplicas int32
@@ -120,22 +117,18 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 	return result
 }
 
-// checkHPAHealth checks HPA health and adjusts the Ready condition. If the HPA is healthy, the existing Ready condition is left as-is.
-// If the HPA is unhealthy, the Ready condition is set to False with an appropriate reason.
+// checkHPAHealth checks HPA health and sets the ScaledObject-only HPAActive condition accordingly.
+// It mirrors the HPA's own ScalingActive condition and does not read or mutate the Ready condition:
+// Ready reflects ScaledObject-level validity only, while HPAActive reflects the HPA's operational health.
 func (e *scaleExecutor) checkHPAHealth(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, result *ScaleResult) {
 	hpaHealthy, hpaMessage := e.getHPAHealth(ctx, logger, scaledObject)
 	if hpaHealthy {
+		result.Conditions.SetHPAActiveCondition(metav1.ConditionTrue, kedav1alpha1.ScaledObjectConditionHPAActiveReason, "HPA is healthy and actively scaling")
 		return
 	}
 
-	readyCondition := result.Conditions.GetReadyCondition()
-	if readyCondition.IsTrue() {
-		msg := fmt.Sprintf("ScaledObject is configured correctly but HPA is not healthy: %v", hpaMessage)
-		result.Conditions.SetReadyCondition(metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, msg)
-	} else {
-		msg := fmt.Sprintf("Not ready because HPA is not healthy: %v and SO is not healthy: %v - %v", hpaMessage, readyCondition.Reason, readyCondition.Message)
-		result.Conditions.SetReadyCondition(metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionScalingDegradedReason, msg)
-	}
+	msg := fmt.Sprintf("HPA is not healthy: %v", hpaMessage)
+	result.Conditions.SetHPAActiveCondition(metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, msg)
 }
 
 // getHPAHealth gets the HPA ScalingActive condition to determine if the HPA is operationally healthy.
@@ -150,12 +143,6 @@ func (e *scaleExecutor) getHPAHealth(ctx context.Context, logger logr.Logger, sc
 	err := e.client.Get(ctx, types.NamespacedName{Name: hpaName, Namespace: scaledObject.Namespace}, hpa)
 	if err != nil {
 		logger.Error(err, "Could not read HPA status, skipping health check")
-		return true, ""
-	}
-
-	// Grace period after HPA creation where we skip health checks to allow HPA to initialize and report metrics and avoid condition flapping.
-	if hpa.CreationTimestamp.Add(hpaHealthGracePeriod).After(time.Now()) {
-		logger.V(1).Info("HPA is still initializing, skipping health check")
 		return true, ""
 	}
 

--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -117,46 +117,74 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 	return result
 }
 
-// checkHPAHealth checks HPA health and sets the ScaledObject-only HPAActive condition accordingly.
-// It mirrors the HPA's own ScalingActive condition and does not read or mutate the Ready condition:
-// Ready reflects ScaledObject-level validity only, while HPAActive reflects the HPA's operational health.
+// checkHPAHealth checks the HPA's health and sets the ScaledObject-only HPAActive condition
+// accordingly. It mirrors the HPA's own ScalingActive condition and does not read or mutate the
+// Ready condition: Ready reflects ScaledObject-level validity only, while HPAActive reflects the
+// HPA's operational health.
+//
+// If the HPA cannot currently be observed (no HPA yet, a transient read error, or the HPA hasn't
+// reported a ScalingActive condition yet), HPAActive is left completely untouched so the last
+// genuinely observed state persists until the HPA can be read again.
 func (e *scaleExecutor) checkHPAHealth(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject, result *ScaleResult) {
-	hpaHealthy, hpaMessage := e.getHPAHealth(ctx, logger, scaledObject)
-	if hpaHealthy {
-		result.Conditions.SetHPAActiveCondition(metav1.ConditionTrue, kedav1alpha1.ScaledObjectConditionHPAActiveReason, "HPA is healthy and actively scaling")
+	status, reason, message := e.getHPAHealth(ctx, logger, scaledObject)
+	if status == "" {
 		return
 	}
-
-	msg := fmt.Sprintf("HPA is not healthy: %v", hpaMessage)
-	result.Conditions.SetHPAActiveCondition(metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, msg)
+	result.Conditions.SetHPAActiveCondition(status, reason, message)
 }
 
-// getHPAHealth gets the HPA ScalingActive condition to determine if the HPA is operationally healthy.
-func (e *scaleExecutor) getHPAHealth(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) (healthy bool, message string) {
+// getHPAHealth inspects the HPA's ScalingActive condition to determine HPA health. It returns a
+// tri-state result:
+//   - metav1.ConditionTrue: the HPA is healthy - either actively scaling (reason
+//     ScaledObjectConditionHPAActiveReason) or intentionally idle because KEDA has scaled the
+//     target to zero (reason ScaledObjectConditionHPAScalingDisabledReason).
+//   - metav1.ConditionFalse: the HPA is unhealthy. The reason is normalized to
+//     ScaledObjectConditionHPAMetricsUnavailableReason; the underlying HPA condition's own reason
+//     and message are preserved in message.
+//   - "" (empty status): the HPA could not be observed on this reconcile (no HPA yet, a transient
+//     read error, or the HPA hasn't reported a ScalingActive condition yet). This is distinct from
+//     "healthy" - callers must not treat it as such.
+func (e *scaleExecutor) getHPAHealth(ctx context.Context, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) (status metav1.ConditionStatus, reason string, message string) {
 	hpaName := scaledObject.Status.HpaName
 	if hpaName == "" {
 		logger.V(1).Info("HPA name not found in ScaledObject status, skipping health check")
-		return true, ""
+		return "", "", ""
 	}
 
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 	err := e.client.Get(ctx, types.NamespacedName{Name: hpaName, Namespace: scaledObject.Namespace}, hpa)
 	if err != nil {
 		logger.Error(err, "Could not read HPA status, skipping health check")
-		return true, ""
+		return "", "", ""
 	}
 
 	// Check HPA's ScalingActive condition
 	for _, cond := range hpa.Status.Conditions {
-		if cond.Type == autoscalingv2.ScalingActive {
-			if cond.Status == corev1.ConditionTrue || cond.Reason == "ScalingDisabled" {
-				return true, ""
-			}
-			return false, cond.Reason
+		if cond.Type != autoscalingv2.ScalingActive {
+			continue
 		}
+		if cond.Reason == "ScalingDisabled" {
+			// KEDA-managed scale-to-zero: the HPA is intentionally idle, not unhealthy.
+			return metav1.ConditionTrue, kedav1alpha1.ScaledObjectConditionHPAScalingDisabledReason, cond.Message
+		}
+		if cond.Status == corev1.ConditionTrue {
+			return metav1.ConditionTrue, kedav1alpha1.ScaledObjectConditionHPAActiveReason, cond.Message
+		}
+		return metav1.ConditionFalse, kedav1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaUnhealthyMessage(cond)
 	}
 
-	return true, ""
+	logger.V(1).Info("HPA has not yet reported a ScalingActive condition, skipping health check")
+	return "", "", ""
+}
+
+// hpaUnhealthyMessage builds the HPAActive message for an unhealthy HPA. Since the Reason field is
+// normalized to ScaledObjectConditionHPAMetricsUnavailableReason, the specific underlying HPA reason
+// is folded into the message alongside the HPA's own message so neither is lost.
+func hpaUnhealthyMessage(cond autoscalingv2.HorizontalPodAutoscalerCondition) string {
+	if cond.Message == "" {
+		return cond.Reason
+	}
+	return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
 }
 
 // An object will be scaled down to 0 only if it's passed its cooldown period

--- a/pkg/scaling/executor/scale_scaledobjects_test.go
+++ b/pkg/scaling/executor/scale_scaledobjects_test.go
@@ -860,7 +860,7 @@ func TestGetHPAHealth_ScalingDisabled(t *testing.T) {
 	assert.Empty(t, msg)
 }
 
-func TestGetHPAHealth_WithinGracePeriod(t *testing.T) {
+func TestGetHPAHealth_NoGracePeriod(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockClient := mock_client.NewMockClient(ctrl)
 	exec := newTestExecutor(mockClient)
@@ -880,9 +880,11 @@ func TestGetHPAHealth_WithinGracePeriod(t *testing.T) {
 			return nil
 		})
 
+	// #7914: the anti-flap grace period was removed. HPAActive now absorbs any flapping instead,
+	// so a freshly created but unhealthy HPA must be reported unhealthy immediately.
 	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
-	assert.True(t, healthy, "should be healthy within grace period even if ScalingActive=False")
-	assert.Empty(t, msg)
+	assert.False(t, healthy, "grace period was removed; a freshly created but unhealthy HPA must be reported unhealthy immediately")
+	assert.Equal(t, "FailedGetExternalMetric", msg)
 }
 
 // --------------------------------------------------------------------------- //
@@ -1023,10 +1025,16 @@ func TestRequestScale_NoError_HPAUnhealthy(t *testing.T) {
 
 	result := exec.RequestScale(context.TODO(), &so, true, false, ScaleExecutorOptions{})
 
+	// #7914: HPA health no longer affects Ready. The ScaledObject itself is valid, so Ready stays True.
 	readyCond := result.Conditions.GetReadyCondition()
-	assert.True(t, readyCond.IsFalse())
-	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, readyCond.Reason)
-	assert.Contains(t, readyCond.Message, "FailedGetExternalMetric")
+	assert.True(t, readyCond.IsTrue())
+	assert.Equal(t, v1alpha1.ScaledObjectConditionReadySuccessReason, readyCond.Reason)
+
+	// HPA unhealthiness is now surfaced exclusively via the HPAActive condition.
+	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
+	assert.True(t, hpaActiveCond.IsFalse())
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
+	assert.Contains(t, hpaActiveCond.Message, "FailedGetExternalMetric")
 }
 
 func TestRequestScale_ScalerError_HPAUnhealthy(t *testing.T) {
@@ -1042,13 +1050,90 @@ func TestRequestScale_ScalerError_HPAUnhealthy(t *testing.T) {
 	mockDeploymentGet(mockClient)
 	mockUnhealthyHPA(mockClient)
 
-	// isActive=false, isError=true, no fallback → ScalingDegraded (both broken)
+	// isActive=false, isError=true, no fallback → TriggerError (SO-level reason only, no more combined ScalingDegraded)
 	result := exec.RequestScale(context.TODO(), &so, false, true, ScaleExecutorOptions{})
 
 	readyCond := result.Conditions.GetReadyCondition()
 	assert.True(t, readyCond.IsFalse())
-	assert.Equal(t, v1alpha1.ScaledObjectConditionScalingDegradedReason, readyCond.Reason)
-	assert.Contains(t, readyCond.Message, "FailedGetExternalMetric")
+	assert.Equal(t, "TriggerError", readyCond.Reason)
+	assert.NotEqual(t, v1alpha1.ScaledObjectConditionScalingDegradedReason, readyCond.Reason)
+
+	// HPA unhealthiness is now surfaced exclusively via the HPAActive condition, independent of Ready.
+	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
+	assert.True(t, hpaActiveCond.IsFalse())
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
+	assert.Contains(t, hpaActiveCond.Message, "FailedGetExternalMetric")
+}
+
+// TestRequestScale_TransientHPAGap_ReadyStaysTrue proves the #7914 fix: a transient HPA metric gap
+// (e.g. during a rolling restart of the metrics adapter) must no longer flip the ScaledObject's Ready
+// condition to False. Only the dedicated HPAActive condition should reflect the HPA's unhealthy state,
+// with the underlying HPA condition reason preserved in the message.
+func TestRequestScale_TransientHPAGap_ReadyStaysTrue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := events.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+	// Ready was already True before this reconcile, as it would be in steady state.
+	so.Status.Conditions.SetReadyCondition(v1.ConditionTrue, v1alpha1.ScaledObjectConditionReadySuccessReason, v1alpha1.ScaledObjectConditionReadySuccessMessage)
+
+	mockDeploymentGet(mockClient)
+	mockUnhealthyHPA(mockClient) // simulates a transient HPAMetricsUnavailable-style gap
+
+	result := exec.RequestScale(context.TODO(), &so, true, false, ScaleExecutorOptions{})
+
+	readyCond := result.Conditions.GetReadyCondition()
+	assert.True(t, readyCond.IsTrue(), "Ready must stay True during a transient HPA metric gap")
+
+	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
+	assert.True(t, hpaActiveCond.IsFalse(), "HPAActive must reflect the transient HPA unhealthiness")
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
+	assert.Contains(t, hpaActiveCond.Message, "FailedGetExternalMetric", "the underlying HPA condition reason must be preserved in the message")
+}
+
+// TestRequestScale_HPAHealthy_HPAActiveTrue proves HPAActive recovers to True (and does not stay
+// permanently stuck False) once the HPA becomes healthy again.
+func TestRequestScale_HPAHealthy_HPAActiveTrue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := events.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+	// Simulate HPAActive having been False on a prior reconcile.
+	so.Status.Conditions.SetHPAActiveCondition(v1.ConditionFalse, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, "HPA is not healthy: FailedGetExternalMetric")
+
+	mockDeploymentGet(mockClient)
+	mockHealthyHPA(mockClient)
+
+	result := exec.RequestScale(context.TODO(), &so, true, false, ScaleExecutorOptions{})
+
+	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
+	assert.True(t, hpaActiveCond.IsTrue(), "HPAActive must recover to True once the HPA is healthy again")
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAActiveReason, hpaActiveCond.Reason)
+}
+
+// TestRequestScale_HPAActive_NotInSharedDefaults proves HPAActive is lazy-set only: it is not part of
+// GetInitializedConditions/AreInitialized, which are shared with ScaledJob (a kind that has no HPA).
+// This is what keeps ScaledJob unaffected by this change - no HPAActive condition is ever initialized
+// on ScaledJob, since ScaledJob never calls checkHPAHealth (only RequestScale for ScaledObject does).
+func TestRequestScale_HPAActive_NotInSharedDefaults(t *testing.T) {
+	initialized := v1alpha1.GetInitializedConditions()
+	assert.Len(t, *initialized, 4, "GetInitializedConditions must remain unchanged so ScaledJob is unaffected")
+	for _, cond := range *initialized {
+		assert.NotEqual(t, v1alpha1.ConditionHPAActive, cond.Type, "HPAActive must not be part of the shared default conditions")
+	}
+
+	// Before checkHPAHealth ever runs (e.g. fresh ScaledJob-style conditions), HPAActive is unset.
+	conditions := *v1alpha1.GetInitializedConditions()
+	hpaActiveCond := conditions.GetHPAActiveCondition()
+	assert.Empty(t, hpaActiveCond.Type, "HPAActive should not appear until explicitly set")
 }
 
 func TestRequestScale_ScalerErrorWithFallback_HPAHealthy(t *testing.T) {

--- a/pkg/scaling/executor/scale_scaledobjects_test.go
+++ b/pkg/scaling/executor/scale_scaledobjects_test.go
@@ -762,8 +762,9 @@ func TestGetHPAHealth_NoHPAName(t *testing.T) {
 	so := &v1alpha1.ScaledObject{}
 	so.Status.HpaName = ""
 
-	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
-	assert.True(t, healthy)
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Empty(t, status, "no HPA name yet means the HPA cannot be observed, not that it is healthy")
+	assert.Empty(t, reason)
 	assert.Empty(t, msg)
 }
 
@@ -781,8 +782,9 @@ func TestGetHPAHealth_HPAReadError(t *testing.T) {
 	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
 		Return(errors.New("api unavailable"))
 
-	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
-	assert.True(t, healthy, "should treat HPA read error as healthy to avoid flapping")
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Empty(t, status, "a read error means the HPA cannot be observed, not that it is healthy")
+	assert.Empty(t, reason)
 	assert.Empty(t, msg)
 }
 
@@ -805,8 +807,9 @@ func TestGetHPAHealth_ScalingActiveTrue(t *testing.T) {
 			return nil
 		})
 
-	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
-	assert.True(t, healthy)
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Equal(t, v1.ConditionTrue, status)
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAActiveReason, reason)
 	assert.Empty(t, msg)
 }
 
@@ -829,9 +832,10 @@ func TestGetHPAHealth_ScalingActiveFalse(t *testing.T) {
 			return nil
 		})
 
-	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
-	assert.False(t, healthy)
-	assert.Equal(t, "FailedGetExternalMetric", msg)
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Equal(t, v1.ConditionFalse, status)
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, reason)
+	assert.Equal(t, "FailedGetExternalMetric: unable to get metrics", msg, "both the HPA's reason and its own message must be preserved")
 }
 
 func TestGetHPAHealth_ScalingDisabled(t *testing.T) {
@@ -855,9 +859,10 @@ func TestGetHPAHealth_ScalingDisabled(t *testing.T) {
 			return nil
 		})
 
-	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
-	assert.True(t, healthy, "ScalingDisabled should be treated as healthy since KEDA manages scale-to-zero")
-	assert.Empty(t, msg)
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Equal(t, v1.ConditionTrue, status, "ScalingDisabled should be treated as healthy since KEDA manages scale-to-zero")
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAScalingDisabledReason, reason, "ScalingDisabled must be distinguishable from a normally-scaling HPA")
+	assert.Equal(t, "scaling is disabled since the replica count of the target is zero", msg)
 }
 
 func TestGetHPAHealth_NoGracePeriod(t *testing.T) {
@@ -882,9 +887,38 @@ func TestGetHPAHealth_NoGracePeriod(t *testing.T) {
 
 	// #7914: the anti-flap grace period was removed. HPAActive now absorbs any flapping instead,
 	// so a freshly created but unhealthy HPA must be reported unhealthy immediately.
-	healthy, msg := exec.getHPAHealth(context.TODO(), logger, so)
-	assert.False(t, healthy, "grace period was removed; a freshly created but unhealthy HPA must be reported unhealthy immediately")
-	assert.Equal(t, "FailedGetExternalMetric", msg)
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Equal(t, v1.ConditionFalse, status, "grace period was removed; a freshly created but unhealthy HPA must be reported unhealthy immediately")
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, reason)
+	assert.Equal(t, "FailedGetExternalMetric", msg, "cond.Message was empty, so the message falls back to the HPA's own reason alone")
+}
+
+// TestGetHPAHealth_NoScalingActiveConditionYet covers the third "cannot observe" path: the HPA
+// exists and was read successfully, but hasn't reported a ScalingActive condition yet (e.g. right
+// after creation, before the HPA controller's first sync). This must not be treated as healthy.
+func TestGetHPAHealth_NoScalingActiveConditionYet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.AbleToScale, Status: corev1.ConditionTrue},
+			}
+			return nil
+		})
+
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Empty(t, status, "an HPA that hasn't reported ScalingActive yet cannot be observed, not treated as healthy")
+	assert.Empty(t, reason)
+	assert.Empty(t, msg)
 }
 
 // --------------------------------------------------------------------------- //
@@ -1030,11 +1064,12 @@ func TestRequestScale_NoError_HPAUnhealthy(t *testing.T) {
 	assert.True(t, readyCond.IsTrue())
 	assert.Equal(t, v1alpha1.ScaledObjectConditionReadySuccessReason, readyCond.Reason)
 
-	// HPA unhealthiness is now surfaced exclusively via the HPAActive condition.
+	// HPA unhealthiness is now surfaced exclusively via the HPAActive condition, with both the
+	// HPA's reason (normalized into HPAMetricsUnavailable) and its own message preserved.
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
 	assert.True(t, hpaActiveCond.IsFalse())
 	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
-	assert.Contains(t, hpaActiveCond.Message, "FailedGetExternalMetric")
+	assert.Equal(t, "FailedGetExternalMetric: metrics not available", hpaActiveCond.Message)
 }
 
 func TestRequestScale_ScalerError_HPAUnhealthy(t *testing.T) {
@@ -1062,7 +1097,7 @@ func TestRequestScale_ScalerError_HPAUnhealthy(t *testing.T) {
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
 	assert.True(t, hpaActiveCond.IsFalse())
 	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
-	assert.Contains(t, hpaActiveCond.Message, "FailedGetExternalMetric")
+	assert.Equal(t, "FailedGetExternalMetric: metrics not available", hpaActiveCond.Message)
 }
 
 // TestRequestScale_TransientHPAGap_ReadyStaysTrue proves the #7914 fix: a transient HPA metric gap
@@ -1092,11 +1127,11 @@ func TestRequestScale_TransientHPAGap_ReadyStaysTrue(t *testing.T) {
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
 	assert.True(t, hpaActiveCond.IsFalse(), "HPAActive must reflect the transient HPA unhealthiness")
 	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
-	assert.Contains(t, hpaActiveCond.Message, "FailedGetExternalMetric", "the underlying HPA condition reason must be preserved in the message")
+	assert.Equal(t, "FailedGetExternalMetric: metrics not available", hpaActiveCond.Message, "both the underlying HPA reason and its own message must be preserved")
 }
 
-// TestRequestScale_HPAHealthy_HPAActiveTrue proves HPAActive recovers to True (and does not stay
-// permanently stuck False) once the HPA becomes healthy again.
+// TestRequestScale_HPAHealthy_HPAActiveTrue proves a healthy, actively-scaling HPA produces
+// HPAActive=True with the active reason, passing through the HPA's own (here empty) message.
 func TestRequestScale_HPAHealthy_HPAActiveTrue(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockClient := mock_client.NewMockClient(ctrl)
@@ -1106,8 +1141,6 @@ func TestRequestScale_HPAHealthy_HPAActiveTrue(t *testing.T) {
 
 	so := newSOWithHPA()
 	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
-	// Simulate HPAActive having been False on a prior reconcile.
-	so.Status.Conditions.SetHPAActiveCondition(v1.ConditionFalse, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, "HPA is not healthy: FailedGetExternalMetric")
 
 	mockDeploymentGet(mockClient)
 	mockHealthyHPA(mockClient)
@@ -1115,8 +1148,70 @@ func TestRequestScale_HPAHealthy_HPAActiveTrue(t *testing.T) {
 	result := exec.RequestScale(context.TODO(), &so, true, false, ScaleExecutorOptions{})
 
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
-	assert.True(t, hpaActiveCond.IsTrue(), "HPAActive must recover to True once the HPA is healthy again")
+	assert.True(t, hpaActiveCond.IsTrue(), "HPAActive must be True when the HPA is actively scaling")
 	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAActiveReason, hpaActiveCond.Reason)
+	assert.Empty(t, hpaActiveCond.Message, "the mocked HPA's ScalingActive condition has no message, so HPAActive.Message passes that through")
+}
+
+// TestRequestScale_HPAScalingDisabled_HPAActiveTrueWithDistinctReason proves the ScalingDisabled
+// case (KEDA-managed scale-to-zero) is surfaced as HPAActive=True but with a reason distinct from a
+// normally-scaling HPA, so consumers can tell "actively scaling" apart from "intentionally idle".
+func TestRequestScale_HPAScalingDisabled_HPAActiveTrueWithDistinctReason(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	recorder := events.NewFakeRecorder(1)
+	mockScaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	exec := NewScaleExecutor(mockClient, mockScaleClient, nil, recorder)
+
+	so := newSOWithHPA()
+	so.Status.Conditions = *v1alpha1.GetInitializedConditions()
+
+	mockDeploymentGet(mockClient)
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.AssignableToTypeOf(&autoscalingv2.HorizontalPodAutoscaler{})).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Reason: "ScalingDisabled", Message: "scaling is disabled since the replica count of the target is zero"},
+			}
+			return nil
+		})
+
+	result := exec.RequestScale(context.TODO(), &so, true, false, ScaleExecutorOptions{})
+
+	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
+	assert.True(t, hpaActiveCond.IsTrue(), "ScalingDisabled must still be reported as HPAActive=True, not unhealthy")
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAScalingDisabledReason, hpaActiveCond.Reason, "the reason must distinguish this from a normally-scaling HPA")
+	assert.Equal(t, "scaling is disabled since the replica count of the target is zero", hpaActiveCond.Message)
+}
+
+// TestCheckHPAHealth_CannotObserve_HPAActiveUnchanged proves the tri-state contract of getHPAHealth:
+// when the HPA cannot currently be observed (e.g. a transient read error), checkHPAHealth must leave
+// a previously-observed HPAActive condition exactly as it was, instead of optimistically flipping it
+// to True or otherwise touching it.
+func TestCheckHPAHealth_CannotObserve_HPAActiveUnchanged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	// HPA read fails (e.g. a transient API server hiccup): getHPAHealth cannot observe the HPA.
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		Return(errors.New("api unavailable"))
+
+	result := &ScaleResult{Conditions: v1alpha1.Conditions{}}
+	// Simulate a previously-observed HPAActive=False from an earlier, successful reconcile.
+	result.Conditions.SetHPAActiveCondition(v1.ConditionFalse, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, "FailedGetExternalMetric: metrics not available")
+
+	exec.checkHPAHealth(context.TODO(), logger, so, result)
+
+	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
+	assert.True(t, hpaActiveCond.IsFalse(), "a transient read error must not flip HPAActive away from its last observed state")
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
+	assert.Equal(t, "FailedGetExternalMetric: metrics not available", hpaActiveCond.Message, "the last genuinely observed HPAActive state must persist untouched")
 }
 
 // TestRequestScale_HPAActive_NotInSharedDefaults proves HPAActive is lazy-set only: it is not part of

--- a/pkg/scaling/executor/scale_scaledobjects_test.go
+++ b/pkg/scaling/executor/scale_scaledobjects_test.go
@@ -810,7 +810,7 @@ func TestGetHPAHealth_ScalingActiveTrue(t *testing.T) {
 	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
 	assert.Equal(t, v1.ConditionTrue, status)
 	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAActiveReason, reason)
-	assert.Empty(t, msg)
+	assert.Equal(t, "HPA is actively scaling", msg)
 }
 
 func TestGetHPAHealth_ScalingActiveFalse(t *testing.T) {
@@ -834,8 +834,8 @@ func TestGetHPAHealth_ScalingActiveFalse(t *testing.T) {
 
 	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
 	assert.Equal(t, v1.ConditionFalse, status)
-	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, reason)
-	assert.Equal(t, "FailedGetExternalMetric: unable to get metrics", msg, "both the HPA's reason and its own message must be preserved")
+	assert.Equal(t, "FailedGetExternalMetric", reason, "the HPA's own reason must be passed through so downstream tooling can filter on it")
+	assert.Equal(t, "HPA is not actively scaling: unable to get metrics", msg)
 }
 
 func TestGetHPAHealth_ScalingDisabled(t *testing.T) {
@@ -889,8 +889,36 @@ func TestGetHPAHealth_NoGracePeriod(t *testing.T) {
 	// so a freshly created but unhealthy HPA must be reported unhealthy immediately.
 	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
 	assert.Equal(t, v1.ConditionFalse, status, "grace period was removed; a freshly created but unhealthy HPA must be reported unhealthy immediately")
-	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, reason)
-	assert.Equal(t, "FailedGetExternalMetric", msg, "cond.Message was empty, so the message falls back to the HPA's own reason alone")
+	assert.Equal(t, "FailedGetExternalMetric", reason)
+	assert.Equal(t, "HPA is not actively scaling: ", msg, "cond.Message was empty, so it's interpolated as an empty string")
+}
+
+// TestGetHPAHealth_EmptyReasonFallback covers the fallback branch: when the HPA's ScalingActive
+// condition is False but reports no reason at all, HPAActive.Reason must fall back to
+// ScaledObjectConditionHPAMetricsUnavailableReason instead of being left empty.
+func TestGetHPAHealth_EmptyReasonFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockClient := mock_client.NewMockClient(ctrl)
+	exec := newTestExecutor(mockClient)
+	logger := logf.Log.WithName("test")
+
+	so := &v1alpha1.ScaledObject{}
+	so.Name = "test-so"
+	so.Namespace = "test-ns"
+	so.Status.HpaName = "my-hpa"
+
+	mockClient.EXPECT().Get(gomock.Any(), types.NamespacedName{Name: "my-hpa", Namespace: "test-ns"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, obj *autoscalingv2.HorizontalPodAutoscaler, _ ...interface{}) error {
+			obj.Status.Conditions = []autoscalingv2.HorizontalPodAutoscalerCondition{
+				{Type: autoscalingv2.ScalingActive, Status: corev1.ConditionFalse, Message: "unable to compute replica count"},
+			}
+			return nil
+		})
+
+	status, reason, msg := exec.getHPAHealth(context.TODO(), logger, so)
+	assert.Equal(t, v1.ConditionFalse, status)
+	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, reason, "an empty HPA reason must fall back to HPAMetricsUnavailable")
+	assert.Equal(t, "HPA is not actively scaling: unable to compute replica count", msg)
 }
 
 // TestGetHPAHealth_NoScalingActiveConditionYet covers the third "cannot observe" path: the HPA
@@ -1064,12 +1092,12 @@ func TestRequestScale_NoError_HPAUnhealthy(t *testing.T) {
 	assert.True(t, readyCond.IsTrue())
 	assert.Equal(t, v1alpha1.ScaledObjectConditionReadySuccessReason, readyCond.Reason)
 
-	// HPA unhealthiness is now surfaced exclusively via the HPAActive condition, with both the
-	// HPA's reason (normalized into HPAMetricsUnavailable) and its own message preserved.
+	// HPA unhealthiness is now surfaced exclusively via the HPAActive condition, with the HPA's own
+	// specific reason passed through so downstream tooling can filter on it directly.
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
 	assert.True(t, hpaActiveCond.IsFalse())
-	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
-	assert.Equal(t, "FailedGetExternalMetric: metrics not available", hpaActiveCond.Message)
+	assert.Equal(t, "FailedGetExternalMetric", hpaActiveCond.Reason)
+	assert.Equal(t, "HPA is not actively scaling: metrics not available", hpaActiveCond.Message)
 }
 
 func TestRequestScale_ScalerError_HPAUnhealthy(t *testing.T) {
@@ -1096,8 +1124,8 @@ func TestRequestScale_ScalerError_HPAUnhealthy(t *testing.T) {
 	// HPA unhealthiness is now surfaced exclusively via the HPAActive condition, independent of Ready.
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
 	assert.True(t, hpaActiveCond.IsFalse())
-	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
-	assert.Equal(t, "FailedGetExternalMetric: metrics not available", hpaActiveCond.Message)
+	assert.Equal(t, "FailedGetExternalMetric", hpaActiveCond.Reason)
+	assert.Equal(t, "HPA is not actively scaling: metrics not available", hpaActiveCond.Message)
 }
 
 // TestRequestScale_TransientHPAGap_ReadyStaysTrue proves the #7914 fix: a transient HPA metric gap
@@ -1126,12 +1154,12 @@ func TestRequestScale_TransientHPAGap_ReadyStaysTrue(t *testing.T) {
 
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
 	assert.True(t, hpaActiveCond.IsFalse(), "HPAActive must reflect the transient HPA unhealthiness")
-	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAMetricsUnavailableReason, hpaActiveCond.Reason)
-	assert.Equal(t, "FailedGetExternalMetric: metrics not available", hpaActiveCond.Message, "both the underlying HPA reason and its own message must be preserved")
+	assert.Equal(t, "FailedGetExternalMetric", hpaActiveCond.Reason, "the specific HPA reason must be passed through")
+	assert.Equal(t, "HPA is not actively scaling: metrics not available", hpaActiveCond.Message)
 }
 
 // TestRequestScale_HPAHealthy_HPAActiveTrue proves a healthy, actively-scaling HPA produces
-// HPAActive=True with the active reason, passing through the HPA's own (here empty) message.
+// HPAActive=True with the active reason and the literal "HPA is actively scaling" message.
 func TestRequestScale_HPAHealthy_HPAActiveTrue(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockClient := mock_client.NewMockClient(ctrl)
@@ -1150,7 +1178,7 @@ func TestRequestScale_HPAHealthy_HPAActiveTrue(t *testing.T) {
 	hpaActiveCond := result.Conditions.GetHPAActiveCondition()
 	assert.True(t, hpaActiveCond.IsTrue(), "HPAActive must be True when the HPA is actively scaling")
 	assert.Equal(t, v1alpha1.ScaledObjectConditionHPAActiveReason, hpaActiveCond.Reason)
-	assert.Empty(t, hpaActiveCond.Message, "the mocked HPA's ScalingActive condition has no message, so HPAActive.Message passes that through")
+	assert.Equal(t, "HPA is actively scaling", hpaActiveCond.Message)
 }
 
 // TestRequestScale_HPAScalingDisabled_HPAActiveTrueWithDistinctReason proves the ScalingDisabled


### PR DESCRIPTION
Ready no longer reflects HPA runtime state; HPA health is now surfaced on a dedicated HPAActive condition mirroring the HPA's ScalingActive.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### What this PR does

Since v2.20 (#7669), the ScaledObject `Ready` condition reflected HPA status, so transient HPA states (e.g. a brief metrics gap while new pods warm up after a rolling restart) flipped `Ready` to `False`. This caused false-positive failures for any downstream tool reading `Ready` as "is this ScaledObject OK", see argoproj/argo-cd#28542 for the discussion that led here.

This moves HPA health onto its own condition:

- New `HPAActive` condition mirroring the HPA's own `ScalingActive`, with `SetHPAActiveCondition`/`GetHPAActiveCondition` helpers following the existing Ready/Active/Fallback/Paused pattern.
- `checkHPAHealth` no longer reads or mutates `Ready`, it sets only `HPAActive`. `Ready` returns to reflecting ScaledObject-level validity only.
- `HPAActive.Reason` is normalized (`HPAActive` / `HPAMetricsUnavailable`), with the underlying HPA reason (e.g. `FailedGetExternalMetric`) preserved in the Message.
- `HPAActive` is set in both directions, so it recovers to `True` on the next healthy reconcile rather than latching `False`.
- Removed `hpaHealthGracePeriod`: it was keyed to HPA `CreationTimestamp`, so it never covered rollouts of long-lived HPAs, and transient flapping on `HPAActive` is now correct behaviour rather than something to suppress.

### Design notes for reviewers

- **`HPAActive` is lazy-set, not added to `GetInitializedConditions()`/`AreInitialized()`.** Those are shared with ScaledJob, which has no HPA. It's appended the first time `checkHPAHealth` sets it (ScaledObject-only path). Happy to change if you'd prefer consistency in the initializer.

- **`ScaledObjectConditionScalingDegradedReason` is retained but no longer emitted**, since `Ready` no longer combines SO + HPA state. Left in place with a TODO rather than deleted, as removing an exported constant could break external consumers, happy to remove it.

- **No printcolumn / CRD manifest regeneration**, to keep the diff focused. Can follow up.

### Testing

- Migrated existing cases asserting `Ready` got `HPAMetricsUnavailable`/`ScalingDegraded` to assert `HPAActive` instead.
- Added a regression test: `Ready` stays `True` while `HPAActive` goes `False` during a transient HPA gap.
- Added a recovery test (`HPAActive` returns to `True`) and one asserting ScaledJob is unaffected.
- `go test ./pkg/scaling/... ./apis/...`, `make build`, `make golangci` all pass locally.



<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7914  

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to argoproj/argo-cd#28542
