### PR TITLE
chore: improve Renovate dependency grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
     ":prHourlyLimitNone",
   ],
   commitBodyTable: true,
-  labels: ["dependencies"],
+  labels: ["dependencies", "kind/dependencies"],
   osvVulnerabilityAlerts: true,
   packageRules: [
     // --- GitHub Actions ---
@@ -24,7 +24,7 @@
     // --- Go modules ---
     {
       matchManagers: ["gomod"],
-      matchUpdateTypes: ["minor", "patch"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
       groupName: "Go Dependencies (non-major)",
     },
     // Split minor and patch for k8s packages so patch fixes
@@ -52,13 +52,27 @@
     },
     {
       matchManagers: ["gomod"],
+      matchPackageNames: [
+        "k8s.io/**",
+        "sigs.k8s.io/controller-runtime",
+        "sigs.k8s.io/controller-tools",
+        "sigs.k8s.io/custom-metrics-apiserver",
+      ],
+      matchUpdateTypes: ["patch", "digest"],
+      groupName: "Kubernetes Dependencies (patch)",
+    },
+    {
+      matchManagers: ["gomod"],
       matchPackageNames: ["github.com/prometheus/**"],
       matchUpdateTypes: ["minor", "patch"],
       groupName: "Prometheus Dependencies",
     },
     {
       matchManagers: ["gomod"],
-      matchPackageNames: ["github.com/aws/aws-sdk-go-v2/**"],
+      matchPackageNames: [
+        "github.com/aws/aws-sdk-go-v2",
+        "github.com/aws/aws-sdk-go-v2/**",
+      ],
       matchUpdateTypes: ["minor", "patch"],
       groupName: "AWS SDK",
     },
@@ -89,6 +103,16 @@
       matchUpdateTypes: ["minor", "major"],
       enabled: false,
     },
+    {
+      matchManagers: ["custom.regex"],
+      matchPackageNames: ["kubernetes-sigs/kind", "kindest/node"],
+      groupName: "kind Test Infrastructure",
+    },
+    {
+      matchManagers: ["custom.regex"],
+      matchPackageNames: ["vishnubijukumar/**"],
+      groupName: "s390x Test Infrastructure",
+    },
 
     // --- Pre-commit ---
     {
@@ -100,6 +124,7 @@
     {
       matchFileNames: [".devcontainer/**"],
       pinDigests: false,
+      groupName: "DevContainer",
     },
   ],
   customManagers: [


### PR DESCRIPTION
Reduce PR noise by adding groups for related dependencies and fixing digest updates being orphaned into individual PRs.

### Changes
- Fix aws deps grouping
- Add `kind/dependencies/` label
- Add digest to Go catch-all group (prevents orphaned pseudo-version PRs)
- Add Kubernetes Dependencies (patch) group for k8s patch+digest updates
- Group kind + kindest/node as "kind Test Infrastructure"
- Group vishnubijukumar/* as "s390x Test Infrastructure"
- Add groupName to DevContainer rule

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7841
