### PR TITLE
CI: wait for what the assertions read in prometheus_metrics

### DIFF
--- a/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
+++ b/tests/sequential/prometheus_metrics/prometheus_metrics_test.go
@@ -35,6 +35,18 @@ const (
 	eventsinkValue        = "prometheus-metrics-test-ce"
 	eventsinkType         = "eventsinktype"
 	eventsinkTypeValue    = "http"
+
+	// The operator records a metric as it reconciles and polls, so a value only becomes
+	// observable some time after the cluster state changed. Nothing buffers the metrics in
+	// between - the operator's own endpoint is scraped directly - so the wait only has to
+	// cover a reconcile and a poll. The scaled objects here poll every 2-5s, so a minute is
+	// more than ten of those cycles and is only reached when something is genuinely broken.
+	metricWaitTimeout = time.Minute
+
+	// Each poll of the operator totals lists every ScaledObject, ScaledJob and
+	// TriggerAuthentication in the cluster, so it runs less aggressively than a plain
+	// metric read.
+	operatorMetricsInterval = 5 * time.Second
 )
 
 var (
@@ -601,9 +613,13 @@ func TestPrometheusMetrics(t *testing.T) {
 	data, templates := getTemplateData()
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
+	// A metric that never converges fails the test from inside a helper, which ends the whole
+	// function, so teardown has to be deferred rather than run at the end. Otherwise a single
+	// timeout leaks this namespace into the sequential tests that run after this one.
+	defer DeleteKubernetesResources(t, testNamespace, data, templates)
 
 	// scaling to max replica count to ensure the counter is registered before we test it
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, 2),
 		"replica count should be 2 after 2 minute")
 
 	testScalerMetricValue(t)
@@ -622,8 +638,6 @@ func TestPrometheusMetrics(t *testing.T) {
 	testEmptyUpstreamResponse(t, data)
 	testHTTPClientMetrics(t, kc, data)
 	testHighCardinalityLabelsDisabled(t, kc, data)
-	// cleanup
-	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 
 func getTemplateData() (templateData, []Template) {
@@ -665,16 +679,30 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func fetchAndParsePrometheusMetrics(t *testing.T, cmd string) map[string]*prommodel.MetricFamily {
+	families, err := fetchPrometheusMetrics(t, cmd)
+	assert.NoErrorf(t, err, "cannot scrape metrics - %s", err)
+
+	return families
+}
+
+// fetchPrometheusMetrics reports a failed scrape instead of failing the test, so that callers
+// polling an endpoint can treat it as "not yet" and try again. A pod that is still rolling out
+// refuses the connection, which is a normal thing to observe part way through a wait.
+func fetchPrometheusMetrics(t *testing.T, cmd string) (map[string]*prommodel.MetricFamily, error) {
 	out, _, err := ExecCommandOnSpecificPodWithoutTTY(t, clientName, testNamespace, cmd)
-	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute command: %w", err)
+	}
 
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	// Ensure EOL
 	reader := strings.NewReader(strings.ReplaceAll(out, "\r\n", "\n"))
 	families, err := parser.TextToMetricFamilies(reader)
-	assert.NoErrorf(t, err, "cannot parse metrics - %s", err)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse metrics: %w", err)
+	}
 
-	return families
+	return families, nil
 }
 
 // WaitForPrometheusMetric waits for a specific metric to appear in the KEDA operator Prometheus endpoint
@@ -687,28 +715,38 @@ func WaitForPrometheusMetric(t *testing.T, metricToWaitFor string, familyValidat
 // WaitForPrometheusMetricAtURL waits for a specific metric to appear in the provided Prometheus endpoint
 // and validates that the MetricFamily has certain conditions using the provided familyValidator function.
 // Returns the parsed MetricFamily.
+//
+// A metric that never arrives ends the test on the spot, so anything that has to be undone
+// afterwards belongs in a defer.
 func WaitForPrometheusMetricAtURL(t *testing.T, metricsURL string, metricToWaitFor string, familyValidator func(family *prommodel.MetricFamily) bool) map[string]*prommodel.MetricFamily {
-	contextWithTimeout, cancel := context.WithTimeout(context.Background(), WaitShort)
+	contextWithTimeout, cancel := context.WithTimeout(context.Background(), metricWaitTimeout)
 	defer cancel()
-	var family map[string]*prommodel.MetricFamily
+
+	var families map[string]*prommodel.MetricFamily
 	err := KedaEventually(contextWithTimeout, func(ctx context.Context) (bool, error) {
 		t.Logf("Waiting for metric %s on %s", metricToWaitFor, metricsURL)
-		family = fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", metricsURL))
 
-		if _, ok := family[metricToWaitFor]; ok {
-			if familyValidator(family[metricToWaitFor]) {
-				return true, nil
-			}
+		scraped, scrapeErr := fetchPrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", metricsURL))
+		if scrapeErr != nil {
+			t.Logf("cannot scrape %s, retrying: %v", metricsURL, scrapeErr)
 			return false, nil
 		}
-		return false, nil
+		families = scraped
+
+		family, ok := families[metricToWaitFor]
+		if !ok {
+			return false, nil
+		}
+
+		return familyValidator(family), nil
 	}, IntervalShort)
-
 	if err != nil {
-		t.Errorf("error waiting for metric %s: %v", metricToWaitFor, err)
+		// The timeout alone does not say how far off the metric was, and the test ends here.
+		t.Logf("last observed %s: %v", metricToWaitFor, families[metricToWaitFor])
 	}
+	require.NoErrorf(t, err, "error waiting for metric %s", metricToWaitFor)
 
-	return family
+	return families
 }
 
 func metricFamilyCounterSumGreaterThanZero(family *prommodel.MetricFamily) bool {
@@ -719,29 +757,45 @@ func metricFamilyCounterSumGreaterThanZero(family *prommodel.MetricFamily) bool 
 	return sum > 0
 }
 
+// testResourceGaugeValues returns the gauge of every series in family that belongs to the scaled
+// object or the scaled job under test.
+func testResourceGaugeValues(family *prommodel.MetricFamily) []float64 {
+	var values []float64
+	for _, metric := range family.GetMetric() {
+		for _, label := range metric.GetLabel() {
+			if (label.GetName() == labelScaledObject && label.GetValue() == scaledObjectName) ||
+				(label.GetName() == labelScaledJob && label.GetValue() == scaledJobName) {
+				values = append(values, metric.GetGauge().GetValue())
+				break
+			}
+		}
+	}
+	return values
+}
+
+func allValuesEqual(values []float64, expected float64) bool {
+	for _, value := range values {
+		if value != expected {
+			return false
+		}
+	}
+	return true
+}
+
 func testScalerMetricValue(t *testing.T) {
 	t.Log("--- testing scaler metric value ---")
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+	// The value is recorded when the scaler is polled, so it appears a poll cycle after the
+	// scaled object was accepted rather than as soon as it exists.
+	families := WaitForPrometheusMetric(t, "keda_scaler_metrics_value", func(family *prommodel.MetricFamily) bool {
+		values := testResourceGaugeValues(family)
+		return len(values) > 0 && allValuesEqual(values, 4)
+	})
 
-	val, ok := family["keda_scaler_metrics_value"]
-	assert.True(t, ok, "keda_scaler_metrics_value not available")
-	if ok {
-		var found bool
-		metrics := val.GetMetric()
-		for _, metric := range metrics {
-			labels := metric.GetLabel()
-			for _, label := range labels {
-				if (*label.Name == labelScaledObject && *label.Value == scaledObjectName) ||
-					(*label.Name == labelScaledJob && *label.Value == scaledJobName) {
-					assert.Equal(t, float64(4), *metric.Gauge.Value)
-					found = true
-				}
-			}
-		}
-		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("metric keda_scaler_metrics_value not available")
+	values := testResourceGaugeValues(families["keda_scaler_metrics_value"])
+	assert.NotEmpty(t, values, "no keda_scaler_metrics_value for %s or %s", scaledObjectName, scaledJobName)
+	for _, value := range values {
+		assert.Equal(t, float64(4), value)
 	}
 }
 
@@ -751,20 +805,18 @@ func testScaledObjectErrors(t *testing.T, data templateData) {
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	KubectlApplyWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
 
-	WaitForPrometheusMetric(t, "keda_scaled_object_errors_total", func(family *prommodel.MetricFamily) bool {
-		errCounterVal1 := getErrorMetricsValue(family)
-
-		// in the nested wait, we are just waiting for errCounterVal2 to eventually be greater that the first errCounterVal1
-		metrics2 := WaitForPrometheusMetric(t, "keda_scaled_object_errors_total", func(family *prommodel.MetricFamily) bool {
-			errCounterVal2 := getErrorMetricsValue(family)
-			return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
-		})
-
-		errCounterVal2 := getErrorMetricsValue(metrics2["keda_scaled_object_errors_total"])
-
-		// we don't have to check again, but extra validation is fine
-		return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+	// Wait for the series to appear, then for it to keep climbing. Both steps have to be
+	// separate waits: nesting one inside the other bounds the inner wait by the outer budget
+	// and reports a failure for every attempt the outer wait was still allowed to retry.
+	families := WaitForPrometheusMetric(t, "keda_scaled_object_errors_total", func(family *prommodel.MetricFamily) bool {
+		return getErrorMetricsValue(family) > 0
 	})
+	errCounterVal1 := getErrorMetricsValue(families["keda_scaled_object_errors_total"])
+
+	families = WaitForPrometheusMetric(t, "keda_scaled_object_errors_total", func(family *prommodel.MetricFamily) bool {
+		return getErrorMetricsValue(family) > errCounterVal1
+	})
+	assert.Greater(t, getErrorMetricsValue(families["keda_scaled_object_errors_total"]), errCounterVal1)
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledObjectTemplate", wrongScaledObjectTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
@@ -776,20 +828,15 @@ func testScaledJobErrors(t *testing.T, data templateData) {
 	KubectlDeleteWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
 	KubectlApplyWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
 
-	WaitForPrometheusMetric(t, "keda_scaled_job_errors_total", func(family *prommodel.MetricFamily) bool {
-		errCounterVal1 := getErrorMetricsValue(family)
-
-		// in the nested wait, we are just waiting for errCounterVal2 to eventually be greater that the first errCounterVal1
-		metrics2 := WaitForPrometheusMetric(t, "keda_scaled_job_errors_total", func(family *prommodel.MetricFamily) bool {
-			errCounterVal2 := getErrorMetricsValue(family)
-			return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
-		})
-
-		errCounterVal2 := getErrorMetricsValue(metrics2["keda_scaled_job_errors_total"])
-
-		// we don't have to check again, but extra validation is fine
-		return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+	families := WaitForPrometheusMetric(t, "keda_scaled_job_errors_total", func(family *prommodel.MetricFamily) bool {
+		return getErrorMetricsValue(family) > 0
 	})
+	errCounterVal1 := getErrorMetricsValue(families["keda_scaled_job_errors_total"])
+
+	families = WaitForPrometheusMetric(t, "keda_scaled_job_errors_total", func(family *prommodel.MetricFamily) bool {
+		return getErrorMetricsValue(family) > errCounterVal1
+	})
+	assert.Greater(t, getErrorMetricsValue(families["keda_scaled_job_errors_total"]), errCounterVal1)
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
@@ -803,20 +850,15 @@ func testScalerErrors(t *testing.T, data templateData) {
 	KubectlDeleteWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
 	KubectlApplyWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
 
-	WaitForPrometheusMetric(t, "keda_scaler_detail_errors_total", func(family *prommodel.MetricFamily) bool {
-		errCounterVal1 := getErrorMetricsValue(family)
-
-		// in the nested wait, we are just waiting for errCounterVal2 to eventually be greater that the first errCounterVal1
-		metrics2 := WaitForPrometheusMetric(t, "keda_scaler_detail_errors_total", func(family *prommodel.MetricFamily) bool {
-			errCounterVal2 := getErrorMetricsValue(family)
-			return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
-		})
-
-		errCounterVal2 := getErrorMetricsValue(metrics2["keda_scaler_detail_errors_total"])
-
-		// we don't have to check again, but extra validation is fine
-		return errCounterVal2 > errCounterVal1 && errCounterVal2 > 0
+	families := WaitForPrometheusMetric(t, "keda_scaler_detail_errors_total", func(family *prommodel.MetricFamily) bool {
+		return getErrorMetricsValue(family) > 0
 	})
+	errCounterVal1 := getErrorMetricsValue(families["keda_scaler_detail_errors_total"])
+
+	families = WaitForPrometheusMetric(t, "keda_scaler_detail_errors_total", func(family *prommodel.MetricFamily) bool {
+		return getErrorMetricsValue(family) > errCounterVal1
+	})
+	assert.Greater(t, getErrorMetricsValue(families["keda_scaler_detail_errors_total"]), errCounterVal1)
 
 	KubectlDeleteWithTemplate(t, data, "wrongScaledJobTemplate", wrongScaledJobTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledJobTemplate", scaledJobTemplate)
@@ -895,94 +937,38 @@ func assertScaledObjectPausedMetric(t *testing.T, families map[string]*prommodel
 func testScalerMetricLatency(t *testing.T) {
 	t.Log("--- testing scaler metric latency ---")
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+	families := WaitForPrometheusMetric(t, "keda_scaler_metrics_latency_seconds", func(family *prommodel.MetricFamily) bool {
+		return len(testResourceGaugeValues(family)) > 0
+	})
 
-	val, ok := family["keda_scaler_metrics_latency_seconds"]
-	assert.True(t, ok, "keda_scaler_metrics_latency_seconds not available")
-	if ok {
-		var found bool
-		metrics := val.GetMetric()
-		for _, metric := range metrics {
-			labels := metric.GetLabel()
-			for _, label := range labels {
-				if (*label.Name == labelScaledObject && *label.Value == scaledObjectName) ||
-					(*label.Name == labelScaledJob && *label.Value == scaledJobName) {
-					assert.InDelta(t, float64(0), *metric.Gauge.Value, 0.001)
-					found = true
-				}
-			}
-		}
-		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("metric keda_scaler_metrics_latency_seconds not available")
+	values := testResourceGaugeValues(families["keda_scaler_metrics_latency_seconds"])
+	assert.NotEmpty(t, values, "no keda_scaler_metrics_latency_seconds for %s or %s", scaledObjectName, scaledJobName)
+	for _, value := range values {
+		assert.InDelta(t, float64(0), value, 0.001)
 	}
 }
 
 func testScalableObjectMetrics(t *testing.T) {
 	t.Log("--- testing scalable objects latency ---")
 
-	family := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+	// Each loop reports its own latency the first time it runs, and the two run independently,
+	// so the scaledjob entry can trail the scaledobject one.
+	families := WaitForPrometheusMetric(t, "keda_internal_scale_loop_latency_seconds", func(family *prommodel.MetricFamily) bool {
+		return hasMetricWithTypeLabel(family, "scaledobject") && hasMetricWithTypeLabel(family, "scaledjob")
+	})
 
-	if val, ok := family["keda_internal_scale_loop_latency_seconds"]; ok {
-		var found bool
-		metrics := val.GetMetric()
+	family := families["keda_internal_scale_loop_latency_seconds"]
+	assert.True(t, hasMetricWithTypeLabel(family, "scaledobject"), "no scale loop latency reported for scaledobject")
+	assert.True(t, hasMetricWithTypeLabel(family, "scaledjob"), "no scale loop latency reported for scaledjob")
+}
 
-		// check scaledobject loop
-		found = false
-		for _, metric := range metrics {
-			labels := metric.GetLabel()
-			for _, label := range labels {
-				if *label.Name == labelType && *label.Value == "scaledobject" {
-					found = true
-				}
-			}
+func hasMetricWithTypeLabel(family *prommodel.MetricFamily, expectedType string) bool {
+	for _, metric := range family.GetMetric() {
+		if ExtractPrometheusLabelValue(labelType, metric.GetLabel()) == expectedType {
+			return true
 		}
-		assert.Equal(t, true, found)
-
-		// check scaledjob loop
-		found = false
-		for _, metric := range metrics {
-			labels := metric.GetLabel()
-			for _, label := range labels {
-				if *label.Name == labelType && *label.Value == "scaledjob" {
-					found = true
-				}
-			}
-		}
-		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("scaledobject metric not available")
 	}
-	if val, ok := family["keda_internal_scale_loop_latency_seconds"]; ok {
-		var found bool
-		metrics := val.GetMetric()
-
-		// check scaledobject loop
-		found = false
-		for _, metric := range metrics {
-			labels := metric.GetLabel()
-			for _, label := range labels {
-				if *label.Name == labelType && *label.Value == "scaledobject" {
-					found = true
-				}
-			}
-		}
-		assert.Equal(t, true, found)
-
-		// check scaledjob loop
-		found = false
-		for _, metric := range metrics {
-			labels := metric.GetLabel()
-			for _, label := range labels {
-				if *label.Name == labelType && *label.Value == "scaledjob" {
-					found = true
-				}
-			}
-		}
-		assert.Equal(t, true, found)
-	} else {
-		t.Errorf("keda_internal_scale_loop_latency_seconds metric not available")
-	}
+	return false
 }
 
 func testScalerActiveMetric(t *testing.T) {
@@ -997,31 +983,22 @@ func testScalerActiveMetric(t *testing.T) {
 		"type":         "scaledobject",
 	}
 
-	family := WaitForPrometheusMetric(t, "keda_scaler_active", func(family *prommodel.MetricFamily) bool {
-		return hasMetricWithLabelsAndGauge(family, resourceScalerLabels, 1)
+	// The CPU scaler and the scalers of the scaled object and the scaled job become active
+	// independently, so the wait has to cover every series the assertions below read.
+	families := WaitForPrometheusMetric(t, "keda_scaler_active", func(family *prommodel.MetricFamily) bool {
+		values := testResourceGaugeValues(family)
+		return hasMetricWithLabelsAndGauge(family, resourceScalerLabels, 1) &&
+			len(values) > 0 && allValuesEqual(values, 1)
 	})
 
-	val, ok := family["keda_scaler_active"]
-	assert.True(t, ok, "keda_scaler_active not available")
-	if ok {
-		var found bool
-		metrics := val.GetMetric()
-		for _, metric := range metrics {
-			labels := metric.GetLabel()
-			for _, label := range labels {
-				if (*label.Name == labelScaledObject && *label.Value == scaledObjectName) ||
-					(*label.Name == labelScaledJob && *label.Value == scaledJobName) {
-					assert.Equal(t, float64(1), *metric.Gauge.Value)
-					found = true
-				}
-			}
-		}
-		assert.Equal(t, true, found)
-		assert.True(t, hasMetricWithLabelsAndGauge(val, resourceScalerLabels, 1),
-			"expected keda_scaler_active for CPU resource scaler")
-	} else {
-		t.Errorf("metric keda_scaler_active not available")
+	family := families["keda_scaler_active"]
+	values := testResourceGaugeValues(family)
+	assert.NotEmpty(t, values, "no keda_scaler_active for %s or %s", scaledObjectName, scaledJobName)
+	for _, value := range values {
+		assert.Equal(t, float64(1), value)
 	}
+	assert.True(t, hasMetricWithLabelsAndGauge(family, resourceScalerLabels, 1),
+		"expected keda_scaler_active for CPU resource scaler")
 }
 
 func hasMetricWithLabelsAndGauge(family *prommodel.MetricFamily, expectedLabels map[string]string, expectedValue float64) bool {
@@ -1177,12 +1154,51 @@ func testMetricServerMetrics(t *testing.T) {
 	checkGRPCClientMetrics(t, families)
 }
 
-func testOperatorMetricValues(t *testing.T, kc *kubernetes.Clientset) {
-	families := fetchAndParsePrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
-	expectedTriggerTotals, expectedCrTotals := getOperatorMetricsManually(t, kc)
+type failureCollector struct {
+	failures []string
+}
 
-	checkTriggerTotalValues(t, families, expectedTriggerTotals)
-	checkCRTotalValues(t, families, expectedCrTotals)
+func (f *failureCollector) Errorf(format string, args ...interface{}) {
+	f.failures = append(f.failures, fmt.Sprintf(format, args...))
+}
+
+func testOperatorMetricValues(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing trigger and resource total metrics ---")
+
+	ctx, cancel := context.WithTimeout(context.Background(), metricWaitTimeout)
+	defer cancel()
+
+	var (
+		families map[string]*prommodel.MetricFamily
+		attempt  failureCollector
+	)
+
+	// A created or deleted CR takes an unpredictable amount of time to reach the totals, since
+	// the operator has to reconcile it before it records the new value. Retrying the assertions
+	// themselves, rather than a predicate that has to be kept in step with them, means a
+	// timeout still reports which total diverged.
+	err := KedaEventually(ctx, func(_ context.Context) (bool, error) {
+		scraped, scrapeErr := fetchPrometheusMetrics(t, fmt.Sprintf("curl --insecure %s", kedaOperatorPrometheusURL))
+		if scrapeErr != nil {
+			t.Logf("cannot scrape the operator, retrying: %v", scrapeErr)
+			return false, nil
+		}
+		families = scraped
+		expectedTriggerTotals, expectedCrTotals := getOperatorMetricsManually(t, kc)
+
+		attempt = failureCollector{}
+		checkTriggerTotalValues(&attempt, families, expectedTriggerTotals)
+		checkCRTotalValues(&attempt, families, expectedCrTotals)
+
+		return len(attempt.failures) == 0, nil
+	}, operatorMetricsInterval)
+
+	// Empty unless the last attempt failed, which only happens once the wait has given up.
+	for _, failure := range attempt.failures {
+		t.Error(failure)
+	}
+	require.NoError(t, err, "exported totals never agreed with the cluster")
+
 	checkGRPCServerMetrics(t, families)
 	checkBuildInfo(t, families)
 }
@@ -1225,8 +1241,9 @@ func getLatestCommit(t *testing.T) string {
 	return strings.Trim(out.String(), "\n")
 }
 
-func checkTriggerTotalValues(t *testing.T, families map[string]*prommodel.MetricFamily, expectedValues map[string]int) {
-	t.Log("--- testing trigger total metrics ---")
+// checkTriggerTotalValues takes an assert.TestingT rather than a *testing.T so that a caller can
+// retry it and only report the failures of the final attempt.
+func checkTriggerTotalValues(t assert.TestingT, families map[string]*prommodel.MetricFamily, expectedValues map[string]int) {
 	expected := map[string]int{}
 	family, ok := families["keda_trigger_registered_total"]
 	assert.True(t, ok, "keda_trigger_registered_total not available")
@@ -1251,37 +1268,10 @@ func checkTriggerTotalValues(t *testing.T, families map[string]*prommodel.Metric
 		}
 	}
 
-	assert.Equal(t, 0, len(expected))
-
-	family, ok = families["keda_trigger_registered_total"]
-	assert.True(t, ok, "keda_trigger_registered_total not available")
-	if !ok {
-		return
-	}
-	maps.Copy(expected, expectedValues)
-	metrics = family.GetMetric()
-	for _, metric := range metrics {
-		labels := metric.GetLabel()
-		for _, label := range labels {
-			if *label.Name == labelType {
-				triggerType := *label.Value
-				metricValue := *metric.Gauge.Value
-				expectedMetricValue := float64(expected[triggerType])
-
-				assert.Equalf(t, expectedMetricValue, metricValue, "expected %f got %f for trigger type %s",
-					expectedMetricValue, metricValue, triggerType)
-
-				delete(expected, triggerType)
-			}
-		}
-	}
-
-	assert.Equal(t, 0, len(expected))
+	assert.Empty(t, expected, "trigger types missing from keda_trigger_registered_total")
 }
 
-func checkCRTotalValues(t *testing.T, families map[string]*prommodel.MetricFamily, expected map[string]map[string]int) {
-	t.Log("--- testing resource total metrics ---")
-
+func checkCRTotalValues(t assert.TestingT, families map[string]*prommodel.MetricFamily, expected map[string]map[string]int) {
 	family, ok := families["keda_resource_registered_total"]
 	assert.True(t, ok, "keda_resource_registered_total not available")
 	if !ok {
@@ -1289,32 +1279,6 @@ func checkCRTotalValues(t *testing.T, families map[string]*prommodel.MetricFamil
 	}
 
 	metrics := family.GetMetric()
-	for _, metric := range metrics {
-		labels := metric.GetLabel()
-		var namespace, crType string
-		for _, label := range labels {
-			switch *label.Name {
-			case labelType:
-				crType = *label.Value
-			case namespaceString:
-				namespace = *label.Value
-			}
-		}
-
-		metricValue := *metric.Gauge.Value
-		expectedMetricValue := float64(expected[crType][namespace])
-
-		assert.Equalf(t, expectedMetricValue, metricValue, "expected %f got %f for cr type %s & namespace %s",
-			expectedMetricValue, metricValue, crType, namespace)
-	}
-
-	family, ok = families["keda_resource_registered_total"]
-	assert.True(t, ok, "keda_resource_registered_total not available")
-	if !ok {
-		return
-	}
-
-	metrics = family.GetMetric()
 	for _, metric := range metrics {
 		labels := metric.GetLabel()
 		var namespace, crType string
@@ -1768,8 +1732,6 @@ func testHighCardinalityLabelsDisabled(t *testing.T, kc *kubernetes.Clientset, d
 		KubectlDeleteWithTemplate(t, data, "httpClientScaledObjectTemplate", httpClientScaledObjectTemplate)
 		KubectlApplyWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	}()
-
-	time.Sleep(20 * time.Second)
 
 	matchLabels := func(labels []*prommodel.LabelPair) bool {
 		return ExtractPrometheusLabelValue("namespace", labels) == data.TestNamespace &&


### PR DESCRIPTION
`prometheus_metrics` already polled for its metrics, but every wait was bounded by `WaitShort` (20s) - the last remaining use of it in the suite - and several waits did not cover what the assertion after them actually read. The result is a test that fails while KEDA is behaving correctly whenever the cluster is slower than the one those numbers were tuned on.

The clearest case is the three error tests, which nested one wait inside another wait's poll predicate. The outer wait polls every second within its own 20s budget, and every attempt started a fresh 20s inner wait, so the inner one could not finish before the outer was due to retry. Giving up called `t.Errorf`, which fails the test for good, so the first inner timeout decided the outcome no matter what the remaining attempts observed. On a cluster slow enough to miss that first window this failed every time rather than intermittently. Each now reads the baseline and then waits for the counter to climb past it, in two separate waits.

Five assertions read the endpoint once with no wait at all: the scaler metric value and latency, the scale loop latencies, and the trigger and resource totals. The totals are the most exposed, since they compare a single scrape against a live listing of the cluster and `testOperatorMetrics` runs them three times, twice straight after creating or deleting a ScaledJob. They are now retried through a failure collector the same way #7974 did it for `opentelemetry_metrics`, so a timeout still reports which total diverged rather than only that one did. `testScalerActiveMetric` waited for the CPU scaler to go active and then asserted on the ScaledObject and ScaledJob series it had never waited for; its wait now covers all three.

The one remaining sleep, 20s in `testHighCardinalityLabelsDisabled`, is dropped rather than converted. `SetDeploymentContainerArg` already waits for the operator rollout, and `RecordHTTPClientRequest` increments the requests counter and observes the duration histogram in the same call, so the wait that follows covers everything the sleep stood in for. Unlike the OpenTelemetry test there is no collector holding a series past the operator's lifetime, so a restart clears the counters and no stale series can satisfy the wait early.

Two supporting changes:

* A scrape that fails part way through a wait, which is what a pod still rolling out looks like, used to fail the test from inside the polling predicate. It is now treated as "not yet" and retried, so `fetchPrometheusMetrics` reports the error rather than asserting on it.
* A wait that gives up now ends the test instead of continuing against metrics it has already established are absent. That also bounds the worst case to a single timeout rather than one per remaining wait. Teardown moves into a `defer` so ending early does not leak the namespace into the sequential tests that follow.

Finally, the duplicated halves of `checkTriggerTotalValues`, `checkCRTotalValues` and `testScalableObjectMetrics` are removed. Each asserted the same thing twice over the same scrape, which is wasted work inside a retry loop and double the output when a comparison fails.

Two things left deliberately out of scope, to keep this to one theme:

* `getOperatorMetricsManually` still asserts on its own list errors from inside the retry loop, so a transient API error there ends the test. Same hazard as the scrape above, worth a follow-up.
* About twelve label loops in this file filter by namespace with a `continue` that applies to the inner label loop, where no code follows it, so the filter does nothing and the sum runs across every namespace. Fixing that changes what is asserted rather than when, and if those gRPC series carry no namespace label at all then making the filter work would make the assertion fail legitimately. It needs its own discussion.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

This is an e2e-test-only change with no end-user impact, so no changelog entry, scaler schema regeneration, Helm chart or docs update is needed.

Relates to #7991