### PR TITLE
CI: e2e rabbitmq eqct purge queue before scale-in assertion

### DIFF
--- a/tests/scalers/rabbitmq/rabbitmq_helper.go
+++ b/tests/scalers/rabbitmq/rabbitmq_helper.go
@@ -434,6 +434,14 @@ func RMQStopPublishingMessages(namespace, queueName string) {
 	_, _ = helper.ExecuteCommand(fmt.Sprintf("kubectl delete jobs/rabbitmq-publish-%s --namespace %s", queueName, namespace))
 }
 
+// RMQPurgeQueue drops the messages remaining in the queue, so scale-in
+// assertions measure the scaler reacting to an empty queue instead of how fast
+// the consumers drain the backlog.
+func RMQPurgeQueue(t *testing.T, namespace, queueName, vhost string) {
+	out, err := helper.ExecuteCommand(fmt.Sprintf("kubectl exec -n %s deploy/rabbitmq -- rabbitmqctl purge_queue %s -p %s", namespace, queueName, vhost))
+	require.NoErrorf(t, err, "cannot purge queue - %s, %s", err, out)
+}
+
 func RMQConsumeMessages(t *testing.T, namespace, connectionString, queueName string) {
 	data := templateData{
 		Namespace:  namespace,

--- a/tests/scalers/rabbitmq/rabbitmq_queue_http_eqct/rabbitmq_queue_http_eqct_test.go
+++ b/tests/scalers/rabbitmq/rabbitmq_queue_http_eqct/rabbitmq_queue_http_eqct_test.go
@@ -121,6 +121,7 @@ func testScaling(t *testing.T, kc *kubernetes.Clientset) {
 		"replica count should be 4 after 3 minute")
 
 	RMQStopPublishingMessages(rmqNamespace, queueName)
+	RMQPurgeQueue(t, rmqNamespace, queueName, vhost)
 	t.Log("--- testing scale in ---")
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
 		"replica count should be 0 after 1 minute")


### PR DESCRIPTION
The rabbitmq_queue_http_eqct e2e needed retries in 11 of the last 34 nightly runs and terminally failed the 07-29 one - fourth biggest flake offender:

```
SUITE                             08-11  08-10  08-09  08-08  08-07  08-06  08-05  08-04  08-03  08-02  08-01  07-31  07-30  07-29  07-28
rabbitmq_queue_http_eqct_test.go  🔁     ✅     ✅     🔁     ✅     ✅     🔁     🔁     🔁     ✅     ✅     ✅     ✅     ❌     ✅
```

All 16 failed assertions across those runs are the same line, scale-in:

```
    rabbitmq_queue_http_eqct_test.go:125:
        Error:          Should be true
        Messages:       replica count should be 0 after 1 minute
```

Root cause is arithmetic, not the scaler: the publish job pushes 3 msg/s *continuously* (`send ... 3 hello 1`), while each consumer drains 1 msg/s (hardcoded 1s sleep, prefetch 1, max 4 replicas). Until the scale-out ramp reaches 4 consumers the queue grows at 1-2 msg/s, so when `RMQStopPublishingMessages` runs, the queue holds a backlog proportional to however long the HPA ramp took that day. The 60s scale-in window then has to cover draining that backlog at <= 4 msg/s *plus* the scale-down chain (HPA stabilization -> 4->1 -> cooldownPeriod -> 0). On a slow ramp day it doesn't fit.

Fix: purge the queue (`rabbitmqctl purge_queue`) right after stopping the publisher, so the scale-in assertion measures the scaler reacting to an empty queue instead of the consumers' drain throughput. Adds a reusable `RMQPurgeQueue` helper.
