### PR TITLE
Github Scaler: key per-run job cache by (repo, runID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Add controller-runtime cache field indexes for ScaledObject admission validation so `verifyScaledObjects` and `verifyHpas` look up duplicate scaleTargetRef and HPA-name conflicts via indexed Lists rather than full-namespace scans, eliminating the webhook OOM under high-scale creation bursts ([#7681](https://github.com/kedacore/keda/pull/7681))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
+- **Github Runner Scaler**: Fix per-repository ETag job cache returning another concurrent workflow run's jobs, inflating the computed queue length when a repository has multiple simultaneous queued/in_progress runs ([#7949](https://github.com/kedacore/keda/issues/7949))
 
 ### Deprecations
 

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -32,24 +32,28 @@ const (
 	// githubScalerMaxCacheEntries caps the etags, previousJobs, and
 	// previousWfrs maps. Without it the etags map grows once per workflow run
 	// for the lifetime of the operator pod (the URL contains the run ID), and
-	// previousJobs and previousWfrs grow once per distinct repository name
-	// returned by the API.
+	// previousWfrs grows once per distinct repository name returned by the
+	// API. previousJobs is keyed by (repository, workflow run ID) and is
+	// bounded by total (repo, runID) pairs across all repositories.
 	githubScalerMaxCacheEntries = 5000
 )
 
 var reservedLabels = []string{"self-hosted", "linux", "x64"}
 
 type githubRunnerScaler struct {
-	metricType              v2.MetricTargetType
-	metadata                *githubRunnerMetadata
-	httpClient              *http.Client
-	logger                  logr.Logger
-	recorder                events.EventRecorder
-	scaledObject            runtime.Object
-	etags                   map[string]string
-	previousRepos           []string
-	previousWfrs            map[string]map[string]*WorkflowRuns
-	previousJobs            map[string][]Job
+	metricType    v2.MetricTargetType
+	metadata      *githubRunnerMetadata
+	httpClient    *http.Client
+	logger        logr.Logger
+	recorder      events.EventRecorder
+	scaledObject  runtime.Object
+	etags         map[string]string
+	previousRepos []string
+	previousWfrs  map[string]map[string]*WorkflowRuns
+	// previousJobs is keyed by repository name, then by workflow run ID —
+	// a single repository can have several runs queued/in_progress at once,
+	// and each run's job list must not be conflated with another's.
+	previousJobs            map[string]map[int64][]Job
 	rateLimit               RateLimit
 	previousQueueLength     int64
 	previousQueueLengthTime time.Time
@@ -380,7 +384,7 @@ func NewGitHubRunnerScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 
 	etags := make(map[string]string)
 	previousRepos := []string{}
-	previousJobs := make(map[string][]Job)
+	previousJobs := make(map[string]map[int64][]Job)
 	previousWfrs := make(map[string]map[string]*WorkflowRuns)
 	rateLimit := RateLimit{}
 	previousQueueLength := int64(0)
@@ -633,8 +637,8 @@ func (s *githubRunnerScaler) getWorkflowRunJobs(ctx context.Context, workflowRun
 		return nil, err
 	}
 	if statusCode == 304 && s.metadata.EnableEtags {
-		if s.previousJobs[repoName] != nil {
-			return s.previousJobs[repoName], nil
+		if jobs, ok := s.previousJobs[repoName][workflowRunID]; ok {
+			return jobs, nil
 		}
 		// Stale etag without a paired previousJobs entry, e.g. after pruneCaches
 		// evicted the previous entry. Drop the etag and retry as a cache miss.
@@ -655,7 +659,11 @@ func (s *githubRunnerScaler) getWorkflowRunJobs(ctx context.Context, workflowRun
 	}
 
 	if s.metadata.EnableEtags {
-		s.previousJobs[repoName] = jobs.Jobs
+		if _, repoFound := s.previousJobs[repoName]; !repoFound {
+			s.previousJobs[repoName] = map[int64][]Job{workflowRunID: jobs.Jobs}
+		} else {
+			s.previousJobs[repoName][workflowRunID] = jobs.Jobs
+		}
 	}
 
 	return jobs.Jobs, nil
@@ -767,8 +775,14 @@ func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 	return -1, fmt.Errorf("GitHub API rate limit exceeded. No cached queue length available")
 }
 
-// pruneCaches removes previousWfrs entries for repos missing from currentRepos
-// and caps all three caches to githubScalerMaxCacheEntries.
+// pruneCaches removes previousWfrs entries for repos missing from
+// currentRepos, and caps all three caches to githubScalerMaxCacheEntries.
+//
+// previousJobs is intentionally not pruned by currentRepos: it is keyed by
+// each workflow run's own repository name (wfr.Repository.Name), which is
+// not guaranteed to be an element of currentRepos (the list used to query
+// workflow runs) — e.g. a run triggered from a fork. It is still bounded by
+// evictExcessJobs below.
 func (s *githubRunnerScaler) pruneCaches(currentRepos []string) {
 	repoSet := make(map[string]struct{}, len(currentRepos))
 	for _, r := range currentRepos {
@@ -780,7 +794,7 @@ func (s *githubRunnerScaler) pruneCaches(currentRepos []string) {
 		}
 	}
 	evictExcess(s.previousWfrs, githubScalerMaxCacheEntries)
-	evictExcess(s.previousJobs, githubScalerMaxCacheEntries)
+	evictExcessJobs(s.previousJobs, githubScalerMaxCacheEntries)
 	evictExcess(s.etags, githubScalerMaxCacheEntries)
 }
 
@@ -794,6 +808,32 @@ func evictExcess[K comparable, V any](m map[K]V, limit int) {
 		}
 		delete(m, k)
 		over--
+	}
+}
+
+// evictExcessJobs removes arbitrary (repo, workflow run ID) entries from m
+// until the total number of cached job lists is <= limit. Map iteration is
+// randomized in Go, so this is a simple bound rather than LRU.
+func evictExcessJobs(m map[string]map[int64][]Job, limit int) {
+	total := 0
+	for _, runs := range m {
+		total += len(runs)
+	}
+	over := total - limit
+	for repo, runs := range m {
+		if over <= 0 {
+			break
+		}
+		for runID := range runs {
+			if over <= 0 {
+				break
+			}
+			delete(runs, runID)
+			over--
+		}
+		if len(runs) == 0 {
+			delete(m, repo)
+		}
 	}
 }
 

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -629,13 +629,19 @@ func stripDeadRuns(allWfrs []WorkflowRuns) []WorkflowRun {
 	return filtered
 }
 
-// getWorkflowRunJobs returns a list of jobs for a given workflow run
-func (s *githubRunnerScaler) getWorkflowRunJobs(ctx context.Context, workflowRunID int64, repoName string) ([]Job, error) {
-	apiURL := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?per_page=100",
+// jobsAPIURL returns the GitHub API URL for a workflow run's jobs, used both
+// to fetch the jobs and as the etags cache key for that same request.
+func (s *githubRunnerScaler) jobsAPIURL(repoName string, workflowRunID int64) string {
+	return fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?per_page=100",
 		s.metadata.GithubAPIURL,
 		url.PathEscape(s.metadata.Owner),
 		url.PathEscape(repoName),
 		workflowRunID)
+}
+
+// getWorkflowRunJobs returns a list of jobs for a given workflow run
+func (s *githubRunnerScaler) getWorkflowRunJobs(ctx context.Context, workflowRunID int64, repoName string) ([]Job, error) {
+	apiURL := s.jobsAPIURL(repoName, workflowRunID)
 
 	body, statusCode, err := s.getGithubRequest(ctx, apiURL, s.metadata, s.httpClient)
 	if err != nil {
@@ -813,6 +819,7 @@ func (s *githubRunnerScaler) pruneCompletedJobs(activeWfrs []WorkflowRun) {
 	for key := range s.previousJobs {
 		if _, ok := active[key]; !ok {
 			delete(s.previousJobs, key)
+			delete(s.etags, s.jobsAPIURL(key.repo, key.runID))
 		}
 	}
 }

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -780,11 +780,13 @@ func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 // pruneCaches removes previousWfrs entries for repos missing from
 // currentRepos, and caps all three caches to githubScalerMaxCacheEntries.
 //
-// previousJobs is intentionally not pruned by currentRepos: it is keyed by
-// each workflow run's own repository name (wfr.Repository.Name), which is
+// previousJobs is intentionally not pruned by currentRepos here: it is keyed
+// by each workflow run's own repository name (wfr.Repository.Name), which is
 // not guaranteed to be an element of currentRepos (the list used to query
-// workflow runs) — e.g. a run triggered from a fork. It is still bounded by
-// evictExcess below.
+// workflow runs) — e.g. a run triggered from a fork. Its entries for runs
+// that have left queued/in_progress are removed by pruneCompletedJobs once
+// the current run list is known (see GetWorkflowQueueLength); the
+// evictExcess cap below is a size-based backstop for both.
 func (s *githubRunnerScaler) pruneCaches(currentRepos []string) {
 	repoSet := make(map[string]struct{}, len(currentRepos))
 	for _, r := range currentRepos {
@@ -798,6 +800,21 @@ func (s *githubRunnerScaler) pruneCaches(currentRepos []string) {
 	evictExcess(s.previousWfrs, githubScalerMaxCacheEntries)
 	evictExcess(s.previousJobs, githubScalerMaxCacheEntries)
 	evictExcess(s.etags, githubScalerMaxCacheEntries)
+}
+
+// pruneCompletedJobs removes previousJobs entries for runs that are no
+// longer queued/in_progress, so a completed run's cached job list is not
+// held indefinitely waiting for size-based eviction in pruneCaches.
+func (s *githubRunnerScaler) pruneCompletedJobs(activeWfrs []WorkflowRun) {
+	active := make(map[jobCacheKey]struct{}, len(activeWfrs))
+	for _, wfr := range activeWfrs {
+		active[jobCacheKey{repo: wfr.Repository.Name, runID: wfr.ID}] = struct{}{}
+	}
+	for key := range s.previousJobs {
+		if _, ok := active[key]; !ok {
+			delete(s.previousJobs, key)
+		}
+	}
 }
 
 // evictExcess removes arbitrary entries from m until len(m) <= limit. Map
@@ -862,6 +879,11 @@ func (s *githubRunnerScaler) GetWorkflowQueueLength(ctx context.Context) (int64,
 	var queueCount int64
 
 	wfrs := stripDeadRuns(allWfrs)
+
+	if s.metadata.EnableEtags {
+		s.pruneCompletedJobs(wfrs)
+	}
+
 	for _, wfr := range wfrs {
 		jobs, err := s.getWorkflowRunJobs(ctx, wfr.ID, wfr.Repository.Name)
 		if err != nil {

--- a/pkg/scalers/github_runner_scaler.go
+++ b/pkg/scalers/github_runner_scaler.go
@@ -32,28 +32,33 @@ const (
 	// githubScalerMaxCacheEntries caps the etags, previousJobs, and
 	// previousWfrs maps. Without it the etags map grows once per workflow run
 	// for the lifetime of the operator pod (the URL contains the run ID), and
-	// previousWfrs grows once per distinct repository name returned by the
-	// API. previousJobs is keyed by (repository, workflow run ID) and is
-	// bounded by total (repo, runID) pairs across all repositories.
+	// previousJobs and previousWfrs grow once per distinct repository name
+	// (previousJobs once per distinct (repository, run ID) pair) returned by
+	// the API.
 	githubScalerMaxCacheEntries = 5000
 )
 
 var reservedLabels = []string{"self-hosted", "linux", "x64"}
 
+// jobCacheKey identifies a single workflow run's job list within
+// previousJobs. A repository can have several runs queued/in_progress at
+// once, so the run ID is required in addition to the repository name.
+type jobCacheKey struct {
+	repo  string
+	runID int64
+}
+
 type githubRunnerScaler struct {
-	metricType    v2.MetricTargetType
-	metadata      *githubRunnerMetadata
-	httpClient    *http.Client
-	logger        logr.Logger
-	recorder      events.EventRecorder
-	scaledObject  runtime.Object
-	etags         map[string]string
-	previousRepos []string
-	previousWfrs  map[string]map[string]*WorkflowRuns
-	// previousJobs is keyed by repository name, then by workflow run ID —
-	// a single repository can have several runs queued/in_progress at once,
-	// and each run's job list must not be conflated with another's.
-	previousJobs            map[string]map[int64][]Job
+	metricType              v2.MetricTargetType
+	metadata                *githubRunnerMetadata
+	httpClient              *http.Client
+	logger                  logr.Logger
+	recorder                events.EventRecorder
+	scaledObject            runtime.Object
+	etags                   map[string]string
+	previousRepos           []string
+	previousWfrs            map[string]map[string]*WorkflowRuns
+	previousJobs            map[jobCacheKey][]Job
 	rateLimit               RateLimit
 	previousQueueLength     int64
 	previousQueueLengthTime time.Time
@@ -384,7 +389,7 @@ func NewGitHubRunnerScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 
 	etags := make(map[string]string)
 	previousRepos := []string{}
-	previousJobs := make(map[string]map[int64][]Job)
+	previousJobs := make(map[jobCacheKey][]Job)
 	previousWfrs := make(map[string]map[string]*WorkflowRuns)
 	rateLimit := RateLimit{}
 	previousQueueLength := int64(0)
@@ -636,8 +641,9 @@ func (s *githubRunnerScaler) getWorkflowRunJobs(ctx context.Context, workflowRun
 	if err != nil {
 		return nil, err
 	}
+	key := jobCacheKey{repo: repoName, runID: workflowRunID}
 	if statusCode == 304 && s.metadata.EnableEtags {
-		if jobs, ok := s.previousJobs[repoName][workflowRunID]; ok {
+		if jobs, ok := s.previousJobs[key]; ok {
 			return jobs, nil
 		}
 		// Stale etag without a paired previousJobs entry, e.g. after pruneCaches
@@ -659,11 +665,7 @@ func (s *githubRunnerScaler) getWorkflowRunJobs(ctx context.Context, workflowRun
 	}
 
 	if s.metadata.EnableEtags {
-		if _, repoFound := s.previousJobs[repoName]; !repoFound {
-			s.previousJobs[repoName] = map[int64][]Job{workflowRunID: jobs.Jobs}
-		} else {
-			s.previousJobs[repoName][workflowRunID] = jobs.Jobs
-		}
+		s.previousJobs[key] = jobs.Jobs
 	}
 
 	return jobs.Jobs, nil
@@ -782,7 +784,7 @@ func (s *githubRunnerScaler) getCachedQueueLength() (int64, error) {
 // each workflow run's own repository name (wfr.Repository.Name), which is
 // not guaranteed to be an element of currentRepos (the list used to query
 // workflow runs) — e.g. a run triggered from a fork. It is still bounded by
-// evictExcessJobs below.
+// evictExcess below.
 func (s *githubRunnerScaler) pruneCaches(currentRepos []string) {
 	repoSet := make(map[string]struct{}, len(currentRepos))
 	for _, r := range currentRepos {
@@ -794,7 +796,7 @@ func (s *githubRunnerScaler) pruneCaches(currentRepos []string) {
 		}
 	}
 	evictExcess(s.previousWfrs, githubScalerMaxCacheEntries)
-	evictExcessJobs(s.previousJobs, githubScalerMaxCacheEntries)
+	evictExcess(s.previousJobs, githubScalerMaxCacheEntries)
 	evictExcess(s.etags, githubScalerMaxCacheEntries)
 }
 
@@ -808,32 +810,6 @@ func evictExcess[K comparable, V any](m map[K]V, limit int) {
 		}
 		delete(m, k)
 		over--
-	}
-}
-
-// evictExcessJobs removes arbitrary (repo, workflow run ID) entries from m
-// until the total number of cached job lists is <= limit. Map iteration is
-// randomized in Go, so this is a simple bound rather than LRU.
-func evictExcessJobs(m map[string]map[int64][]Job, limit int) {
-	total := 0
-	for _, runs := range m {
-		total += len(runs)
-	}
-	over := total - limit
-	for repo, runs := range m {
-		if over <= 0 {
-			break
-		}
-		for runID := range runs {
-			if over <= 0 {
-				break
-			}
-			delete(runs, runID)
-			over--
-		}
-		if len(runs) == 0 {
-			delete(m, repo)
-		}
 	}
 }
 

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -886,11 +886,18 @@ func TestGithubRunnerPruneCachesDropsAbsentWfrRepos(t *testing.T) {
 }
 
 func TestGithubRunnerPruneCompletedJobsDropsFinishedRuns(t *testing.T) {
+	meta := &githubRunnerMetadata{GithubAPIURL: "https://api.github.com", Owner: "owner"}
+
 	s := githubRunnerScaler{
+		metadata: meta,
 		previousJobs: map[jobCacheKey][]Job{
 			{repo: "repo", runID: 100}: nil, // still active, kept
 			{repo: "repo", runID: 200}: nil, // completed, dropped
 		},
+	}
+	s.etags = map[string]string{
+		s.jobsAPIURL("repo", 100): "etag-100", // still active, kept
+		s.jobsAPIURL("repo", 200): "etag-200", // completed, dropped
 	}
 
 	s.pruneCompletedJobs([]WorkflowRun{
@@ -902,6 +909,12 @@ func TestGithubRunnerPruneCompletedJobsDropsFinishedRuns(t *testing.T) {
 	}
 	if _, ok := s.previousJobs[jobCacheKey{repo: "repo", runID: 100}]; !ok {
 		t.Errorf("previousJobs lost still-active run 100 after pruneCompletedJobs")
+	}
+	if _, ok := s.etags[s.jobsAPIURL("repo", 200)]; ok {
+		t.Errorf("etags still contains completed run 200's jobs URL after pruneCompletedJobs")
+	}
+	if _, ok := s.etags[s.jobsAPIURL("repo", 100)]; !ok {
+		t.Errorf("etags lost still-active run 100's jobs URL after pruneCompletedJobs")
 	}
 }
 

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -885,6 +885,26 @@ func TestGithubRunnerPruneCachesDropsAbsentWfrRepos(t *testing.T) {
 	}
 }
 
+func TestGithubRunnerPruneCompletedJobsDropsFinishedRuns(t *testing.T) {
+	s := githubRunnerScaler{
+		previousJobs: map[jobCacheKey][]Job{
+			{repo: "repo", runID: 100}: nil, // still active, kept
+			{repo: "repo", runID: 200}: nil, // completed, dropped
+		},
+	}
+
+	s.pruneCompletedJobs([]WorkflowRun{
+		{ID: 100, Repository: Repo{Name: "repo"}},
+	})
+
+	if _, ok := s.previousJobs[jobCacheKey{repo: "repo", runID: 200}]; ok {
+		t.Errorf("previousJobs still contains completed run 200 after pruneCompletedJobs")
+	}
+	if _, ok := s.previousJobs[jobCacheKey{repo: "repo", runID: 100}]; !ok {
+		t.Errorf("previousJobs lost still-active run 100 after pruneCompletedJobs")
+	}
+}
+
 func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 	overflow := githubScalerMaxCacheEntries + 100
 	currentRepos := make([]string, overflow)

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -504,8 +504,8 @@ func TestNewGitHubRunnerScaler_QueueLength_SingleRepo_WithNotModified(t *testing
 	if err := json.Unmarshal([]byte(testGhWFJobResponse), &jobs); err != nil {
 		t.Fail()
 	}
-	previousJobs := map[string]map[int64][]Job{
-		"Hello-World": {30433642: jobs.Jobs},
+	previousJobs := map[jobCacheKey][]Job{
+		{repo: "Hello-World", runID: 30433642}: jobs.Jobs,
 	}
 
 	mockGitHubRunnerScaler := githubRunnerScaler{
@@ -867,7 +867,7 @@ var githubRunnerMetricIdentifiers = []githubRunnerMetricIdentifier{
 func TestGithubRunnerPruneCachesDropsAbsentWfrRepos(t *testing.T) {
 	s := githubRunnerScaler{
 		metadata:     &githubRunnerMetadata{},
-		previousJobs: map[string]map[int64][]Job{},
+		previousJobs: map[jobCacheKey][]Job{},
 		previousWfrs: map[string]map[string]*WorkflowRuns{
 			"keep-1": {"queued": &WorkflowRuns{}},
 			"drop-2": {"queued": &WorkflowRuns{}},
@@ -891,7 +891,7 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 
 	s := githubRunnerScaler{
 		metadata:     &githubRunnerMetadata{},
-		previousJobs: make(map[string]map[int64][]Job, overflow),
+		previousJobs: make(map[jobCacheKey][]Job, overflow),
 		previousWfrs: make(map[string]map[string]*WorkflowRuns, overflow),
 		etags:        make(map[string]string, overflow),
 	}
@@ -901,7 +901,8 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 		s.etags[fmt.Sprintf("https://api.github.com/run/%d", i)] = "etag"
 		// Two runs per repo, so the (repo, runID) pair count exceeds the repo
 		// count and genuinely tests the total-entries bound, not just len(map).
-		s.previousJobs[repo] = map[int64][]Job{int64(i): nil, int64(i + overflow): nil}
+		s.previousJobs[jobCacheKey{repo: repo, runID: int64(i)}] = nil
+		s.previousJobs[jobCacheKey{repo: repo, runID: int64(i + overflow)}] = nil
 		s.previousWfrs[repo] = map[string]*WorkflowRuns{"queued": {}}
 	}
 
@@ -910,12 +911,8 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 	if got := len(s.etags); got > githubScalerMaxCacheEntries {
 		t.Errorf("etags map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
 	}
-	jobEntries := 0
-	for _, runs := range s.previousJobs {
-		jobEntries += len(runs)
-	}
-	if jobEntries > githubScalerMaxCacheEntries {
-		t.Errorf("previousJobs total (repo, runID) entries %d exceeds cap %d after prune", jobEntries, githubScalerMaxCacheEntries)
+	if got := len(s.previousJobs); got > githubScalerMaxCacheEntries {
+		t.Errorf("previousJobs map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
 	}
 	if got := len(s.previousWfrs); got > githubScalerMaxCacheEntries {
 		t.Errorf("previousWfrs map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
@@ -950,7 +947,7 @@ func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
 		metadata:     meta,
 		httpClient:   http.DefaultClient,
 		etags:        map[string]string{apiURL: `"stale-etag"`},
-		previousJobs: map[string]map[int64][]Job{},
+		previousJobs: map[jobCacheKey][]Job{},
 		previousWfrs: map[string]map[string]*WorkflowRuns{},
 	}
 
@@ -1006,11 +1003,9 @@ func TestGetWorkflowRunJobs_PerRunCacheDoesNotConflateConcurrentRuns(t *testing.
 			urlA: `"etag-a"`,
 			urlB: `"etag-b"`,
 		},
-		previousJobs: map[string]map[int64][]Job{
-			repo: {
-				runA: jobsA,
-				runB: jobsB,
-			},
+		previousJobs: map[jobCacheKey][]Job{
+			{repo: repo, runID: runA}: jobsA,
+			{repo: repo, runID: runB}: jobsB,
 		},
 	}
 
@@ -1059,7 +1054,7 @@ func TestGetWorkflowRuns_StaleEtagWithoutPreviousRetries(t *testing.T) {
 		metadata:     meta,
 		httpClient:   http.DefaultClient,
 		etags:        map[string]string{apiURL: `"stale-etag"`},
-		previousJobs: map[string]map[int64][]Job{},
+		previousJobs: map[jobCacheKey][]Job{},
 		previousWfrs: map[string]map[string]*WorkflowRuns{},
 	}
 

--- a/pkg/scalers/github_runner_scaler_test.go
+++ b/pkg/scalers/github_runner_scaler_test.go
@@ -504,8 +504,8 @@ func TestNewGitHubRunnerScaler_QueueLength_SingleRepo_WithNotModified(t *testing
 	if err := json.Unmarshal([]byte(testGhWFJobResponse), &jobs); err != nil {
 		t.Fail()
 	}
-	previousJobs := map[string][]Job{
-		"Hello-World": jobs.Jobs,
+	previousJobs := map[string]map[int64][]Job{
+		"Hello-World": {30433642: jobs.Jobs},
 	}
 
 	mockGitHubRunnerScaler := githubRunnerScaler{
@@ -867,7 +867,7 @@ var githubRunnerMetricIdentifiers = []githubRunnerMetricIdentifier{
 func TestGithubRunnerPruneCachesDropsAbsentWfrRepos(t *testing.T) {
 	s := githubRunnerScaler{
 		metadata:     &githubRunnerMetadata{},
-		previousJobs: map[string][]Job{},
+		previousJobs: map[string]map[int64][]Job{},
 		previousWfrs: map[string]map[string]*WorkflowRuns{
 			"keep-1": {"queued": &WorkflowRuns{}},
 			"drop-2": {"queued": &WorkflowRuns{}},
@@ -891,7 +891,7 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 
 	s := githubRunnerScaler{
 		metadata:     &githubRunnerMetadata{},
-		previousJobs: make(map[string][]Job, overflow),
+		previousJobs: make(map[string]map[int64][]Job, overflow),
 		previousWfrs: make(map[string]map[string]*WorkflowRuns, overflow),
 		etags:        make(map[string]string, overflow),
 	}
@@ -899,7 +899,9 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 		repo := fmt.Sprintf("repo-%d", i)
 		currentRepos[i] = repo
 		s.etags[fmt.Sprintf("https://api.github.com/run/%d", i)] = "etag"
-		s.previousJobs[repo] = nil
+		// Two runs per repo, so the (repo, runID) pair count exceeds the repo
+		// count and genuinely tests the total-entries bound, not just len(map).
+		s.previousJobs[repo] = map[int64][]Job{int64(i): nil, int64(i + overflow): nil}
 		s.previousWfrs[repo] = map[string]*WorkflowRuns{"queued": {}}
 	}
 
@@ -908,8 +910,12 @@ func TestGithubRunnerPruneCachesBoundsMaps(t *testing.T) {
 	if got := len(s.etags); got > githubScalerMaxCacheEntries {
 		t.Errorf("etags map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
 	}
-	if got := len(s.previousJobs); got > githubScalerMaxCacheEntries {
-		t.Errorf("previousJobs map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
+	jobEntries := 0
+	for _, runs := range s.previousJobs {
+		jobEntries += len(runs)
+	}
+	if jobEntries > githubScalerMaxCacheEntries {
+		t.Errorf("previousJobs total (repo, runID) entries %d exceeds cap %d after prune", jobEntries, githubScalerMaxCacheEntries)
 	}
 	if got := len(s.previousWfrs); got > githubScalerMaxCacheEntries {
 		t.Errorf("previousWfrs map size %d exceeds cap %d after prune", got, githubScalerMaxCacheEntries)
@@ -944,7 +950,7 @@ func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
 		metadata:     meta,
 		httpClient:   http.DefaultClient,
 		etags:        map[string]string{apiURL: `"stale-etag"`},
-		previousJobs: map[string][]Job{},
+		previousJobs: map[string]map[int64][]Job{},
 		previousWfrs: map[string]map[string]*WorkflowRuns{},
 	}
 
@@ -963,6 +969,65 @@ func TestGetWorkflowRunJobs_StaleEtagWithoutPreviousRetries(t *testing.T) {
 	}
 	if got := s.etags[apiURL]; got != `"fresh-etag"` {
 		t.Fatalf("expected etag to be refreshed to %q, got %q", `"fresh-etag"`, got)
+	}
+}
+
+// TestGetWorkflowRunJobs_PerRunCacheDoesNotConflateConcurrentRuns is a
+// regression test for a bug where previousJobs was keyed by repo name only.
+// A repository can have several workflow runs queued/in_progress at once
+// (e.g. a matrix-heavy release workflow plus a concurrent scheduled sync
+// run); getWorkflowRunJobs is called once per run, and a 304 for one run's
+// jobs URL must return that same run's own cached jobs, not whichever run's
+// jobs happened to be cached last for the repo.
+func TestGetWorkflowRunJobs_PerRunCacheDoesNotConflateConcurrentRuns(t *testing.T) {
+	const repo = "repo"
+	const runA, runB int64 = 100, 200
+
+	jobsA := []Job{{ID: 1, RunID: int(runA), Status: "queued", Labels: []string{"foo", "bar"}}}
+	jobsB := []Job{{ID: 2, RunID: int(runB), Status: "queued", Labels: []string{"foo", "bar"}}}
+
+	// Both runs' etags are already known from an earlier poll, so any request
+	// in this test is answered with 304 Not Modified.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	meta := getGitHubTestMetaData(srv.URL)
+	meta.EnableEtags = true
+
+	urlA := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?per_page=100", meta.GithubAPIURL, meta.Owner, repo, runA)
+	urlB := fmt.Sprintf("%s/repos/%s/%s/actions/runs/%d/jobs?per_page=100", meta.GithubAPIURL, meta.Owner, repo, runB)
+
+	s := githubRunnerScaler{
+		metadata:   meta,
+		httpClient: http.DefaultClient,
+		etags: map[string]string{
+			urlA: `"etag-a"`,
+			urlB: `"etag-b"`,
+		},
+		previousJobs: map[string]map[int64][]Job{
+			repo: {
+				runA: jobsA,
+				runB: jobsB,
+			},
+		},
+	}
+
+	got, err := s.getWorkflowRunJobs(context.Background(), runA, repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].RunID != int(runA) {
+		t.Fatalf("expected run %d's own cached jobs, got jobs from run_id=%v", runA, got)
+	}
+
+	got, err = s.getWorkflowRunJobs(context.Background(), runB, repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].RunID != int(runB) {
+		t.Fatalf("expected run %d's own cached jobs, got jobs from run_id=%v", runB, got)
 	}
 }
 
@@ -994,7 +1059,7 @@ func TestGetWorkflowRuns_StaleEtagWithoutPreviousRetries(t *testing.T) {
 		metadata:     meta,
 		httpClient:   http.DefaultClient,
 		etags:        map[string]string{apiURL: `"stale-etag"`},
-		previousJobs: map[string][]Job{},
+		previousJobs: map[string]map[int64][]Job{},
 		previousWfrs: map[string]map[string]*WorkflowRuns{},
 	}
 


### PR DESCRIPTION
## Summary

`previousJobs` was keyed by repository name only, but `getWorkflowRunJobs` is called once per individual workflow run. When a repository has multiple simultaneous queued/in_progress runs (e.g. a matrix-heavy release workflow plus a concurrent scheduled sync run), a `304` for one run's jobs URL could return whichever run's job list was cached last for that repo — silently double-counting one run's jobs in place of another's and inflating the computed `GetWorkflowQueueLength()` target.

This keys `previousJobs` by a small `jobCacheKey{repo, runID}` composite struct instead — a flat `map[jobCacheKey][]Job`, so the existing generic `evictExcess` helper bounds it directly, same as `etags` and `previousWfrs` (no separate helper needed).

Additionally, `pruneCompletedJobs` now actively removes a run's `previousJobs` entry as soon as it leaves the queued/in_progress list, rather than relying solely on size-based eviction to eventually clear it out.

Added a regression test covering two concurrent runs in the same repo both hitting `304`, and a test covering completed-run cleanup.

Fixes #7949

## Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Commits are signed with Developer Certificate of Origin (DCO)