### PR TITLE
AWS Secret Manager: Guard nil credentials in handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
+- **General**: Fix nil pointer dereference in AWS Secret Manager `TriggerAuthentication` when `awsSecretManager.credentials` is omitted and no `awsSecretManager.podIdentity` is set ([#7927](https://github.com/kedacore/keda/issues/7927))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix `ScaledJob` CRD validation to include "default" as a valid value for `scalingStrategy.strategy` ([#7855](https://github.com/kedacore/keda/issues/7855))
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))

--- a/pkg/scaling/resolver/aws_secretmanager_handler.go
+++ b/pkg/scaling/resolver/aws_secretmanager_handler.go
@@ -103,6 +103,11 @@ func (ash *AwsSecretManagerHandler) Initialize(ctx context.Context, client clien
 
 	switch podIdentity.Provider {
 	case "", kedav1alpha1.PodIdentityProviderNone:
+		if ash.secretManager.Credentials == nil ||
+			ash.secretManager.Credentials.AccessKey == nil ||
+			ash.secretManager.Credentials.AccessSecretKey == nil {
+			return fmt.Errorf("AccessKeyID and AccessSecretKey are expected when not using a pod identity provider")
+		}
 		ash.awsMetadata.AwsAccessKeyID = resolveAuthSecret(ctx, client, logger, ash.secretManager.Credentials.AccessKey.ValueFrom.SecretKeyRef.Name, triggerNamespace, ash.secretManager.Credentials.AccessKey.ValueFrom.SecretKeyRef.Key, secretsLister)
 		ash.awsMetadata.AwsSecretAccessKey = resolveAuthSecret(ctx, client, logger, ash.secretManager.Credentials.AccessSecretKey.ValueFrom.SecretKeyRef.Name, triggerNamespace, ash.secretManager.Credentials.AccessSecretKey.ValueFrom.SecretKeyRef.Key, secretsLister)
 		if ash.awsMetadata.AwsAccessKeyID == "" || ash.awsMetadata.AwsSecretAccessKey == "" {

--- a/pkg/scaling/resolver/aws_secretmanager_handler_test.go
+++ b/pkg/scaling/resolver/aws_secretmanager_handler_test.go
@@ -99,3 +99,45 @@ func TestAwsSecretManagerHandler_InitializeUsingPodIdentity(t *testing.T) {
 		}
 	}
 }
+
+func TestAwsSecretManagerHandler_InitializeMissingCredentials(t *testing.T) {
+	tests := []struct {
+		name          string
+		secretManager *kedav1alpha1.AwsSecretManager
+	}{
+		{
+			name: "nil credentials and nil pod identity",
+			secretManager: &kedav1alpha1.AwsSecretManager{
+				Region: "mocked-region",
+			},
+		},
+		{
+			name: "nil credentials with explicit none pod identity",
+			secretManager: &kedav1alpha1.AwsSecretManager{
+				Region: "mocked-region",
+				PodIdentity: &kedav1alpha1.AuthPodIdentity{
+					Provider: kedav1alpha1.PodIdentityProviderNone,
+				},
+			},
+		},
+		{
+			name: "credentials without an access key",
+			secretManager: &kedav1alpha1.AwsSecretManager{
+				Region:      "mocked-region",
+				Credentials: &kedav1alpha1.AwsSecretManagerCredentials{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			awsSecretManagerHandler := &AwsSecretManagerHandler{
+				secretManager: tc.secretManager,
+			}
+
+			err := awsSecretManagerHandler.Initialize(context.Background(), nil, logr.Discard(), "mocked-trigger-namespace", nil, &corev1.PodSpec{})
+
+			assert.ErrorContains(t, err, "AccessKeyID and AccessSecretKey are expected")
+		})
+	}
+}


### PR DESCRIPTION
Fixes #7927

### Problem

`AwsSecretManagerHandler.Initialize` dereferences `ash.secretManager.Credentials` without a nil check:

https://github.com/kedacore/keda/blob/main/pkg/scaling/resolver/aws_secretmanager_handler.go#L106

`Credentials` is a `*AwsSecretManagerCredentials` marked `// +optional`, and the generated CRD lists only `secrets` as required under `awsSecretManager`. So this TriggerAuthentication is valid and is accepted by the API server:

```yaml
spec:
  podIdentity:
    provider: aws
  awsSecretManager:
    region: eu-central-1
    secrets:
      - parameter: host
        name: my-secret
```

Note the `podIdentity` sits at `spec.podIdentity`, not at `spec.awsSecretManager.podIdentity`. Nothing propagates it down, so `ash.secretManager.PodIdentity` is nil, the existing guard on L100 substitutes an empty `AuthPodIdentity` whose `Provider` is `""`, and execution enters the `case "", PodIdentityProviderNone:` arm — which immediately dereferences the nil `Credentials`.

The result is that every reconcile of any ScaledObject referencing that TriggerAuthentication fails on a recovered nil-pointer panic, so the HPA is never created and the ScaledObject stays in `Unknown`.

### Fix

Return the error this branch already produces two lines later (L109) instead of panicking. The caller in `scale_resolvers.go` already treats a returned error non-fatally — it logs `"error authenticating to Aws Secret Manager"` and carries on — so there is no new behaviour and no new message text.

`AccessKey` and `AccessSecretKey` are pointers too, so they get the same guard. The CRD marks both required inside `credentials`, so that part is defensive only.

### Scope

This PR only removes the panic. Two adjacent questions I deliberately left out:

- Whether `spec.podIdentity` should be inherited by `spec.awsSecretManager` when the nested one is omitted, which would make the reporter's config behave the way they expected. That is a semantics change and needs a signature change to pass the parent spec down — happy to follow up separately if you want it.
- Whether the webhook should reject this at admission. The in-process guard is needed regardless, since the operator also reads cached objects that predate any new webhook rule.

### Testing

Added `TestAwsSecretManagerHandler_InitializeMissingCredentials` with three cases: nil credentials with no pod identity, nil credentials with an explicit `none` pod identity, and a `credentials` block with no access key.

The first case panics on `main` — verified before writing the fix:

```
--- FAIL: TestAwsSecretManagerHandler_InitializeMissingCredentials/nil_credentials_and_nil_pod_identity
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0]
	pkg/scaling/resolver/aws_secretmanager_handler.go:106
```

With the change all three return the expected error, and the two existing tests in the file stay green. No AWS credentials and no cluster are needed — the guard returns before any SDK call is reached.
