### PR TITLE
CI: e2e azure_pipelines scope build cleanup to own definition

### DIFF
--- a/tests/scalers/azure/azure_pipelines/azure_pipelines_test.go
+++ b/tests/scalers/azure/azure_pipelines/azure_pipelines_test.go
@@ -242,9 +242,17 @@ func clearAllBuilds(t *testing.T, connection *azuredevops.Connection) {
 	if err != nil {
 		t.Error(fmt.Sprintf("unable to create build client: %s", err.Error()), err)
 	}
+	definitionID, err := strconv.Atoi(buildID)
+	if err != nil {
+		t.Errorf("unable to parse buildID")
+	}
 	var top = 20
+	// Scope the cleanup to this test's build definition - the azure_pipelines
+	// e2e variants share one project and run in parallel, so cancelling every
+	// build in the project kills the sibling tests' queued builds mid-flight.
 	args := build.GetBuildsArgs{
 		Project:      &project,
+		Definitions:  &[]int{definitionID},
 		StatusFilter: &build.BuildStatusValues.All,
 		QueryOrder:   &build.BuildQueryOrderValues.QueueTimeDescending,
 		Top:          &top,

--- a/tests/scalers/azure/azure_pipelines_aad_wi/azure_pipelines_aad_wi_test.go
+++ b/tests/scalers/azure/azure_pipelines_aad_wi/azure_pipelines_aad_wi_test.go
@@ -249,9 +249,17 @@ func clearAllBuilds(t *testing.T, connection *azuredevops.Connection) {
 	if err != nil {
 		t.Error(fmt.Sprintf("unable to create build client: %s", err.Error()), err)
 	}
+	definitionID, err := strconv.Atoi(buildID)
+	if err != nil {
+		t.Errorf("unable to parse buildID")
+	}
 	var top = 20
+	// Scope the cleanup to this test's build definition - the azure_pipelines
+	// e2e variants share one project and run in parallel, so cancelling every
+	// build in the project kills the sibling tests' queued builds mid-flight.
 	args := build.GetBuildsArgs{
 		Project:      &project,
+		Definitions:  &[]int{definitionID},
 		StatusFilter: &build.BuildStatusValues.All,
 		QueryOrder:   &build.BuildQueryOrderValues.QueueTimeDescending,
 		Top:          &top,

--- a/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
+++ b/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
@@ -371,9 +371,17 @@ func clearAllBuilds(t *testing.T, connection *azuredevops.Connection) {
 	if err != nil {
 		t.Error(fmt.Sprintf("unable to create build client: %s", err.Error()), err)
 	}
+	definitionID, err := strconv.Atoi(demandParentBuildID)
+	if err != nil {
+		t.Errorf("unable to parse demandParentBuildID")
+	}
 	var top = 20
+	// Scope the cleanup to this test's build definition - the azure_pipelines
+	// e2e variants share one project and run in parallel, so cancelling every
+	// build in the project kills the sibling tests' queued builds mid-flight.
 	args := build.GetBuildsArgs{
 		Project:      &project,
+		Definitions:  &[]int{definitionID},
 		StatusFilter: &build.BuildStatusValues.All,
 		QueryOrder:   &build.BuildQueryOrderValues.QueueTimeDescending,
 		Top:          &top,


### PR DESCRIPTION
The `azure_pipelines` family (azure_pipelines / _aad_wi / _adv) flake very frequently because they suffer from running in parallel and affecting each other - 16 retries across the three suites in the last 34 nightlies, and the retries cluster in the same runs (07-26, 07-27, 07-30, 08-05):

```
SUITE                           08-05  08-04  08-03  08-02  08-01  07-31  07-30  07-29  07-28  07-27  07-26
azure_pipelines_test.go           🔁     ✅     ✅     ✅     🔁     ✅     ✅     🔁     ✅     🔁     ✅
azure_pipelines_aad_wi_test.go    🔁     ✅     ✅     ✅     ✅     ✅     🔁     ✅     ✅     🔁     🔁
azure_pipelines_adv_test.go       ✅     ✅     ✅     ✅     ✅     ✅     🔁     ✅     ✅     🔁     🔁
```

The failed attempts always look the same - activation passes, then scale-out queues a second build and the deployment stays at 0 for the full 60s window:

```
    azure_pipelines_test.go:298: --- testing scale out ---
    helper.go:565: Waiting for deployment replicas to hit target. Deployment - azure-pipelines-test-deployment, Current - 0, Target - 1
    ... (60 polls)
        Error:          Should be true
        Messages:       replica count should be 1 after 1 minute
```

i.e. the scaler never saw the pool queue cross the activation threshold.

Root cause: all three variants share one Azure DevOps project and run in the parallel e2e pool, but each test's `clearAllBuilds` cancels the **top 20 builds of the whole project** - including the sibling tests' queued activation/scale-out builds.

Fix: pass `Definitions: &[]int{<own definition id>}` to `GetBuilds` so each test only cancels builds of its own build definition (`AZURE_DEVOPS_BUILD_DEFINITION_ID` / `AZURE_DEVOPS_AAD_WI_BUILD_DEFINITION_ID` / `AZURE_DEVOPS_DEMAND_PARENT_BUILD_DEFINITION_ID`).
