### PR TITLE
fix: off-by-one in liiklus replica cap over-scales near partition bou…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Restore gRPC reconnect backoff in the metrics service client; an unset `Backoff` in `WithConnectParams` disabled backoff and caused a zero-delay reconnect loop that flooded logs when keda-operator was unreachable ([#7856](https://github.com/kedacore/keda/issues/7856))
 - **General**: Treat negative external metric values as zero to prevent incorrect HPA scaling ([#7880](https://github.com/kedacore/keda/issues/7880))
 - **Azure Blob Storage Scaler**: Fix `globPattern` never matching when written in path-style with a leading `/`, since blob names never have one ([#6492](https://github.com/kedacore/keda/issues/6492))
+- **Liiklus Scaler**: Fix off-by-one in replica cap that allowed scaling one past the partition count when total lag is in range [P*T+1, (P+1)*T-1] ([#7930](https://github.com/kedacore/keda/issues/7930))
 - **MongoDB Scaler**: Disconnect the client when the initial `Ping` fails so the background topology-monitoring connections opened by `mongo.Connect` are not leaked ([#5612](https://github.com/kedacore/keda/issues/5612))
 
 ### Deprecations

--- a/pkg/scalers/liiklus_scaler.go
+++ b/pkg/scalers/liiklus_scaler.go
@@ -86,7 +86,7 @@ func (s *liiklusScaler) GetMetricsAndActivity(ctx context.Context, metricName st
 		return nil, false, err
 	}
 
-	if totalLag/uint64(s.metadata.LagThreshold) > uint64(len(lags)) {
+	if totalLag/uint64(s.metadata.LagThreshold) >= uint64(len(lags)) {
 		totalLag = uint64(s.metadata.LagThreshold) * uint64(len(lags))
 	}
 

--- a/pkg/scalers/liiklus_scaler_test.go
+++ b/pkg/scalers/liiklus_scaler_test.go
@@ -240,3 +240,47 @@ func TestLiiklusGetMetricSpecForScaling(t *testing.T) {
 		})
 	}
 }
+
+func TestLiiklusReplicaCapBoundary(t *testing.T) {
+	// Regression test for off-by-one in replica cap (issue #7930).
+	// With lagThreshold=10 and 2 partitions, any totalLag in [21,29]
+	// previously escaped the cap and reported 3 replicas instead of 2.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	lm, _ := parseLiiklusMetadata(&scalersconfig.ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"topic":        "foo",
+			"address":      "using-mock",
+			"group":        "mygroup",
+			"lagThreshold": "10",
+		},
+	})
+	mockClient := mock_liiklus.NewMockLiiklusServiceClient(ctrl)
+	scaler := &liiklusScaler{
+		metadata: lm,
+		client:   mockClient,
+	}
+
+	// totalLag = 21 (partition 0 lag=11, partition 1 lag=10)
+	// Before fix: 21/10=2, 2>2 is false → cap skipped → metric=21 → ceil(21/10)=3 replicas
+	// After fix:  21/10=2, 2>=2 is true → totalLag capped to 20 → metric=20 → ceil(20/10)=2 replicas
+	mockClient.EXPECT().
+		GetOffsets(gomock.Any(), gomock.Any()).
+		Return(&liiklus.GetOffsetsReply{Offsets: map[uint32]uint64{0: 0, 1: 0}}, nil)
+	mockClient.EXPECT().
+		GetEndOffsets(gomock.Any(), gomock.Any()).
+		Return(&liiklus.GetEndOffsetsReply{Offsets: map[uint32]uint64{0: 11, 1: 10}}, nil)
+
+	values, _, err := scaler.GetMetricsAndActivity(context.Background(), "m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Metric must be capped at lagThreshold * partitions = 10 * 2 = 20
+	wantMilli := int64(20 * 1000)
+	if values[0].Value.MilliValue() != wantMilli {
+		t.Errorf("expected metric %d milli (capped at T*P=20), got %d milli (off-by-one cap escape)",
+			wantMilli, values[0].Value.MilliValue())
+	}
+}


### PR DESCRIPTION
What's the problem?

The replica cap in GetMetricsAndActivity uses a strict > comparison:

go
if totalLag/uint64(s.metadata.LagThreshold) > uint64(len(lags)) {
    totalLag = uint64(s.metadata.LagThreshold) * uint64(len(lags))
}

Because integer division floors, any totalLag in the range [P*T+1, (P+1)*T-1] (where T = lagThreshold, P = partition count) produces a quotient equal to P — so the condition P > P is false and the cap is skipped. The reported metric then exceeds T*P, and the HPA scales to P+1 replicas for P partitions.

Concrete example (lagThreshold=10, partitions=2, totalLag=21):

Before: 21/10=2, 2>2 is false → cap skipped → metric=21 → ceil(21/10)=3 replicas
After: 21/10=2, 2>=2 is true → totalLag capped to 20 → metric=20 → 2 replicas

The fix

One character — change > to >=:

go
if totalLag/uint64(s.metadata.LagThreshold) >= uint64(len(lags)) {

Testing

Added TestLiiklusReplicaCapBoundary — a boundary regression test using the exact scenario from the issue report. It fails before the fix and passes after.

All existing liiklus tests continue to pass.

Fixes #7930