### PR TITLE
bump go to 1.26.5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM golang:1.26.2
+FROM golang:1.26.5
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 
     # keda-tools is built from github.com/test-tools/tools/Dockerfile
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -12,7 +12,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     name: Comment evaluate
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     outputs:
       run-e2e: ${{ startsWith(github.event.comment.body,'/run-e2e') && steps.checkUserMember.outputs.isTeamMember == 'true' }}
       pr_num: ${{ steps.parser.outputs.pr_num }}
@@ -71,7 +71,7 @@ jobs:
     needs: triage
     runs-on: ubuntu-24.04-arm
     name: Build images
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     if: needs.triage.outputs.run-e2e == 'true'
     steps:
       - name: Set status in-progress
@@ -241,7 +241,7 @@ jobs:
     needs: [triage, build-test-images]
     runs-on: e2e
     name: Execute e2e tests
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     if: needs.triage.outputs.run-e2e == 'true'
     outputs:
       test-outcome: ${{ steps.test.outcome }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,7 +11,7 @@ jobs:
     name: validate - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     container:
-      image: ghcr.io/kedacore/keda-tools:1.26.2
+      image: ghcr.io/kedacore/keda-tools:1.26.5
       volumes:
         - /usr:/host/usr
         - /opt:/host/opt
@@ -131,7 +131,7 @@ jobs:
       pull-requests: read # for dorny/paths-filter to read pull requests
     name: validate-dockerfiles - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     strategy:
       matrix:
         include:
@@ -167,7 +167,7 @@ jobs:
       pull-requests: read # for dorny/paths-filter to read pull requests
     name: Validate dev-container - ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     strategy:
       matrix:
         include:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 
     # keda-tools is built from github.com/test-tools/tools/Dockerfile
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -17,7 +17,7 @@ jobs:
   codeQl:
     name: Analyze CodeQL Go
     runs-on: ubuntu-latest
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     if: (github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout repository

--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run e2e test
     runs-on: ubuntu-24.04-arm
     # keda-tools is built from github.com/test-tools/tools/Dockerfile
-    container: ghcr.io/kedacore/keda-tools:1.26.2
+    container: ghcr.io/kedacore/keda-tools:1.26.5
     concurrency: e2e-tests
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/keda-tools:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/keda-tools:1.26.5 AS builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -1,5 +1,5 @@
 # Build the adapter binary
-FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/keda-tools:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/keda-tools:1.26.5 AS builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD

--- a/Dockerfile.webhooks
+++ b/Dockerfile.webhooks
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/keda-tools:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/kedacore/keda-tools:1.26.5 AS builder
 
 ARG BUILD_VERSION=main
 ARG GIT_COMMIT=HEAD


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

This commit updates the Go version from 1.26.2 to 1.26.5, which address the following CVEs scanned by Trivy: https://github.com/advisories/GHSA-h524-452v-82p9, https://github.com/advisories/GHSA-xq5j-9r39-c3vf, https://github.com/advisories/GHSA-8g2r-hhvj-mv99, https://github.com/advisories/GHSA-p9h5-jm8x-mjm5, https://github.com/advisories/GHSA-497x-jcxf-m478, https://github.com/advisories/GHSA-4279-q6mj-392r. 

See linked issue and related PR from `kedacore/test-tools` for more context.

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #7890

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/test-tools/pull/251
