### PR TITLE
Return typed API status errors from the external metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Fix concurrent map writes panic in the shared root CA `CertPool` ([#7910](https://github.com/kedacore/keda/issues/7910))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
+- **General**: Fix external metrics endpoint returning plain errors that the metrics apiserver logs as `received an error that is not an metav1.Status`; errors are now returned as typed API status errors ([#7575](https://github.com/kedacore/keda/issues/7575))
 - **General**: Fix nil pointer dereference in AWS Secret Manager `TriggerAuthentication` when `awsSecretManager.credentials` is omitted and no `awsSecretManager.podIdentity` is set ([#7927](https://github.com/kedacore/keda/issues/7927))
 - **General**: Fix nil pointer dereference in `customScalingStrategy.GetEffectiveMaxScale` when `customScalingQueueLengthDeduction` is omitted; the optional field is now treated as zero deduction instead of panicking ([#7798](https://github.com/kedacore/keda/issues/7798))
 - **General**: Fix nil pointer dereference in `GetCurrentReplicas` when a Deployment/StatefulSet/ReplicaSet is returned from the informer cache with an undefaulted `spec.replicas`; a nil value is now treated as the Kubernetes default of 1 instead of panicking ([#7863](https://github.com/kedacore/keda/issues/7863))

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -123,7 +123,7 @@ func (a *Adapter) makeProvider(ctx context.Context) (provider.ExternalMetricsPro
 			os.Exit(1)
 		}
 	}()
-	return kedaprovider.NewProvider(ctx, setupLog, mgr.GetClient(), *grpcClient), nil
+	return kedaprovider.NewProvider(ctx, setupLog, mgr.GetClient(), grpcClient), nil
 }
 
 // getMetricHandler returns a http handler that exposes metrics from controller-runtime and apiserver

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,8 +29,15 @@ import (
 	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider/defaults"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
-	"github.com/kedacore/keda/v2/pkg/metricsservice"
 )
+
+// metricsServiceClient is the subset of *metricsservice.GrpcClient that the provider relies on.
+// It is defined as an interface so the metric retrieval paths can be exercised in unit tests.
+type metricsServiceClient interface {
+	GetMetrics(ctx context.Context, scaledObjectName, scaledObjectNamespace, metricName string) (*external_metrics.ExternalMetricValueList, error)
+	WaitForConnectionReady(ctx context.Context, logger logr.Logger) bool
+	GetServerURL() string
+}
 
 // KedaProvider implements External Metrics Provider
 type KedaProvider struct {
@@ -37,7 +45,7 @@ type KedaProvider struct {
 
 	client client.Client
 
-	grpcClient metricsservice.GrpcClient
+	grpcClient metricsServiceClient
 }
 
 var (
@@ -47,7 +55,7 @@ var (
 )
 
 // NewProvider returns an instance of KedaProvider
-func NewProvider(ctx context.Context, adapterLogger logr.Logger, client client.Client, grpcClient metricsservice.GrpcClient) provider.ExternalMetricsProvider {
+func NewProvider(ctx context.Context, adapterLogger logr.Logger, client client.Client, grpcClient metricsServiceClient) provider.ExternalMetricsProvider {
 	provider := &KedaProvider{
 		client:     client,
 		grpcClient: grpcClient,
@@ -80,7 +88,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 	selector, err := labels.ConvertSelectorToLabelsMap(metricSelector.String())
 	if err != nil {
 		logger.Error(err, "error converting Selector to Labels Map")
-		return nil, err
+		return nil, apierrors.NewBadRequest(err.Error())
 	}
 
 	// Get Metrics from Metrics Service gRPC Server
@@ -88,7 +96,7 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 		grpcClientConnected = false
 		err := fmt.Errorf("timeout while waiting to establish gRPC connection to KEDA Metrics Service server")
 		logger.Error(err, "timeout", "server", p.grpcClient.GetServerURL())
-		return nil, err
+		return nil, apierrors.NewServiceUnavailable(err.Error())
 	}
 	if !grpcClientConnected {
 		grpcClientConnected = true
@@ -101,11 +109,15 @@ func (p *KedaProvider) GetExternalMetric(ctx context.Context, namespace string, 
 		err := fmt.Errorf("scaledObject name is not specified")
 		logger.Error(err, fmt.Sprintf("please specify scaledObject name, it needs to be set as value of label selector %q on the query", kedav1alpha1.ScaledObjectOwnerAnnotation))
 
-		return &external_metrics.ExternalMetricValueList{}, err
+		return &external_metrics.ExternalMetricValueList{}, apierrors.NewBadRequest(err.Error())
 	}
 
 	metrics, err := p.grpcClient.GetMetrics(ctx, scaledObjectName, namespace, info.Metric)
+	if err != nil {
+		logger.Error(err, "error getting metrics from KEDA Metrics Service gRPC server", "scaledObjectName", scaledObjectName, "scaledObjectNamespace", namespace)
+		return nil, apierrors.NewInternalError(err)
+	}
 	logger.V(1).WithValues("scaledObjectName", scaledObjectName, "scaledObjectNamespace", namespace, "metrics", metrics).Info("Receiving metrics")
 
-	return metrics, err
+	return metrics, nil
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+	"sigs.k8s.io/custom-metrics-apiserver/pkg/provider"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+)
+
+type fakeMetricsServiceClient struct {
+	ready         bool
+	metrics       *external_metrics.ExternalMetricValueList
+	getMetricsErr error
+}
+
+func (f *fakeMetricsServiceClient) GetMetrics(_ context.Context, _, _, _ string) (*external_metrics.ExternalMetricValueList, error) {
+	return f.metrics, f.getMetricsErr
+}
+
+func (f *fakeMetricsServiceClient) WaitForConnectionReady(_ context.Context, _ logr.Logger) bool {
+	return f.ready
+}
+
+func (f *fakeMetricsServiceClient) GetServerURL() string { return "fake:0" }
+
+func newTestProvider(client metricsServiceClient) *KedaProvider {
+	logger = logr.Discard()
+	return &KedaProvider{grpcClient: client}
+}
+
+// assertAPIStatus fails the test unless err implements apierrors.APIStatus. The custom metrics
+// apiserver expects handler errors to be renderable as metav1.Status; a plain error triggers the
+// "apiserver received an error that is not an metav1.Status" log spam this change fixes.
+func assertAPIStatus(t *testing.T, err error) {
+	t.Helper()
+	assert.Error(t, err)
+	var apiStatus apierrors.APIStatus
+	assert.True(t, errors.As(err, &apiStatus),
+		"expected error to implement apierrors.APIStatus, got %T: %v", err, err)
+}
+
+func TestGetExternalMetricReturnsAPIStatusErrors(t *testing.T) {
+	soSelector := labels.SelectorFromSet(labels.Set{kedav1alpha1.ScaledObjectOwnerAnnotation: "my-scaledobject"})
+	info := provider.ExternalMetricInfo{Metric: "my-metric"}
+
+	t.Run("gRPC connection not ready is reported as ServiceUnavailable", func(t *testing.T) {
+		p := newTestProvider(&fakeMetricsServiceClient{ready: false})
+		_, err := p.GetExternalMetric(context.Background(), "default", soSelector, info)
+		assertAPIStatus(t, err)
+		assert.True(t, apierrors.IsServiceUnavailable(err))
+	})
+
+	t.Run("missing scaledObject name is reported as BadRequest", func(t *testing.T) {
+		p := newTestProvider(&fakeMetricsServiceClient{ready: true})
+		_, err := p.GetExternalMetric(context.Background(), "default", labels.Everything(), info)
+		assertAPIStatus(t, err)
+		assert.True(t, apierrors.IsBadRequest(err))
+	})
+
+	t.Run("metrics service error is reported as InternalError", func(t *testing.T) {
+		p := newTestProvider(&fakeMetricsServiceClient{ready: true, getMetricsErr: errors.New("rpc error: code = Unavailable")})
+		_, err := p.GetExternalMetric(context.Background(), "default", soSelector, info)
+		assertAPIStatus(t, err)
+		assert.True(t, apierrors.IsInternalError(err))
+	})
+
+	t.Run("metrics are returned without error on success", func(t *testing.T) {
+		want := &external_metrics.ExternalMetricValueList{
+			Items: []external_metrics.ExternalMetricValue{{MetricName: "my-metric"}},
+		}
+		p := newTestProvider(&fakeMetricsServiceClient{ready: true, metrics: want})
+		got, err := p.GetExternalMetric(context.Background(), "default", soSelector, info)
+		assert.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+}


### PR DESCRIPTION
### Provide a description of what has been changed

`KedaProvider.GetExternalMetric` returned plain Go errors — `fmt.Errorf(...)` for the connection timeout and missing ScaledObject name, and the raw gRPC error from `GetMetrics`. The custom metrics apiserver expects handler errors to implement `metav1.Status`, so a plain error produces the `"apiserver received an error that is not an metav1.Status"` Unhandled-Error log instead of a useful message (as reported in #7575, and the root cause @zroubalik confirmed).

This wraps the error paths in `GetExternalMetric` with the appropriate `k8s.io/apimachinery/pkg/api/errors` types:

- invalid label selector / missing ScaledObject name -> `NewBadRequest`
- gRPC connection not ready -> `NewServiceUnavailable`
- `GetMetrics` failure -> `NewInternalError`

To make these paths unit-testable, the provider's dependency on `*metricsservice.GrpcClient` is expressed as a small interface (the three methods the provider actually uses). `*metricsservice.GrpcClient` satisfies it, so the only caller change is dropping a dereference in `cmd/adapter/main.go`.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added (new `pkg/provider/provider_test.go` covering each error path returns an `apierrors.APIStatus`, plus the success path)
- [x] A PR is opened to update the documentation on (n/a — internal error handling, no user-facing docs)
- [x] Changelog has been updated

Fixes #7575