### PR TITLE
CI: e2e vault wait for vault pod ready

### DIFF
--- a/tests/secret-providers/hashicorp_vault/hashicorp_vault_test.go
+++ b/tests/secret-providers/hashicorp_vault/hashicorp_vault_test.go
@@ -13,6 +13,7 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
@@ -590,24 +591,24 @@ func setupHashiCorpVaultPki(t *testing.T, podName string, nameSpace string) *pro
 		fmt.Sprintf("vault write pki/roles/%s require_cn=false allowed_domains=%s.svc allow_subdomains=true max_ttl=72h", testNamespace, testNamespace),
 	}
 	for _, vaultCommand := range vaultCommands {
-		_, _, err := ExecCommandOnSpecificPod(
+		out, errOut, err := ExecCommandOnSpecificPod(
 			t,
 			podName,
 			nameSpace,
 			vaultCommand,
 		)
-		assert.NoErrorf(t, err, "cannot set vault pki command %s - %s", vaultCommand, err)
+		require.NoErrorf(t, err, "cannot set vault pki command %s - %s, stdout: %s, stderr: %s", vaultCommand, err, out, errOut)
 	}
-	rawPkiSecret, _, err := ExecCommandOnSpecificPod(
+	rawPkiSecret, errOut, err := ExecCommandOnSpecificPod(
 		t,
 		podName,
 		nameSpace,
 		fmt.Sprintf("vault write pki/issue/%s common_name=%s.%s.svc -format=json", testNamespace, prometheusServerName, testNamespace),
 	)
-	assert.NoErrorf(t, err, "cannot issue certificate - %s", err)
+	require.NoErrorf(t, err, "cannot issue certificate - %s, stdout: %s, stderr: %s", err, rawPkiSecret, errOut)
 	var pkiSecret vaultapi.Secret
 	err = json.Unmarshal([]byte(rawPkiSecret), &pkiSecret)
-	assert.NoErrorf(t, err, "cannot read certificate raw secret - %s", err)
+	require.NoErrorf(t, err, "cannot read certificate raw secret - %s, raw output: %s", err, rawPkiSecret)
 	serverKey := b64.StdEncoding.EncodeToString([]byte(pkiSecret.Data["private_key"].(string)))
 	serverCertificate := b64.StdEncoding.EncodeToString([]byte(pkiSecret.Data["certificate"].(string)))
 	caCertificate := b64.StdEncoding.EncodeToString([]byte((pkiSecret.Data["ca_chain"].([]interface{}))[0].(string)))
@@ -623,10 +624,10 @@ func setupHashiCorpVault(t *testing.T, kc *kubernetes.Clientset, kvVersion uint,
 	CreateNamespace(t, kc, vaultNamespace)
 
 	_, err := ExecuteCommand("helm repo add hashicorp https://helm.releases.hashicorp.com")
-	assert.NoErrorf(t, err, "cannot add hashicorp repo - %s", err)
+	require.NoErrorf(t, err, "cannot add hashicorp repo - %s", err)
 
 	_, err = ExecuteCommand("helm repo update")
-	assert.NoErrorf(t, err, "cannot update repos - %s", err)
+	require.NoErrorf(t, err, "cannot update repos - %s", err)
 
 	var helmValues strings.Builder
 	helmValues.WriteString("--set server.dev.enabled=true")
@@ -636,41 +637,44 @@ func setupHashiCorpVault(t *testing.T, kc *kubernetes.Clientset, kvVersion uint,
 	}
 
 	_, err = ExecuteCommand(fmt.Sprintf(`helm upgrade --install %s --namespace %s --wait vault hashicorp/vault`, helmValues.String(), vaultNamespace))
-	assert.NoErrorf(t, err, "cannot install hashicorp vault - %s", err)
+	require.NoErrorf(t, err, "cannot install hashicorp vault - %s", err)
 
 	podName := "vault-0"
+
+	ready, _, execErrOut, err := WaitForSuccessfulExecCommandOnSpecificPod(t, podName, vaultNamespace, "vault status", 12, 5)
+	require.True(t, ready, "vault-0 is not ready - %s, %s", execErrOut, err)
 
 	// Enable Kubernetes auth
 	if useKubernetesAuth {
 		if pki {
 			remoteFile := "/tmp/pki_policy.hcl"
 			KubectlCopyToPod(t, pkiPolicyTemplate, remoteFile, podName, vaultNamespace)
-			assert.NoErrorf(t, err, "cannot create policy file in hashicorp vault - %s", err)
+			require.NoErrorf(t, err, "cannot create policy file in hashicorp vault - %s", err)
 			_, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, fmt.Sprintf("vault policy write pkiPolicy %s", remoteFile))
-			assert.NoErrorf(t, err, "cannot create policy in hashicorp vault - %s", err)
+			require.NoErrorf(t, err, "cannot create policy in hashicorp vault - %s", err)
 		}
 		_, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, "vault auth enable kubernetes")
-		assert.NoErrorf(t, err, "cannot enable kubernetes in hashicorp vault - %s", err)
+		require.NoErrorf(t, err, "cannot enable kubernetes in hashicorp vault - %s", err)
 		_, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, "vault write auth/kubernetes/config kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT")
-		assert.NoErrorf(t, err, "cannot set kubernetes host in hashicorp vault - %s", err)
+		require.NoErrorf(t, err, "cannot set kubernetes host in hashicorp vault - %s", err)
 		_, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, "vault write auth/kubernetes/role/keda bound_service_account_names=keda-operator bound_service_account_namespaces=keda policies=pkiPolicy ttl=1h")
-		assert.NoErrorf(t, err, "cannot cerate keda role in hashicorp vault - %s", err)
+		require.NoErrorf(t, err, "cannot cerate keda role in hashicorp vault - %s", err)
 		if delegatedAuth {
 			remoteFile := "/tmp/secret_read_policy.hcl"
 			KubectlCopyToPod(t, secretReadPolicyTemplate, remoteFile, podName, vaultNamespace)
-			assert.NoErrorf(t, err, "cannot create policy file in hashicorp vault - %s", err)
+			require.NoErrorf(t, err, "cannot create policy file in hashicorp vault - %s", err)
 			_, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, fmt.Sprintf("vault policy write secretReadPolicy %s", remoteFile))
-			assert.NoErrorf(t, err, "cannot create policy in hashicorp vault - %s", err)
+			require.NoErrorf(t, err, "cannot create policy in hashicorp vault - %s", err)
 
 			_, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, fmt.Sprintf("vault write auth/kubernetes/role/vault-delegated-sa bound_service_account_names=default bound_service_account_namespaces=%s policies=secretReadPolicy ttl=1h", testNamespace))
-			assert.NoErrorf(t, err, "cannot cerate keda role in hashicorp vault - %s", err)
+			require.NoErrorf(t, err, "cannot cerate keda role in hashicorp vault - %s", err)
 		}
 	}
 
 	// Create kv secret
 	if !pki {
 		_, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, fmt.Sprintf("vault kv put secret/keda connectionString=%s", postgreSQLConnectionString))
-		assert.NoErrorf(t, err, "cannot put connection string in hashicorp vault - %s", err)
+		require.NoErrorf(t, err, "cannot put connection string in hashicorp vault - %s", err)
 	}
 
 	// Create PKI Backend
@@ -683,7 +687,7 @@ func setupHashiCorpVault(t *testing.T, kc *kubernetes.Clientset, kvVersion uint,
 	token := "INVALID"
 	if !useKubernetesAuth {
 		token, _, err = ExecCommandOnSpecificPod(t, podName, vaultNamespace, "vault token create -field token")
-		assert.NoErrorf(t, err, "cannot create hashicorp vault token - %s", err)
+		require.NoErrorf(t, err, "cannot create hashicorp vault token - %s", err)
 	}
 	return token, pkiData
 }


### PR DESCRIPTION
The `hashicorp_vault` e2e is currently one of the biggest flake offender, rarely passes on the first try and frequently fails all three runs

```
SUITE                        08-06  08-05  08-04  08-03  08-02  08-01  07-30  07-29  07-28  07-27  07-26
hashicorp_vault_test.go      🔁     ✅     ✅     🔁     ✅      ✅    🔁     🔁     🔁     ❌     🔁

```

The failure always starts the same way - right after `helm upgrade --install --wait vault`, every exec into `vault-0` fails:

```
=== RUN   TestPkiSecretsEngine/token
    helper.go: deleting namespace hashicorp-ns
    helper.go: Creating namespace - hashicorp-ns
    hashicorp_vault_test.go:599:
        Error:      unable to upgrade connection: container not found ("vault")
        Messages:   cannot set vault pki command vault secrets enable pki - ...
```

and a few seconds later the container is up, but because the earlier setup commands never ran, the remaining ones fail with nonzero exits and the test ends in a misleading `cannot read certificate raw secret - unexpected end of JSON input` plus a nil-interface panic that kills the whole attempt.

Root cause: the vault chart deploys the server `StatefulSet` with the `OnDelete` update strategy ([values.yaml](https://github.com/hashicorp/vault-helm/blob/main/values.yaml#L426)), and helm `--wait` [skips the readiness check for StatefulSets that don't use RollingUpdate](https://github.com/helm/helm/blob/main/pkg/kube/ready.go#L393-L397). So helm returns before `vault-0` is even scheduled and the test races container startup - on a busy node, it loses.

Fixes:
* wait for `vault status` to succeed before configuring vault
* fail setup fast (`require` instead of `assert`) so a broken step no longer cascades into the JSON parse error and the panic
* include vault CLI stdout/stderr in failure messages for future diagnostics
