### PR TITLE
General: correct pollingInterval and cooldownPeriod relevance check for idleReplicaCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 
 - **General**: Add controller-runtime cache field indexes for ScaledObject admission validation so `verifyScaledObjects` and `verifyHpas` look up duplicate scaleTargetRef and HPA-name conflicts via indexed Lists rather than full-namespace scans, eliminating the webhook OOM under high-scale creation bursts ([#7681](https://github.com/kedacore/keda/pull/7681))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
+- **General**: Fix `pollingInterval` and `cooldownPeriod` relevance warnings incorrectly firing when `idleReplicaCount` is set to a value greater than 0, since idle mode keeps both settings relevant ([#7984](https://github.com/kedacore/keda/pull/7984))
 - **General**: Fix `ScaledJob` removal event using `namespace/name` in place of the namespace, which malformed the emitted CloudEvent's subject and the `namespace` label on the CloudEventSource metrics ([#7967](https://github.com/kedacore/keda/issues/7967))
 - **Azure Event Hub Scaler**: Fix authentication failures caused by appending a duplicate `EntityPath` when `eventHubName` is provided ([#7926](https://github.com/kedacore/keda/issues/7926))
 

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -376,11 +376,13 @@ func verifyScaledObjects(incomingSo *ScaledObject, action string, _ bool) (admis
 		}
 	}
 
-	// PollingInterval warning: if minReplicaCount > 0 AND (idleReplicaCount is not set OR idleReplicaCount != 0) AND NOT useCachedMetrics
+	// PollingInterval warning: if minReplicaCount > 0 AND idleReplicaCount is not set (idle mode disabled) AND NOT useCachedMetrics.
+	// When idle mode is enabled (idleReplicaCount is set to any value), the scale loop is what detects the
+	// idle<->active transitions, so pollingInterval stays relevant regardless of the idle value.
 	if incomingSo.Spec.PollingInterval != nil {
-		idleReplicaNotZero := incomingSo.Spec.IdleReplicaCount == nil || *incomingSo.Spec.IdleReplicaCount != 0
-		if minReplicas > 0 && idleReplicaNotZero && !usesCachedMetrics {
-			msg := "PollingInterval is configured but is not relevant. PollingInterval is only relevant when minReplicaCount = 0 or idleReplicaCount = 0 or useCachedMetrics is enabled"
+		idleModeDisabled := incomingSo.Spec.IdleReplicaCount == nil
+		if minReplicas > 0 && idleModeDisabled && !usesCachedMetrics {
+			msg := "PollingInterval is configured but is not relevant. PollingInterval is only relevant when minReplicaCount = 0, idleReplicaCount is set, or useCachedMetrics is enabled"
 			warnings = append(warnings, msg)
 			if eventRecorder != nil {
 				eventRecorder.Eventf(incomingSo, nil, corev1.EventTypeNormal, eventreason.KEDAScalersInfo, eventreason.KEDAScalersInfo, "%s", msg)
@@ -388,11 +390,13 @@ func verifyScaledObjects(incomingSo *ScaledObject, action string, _ bool) (admis
 		}
 	}
 
-	// CooldownPeriod warning: if minReplicaCount > 0 AND (idleReplicaCount is not set OR idleReplicaCount != 0)
+	// CooldownPeriod warning: if minReplicaCount > 0 AND idleReplicaCount is not set (idle mode disabled).
+	// When idle mode is enabled, the target still scales down to the idle replica count on inactivity,
+	// so cooldownPeriod stays relevant regardless of the idle value.
 	if incomingSo.Spec.CooldownPeriod != nil {
-		idleReplicaNotZero := incomingSo.Spec.IdleReplicaCount == nil || *incomingSo.Spec.IdleReplicaCount != 0
-		if minReplicas > 0 && idleReplicaNotZero {
-			msg := "CooldownPeriod is configured but is not relevant. CooldownPeriod is only relevant when minReplicaCount = 0 or idleReplicaCount = 0"
+		idleModeDisabled := incomingSo.Spec.IdleReplicaCount == nil
+		if minReplicas > 0 && idleModeDisabled {
+			msg := "CooldownPeriod is configured but is not relevant. CooldownPeriod is only relevant when minReplicaCount = 0 or idleReplicaCount is set"
 			warnings = append(warnings, msg)
 			if eventRecorder != nil {
 				eventRecorder.Eventf(incomingSo, nil, corev1.EventTypeNormal, eventreason.KEDAScalersInfo, eventreason.KEDAScalersInfo, "%s", msg)

--- a/apis/keda/v1alpha1/scaledobject_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook_test.go
@@ -1289,8 +1289,8 @@ var _ = It("should emit warning when PollingInterval is set with minReplicaCount
 	Expect(warnings).To(ContainElement(ContainSubstring("PollingInterval is configured but is not relevant")))
 })
 
-var _ = It("should emit warning when PollingInterval is set with minReplicaCount > 0 and idleReplicaCount > 0", func() {
-	namespaceName := "polling-interval-warning-idle-greater-zero"
+var _ = It("should NOT emit warning when PollingInterval is set with minReplicaCount > 0 and idleReplicaCount > 0", func() {
+	namespaceName := "polling-interval-no-warning-idle-greater-zero"
 	namespace := createNamespace(namespaceName)
 	workload := createDeployment(namespaceName, true, true)
 	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
@@ -1307,7 +1307,7 @@ var _ = It("should emit warning when PollingInterval is set with minReplicaCount
 
 	warnings, err := so.ValidateCreate(ptr.To(false))
 	Expect(err).ToNot(HaveOccurred())
-	Expect(warnings).To(ContainElement(ContainSubstring("PollingInterval is configured but is not relevant")))
+	Expect(warnings).ToNot(ContainElement(ContainSubstring("PollingInterval is configured but is not relevant")))
 })
 
 var _ = It("should NOT emit warning when PollingInterval is set with idleReplicaCount = 0", func() {
@@ -1408,8 +1408,8 @@ var _ = It("should emit warning when CooldownPeriod is set with minReplicaCount 
 	Expect(warnings).To(ContainElement(ContainSubstring("CooldownPeriod is configured but is not relevant")))
 })
 
-var _ = It("should emit warning when CooldownPeriod is set with minReplicaCount > 0 and idleReplicaCount > 0", func() {
-	namespaceName := "cooldown-warning-idle-greater-zero"
+var _ = It("should NOT emit warning when CooldownPeriod is set with minReplicaCount > 0 and idleReplicaCount > 0", func() {
+	namespaceName := "cooldown-no-warning-idle-greater-zero"
 	namespace := createNamespace(namespaceName)
 	workload := createDeployment(namespaceName, true, true)
 	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
@@ -1426,7 +1426,7 @@ var _ = It("should emit warning when CooldownPeriod is set with minReplicaCount 
 
 	warnings, err := so.ValidateCreate(ptr.To(false))
 	Expect(err).ToNot(HaveOccurred())
-	Expect(warnings).To(ContainElement(ContainSubstring("CooldownPeriod is configured but is not relevant")))
+	Expect(warnings).ToNot(ContainElement(ContainSubstring("CooldownPeriod is configured but is not relevant")))
 })
 
 var _ = It("should NOT emit warning when CooldownPeriod is set with idleReplicaCount = 0", func() {
@@ -1480,7 +1480,7 @@ var _ = It("should emit both warnings when both PollingInterval and CooldownPeri
 	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
 
 	so.Spec.MinReplicaCount = ptr.To[int32](2)
-	so.Spec.IdleReplicaCount = ptr.To[int32](1)
+	so.Spec.IdleReplicaCount = nil
 	so.Spec.PollingInterval = ptr.To[int32](30)
 	so.Spec.CooldownPeriod = ptr.To[int32](300)
 


### PR DESCRIPTION
The relevance warnings for pollingInterval and cooldownPeriod used `idleReplicaCount != 0` as the condition, which incorrectly flagged them as not relevant when idleReplicaCount was set to a value greater than 0.

When idle mode is enabled the scale loop is what detects the idle-to-active transition, so both settings stay relevant regardless of the idle value. The condition now checks whether idle mode is disabled (idleReplicaCount is not set) instead.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates: https://github.com/kedacore/keda/pull/7271