### PR TITLE
CI: e2e selenium pre-pull browser node images before scaling assertions

### DIFF
--- a/tests/scalers/selenium/selenium_test.go
+++ b/tests/scalers/selenium/selenium_test.go
@@ -135,6 +135,16 @@ spec:
       annotations:
         checksum/event-bus-configmap: 0e5e9d25a669359a37dd0d684c485f4c05729da5a26a841ad9a2743d99460f73
     spec:
+      # prefer the hub's node so the image pre-pulled during setup stays local
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: selenium-hub
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: selenium-chrome-node
         image: selenium/node-chrome:nightly
@@ -258,6 +268,16 @@ spec:
       annotations:
         checksum/event-bus-configmap: 0e5e9d25a669359a37dd0d684c485f4c05729da5a26a841ad9a2743d99460f73
     spec:
+      # prefer the hub's node so the image pre-pulled during setup stays local
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: selenium-hub
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: selenium-firefox-node
         image: selenium/node-firefox:nightly
@@ -354,6 +374,16 @@ spec:
       annotations:
         checksum/event-bus-configmap: 0e5e9d25a669359a37dd0d684c485f4c05729da5a26a841ad9a2743d99460f73
     spec:
+      # prefer the hub's node so the image pre-pulled during setup stays local
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: selenium-hub
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: selenium-edge-node
         image: selenium/node-edge:nightly

--- a/tests/scalers/selenium/selenium_test.go
+++ b/tests/scalers/selenium/selenium_test.go
@@ -125,7 +125,7 @@ metadata:
     app.kubernetes.io/component: latest
     helm.sh/chart: latest
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: selenium-chrome-node
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/component: latest
     helm.sh/chart: latest
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: selenium-firefox-node
@@ -344,7 +344,7 @@ metadata:
     app.kubernetes.io/component: latest
     helm.sh/chart: latest
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app: selenium-edge-node
@@ -532,14 +532,28 @@ spec:
 func TestSeleniumScaler(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	data, templates := getTemplateData()
+	soTemplates := []Template{
+		{Name: "chromeScaledObjectTemplate", Config: chromeScaledObjectTemplate},
+		{Name: "firefoxScaledObjectTemplate", Config: firefoxScaledObjectTemplate},
+		{Name: "edgeScaledObjectTemplate", Config: edgeScaledObjectTemplate},
+	}
 	t.Cleanup(func() {
-		DeleteKubernetesResources(t, testNamespace, data, templates)
+		DeleteKubernetesResources(t, testNamespace, data, append(templates, soTemplates...))
 	})
 
 	// Create kubernetes resources
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, hubDeploymentName, testNamespace, 1, 60, 1),
 		"replica count should be 1 after 1 minute")
+
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, chromeDeploymentName, testNamespace, 1, 60, 3),
+		"replica count should be 1 after 3 minutes")
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, firefoxDeploymentName, testNamespace, 1, 60, 3),
+		"replica count should be 1 after 3 minutes")
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, edgeDeploymentName, testNamespace, 1, 60, 3),
+		"replica count should be 1 after 3 minutes")
+
+	KubectlApplyMultipleWithTemplate(t, data, soTemplates)
 	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, chromeDeploymentName, testNamespace, minReplicaCount, 60, 1),
 		"replica count should be 0 after 1 minute")
 	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, firefoxDeploymentName, testNamespace, minReplicaCount, 60, 1),
@@ -619,12 +633,9 @@ func getTemplateData() (templateData, []Template) {
 			{Name: "hubServiceTemplate", Config: hubServiceTemplate},
 			{Name: "chromeNodeServiceTemplate", Config: chromeNodeServiceTemplate},
 			{Name: "chromeNodeDeploymentTemplate", Config: chromeNodeDeploymentTemplate},
-			{Name: "chromeScaledObjectTemplate", Config: chromeScaledObjectTemplate},
 			{Name: "firefoxNodeServiceTemplate", Config: firefoxNodeServiceTemplate},
 			{Name: "firefoxNodeDeploymentTemplate", Config: firefoxNodeDeploymentTemplate},
-			{Name: "firefoxScaledObjectTemplate", Config: firefoxScaledObjectTemplate},
 			{Name: "edgeNodeServiceTemplate", Config: edgeNodeServiceTemplate},
 			{Name: "edgeNodeDeploymentTemplate", Config: edgeNodeDeploymentTemplate},
-			{Name: "edgeScaledObjectTemplate", Config: edgeScaledObjectTemplate},
 		}
 }


### PR DESCRIPTION
The selenium e2e is the second biggest flake offender in the nightly suite, also rarely passes on first run

```
SUITE            08-07  08-06  08-05  08-04  08-03  08-02  08-01 07-31  07-30  07-29
selenium_test.go    🔁     ✅     🔁     🔁     🔁     🔁     ✅    🔁     🔁     🔁
```

Every one of the 18 failed assertions across those runs is in **scale out** (chrome 8x, firefox 6x, edge 4x) - never activation, never scale in:

```
    selenium_test.go:569: --- testing scale out ---
    helper.go:565: Waiting for deployment replicas to hit target. Deployment - selenium-test-chrome, Current - 0, Target - 1
    ... (60 polls, never scales)
        Error:          Should be true
        Messages:       replica count should be %!s(int=1) after 1 minute
```

Root cause: the chrome/firefox/edge images are pretty large and image pull happens on activations 0->1 replicas and tests expect the scale out to happen in 60s window.

Fix: best-effort pre-pull the image. The selenium browser deployments will get affinity to try to stay on the same node as `selenium-hub`. Affinity is only a weak promise with `preferredDuringSchedulingIgnoredDuringExecution` to not block e2e test execution. Hopefully this sufficiently improves the test flakiness.