### PR TITLE
CI: ensure e2e check runs are always finalized instead of left hanging

### DIFF
--- a/.github/workflows/pr-e2e-checker.yml
+++ b/.github/workflows/pr-e2e-checker.yml
@@ -5,6 +5,9 @@ on:
       - labeled
       - unlabeled
 
+permissions:
+  checks: write
+
 env:
   SKIP_E2E_TAG: skip-e2e
   E2E_CHECK_NAME: e2e tests
@@ -22,62 +25,50 @@ jobs:
     runs-on: ubuntu-slim
     if: github.event.label.name == 'skip-e2e'
     steps:
-      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Enqueue e2e
-        id: create
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        name: Update e2e checks
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          name: ${{ env.E2E_CHECK_NAME }}
-          status: queued
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const skip = context.payload.pull_request.labels.some((label) => label.name === process.env.SKIP_E2E_TAG);
+            const checkNames = [
+              process.env.E2E_CHECK_NAME,
+              process.env.ARM_SMOKE_CHECK_NAME,
+              process.env.S390X_SMOKE_CHECK_NAME,
+            ];
 
-      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Skip e2e
-        if: ${{ contains(github.event.pull_request.labels.*.name, env.SKIP_E2E_TAG )}}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          check_id: ${{ steps.create.outputs.check_id }}
-          conclusion: success
-          output: |
-            {"summary": "skipped by maintainer"}
+            for (const name of checkNames) {
+              const skipPayload = {
+                status: 'completed',
+                conclusion: 'success',
+                output: { title: name, summary: 'skipped by maintainer' },
+              };
+              const queuedPayload = { status: 'queued' };
 
-      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Enqueue e2e
-        id: create-arm
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          name: ${{ env.ARM_SMOKE_CHECK_NAME }}
-          status: queued
+              // Update every existing check run with this name
+              const runs = await github.paginate(github.rest.checks.listForRef, {
+                ...context.repo,
+                ref: sha,
+                check_name: name,
+                filter: 'all',
+                per_page: 100,
+              });
 
-      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Skip e2e
-        if: ${{ contains(github.event.pull_request.labels.*.name, env.SKIP_E2E_TAG )}}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          check_id: ${{ steps.create-arm.outputs.check_id }}
-          conclusion: success
-          output: |
-            {"summary": "skipped by maintainer"}
+              const payload = skip ? skipPayload : queuedPayload;
+              for (const run of runs) {
+                await github.rest.checks.update({
+                  ...context.repo,
+                  check_run_id: run.id,
+                  ...payload,
+                });
+              }
 
-      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Enqueue e2e
-        id: create-s390x
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          status: queued
-
-      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Skip e2e
-        if: ${{ contains(github.event.pull_request.labels.*.name, env.SKIP_E2E_TAG )}}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          check_id: ${{ steps.create-s390x.outputs.check_id }}
-          conclusion: success
-          output: |
-            {"summary": "skipped by maintainer"}
+              if (runs.length === 0) {
+                await github.rest.checks.create({
+                  ...context.repo,
+                  head_sha: sha,
+                  name,
+                  ...payload,
+                });
+              }
+            }

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -161,7 +161,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.ARM_SMOKE_CHECK_NAME }}
-          status: failure
+          conclusion: failure
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
             {"summary": "❌ Tests Failed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
@@ -173,7 +173,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          status: failure
+          conclusion: failure
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
             {"summary": "❌ Tests Failed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
@@ -200,6 +200,42 @@ jobs:
         env:
           VERSION: ${{ needs.triage.outputs.image_tag }}
           SUFFIX: "-test"
+
+      - name: Set status cancelled or failure
+        uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
+        if: always() && (failure() || cancelled()) && steps.regex-validation.outcome != 'failure'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ needs.triage.outputs.commit_sha }}
+          name: ${{ env.E2E_CHECK_NAME }}
+          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
+          output: |
+            {"summary": "${{ cancelled() && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+
+      - name: Set status cancelled or failure
+        uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
+        if: always() && (failure() || cancelled()) && steps.regex-validation.outcome != 'failure'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ needs.triage.outputs.commit_sha }}
+          name: ${{ env.ARM_SMOKE_CHECK_NAME }}
+          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
+          output: |
+            {"summary": "${{ cancelled() && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+
+      - name: Set status cancelled or failure
+        uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
+        if: always() && (failure() || cancelled()) && steps.regex-validation.outcome != 'failure'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ needs.triage.outputs.commit_sha }}
+          name: ${{ env.S390X_SMOKE_CHECK_NAME }}
+          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
+          output: |
+            {"summary": "${{ cancelled() && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
   run-e2e-test:
     needs: [triage, build-test-images]
@@ -351,7 +387,7 @@ jobs:
 
       - name: Set status success
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: steps.test.outcome == 'success'
+        if: always() && steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
@@ -363,15 +399,15 @@ jobs:
 
       - name: Set status failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: steps.test.outcome != 'success'
+        if: always() && steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.E2E_CHECK_NAME }}
-          conclusion: failure
+          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "❌ Tests Failed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ cancelled() && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -432,7 +468,7 @@ jobs:
 
       - name: Set status success
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: steps.test.outcome == 'success'
+        if: always() && steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
@@ -444,15 +480,15 @@ jobs:
 
       - name: Set status failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: steps.test.outcome != 'success'
+        if: always() && steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.ARM_SMOKE_CHECK_NAME }}
-          conclusion: failure
+          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "❌ Tests Failed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ cancelled() && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -520,7 +556,7 @@ jobs:
 
       - name: Set status success
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: steps.test.outcome == 'success'
+        if: always() && steps.test.outcome == 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
@@ -532,15 +568,15 @@ jobs:
 
       - name: Set status failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: steps.test.outcome != 'success'
+        if: always() && steps.test.outcome != 'success'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          conclusion: failure
+          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "❌ Tests Failed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ cancelled() && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Remove Kubernetes
         run: |


### PR DESCRIPTION
The skip-e2e label checker created new check runs instead of updating existing ones, leaving stale queued runs behind that kept blocking PRs (see. #7963). It now updates every existing check run in place and adds a least-privilege permissions block.

Also, the pr-e2e workflow never closed its in_progress check runs when a job was cancelled or timed out (see #7960). Status steps now run with always(), report a cancelled conclusion on cancellation, and the image build job closes its checks on failure or cancellation. Also fixes the two smoke test steps that passed "status: failure" instead of "conclusion: failure".

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))