### PR TITLE
fallback: read the ready-replica count once per reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Kafka Scaler**: Add optional `fullMetadata` trigger metadata field to control Sarama's full cluster metadata refresh, reducing operator memory for topic scoped triggers ([#7453](https://github.com/kedacore/keda/issues/7453))
 - **Temporal Scaler**: Add `enableTLS` parameter to allow disabling TLS when using API key authentication (e.g. plaintext gRPC endpoints) ([#7854](https://github.com/kedacore/keda/pull/7854))
 - **Temporal Scaler**: Add opt-in `includeRunningWorkflowCount` (with optional `workflowTaskQueueForCount`) to block premature scale-down when the backlog is momentarily zero but Workflow workers are still busy. Worker Deployment Version scalers short-circuit on Version status (`DRAINING` stays active, `DRAINED`/`INACTIVE` scale down); other modes issue a scoped `CountWorkflow` visibility query — including `TemporalWorkerDeploymentVersion is null` for unversioned workers. ([#7459](https://github.com/kedacore/keda/issues/7459))
+- **General**: Read the ready-replica count once per reconcile when falling back on a `Value` target, instead of issuing a Scale read and a full Pod list per metric ([#5359](https://github.com/kedacore/keda/issues/5359))
 - TODO ([#XXX](https://github.com/kedacore/keda/issues/XXX))
 
 ### Fixes

--- a/pkg/fallback/fallback.go
+++ b/pkg/fallback/fallback.go
@@ -47,6 +47,43 @@ type ScaledObjectHandler struct {
 	ScaleClient  scale.ScalesGetter
 	UpdateLock   *sync.RWMutex
 	ScaledObject *kedav1alpha1.ScaledObject
+	// ReadyReplicas is shared by every handler built for the same reconcile so
+	// the ready-replica count is read once instead of once per metric. May be
+	// nil, in which case each lookup reads through.
+	ReadyReplicas *ReadyReplicasCache
+}
+
+// ReadyReplicasCache memoises the ready-replica count for the lifetime of a
+// single reconcile.
+//
+// getReadyReplicasCount issues a Scale subresource read plus a full Pod list,
+// and it runs once per metric that falls back on a Value target. A ScaledObject
+// with N such triggers therefore repeated that pair of API calls N times per
+// reconcile to compute a number that is identical every time, because all of
+// its metrics share one scale target.
+//
+// The zero value is ready to use. A nil cache reads through, so callers that do
+// not have one - the fallback unit tests, and any future call site - keep the
+// previous behaviour.
+type ReadyReplicasCache struct {
+	once  sync.Once
+	count int32
+	err   error
+}
+
+// get returns the memoised count, calling fetch at most once. The handlers that
+// share a cache run concurrently (both GetScaledObjectMetrics and
+// getScaledObjectState fan out over goroutines), so the first caller fetches
+// and the rest block on that same result rather than racing to issue their own
+// API calls.
+func (c *ReadyReplicasCache) get(fetch func() (int32, error)) (int32, error) {
+	if c == nil {
+		return fetch()
+	}
+	c.once.Do(func() {
+		c.count, c.err = fetch()
+	})
+	return c.count, c.err
 }
 
 // UpdateHealthStatus safely serializes updates to ScaledObject's health status and ships them to kube-api
@@ -207,8 +244,17 @@ func IsPodReady(pod *v1.Pod) bool {
 	return false
 }
 
-// Similar to how it's done in HPA's code: https://github.com/kubernetes/kubernetes/blob/091f87c10bc3532041b77a783a5f832de5506dc8/pkg/controller/podautoscaler/replica_calculator.go#L323
+// getReadyReplicasCount returns the ready-replica count for the scale target,
+// reusing the value already computed for this reconcile when the handler
+// carries a cache.
 func getReadyReplicasCount(soh ScaledObjectHandler) (int32, error) {
+	return soh.ReadyReplicas.get(func() (int32, error) {
+		return fetchReadyReplicasCount(soh)
+	})
+}
+
+// Similar to how it's done in HPA's code: https://github.com/kubernetes/kubernetes/blob/091f87c10bc3532041b77a783a5f832de5506dc8/pkg/controller/podautoscaler/replica_calculator.go#L323
+func fetchReadyReplicasCount(soh ScaledObjectHandler) (int32, error) {
 	scaledObject := soh.ScaledObject
 	if scaledObject == nil || scaledObject.Spec.ScaleTargetRef == nil || scaledObject.Status.ScaleTargetGVKR == nil {
 		return -1, fmt.Errorf("")

--- a/pkg/fallback/readyreplicas_cache_test.go
+++ b/pkg/fallback/readyreplicas_cache_test.go
@@ -1,0 +1,138 @@
+package fallback
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kedacore/keda/v2/pkg/mock/mock_client"
+	"github.com/kedacore/keda/v2/pkg/mock/mock_scale"
+)
+
+// primeReadyReplicas wires the Scale read and the Pod list that
+// fetchReadyReplicasCount performs, and asserts each happens exactly `times`
+// times. The Pod list is left empty: this exercises how often the API is hit,
+// not what the count comes out to.
+func primeReadyReplicas(t *testing.T, times int) (ScaledObjectHandler, *gomock.Controller) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	client := mock_client.NewMockClient(ctrl)
+	scaleClient := mock_scale.NewMockScalesGetter(ctrl)
+	scaleInterface := mock_scale.NewMockScaleInterface(ctrl)
+
+	scaleClient.EXPECT().Scales(gomock.Eq("default")).Return(scaleInterface).Times(times)
+	// The resource argument arrives as a schema.GroupResource, so it is matched
+	// loosely here - this test is about how many times the call happens.
+	scaleInterface.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.Eq("myapp"), gomock.Any()).
+		Return(&autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{Name: "myapp", Namespace: "default"},
+		}, nil).
+		Times(times)
+	client.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(times)
+
+	return ScaledObjectHandler{
+		Ctx:          context.Background(),
+		KubeClient:   client,
+		ScaleClient:  scaleClient,
+		UpdateLock:   &sync.RWMutex{},
+		ScaledObject: buildScaledObject(nil, nil),
+	}, ctrl
+}
+
+// The point of the cache: a ScaledObject with several Value-target triggers used
+// to repeat a Scale read plus a full Pod list once per metric, for a number that
+// is identical across all of them because they share one scale target.
+func TestReadyReplicasCacheFetchesOnce(t *testing.T) {
+	soh, ctrl := primeReadyReplicas(t, 1)
+	defer ctrl.Finish()
+	soh.ReadyReplicas = &ReadyReplicasCache{}
+
+	for i := 0; i < 5; i++ {
+		if _, err := getReadyReplicasCount(soh); err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+	}
+}
+
+// Without a cache the behaviour is unchanged, so call sites that do not carry
+// one - the other fallback tests among them - still read through every time.
+func TestReadyReplicasNoCacheReadsThrough(t *testing.T) {
+	soh, ctrl := primeReadyReplicas(t, 5)
+	defer ctrl.Finish()
+
+	for i := 0; i < 5; i++ {
+		if _, err := getReadyReplicasCount(soh); err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+	}
+}
+
+// Both handlers that share a cache fan out over goroutines, so concurrent
+// callers must collapse onto one fetch rather than racing to issue their own.
+func TestReadyReplicasCacheIsConcurrencySafe(t *testing.T) {
+	soh, ctrl := primeReadyReplicas(t, 1)
+	defer ctrl.Finish()
+	soh.ReadyReplicas = &ReadyReplicasCache{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := getReadyReplicasCount(soh); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// A failed lookup is memoised too. Retrying inside a single reconcile would hit
+// the API once per metric precisely when the API is already unhappy, and every
+// caller in that pass would fail anyway.
+func TestReadyReplicasCacheMemoisesFailure(t *testing.T) {
+	cache := &ReadyReplicasCache{}
+	wantErr := errors.New("scale target is gone")
+
+	var calls int
+	fetch := func() (int32, error) {
+		calls++
+		return -1, wantErr
+	}
+
+	for i := 0; i < 3; i++ {
+		count, err := cache.get(fetch)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("call %d: got error %v, want %v", i, err, wantErr)
+		}
+		if count != -1 {
+			t.Fatalf("call %d: got count %d, want -1", i, count)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("fetched %d times, want 1", calls)
+	}
+}
+
+// A nil cache is a valid zero state - ScaledObjectHandler carries the field as a
+// pointer and not every call site sets it.
+func TestReadyReplicasNilCacheReadsThrough(t *testing.T) {
+	var cache *ReadyReplicasCache
+
+	var calls int
+	for i := 0; i < 3; i++ {
+		if _, err := cache.get(func() (int32, error) { calls++; return 7, nil }); err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i, err)
+		}
+	}
+	if calls != 3 {
+		t.Errorf("fetched %d times, want 3 - a nil cache must not memoise", calls)
+	}
+}

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -697,6 +697,11 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 	isScalerError := false
 	scaledObjectIdentifier := scaledObject.GenerateIdentifier()
 
+	// One cache for the whole call, shared by every per-metric handler below, so
+	// the ready-replica count behind a Value-target fallback costs one Scale read
+	// and one Pod list instead of one of each per metric.
+	readyReplicas := &fallback.ReadyReplicasCache{}
+
 	// returns all relevant metrics for current scaler (standard is one metric,
 	// composite scaler gets all external metrics for further computation)
 	metricsArray, err := h.getTrueMetricArray(ctx, metricsName, scaledObject)
@@ -802,11 +807,12 @@ func (h *scaleHandler) GetScaledObjectMetrics(ctx context.Context, scaledObjectN
 
 					// Use the helper function to process metrics with fallback
 					soh := fallback.ScaledObjectHandler{
-						Ctx:          ctx,
-						KubeClient:   h.client,
-						ScaleClient:  h.scaleClient,
-						UpdateLock:   &scalersCache.ScaledObjectUpdateLock,
-						ScaledObject: scaledObject,
+						Ctx:           ctx,
+						KubeClient:    h.client,
+						ScaleClient:   h.scaleClient,
+						UpdateLock:    &scalersCache.ScaledObjectUpdateLock,
+						ScaledObject:  scaledObject,
+						ReadyReplicas: readyReplicas,
 					}
 					metrics, fallbackActive, err := h.processMetricsWithFallback(soh, rawMetrics, rawErr, metricName, triggerName, triggerIndex, spec, shouldSendRawMetrics(RawMetricsHPA), isMetricActive, logger)
 
@@ -925,11 +931,14 @@ func (h *scaleHandler) getScaledObjectState(ctx context.Context, scaledObject *k
 	// no matter if any scaler raises error or is active
 	allScalers, scalerConfigs := scalersCache.GetScalers()
 	results := make(chan scalerState, len(allScalers))
+	// Shared by every scaler in this pass: the ready-replica count is a property
+	// of the scale target, not of the individual trigger, so it is read once.
+	readyReplicas := &fallback.ReadyReplicasCache{}
 	wg := sync.WaitGroup{}
 	for scalerIndex := 0; scalerIndex < len(allScalers); scalerIndex++ {
 		wg.Add(1)
 		go func(scaler scalers.Scaler, index int, scalerConfig scalersconfig.ScalerConfig, results chan scalerState, wg *sync.WaitGroup) {
-			results <- h.getScalerState(ctx, scaler, index, scalerConfig, scalersCache, logger, scaledObject)
+			results <- h.getScalerState(ctx, scaler, index, scalerConfig, scalersCache, logger, scaledObject, readyReplicas)
 			wg.Done()
 		}(allScalers[scalerIndex], scalerIndex, scalerConfigs[scalerIndex], results, &wg)
 	}
@@ -1020,7 +1029,8 @@ func (h *scaleHandler) getScaledObjectState(ctx context.Context, scaledObject *k
 // with errors, but also the records for the cache and the metrics
 // for the custom formulas
 func (h *scaleHandler) getScalerState(ctx context.Context, scaler scalers.Scaler, triggerIndex int, scalerConfig scalersconfig.ScalerConfig,
-	scalersCache *cache.ScalersCache, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject) scalerState {
+	scalersCache *cache.ScalersCache, logger logr.Logger, scaledObject *kedav1alpha1.ScaledObject,
+	readyReplicas *fallback.ReadyReplicasCache) scalerState {
 	result := scalerState{
 		IsActive:        false,
 		Err:             nil,
@@ -1075,11 +1085,12 @@ func (h *scaleHandler) getScalerState(ctx context.Context, scaler scalers.Scaler
 
 		// Use the helper function to process metrics with fallback
 		soh := fallback.ScaledObjectHandler{
-			Ctx:          ctx,
-			KubeClient:   h.client,
-			ScaleClient:  h.scaleClient,
-			UpdateLock:   &scalersCache.ScaledObjectUpdateLock,
-			ScaledObject: scaledObject,
+			Ctx:           ctx,
+			KubeClient:    h.client,
+			ScaleClient:   h.scaleClient,
+			UpdateLock:    &scalersCache.ScaledObjectUpdateLock,
+			ScaledObject:  scaledObject,
+			ReadyReplicas: readyReplicas,
 		}
 		metrics, fallbackActive, err := h.processMetricsWithFallback(soh, rawMetrics, rawErr, metricName, result.TriggerName, triggerIndex, spec, shouldSendRawMetrics(RawMetricsPollingInterval), isMetricActive, logger)
 


### PR DESCRIPTION
### Provide a description of what has been changed

Part of #5359, which asks for the fallback path to be refactored and optimised.

`getReadyReplicasCount` issues a Scale subresource read plus a full Pod list, and it runs once per metric that falls back on a `Value` target. Since #5296 parallelised metric requests, fallback itself stayed per-metric — `GetMetricsWithFallback` is called once per metric spec in the loops in `scale_handler.go`. A ScaledObject with N such triggers therefore repeated that pair of API calls N times per reconcile to compute a number that is identical every time, because all of its metrics share one scale target.

This adds a `ReadyReplicasCache` that memoises the count for the lifetime of a single reconcile, and threads one instance through the handlers built in `GetScaledObjectMetrics` and `getScaledObjectState`.

Notes on the details:

- **Concurrency.** Both call sites fan out over goroutines, so the cache uses `sync.Once` — the first caller fetches and the rest wait on that same result rather than racing to issue their own requests. `ScaledObjectHandler` is passed by value, so the field is a pointer and the `Once` is never copied.
- **Failures are memoised too.** Retrying once per metric would hit the API hardest exactly when it is already failing, and every caller in that pass fails regardless.
- **Nil means read through.** The field is optional, so any call site without a cache — the existing fallback unit tests among them — keeps the previous behaviour unchanged.

This is the self-contained half of what I proposed in [my comment on #5359](https://github.com/kedacore/keda/issues/5359#issuecomment-3092820000). The other half, batching the per-metric health-status patches into one write, needs a design call on whether to reshape `GetMetricsWithFallback` or add a flush-once accumulator, so I have left it out of this PR.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] Tests have been added
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs) (not applicable — no user-facing API change)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Relates to #5359
