### PR TITLE
CI: e2e forgejo bump scale-in timeout 1min -> 3min

### DIFF
--- a/tests/scalers/forgejo_runner/forgejo_runner_test.go
+++ b/tests/scalers/forgejo_runner/forgejo_runner_test.go
@@ -293,7 +293,7 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	t.Log("--- testing scale in ---")
 
-	if !assert.True(t, WaitForPodsCompleted(t, kc, "app=forgejo-job", testNamespace, 60, 1), "pods count should be 1 after 1 minute") {
+	if !assert.True(t, WaitForPodsCompleted(t, kc, "app=forgejo-job", testNamespace, 180, 1), "pods should complete within 3 minutes") {
 		dumpScaleInDiagnostics(t, kc)
 	}
 }


### PR DESCRIPTION
the forgejo e2e test is very flaky https://github.com/kedacore/keda/pull/7921 in the scale-in part of the test (so scaler works, just something seems to be taking longer to finish).

This PR bumps the timeout from 60s to 180s because the extra diagnostics show that:
* the failure remains in the same part, scale-in
```
      helper.go:47***: Waiting for pods with label app=forgejo-job to complete
      forgejo_runner_test.go:***96:
                Error:          Should be true
                Messages:       pods count should be *** after *** minute
```
* the jobs are still running when it times out, no failure, no cancellations
```
      forgejo_runner_test.go:***0***: --- scale-in failure diagnostics ---
      forgejo_runner_test.go:***: job forgejo-test-so-znv9l: active=*** succeeded=0 failed=0
      forgejo_runner_test.go:***9: pod forgejo-test-so-znv9l-mlkhr container runner: restarts=0 state=running startedAt=***0***6-07-***T***6:04:***Z
```
* and the times this test passes, it is usually very close to the 60s timeout, around 57s - 59s.