### PR TITLE
feat: report scaler and scale-loop latency as histograms alongside the gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Kafka Scaler**: Add optional `fullMetadata` trigger metadata field to control Sarama's full cluster metadata refresh, reducing operator memory for topic scoped triggers ([#7453](https://github.com/kedacore/keda/issues/7453))
 - **Temporal Scaler**: Add `enableTLS` parameter to allow disabling TLS when using API key authentication (e.g. plaintext gRPC endpoints) ([#7854](https://github.com/kedacore/keda/pull/7854))
 - **Temporal Scaler**: Add opt-in `includeRunningWorkflowCount` (with optional `workflowTaskQueueForCount`) to block premature scale-down when the backlog is momentarily zero but Workflow workers are still busy. Worker Deployment Version scalers short-circuit on Version status (`DRAINING` stays active, `DRAINED`/`INACTIVE` scale down); other modes issue a scoped `CountWorkflow` visibility query — including `TemporalWorkerDeploymentVersion is null` for unversioned workers. ([#7459](https://github.com/kedacore/keda/issues/7459))
+- **General**: Report scaler and scale-loop latency as histograms via the new `keda_scaler_metrics_duration_seconds` and `keda_internal_scale_loop_duration_seconds` metrics, so percentiles are computable; the existing `_latency_seconds` gauges keep being written unchanged ([#7675](https://github.com/kedacore/keda/issues/7675))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
 ### Fixes

--- a/pkg/metricscollector/opentelemetry.go
+++ b/pkg/metricscollector/opentelemetry.go
@@ -36,6 +36,12 @@ var (
 	otCrdRegisteredTotalsCounter     api.Int64UpDownCounter
 	otEmptyUpstreamResponses         api.Int64Counter
 
+	// Synchronous histograms mirroring the latency gauges below. Recorded
+	// directly at observation time rather than drained by a callback, because a
+	// histogram accumulates every observation instead of holding only the last.
+	otScalerMetricsDuration api.Float64Histogram
+	otInternalLoopDuration  api.Float64Histogram
+
 	otelScalerMetricVals                  []OtelMetricFloat64Val
 	otelScalerMetricsLatencyVals          []OtelMetricFloat64Val
 	otelScalerMetricsLatencyValDeprecated []OtelMetricFloat64Val
@@ -172,6 +178,15 @@ func initMeters() {
 		otLog.Error(err, msg)
 	}
 
+	otScalerMetricsDuration, err = meter.Float64Histogram(
+		"keda.scaler.metrics.duration.seconds",
+		api.WithDescription("The duration of retrieving current metric from each scaler"),
+		api.WithUnit("s"),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
 	_, err = meter.Float64ObservableGauge(
 		"keda.internal.scale.loop.latency",
 		api.WithDescription("DEPRECATED - use `keda.internal.scale.loop.latency.seconds` instead"),
@@ -185,6 +200,15 @@ func initMeters() {
 		api.WithDescription("Internal latency of ScaledObject/ScaledJob loop execution"),
 		api.WithUnit("s"),
 		api.WithFloat64Callback(ScalableObjectLatencyCallback),
+	)
+	if err != nil {
+		otLog.Error(err, msg)
+	}
+
+	otInternalLoopDuration, err = meter.Float64Histogram(
+		"keda.internal.scale.loop.duration.seconds",
+		api.WithDescription("Internal duration of ScaledObject/ScaledJob loop execution"),
+		api.WithUnit("s"),
 	)
 	if err != nil {
 		otLog.Error(err, msg)
@@ -316,6 +340,13 @@ func (o *OtelMetrics) RecordScalerLatency(namespace string, scaledResource strin
 	otelScalerMetricsLatencyValD.val = float64(value.Milliseconds())
 	otelScalerMetricsLatencyValD.measurementOption = getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
 	otelScalerMetricsLatencyValDeprecated = append(otelScalerMetricsLatencyValDeprecated, otelScalerMetricsLatencyValD)
+
+	// nil when the meter failed to initialise; the gauges above degrade to
+	// no-ops in that case, so this should not be the one thing that panics.
+	if otScalerMetricsDuration != nil {
+		otScalerMetricsDuration.Record(context.Background(), value.Seconds(),
+			getScalerMeasurementOption(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject))
+	}
 }
 
 func ScalableObjectLatencyCallback(_ context.Context, obsrv api.Float64Observer) error {
@@ -355,6 +386,11 @@ func (o *OtelMetrics) RecordScalableObjectLatency(namespace string, name string,
 	otelInternalLoopLatencyD.val = float64(value.Milliseconds())
 	otelInternalLoopLatencyD.measurementOption = opt
 	otelInternalLoopLatencyValDeprecated = append(otelInternalLoopLatencyValDeprecated, otelInternalLoopLatencyD)
+
+	// See the nil note in RecordScalerLatency.
+	if otInternalLoopDuration != nil {
+		otInternalLoopDuration.Record(context.Background(), value.Seconds(), opt)
+	}
 }
 
 func ScalerActiveCallback(_ context.Context, obsrv api.Float64Observer) error {

--- a/pkg/metricscollector/prommetrics.go
+++ b/pkg/metricscollector/prommetrics.go
@@ -59,6 +59,21 @@ var (
 		},
 		metricLabels,
 	)
+	// scalerMetricsDuration mirrors scalerMetricsLatency as a histogram. A gauge
+	// only retains the most recent observation, so it cannot answer the
+	// questions latency is actually measured for -- p95, p99, or how often a
+	// scaler is slow. The gauge is kept for backwards compatibility and both are
+	// written on every observation.
+	scalerMetricsDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "scaler",
+			Name:      "metrics_duration_seconds",
+			Help:      "The duration of retrieving current metric from each scaler, in seconds.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		metricLabels,
+	)
 	scalerActive = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: DefaultPromMetricsNamespace,
@@ -140,6 +155,18 @@ var (
 		},
 		[]string{"namespace", "type", "resource"},
 	)
+	// internalLoopDuration mirrors internalLoopLatency as a histogram, for the
+	// same reason as scalerMetricsDuration above.
+	internalLoopDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: DefaultPromMetricsNamespace,
+			Subsystem: "internal_scale_loop",
+			Name:      "duration_seconds",
+			Help:      "Total deviation (in seconds) between the expected execution time and the actual execution time for the scaling loop.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"namespace", "type", "resource"},
+	)
 
 	// Total emitted cloudevents.
 	cloudeventEmitted = prometheus.NewCounterVec(
@@ -184,7 +211,9 @@ type PromMetrics struct {
 func NewPromMetrics(enableHighCardinalityLabels bool) *PromMetrics {
 	metrics.Registry.MustRegister(scalerMetricsValue)
 	metrics.Registry.MustRegister(scalerMetricsLatency)
+	metrics.Registry.MustRegister(scalerMetricsDuration)
 	metrics.Registry.MustRegister(internalLoopLatency)
+	metrics.Registry.MustRegister(internalLoopDuration)
 	metrics.Registry.MustRegister(scalerActive)
 	metrics.Registry.MustRegister(scalerErrors)
 	metrics.Registry.MustRegister(scaledObjectErrors)
@@ -244,16 +273,20 @@ func (p *PromMetrics) DeleteScalerMetrics(namespace string, scaledResource strin
 	scalerActive.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerErrors.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 	scalerMetricsLatency.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
+	scalerMetricsDuration.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "scaledObject": scaledResource, "type": getResourceType(isScaledObject)})
 }
 
 // RecordScalerLatency create a measurement of the latency to external metric
 func (p *PromMetrics) RecordScalerLatency(namespace string, scaledResource string, scaler string, triggerIndex int, metric string, isScaledObject bool, value time.Duration) {
-	scalerMetricsLatency.With(getLabels(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)).Set(value.Seconds())
+	labels := getLabels(namespace, scaledResource, scaler, triggerIndex, metric, isScaledObject)
+	scalerMetricsLatency.With(labels).Set(value.Seconds())
+	scalerMetricsDuration.With(labels).Observe(value.Seconds())
 }
 
 // RecordScalableObjectLatency create a measurement of the latency executing scalable object loop
 func (p *PromMetrics) RecordScalableObjectLatency(namespace string, name string, isScaledObject bool, value time.Duration) {
 	internalLoopLatency.WithLabelValues(namespace, getResourceType(isScaledObject), name).Set(value.Seconds())
+	internalLoopDuration.WithLabelValues(namespace, getResourceType(isScaledObject), name).Observe(value.Seconds())
 }
 
 // RecordScalerActive create a measurement of the activity of the scaler

--- a/pkg/metricscollector/prommetrics_test.go
+++ b/pkg/metricscollector/prommetrics_test.go
@@ -18,8 +18,10 @@ package metricscollector
 
 import (
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,4 +128,83 @@ func TestNewPromMetrics_DisablesHighCardinalityLabels(t *testing.T) {
 
 	_, err = p.httpClientRequestDuration.GetMetricWithLabelValues("default", "my-so", "prometheus", "my-trigger", "my-metric", "200")
 	assert.Error(t, err, "high-cardinality labels should not be accepted when disabled")
+}
+
+// TestPromMetrics_LatencyDualWrite pins the dual-write of the latency gauges
+// and their new histogram mirrors. A gauge keeps only the most recent
+// observation, so it cannot answer what latency metrics exist to answer (p95,
+// p99, how often a scaler is slow); the histogram accumulates every one. The
+// gauges stay for backwards compatibility, so both must be written.
+func TestPromMetrics_LatencyDualWrite(t *testing.T) {
+	p := &PromMetrics{}
+
+	const (
+		namespace      = "default"
+		scaledResource = "myScaledObject"
+		scaler         = "cpuScaler"
+		triggerIndex   = 0
+		metric         = "cpu"
+	)
+
+	p.RecordScalerLatency(namespace, scaledResource, scaler, triggerIndex, metric, true, 250*time.Millisecond)
+	p.RecordScalerLatency(namespace, scaledResource, scaler, triggerIndex, metric, true, 750*time.Millisecond)
+
+	labels := getLabels(namespace, scaledResource, scaler, triggerIndex, metric, true)
+
+	// Gauge: last observation only — the pre-existing behaviour.
+	gauge := &dto.Metric{}
+	require.NoError(t, scalerMetricsLatency.With(labels).Write(gauge))
+	assert.InDelta(t, 0.75, gauge.GetGauge().GetValue(), 1e-9)
+
+	// Histogram: both observations, so quantiles are computable.
+	hist := &dto.Metric{}
+	require.NoError(t, scalerMetricsDuration.With(labels).(prometheus.Metric).Write(hist))
+	assert.Equal(t, uint64(2), hist.GetHistogram().GetSampleCount())
+	assert.InDelta(t, 1.0, hist.GetHistogram().GetSampleSum(), 1e-9)
+}
+
+func TestPromMetrics_ScalableObjectLatencyDualWrite(t *testing.T) {
+	p := &PromMetrics{}
+
+	const (
+		namespace = "default"
+		name      = "myScaledObject2"
+	)
+
+	p.RecordScalableObjectLatency(namespace, name, true, 100*time.Millisecond)
+	p.RecordScalableObjectLatency(namespace, name, true, 300*time.Millisecond)
+
+	gauge := &dto.Metric{}
+	require.NoError(t, internalLoopLatency.WithLabelValues(namespace, "scaledobject", name).Write(gauge))
+	assert.InDelta(t, 0.3, gauge.GetGauge().GetValue(), 1e-9)
+
+	hist := &dto.Metric{}
+	require.NoError(t, internalLoopDuration.WithLabelValues(namespace, "scaledobject", name).(prometheus.Metric).Write(hist))
+	assert.Equal(t, uint64(2), hist.GetHistogram().GetSampleCount())
+	assert.InDelta(t, 0.4, hist.GetHistogram().GetSampleSum(), 1e-9)
+}
+
+// TestPromMetrics_DeleteScalerMetricsClearsHistogram guards against the new
+// histogram outliving a deleted trigger and reporting stale series, which is
+// exactly what DeleteScalerMetrics exists to prevent for the other scaler
+// metrics.
+func TestPromMetrics_DeleteScalerMetricsClearsHistogram(t *testing.T) {
+	p := &PromMetrics{}
+
+	const (
+		namespace      = "delete-ns"
+		scaledResource = "goingAway"
+	)
+
+	// scalerMetricsDuration is package-level and shared with the other tests in
+	// this file, so assert on the delta rather than an absolute series count.
+	before := testutil.CollectAndCount(scalerMetricsDuration)
+
+	p.RecordScalerLatency(namespace, scaledResource, "cpuScaler", 0, "cpu", true, time.Second)
+	require.Equal(t, before+1, testutil.CollectAndCount(scalerMetricsDuration),
+		"recording should add exactly one series")
+
+	p.DeleteScalerMetrics(namespace, scaledResource, true)
+	assert.Equal(t, before, testutil.CollectAndCount(scalerMetricsDuration),
+		"a deleted trigger must not leave a stale histogram series behind")
 }


### PR DESCRIPTION
Closes #7675.

### Problem

`keda_scaler_metrics_latency_seconds` and `keda_internal_scale_loop_latency_seconds` are gauges, so a scrape sees only the most recent observation. That can't answer what a latency metric exists to answer — p95, p99, or how often a scaler was slow — and it's inconsistent with every other duration keda-operator reports (`controller_runtime_reconcile_time_seconds`, `workqueue_work_duration_seconds`, `keda_internal_metricsservice_grpc_server_handling_seconds` are all histograms).

### Approach

Took the dual-write shape suggested in the issue, rather than converting the existing instruments:

| metric | type | status |
|---|---|---|
| `keda_scaler_metrics_latency_seconds` | gauge | unchanged |
| `keda_scaler_metrics_duration_seconds` | **histogram** | new |
| `keda_internal_scale_loop_latency_seconds` | gauge | unchanged |
| `keda_internal_scale_loop_duration_seconds` | **histogram** | new |

Nothing is removed or renamed, so existing dashboards and alerts keep working. `_duration_` follows the Prometheus guidance for an accumulated time series, and matches the naming already used by `keda_internal_metricsservice_grpc_server_handling_seconds` and the http client duration metric.

Buckets are `prometheus.DefBuckets` (5ms → 10s), which spans the range these two actually operate in. Easy to change if you'd prefer something tuned.

### Both collectors

The OTel collector mirrors these metrics too, so it gets `keda.scaler.metrics.duration.seconds` and `keda.internal.scale.loop.duration.seconds`.

Worth flagging one implementation difference: the OTel latency gauges are `Float64ObservableGauge`s whose callbacks drain a slice of pending values. A histogram can't work that way — it accumulates every observation rather than replaying the last batch — so these are synchronous `Float64Histogram`s recorded at observation time. The instruments are nil if `initMeters` failed, so the `Record` calls are guarded: the gauges degrade to no-ops in that case, and the new histograms shouldn't be the one thing that panics.

### Also

`DeleteScalerMetrics` now clears the scaler histogram as well, so a removed trigger doesn't leave a stale series behind — same reason the other scaler metrics are deleted there.

### Tests

Three tests in `prommetrics_test.go`:

- **Scaler dual-write** — after two observations (250ms, 750ms) the gauge holds `0.75` (last only) while the histogram reports `SampleCount=2`, `SampleSum=1.0`.
- **Scale-loop dual-write** — same shape for `RecordScalableObjectLatency`.
- **Delete clears the histogram** — asserts on the series-count delta rather than an absolute, since `scalerMetricsDuration` is package-level and shared with the other tests in the file.

```
go build ./...                       clean
go vet ./pkg/metricscollector/...    clean
go test ./pkg/metricscollector/...   ok
gofmt                                clean
```

### Checklist

- [x] Commits are signed off (DCO)
- [x] Tests added
- [x] CHANGELOG.md entry added under Unreleased → Improvements
- [ ] Docs — these are new public metrics, so keda-docs needs a matching entry. Happy to open that PR; tell me if you'd like it before or after this merges, and whether the gauges should be marked deprecated there or left as-is.

### One open question

The issue title says the gauges are "incorrectly implemented" and asks for either conversion *or* mirrored histograms. I went with mirroring because converting would be a breaking change for anyone alerting on the gauges. If you'd rather deprecate the gauges now (description prefixed `DEPRECATED - use ... instead`, as was done for the non-`_seconds` names), that's a small follow-up — I just didn't want to start a deprecation clock without a maintainer calling it.
