### PR TITLE
feat(metrics): add scaler and scale loop latency histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 ### Improvements
 
+- **General**: Add histogram metrics `keda_scaler_metrics_duration_seconds` and `keda_internal_scale_loop_duration_seconds` (and OpenTelemetry equivalents) mirroring the existing latency gauges, labeled by scaler/resource type by default with a new `--enable-high-cardinality-metric-labels` flag to opt in to the full label set ([#7675](https://github.com/kedacore/keda/issues/7675))
 - **Kafka Scaler**: Add optional `fullMetadata` trigger metadata field to control Sarama's full cluster metadata refresh, reducing operator memory for topic scoped triggers ([#7453](https://github.com/kedacore/keda/issues/7453))
 - **Temporal Scaler**: Add opt-in `includeRunningWorkflowCount` (with optional `workflowTaskQueueForCount`) to block premature scale-down when the backlog is momentarily zero but Workflow workers are still busy. Worker Deployment Version scalers short-circuit on Version status (`DRAINING` stays active, `DRAINED`/`INACTIVE` scale down); other modes issue a scoped `CountWorkflow` visibility query — including `TemporalWorkerDeploymentVersion is null` for unversioned workers. ([#7459](https://github.com/kedacore/keda/issues/7459))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -69,6 +69,7 @@ func init() {
 func main() {
 	var enablePrometheusMetrics bool
 	var enableOpenTelemetryMetrics bool
+	var enableHighCardinalityMetricLabels bool
 	var metricsAddr string
 	var probeAddr string
 	var metricsServiceAddr string
@@ -93,6 +94,7 @@ func main() {
 	var filePathAuthRootPath string
 	pflag.BoolVar(&enablePrometheusMetrics, "enable-prometheus-metrics", true, "Enable the prometheus metric of keda-operator.")
 	pflag.BoolVar(&enableOpenTelemetryMetrics, "enable-opentelemetry-metrics", false, "Enable the opentelemetry metric of keda-operator.")
+	pflag.BoolVar(&enableHighCardinalityMetricLabels, "enable-high-cardinality-metric-labels", false, "Enable the full label set on the duration histogram metrics. When disabled, they are emitted with a reduced label set to keep metric cardinality bounded.")
 	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the prometheus metric endpoint binds to.")
 	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	pflag.StringVar(&metricsServiceAddr, "metrics-service-bind-address", ":9666", "The address the gRPRC Metrics Service endpoint binds to.")
@@ -176,7 +178,7 @@ func main() {
 	if !enablePrometheusMetrics {
 		metricsAddr = "0"
 	}
-	metricscollector.NewMetricsCollectors(enablePrometheusMetrics, enableOpenTelemetryMetrics)
+	metricscollector.NewMetricsCollectors(enablePrometheusMetrics, enableOpenTelemetryMetrics, enableHighCardinalityMetricLabels)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,

--- a/pkg/metricscollector/metricscollectors.go
+++ b/pkg/metricscollector/metricscollectors.go
@@ -36,6 +36,11 @@ const (
 var (
 	collectors        []MetricsCollector
 	promServerMetrics *grpcprom.ServerMetrics
+
+	// highCardinalityMetricLabels determines whether the duration histogram metrics
+	// are emitted with their full (high-cardinality) label sets or with reduced ones
+	// that keep the number of time series bounded in large clusters.
+	highCardinalityMetricLabels bool
 )
 
 type MetricsCollector interface {
@@ -43,8 +48,11 @@ type MetricsCollector interface {
 
 	DeleteScalerMetrics(namespace string, scaledResource string, isScaledObject bool)
 
-	// RecordScalerLatency create a measurement of the latency to external metric
-	RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration)
+	// RecordScalerLatency create a measurement of the latency to external metric.
+	// scaler is the user-defined trigger name when set (otherwise the scaler type) and
+	// feeds the gauge labels; triggerType is always the scaler type from the trigger spec
+	// (a bounded set, e.g. "prometheus") and feeds the default histogram label.
+	RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerType string, triggerIndex int, metric string, isScaledObject bool, value time.Duration)
 
 	// RecordScalableObjectLatency create a measurement of the latency executing scalable object loop
 	RecordScalableObjectLatency(namespace string, name string, isScaledObject bool, value time.Duration)
@@ -91,7 +99,9 @@ type MetricsCollector interface {
 	RecordHTTPClientRequest(durationSeconds float64, statusCode int, isError bool, scaler, triggerName, metricName, namespace, scaledResource string)
 }
 
-func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool) {
+func NewMetricsCollectors(enablePrometheusMetrics bool, enableOpenTelemetryMetrics bool, enableHighCardinalityMetricLabels bool) {
+	highCardinalityMetricLabels = enableHighCardinalityMetricLabels
+
 	if enablePrometheusMetrics {
 		promometrics := NewPromMetrics()
 		collectors = append(collectors, promometrics)
@@ -122,9 +132,9 @@ func DeleteScalerMetrics(namespace string, scaledObject string, isScaledObject b
 }
 
 // RecordScalerLatency create a measurement of the latency to external metric
-func RecordScalerLatency(namespace string, scaledObject string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
+func RecordScalerLatency(namespace string, scaledObject string, scaler string, triggerType string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
 	for _, element := range collectors {
-		element.RecordScalerLatency(namespace, scaledObject, scaler, triggerIndex, metric, isScaledObject, value)
+		element.RecordScalerLatency(namespace, scaledObject, scaler, triggerType, triggerIndex, metric, isScaledObject, value)
 	}
 }
 

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -51,6 +51,9 @@ var (
 
 	otHTTPClientRequestsCounter api.Int64Counter
 	otHTTPClientRequestDuration api.Float64Histogram
+
+	otScalerMetricsDuration api.Float64Histogram
+	otInternalLoopDuration  api.Float64Histogram
 )
 
 type OtelMetrics struct {
@@ -170,6 +173,14 @@ func initMeters() {
 	if err != nil {
 		otLog.Error(err, msg)
 	}
+	otScalerMetricsDuration, err = meter.Float64Histogram(
+		"keda.scaler.metrics.duration.seconds",
+		api.WithDescription("The latency of retrieving current metric from each scaler, as a histogram"),
+		api.WithUnit("s"),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
 
 	_, err = meter.Float64ObservableGauge(
 		"keda.internal.scale.loop.latency",
@@ -184,6 +195,14 @@ func initMeters() {
 		api.WithDescription("Internal latency of ScaledObject/ScaledJob loop execution"),
 		api.WithUnit("s"),
 		api.WithFloat64Callback(ScalableObjectLatencyCallback),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+	otInternalLoopDuration, err = meter.Float64Histogram(
+		"keda.internal.scale.loop.duration.seconds",
+		api.WithDescription("Internal latency of ScaledObject/ScaledJob loop execution, as a histogram"),
+		api.WithUnit("s"),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
@@ -305,7 +324,7 @@ func ScalerMetricsLatencyCallbackDeprecated(_ context.Context, obsrv api.Float64
 }
 
 // RecordScalerLatency create a measurement of the latency to external metric
-func (o *OtelMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
+func (o *OtelMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerType string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
 	otelScalerMetricsLatency := OtelMetricFloat64Val{}
 	otelScalerMetricsLatency.val = value.Seconds()
 	otelScalerMetricsLatency.measurementOption = getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
@@ -315,6 +334,15 @@ func (o *OtelMetrics) RecordScalerLatency(namespace string, scaledResource strin
 	otelScalerMetricsLatencyValD.val = float64(value.Milliseconds())
 	otelScalerMetricsLatencyValD.measurementOption = getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
 	otelScalerMetricsLatencyValDeprecated = append(otelScalerMetricsLatencyValDeprecated, otelScalerMetricsLatencyValD)
+
+	// in default mode the single scaler attribute carries triggerType (the scaler type
+	// from the trigger spec, a bounded set) rather than the user-defined trigger name
+	// the gauge uses, so that cardinality stays bounded regardless of trigger naming
+	durationOpt := api.WithAttributes(attribute.Key("scaler").String(triggerType))
+	if highCardinalityMetricLabels {
+		durationOpt = getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
+	}
+	otScalerMetricsDuration.Record(context.Background(), value.Seconds(), durationOpt)
 }
 
 func ScalableObjectLatencyCallback(_ context.Context, obsrv api.Float64Observer) error {
@@ -354,6 +382,12 @@ func (o *OtelMetrics) RecordScalableObjectLatency(namespace string, name string,
 	otelInternalLoopLatencyD.val = float64(value.Milliseconds())
 	otelInternalLoopLatencyD.measurementOption = opt
 	otelInternalLoopLatencyValDeprecated = append(otelInternalLoopLatencyValDeprecated, otelInternalLoopLatencyD)
+
+	durationOpt := api.WithAttributes(attribute.Key("type").String(resourceType))
+	if highCardinalityMetricLabels {
+		durationOpt = opt
+	}
+	otInternalLoopDuration.Record(context.Background(), value.Seconds(), durationOpt)
 }
 
 func ScalerActiveCallback(_ context.Context, obsrv api.Float64Observer) error {

--- a/pkg/metricscollector/opentelemetry_test.go
+++ b/pkg/metricscollector/opentelemetry_test.go
@@ -101,6 +101,101 @@ func TestLoopLatency(t *testing.T) {
 	assert.Equal(t, latencySeconds.Unit, "s")
 	data = latencySeconds.Data.(metricdata.Gauge[float64]).DataPoints[0]
 	assert.Equal(t, data.Value, float64(0.5))
+
+	duration := retrieveMetric(scopeMetrics.Metrics, "keda.internal.scale.loop.duration.seconds")
+	assert.NotNil(t, duration)
+	assert.Equal(t, duration.Unit, "s")
+	histogram := duration.Data.(metricdata.Histogram[float64]).DataPoints[0]
+	assert.Equal(t, histogram.Count, uint64(1))
+	assert.Equal(t, histogram.Sum, float64(0.5))
+	// by default the histogram is only labeled by resource type
+	typeAttribute, ok := histogram.Attributes.Value("type")
+	assert.True(t, ok)
+	assert.Equal(t, typeAttribute.AsString(), "scaledobject")
+	assert.False(t, histogram.Attributes.HasValue("namespace"))
+	assert.False(t, histogram.Attributes.HasValue("name"))
+}
+
+func TestScalerMetricsLatency(t *testing.T) {
+	// scaler carries the user-defined trigger name, triggerType the bounded scaler type
+	testOtel.RecordScalerLatency("namespace", "name", "my-trigger", "cron", 0, "metric", true, 500*time.Millisecond)
+	got := metricdata.ResourceMetrics{}
+	err := testReader.Collect(context.Background(), &got)
+
+	assert.Nil(t, err)
+	scopeMetrics := got.ScopeMetrics[0]
+	assert.NotEqual(t, len(scopeMetrics.Metrics), 0)
+
+	latencySeconds := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.metrics.latency.seconds")
+	assert.NotNil(t, latencySeconds)
+	assert.Equal(t, latencySeconds.Unit, "s")
+	data := latencySeconds.Data.(metricdata.Gauge[float64]).DataPoints[0]
+	assert.Equal(t, data.Value, float64(0.5))
+
+	duration := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.metrics.duration.seconds")
+	assert.NotNil(t, duration)
+	assert.Equal(t, duration.Unit, "s")
+	histogram := duration.Data.(metricdata.Histogram[float64]).DataPoints[0]
+	assert.Equal(t, histogram.Count, uint64(1))
+	assert.Equal(t, histogram.Sum, float64(0.5))
+	// by default the histogram is only labeled by the bounded trigger type,
+	// not by the user-defined trigger name the gauge uses
+	scalerAttribute, ok := histogram.Attributes.Value("scaler")
+	assert.True(t, ok)
+	assert.Equal(t, scalerAttribute.AsString(), "cron")
+	assert.False(t, histogram.Attributes.HasValue("namespace"))
+	assert.False(t, histogram.Attributes.HasValue("scaledObject"))
+	assert.False(t, histogram.Attributes.HasValue("metric"))
+}
+
+func TestDurationHistogramsHighCardinalityLabels(t *testing.T) {
+	prevMode := highCardinalityMetricLabels
+	t.Cleanup(func() {
+		highCardinalityMetricLabels = prevMode
+	})
+	highCardinalityMetricLabels = true
+
+	testOtel.RecordScalerLatency("hc-namespace", "hc-name", "hc-scaler", "hc-trigger-type", 1, "hc-metric", true, 250*time.Millisecond)
+	testOtel.RecordScalableObjectLatency("hc-namespace", "hc-name", true, 250*time.Millisecond)
+	got := metricdata.ResourceMetrics{}
+	err := testReader.Collect(context.Background(), &got)
+
+	assert.Nil(t, err)
+	scopeMetrics := got.ScopeMetrics[0]
+
+	duration := retrieveMetric(scopeMetrics.Metrics, "keda.scaler.metrics.duration.seconds")
+	assert.NotNil(t, duration)
+	var scalerDataPoint *metricdata.HistogramDataPoint[float64]
+	for _, dp := range duration.Data.(metricdata.Histogram[float64]).DataPoints {
+		if attr, ok := dp.Attributes.Value("scaler"); ok && attr.AsString() == "hc-scaler" {
+			scalerDataPoint = &dp
+			break
+		}
+	}
+	assert.NotNil(t, scalerDataPoint)
+	assert.Equal(t, scalerDataPoint.Count, uint64(1))
+	assert.Equal(t, scalerDataPoint.Sum, float64(0.25))
+	namespaceAttribute, ok := scalerDataPoint.Attributes.Value("namespace")
+	assert.True(t, ok)
+	assert.Equal(t, namespaceAttribute.AsString(), "hc-namespace")
+	assert.True(t, scalerDataPoint.Attributes.HasValue("scaledObject"))
+	assert.True(t, scalerDataPoint.Attributes.HasValue("metric"))
+
+	loopDuration := retrieveMetric(scopeMetrics.Metrics, "keda.internal.scale.loop.duration.seconds")
+	assert.NotNil(t, loopDuration)
+	var loopDataPoint *metricdata.HistogramDataPoint[float64]
+	for _, dp := range loopDuration.Data.(metricdata.Histogram[float64]).DataPoints {
+		if attr, ok := dp.Attributes.Value("namespace"); ok && attr.AsString() == "hc-namespace" {
+			loopDataPoint = &dp
+			break
+		}
+	}
+	assert.NotNil(t, loopDataPoint)
+	assert.Equal(t, loopDataPoint.Count, uint64(1))
+	assert.Equal(t, loopDataPoint.Sum, float64(0.25))
+	nameAttribute, ok := loopDataPoint.Attributes.Value("name")
+	assert.True(t, ok)
+	assert.Equal(t, nameAttribute.AsString(), "hc-name")
 }
 
 func TestRecordHTTPClientRequest(t *testing.T) {

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -59,7 +59,9 @@ var (
 		},
 		metricLabels,
 	)
-	scalerActive = prometheus.NewGaugeVec(
+	scalerMetricsDuration = newScalerMetricsDurationHistogram(false)
+	internalLoopDuration  = newInternalLoopDurationHistogram(false)
+	scalerActive          = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: DefaultPromMetricsNamespace,
 			Subsystem: "scaler",
@@ -184,13 +186,61 @@ var (
 	)
 )
 
+// newScalerMetricsDurationHistogram builds the histogram mirror of the
+// keda_scaler_metrics_latency_seconds gauge. By default it is only labeled by
+// scaler type (the trigger type from the trigger spec, a bounded set) to keep
+// the number of time series bounded; the full label set can be enabled with
+// the --enable-high-cardinality-metric-labels flag.
+func newScalerMetricsDurationHistogram(highCardinality bool) *prometheus.HistogramVec {
+	labelNames := []string{"scaler"}
+	if highCardinality {
+		labelNames = metricLabels
+	}
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "scaler",
+			Name:      "metrics_duration_seconds",
+			Help:      "The latency of retrieving current metric from each scaler, in seconds, as a histogram.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		labelNames,
+	)
+}
+
+// newInternalLoopDurationHistogram builds the histogram mirror of the
+// keda_internal_scale_loop_latency_seconds gauge. By default it is only labeled
+// by resource type to keep the number of time series bounded; the full label set
+// can be enabled with the --enable-high-cardinality-metric-labels flag.
+func newInternalLoopDurationHistogram(highCardinality bool) *prometheus.HistogramVec {
+	labelNames := []string{"type"}
+	if highCardinality {
+		labelNames = []string{"namespace", "type", "resource"}
+	}
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "internal_scale_loop",
+			Name:      "duration_seconds",
+			Help:      "Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop, as a histogram.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		labelNames,
+	)
+}
+
 type PromMetrics struct {
 }
 
 func NewPromMetrics() *PromMetrics {
+	scalerMetricsDuration = newScalerMetricsDurationHistogram(highCardinalityMetricLabels)
+	internalLoopDuration = newInternalLoopDurationHistogram(highCardinalityMetricLabels)
+
 	metrics.Registry.MustRegister(scalerMetricsValue)
 	metrics.Registry.MustRegister(scalerMetricsLatency)
+	metrics.Registry.MustRegister(scalerMetricsDuration)
 	metrics.Registry.MustRegister(internalLoopLatency)
+	metrics.Registry.MustRegister(internalLoopDuration)
 	metrics.Registry.MustRegister(scalerActive)
 	metrics.Registry.MustRegister(scalerErrors)
 	metrics.Registry.MustRegister(scaledObjectErrors)
@@ -228,16 +278,23 @@ func (p *PromMetrics) DeleteScalerMetrics(namespace string, scaledResource strin
 	scalerActive.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerErrors.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerMetricsLatency.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
+	if highCardinalityMetricLabels {
+		// with the reduced label set the histogram series are shared across scaled resources,
+		// so there is nothing to delete when a single resource is gone
+		scalerMetricsDuration.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
+	}
 }
 
 // RecordScalerLatency create a measurement of the latency to external metric
-func (p *PromMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
+func (p *PromMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerType string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
 	scalerMetricsLatency.With(getLabels(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)).Set(value.Seconds())
+	scalerMetricsDuration.With(getScalerDurationLabels(namespace, scaledResource, scaler, triggerType, triggerIndex, metric, isScaledObject)).Observe(value.Seconds())
 }
 
 // RecordScalableObjectLatency create a measurement of the latency executing scalable object loop
 func (p *PromMetrics) RecordScalableObjectLatency(namespace string, name string, isScaledObject bool, value time.Duration) {
 	internalLoopLatency.WithLabelValues(namespace, getResourceType(isScaledObject), name).Set(value.Seconds())
+	internalLoopDuration.With(getLoopDurationLabels(namespace, name, isScaledObject)).Observe(value.Seconds())
 }
 
 // RecordScalerActive create a measurement of the activity of the scaler
@@ -308,6 +365,27 @@ func (p *PromMetrics) RecordScaledJobError(namespace string, scaledJob string, e
 
 func getLabels(namespace string, scaledObject string, scaler string, triggerIndex int, metric string, isScaledObject bool) prometheus.Labels {
 	return prometheus.Labels{"namespace": namespace, "scaledObject": scaledObject, "scaler": scaler, "triggerIndex": strconv.Itoa(triggerIndex), "metric": metric, "type": getResourceType(isScaledObject)}
+}
+
+// getScalerDurationLabels returns the labels of the scaler metrics duration histogram,
+// matching the label names the histogram was created with in newScalerMetricsDurationHistogram.
+// In default mode the single scaler label carries triggerType (the scaler type from the
+// trigger spec, a bounded set) rather than the user-defined trigger name the gauge uses,
+// so that cardinality stays bounded regardless of how triggers are named.
+func getScalerDurationLabels(namespace string, scaledObject string, scaler string, triggerType string, triggerIndex int, metric string, isScaledObject bool) prometheus.Labels {
+	if highCardinalityMetricLabels {
+		return getLabels(namespace, scaledObject, scaler, triggerIndex, metric, isScaledObject)
+	}
+	return prometheus.Labels{"scaler": triggerType}
+}
+
+// getLoopDurationLabels returns the labels of the internal scale loop duration histogram,
+// matching the label names the histogram was created with in newInternalLoopDurationHistogram
+func getLoopDurationLabels(namespace string, resource string, isScaledObject bool) prometheus.Labels {
+	if highCardinalityMetricLabels {
+		return prometheus.Labels{"namespace": namespace, "type": getResourceType(isScaledObject), "resource": resource}
+	}
+	return prometheus.Labels{"type": getResourceType(isScaledObject)}
 }
 
 func getResourceType(isScaledObject bool) string {

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -18,6 +18,7 @@ package metricscollector
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -87,4 +88,100 @@ func TestPromMetrics_RecordHTTPClientRequest(t *testing.T) {
 	require.NoError(t, hist.(prometheus.Metric).Write(m))
 	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
 	assert.InDelta(t, 0.05, m.Histogram.GetSampleSum(), 0.001)
+}
+
+func TestPromMetrics_RecordScalerLatency_DefaultLabels(t *testing.T) {
+	p := &PromMetrics{}
+
+	// scaler carries the user-defined trigger name, triggerType the bounded scaler type
+	p.RecordScalerLatency("latency-ns", "latency-so", "my-cron-trigger", "cron", 0, "latency-metric", true, 250*time.Millisecond)
+
+	// the deprecated gauge keeps the full label set, with the trigger name as scaler
+	m := &dto.Metric{}
+	gauge, err := scalerMetricsLatency.GetMetricWith(getLabels("latency-ns", "latency-so", "my-cron-trigger", 0, "latency-metric", true))
+	require.NoError(t, err)
+	require.NoError(t, gauge.Write(m))
+	assert.InDelta(t, 0.25, m.Gauge.GetValue(), 0.001)
+
+	// the histogram mirror is labeled by the bounded trigger type only by default,
+	// even when the user gave the trigger a custom name
+	hist, err := scalerMetricsDuration.GetMetricWithLabelValues("cron")
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+	assert.InDelta(t, 0.25, m.Histogram.GetSampleSum(), 0.001)
+
+	// no histogram series was created for the user-defined trigger name
+	assert.Zero(t, scalerMetricsDuration.DeletePartialMatch(prometheus.Labels{"scaler": "my-cron-trigger"}))
+
+	// the full label set is not accepted without the high-cardinality flag
+	_, err = scalerMetricsDuration.GetMetricWith(getLabels("latency-ns", "latency-so", "my-cron-trigger", 0, "latency-metric", true))
+	assert.Error(t, err)
+
+	// deleting the scaled resource keeps the shared reduced-label series intact
+	p.DeleteScalerMetrics("latency-ns", "latency-so", true)
+	hist, err = scalerMetricsDuration.GetMetricWithLabelValues("cron")
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+}
+
+func TestPromMetrics_RecordScalableObjectLatency_DefaultLabels(t *testing.T) {
+	p := &PromMetrics{}
+
+	p.RecordScalableObjectLatency("loop-ns", "loop-so", true, 100*time.Millisecond)
+	p.RecordScalableObjectLatency("loop-ns", "loop-sj", false, 200*time.Millisecond)
+
+	m := &dto.Metric{}
+	hist, err := internalLoopDuration.GetMetricWithLabelValues("scaledobject")
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+	assert.InDelta(t, 0.1, m.Histogram.GetSampleSum(), 0.001)
+
+	hist, err = internalLoopDuration.GetMetricWithLabelValues("scaledjob")
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+	assert.InDelta(t, 0.2, m.Histogram.GetSampleSum(), 0.001)
+}
+
+func TestPromMetrics_DurationHistograms_HighCardinalityLabels(t *testing.T) {
+	prevMode := highCardinalityMetricLabels
+	prevScalerHist := scalerMetricsDuration
+	prevLoopHist := internalLoopDuration
+	t.Cleanup(func() {
+		highCardinalityMetricLabels = prevMode
+		scalerMetricsDuration = prevScalerHist
+		internalLoopDuration = prevLoopHist
+	})
+	highCardinalityMetricLabels = true
+	scalerMetricsDuration = newScalerMetricsDurationHistogram(true)
+	internalLoopDuration = newInternalLoopDurationHistogram(true)
+
+	p := &PromMetrics{}
+	p.RecordScalerLatency("hc-ns", "hc-so", "hc-trigger", "prometheus", 1, "hc-metric", true, 500*time.Millisecond)
+	p.RecordScalableObjectLatency("hc-ns", "hc-so", true, 300*time.Millisecond)
+
+	// in high-cardinality mode the histogram carries the same label set as the gauge,
+	// including the user-defined trigger name as scaler
+	m := &dto.Metric{}
+	hist, err := scalerMetricsDuration.GetMetricWith(getLabels("hc-ns", "hc-so", "hc-trigger", 1, "hc-metric", true))
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+	assert.InDelta(t, 0.5, m.Histogram.GetSampleSum(), 0.001)
+
+	hist, err = internalLoopDuration.GetMetricWith(prometheus.Labels{"namespace": "hc-ns", "type": "scaledobject", "resource": "hc-so"})
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 1, m.Histogram.GetSampleCount())
+	assert.InDelta(t, 0.3, m.Histogram.GetSampleSum(), 0.001)
+
+	// deleting the scaled resource also deletes its histogram series in high-cardinality mode
+	p.DeleteScalerMetrics("hc-ns", "hc-so", true)
+	hist, err = scalerMetricsDuration.GetMetricWith(getLabels("hc-ns", "hc-so", "hc-trigger", 1, "hc-metric", true))
+	require.NoError(t, err)
+	require.NoError(t, hist.(prometheus.Metric).Write(m))
+	assert.EqualValues(t, 0, m.Histogram.GetSampleCount())
 }

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -693,7 +693,7 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 						var latency time.Duration
 						rawMetrics, isMetricActive, latency, rawErr = scalersCache.GetMetricsAndActivityForScaler(ctx, triggerIndex, metricName)
 						if latency != -1 {
-							metricscollector.RecordScalerLatency(scaledObjectNamespace, scaledObject.Name, triggerName, triggerIndex, metricName, true, latency)
+							metricscollector.RecordScalerLatency(scaledObjectNamespace, scaledObject.Name, triggerName, scalerConfig.TriggerType, triggerIndex, metricName, true, latency)
 						}
 						logger.V(1).Info("Getting metrics from trigger", "trigger", triggerName, "metricName", metricName, "metrics", rawMetrics, "scalerError", rawErr)
 					}
@@ -976,7 +976,7 @@ func (h *scaleHandler) getScalerState(ctx context.Context, scaler scalers.Scaler
 			continue
 		}
 		if latency != -1 {
-			metricscollector.RecordScalerLatency(scaledObject.Namespace, scaledObject.Name, result.TriggerName, triggerIndex, metricName, true, latency)
+			metricscollector.RecordScalerLatency(scaledObject.Namespace, scaledObject.Name, result.TriggerName, scalerConfig.TriggerType, triggerIndex, metricName, true, latency)
 		}
 
 		logger.V(1).Info("Getting metrics and activity from scaler", "scaler", result.TriggerName, "metricName", metricName, "metrics", rawMetrics, "activity", isMetricActive, "scalerError", rawErr)
@@ -1091,7 +1091,7 @@ func (h *scaleHandler) getScaledJobMetrics(ctx context.Context, scaledJob *kedav
 			}
 			metricscollector.RecordScaledJobError(scaledJob.Namespace, scaledJob.Name, err)
 			if latency != -1 {
-				metricscollector.RecordScalerLatency(scaledJob.Namespace, scaledJob.Name, scalerName, scalerIndex, metricName, false, latency)
+				metricscollector.RecordScalerLatency(scaledJob.Namespace, scaledJob.Name, scalerName, scalerConfigs[scalerIndex].TriggerType, scalerIndex, metricName, false, latency)
 			}
 			if err != nil {
 				scalerLogger.Error(err, "Error getting scaler metrics and activity, but continue")

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -663,7 +663,7 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 
 func TestGetScaledObjectStateRecordsResourceScalerActiveMetric(t *testing.T) {
 	promMetricsCollectorOnce.Do(func() {
-		metricscollector.NewMetricsCollectors(true, false)
+		metricscollector.NewMetricsCollectors(true, false, false)
 	})
 
 	ctrl := gomock.NewController(t)
@@ -740,7 +740,7 @@ func TestGetScaledObjectStateRecordsResourceScalerActiveMetric(t *testing.T) {
 
 func TestGetScaledObjectStateSkipsResourceScalerActiveMetricWithModifiers(t *testing.T) {
 	promMetricsCollectorOnce.Do(func() {
-		metricscollector.NewMetricsCollectors(true, false)
+		metricscollector.NewMetricsCollectors(true, false, false)
 	})
 
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
`keda_scaler_metrics_latency_seconds` and `keda_internal_scale_loop_latency_seconds` are gauges, so they only expose the last observed value per scrape and lose everything in between — no percentiles, no aggregation. Every comparable latency metric KEDA exposes (`keda_internal_metricsservice_grpc_server_handling_seconds`, `keda_scaler_http_request_duration_seconds`, controller-runtime/workqueue metrics) is a histogram.

This PR adds histogram mirrors alongside the existing gauges, following the dual-write approach proposed in the issue. The gauges are kept unchanged so nothing downstream breaks.

### New metrics

| Backend | Metric | Type |
|---|---|---|
| Prometheus | `keda_scaler_metrics_duration_seconds` | histogram |
| Prometheus | `keda_internal_scale_loop_duration_seconds` | histogram |
| OpenTelemetry | `keda.scaler.metrics.duration.seconds` | histogram (unit `s`) |
| OpenTelemetry | `keda.internal.scale.loop.duration.seconds` | histogram (unit `s`) |

### Cardinality

Per the review discussion on the previous attempt (https://github.com/kedacore/keda/pull/7682#discussion_r3143777480) and the direction agreed in https://github.com/kedacore/keda/pull/7644#discussion_r3143770321, the histograms use a reduced label set by default, and a new operator flag opts in to the full one:

| Mode | `keda_scaler_metrics_duration_seconds` | `keda_internal_scale_loop_duration_seconds` |
|---|---|---|
| default | `{scaler}` = trigger **type** (bounded set) | `{type}` |
| `--enable-high-cardinality-metric-labels` | `{namespace, metric, scaledObject, scaler, triggerIndex, type}` (same as the gauge) | `{namespace, type, resource}` (same as the gauge) |

The default follows @aliaqel-stripe's suggestion that latency by scaler type (`prometheus`, `aws-sqs-queue`, ...) is what most users want, mirroring the merged `keda_scaler_http_request_duration_seconds`, which is labeled by `scaler`/`status_code` only.

One subtlety worth calling out: the existing gauge's `scaler` label carries the user-defined `triggers[].name` whenever one is set (and setting one is mandatory with `scalingModifiers` formulas), so it is not actually bounded. To keep the default histogram truly bounded, `RecordScalerLatency` gains a `triggerType` parameter fed from `ScalerConfig.TriggerType` at the call sites — the same bounded value `keda_scaler_http_request_duration_seconds` uses for its `scaler` label — and the default-mode histogram is labeled with that, never with the trigger name. The gauge's labels are unchanged. In high-cardinality mode the histogram carries the exact gauge label set (including the trigger name as `scaler`), and `DeleteScalerMetrics` deletes a removed scaled resource's histogram series via the same `DeletePartialMatch` pattern as the gauges, so scaler histogram series don't accumulate for deleted objects. (The loop histogram's per-resource series in high-cardinality mode mirror the existing `keda_internal_scale_loop_latency_seconds` gauge, which has no deletion path either.)

OTel attributes follow the same rule (the loop histogram uses `name` in high-cardinality mode, matching the existing OTel gauge attribute).

Buckets are `prometheus.DefBuckets` (5ms–10s, the same boundaries as `keda_scaler_http_request_duration_seconds`); happy to tune if maintainers have preferred ranges. OTel instruments use SDK default aggregation (overridable with Views), like the existing HTTP request duration histogram.

### Open points for maintainers

- The existing gauges are intentionally **not** marked deprecated here — happy to add `DEPRECATED - will be removed in x.y` help text plus a Deprecations changelog entry in this PR or a follow-up once a removal timeline is agreed per the deprecations policy.
- If the flag should instead disable the histograms entirely (rather than reduce their labels), that is a small change — implemented the reduced-label variant since that was the concrete suggestion on #7682.

### Testing

- `go test ./pkg/metricscollector/... -count=1` (also with `-race`) — pass; new unit tests cover both Prometheus and OTel histograms in default and high-cardinality modes, dual-write behavior (gauge keeps the trigger name, default histogram gets the bounded trigger type and no trigger-name series is created), and series deletion on resource removal.
- `go test ./pkg/scaling/... -count=1` — pass (call sites of `RecordScalerLatency` and `NewMetricsCollectors`).
- `golangci-lint run ./pkg/metricscollector/... ./cmd/operator/... ./pkg/scaling/...` — 0 issues.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*: kedacore/keda-docs#1816
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #7675

Relates to #7682, #7644
Documentation PR: kedacore/keda-docs#1816

