### PR TITLE
CI: replace status check functions in with: expressions

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -208,10 +208,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.E2E_CHECK_NAME }}
-          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "${{ cancelled() && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ job.status == 'cancelled' && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Set status cancelled or failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -220,10 +220,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.ARM_SMOKE_CHECK_NAME }}
-          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "${{ cancelled() && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ job.status == 'cancelled' && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Set status cancelled or failure
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
@@ -232,10 +232,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "${{ cancelled() && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ job.status == 'cancelled' && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
   run-e2e-test:
     needs: [triage, build-test-images]
@@ -404,10 +404,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.E2E_CHECK_NAME }}
-          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "${{ cancelled() && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ job.status == 'cancelled' && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -485,10 +485,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.ARM_SMOKE_CHECK_NAME }}
-          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "${{ cancelled() && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ job.status == 'cancelled' && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Upload test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -573,10 +573,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          conclusion: ${{ cancelled() && 'cancelled' || 'failure' }}
+          conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "${{ cancelled() && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "${{ job.status == 'cancelled' && '🚫 Tests were cancelled.' || '❌ Tests Failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
       - name: Remove Kubernetes
         run: |


### PR DESCRIPTION
Sorry, I have broken some things in the e2e. The status check functions cancelled() and failure() are only valid in if: conditions. Using cancelled() inside with: expressions made pr-e2e.yml invalid, breaking /run-e2e and creating failed workflow runs on every push. Use job.status == 'cancelled' instead.


### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Follow-up to #7965.
