### PR TITLE
General: Emit ScaledJob removal event with the ScaledJob's namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Add controller-runtime cache field indexes for ScaledObject admission validation so `verifyScaledObjects` and `verifyHpas` look up duplicate scaleTargetRef and HPA-name conflicts via indexed Lists rather than full-namespace scans, eliminating the webhook OOM under high-scale creation bursts ([#7681](https://github.com/kedacore/keda/pull/7681))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
+- **General**: Fix `ScaledJob` removal event using `namespace/name` in place of the namespace, which malformed the emitted CloudEvent's subject and the `namespace` label on the CloudEventSource metrics ([#7967](https://github.com/kedacore/keda/issues/7967))
 
 ### Deprecations
 

--- a/controllers/keda/scaledjob_finalizer.go
+++ b/controllers/keda/scaledjob_finalizer.go
@@ -59,7 +59,7 @@ func (r *ScaledJobReconciler) finalizeScaledJob(ctx context.Context, logger logr
 	}
 
 	logger.Info("Successfully finalized ScaledJob")
-	r.EventEmitter.Emit(scaledJob, namespacedName, corev1.EventTypeWarning, eventingv1alpha1.ScaledJobRemovedType, eventreason.ScaledJobDeleted, message.ScaledJobRemoved)
+	r.EventEmitter.Emit(scaledJob, scaledJob.Namespace, corev1.EventTypeWarning, eventingv1alpha1.ScaledJobRemovedType, eventreason.ScaledJobDeleted, message.ScaledJobRemoved)
 	return nil
 }
 

--- a/controllers/keda/scaledjob_finalizer_test.go
+++ b/controllers/keda/scaledjob_finalizer_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keda
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	eventingv1alpha1 "github.com/kedacore/keda/v2/apis/eventing/v1alpha1"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
+	"github.com/kedacore/keda/v2/pkg/mock/mock_eventemitter"
+	"github.com/kedacore/keda/v2/pkg/mock/mock_scaling"
+)
+
+var _ = Describe("ScaledJobFinalizer", func() {
+	var (
+		reconciler   ScaledJobReconciler
+		client       *mock_client.MockClient
+		scaleHandler *mock_scaling.MockScaleHandler
+		eventEmitter *mock_eventemitter.MockEventHandler
+		logger       logr.Logger
+		ctrl         *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		client = mock_client.NewMockClient(ctrl)
+		scaleHandler = mock_scaling.NewMockScaleHandler(ctrl)
+		eventEmitter = mock_eventemitter.NewMockEventHandler(ctrl)
+		logger = logr.Discard()
+		reconciler = ScaledJobReconciler{
+			Client:       client,
+			EventEmitter: eventEmitter,
+			scaleHandler: scaleHandler,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("emits the removal event with the ScaledJob's namespace", func() {
+		scaledJob := &kedav1alpha1.ScaledJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "my-sj",
+				Namespace:  "my-ns",
+				Finalizers: []string{scaledJobFinalizer},
+			},
+			Spec: kedav1alpha1.ScaledJobSpec{
+				Triggers: []kedav1alpha1.ScaleTriggers{{Type: "cron"}},
+			},
+		}
+
+		scaleHandler.EXPECT().DeleteScalableObject(gomock.Any(), gomock.Any()).Return(nil)
+		client.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil)
+
+		var emittedNamespace string
+		eventEmitter.EXPECT().Emit(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(_ runtime.Object, namespace, _ string, _ eventingv1alpha1.CloudEventType, _, _ string) {
+				emittedNamespace = namespace
+			})
+
+		err := reconciler.finalizeScaledJob(context.Background(), logger, scaledJob,
+			types.NamespacedName{Namespace: "my-ns", Name: "my-sj"}.String())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(emittedNamespace).To(Equal("my-ns"))
+	})
+})


### PR DESCRIPTION

`finalizeScaledJob` passed `namespacedName` (a `"namespace/name"` string) into `EventEmitter.Emit`,
instead of `scaledJob.Namespace`

The original change was made 2 years ago, perhaps it's a miss.

```
/<cluster>/my-ns/my-sj/scaledjob/my-sj   before
/<cluster>/my-ns/scaledjob/my-sj         after
```

Test added; it fails without the fix.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Unchecked items are not applicable.

Fixes #7967
