### PR TITLE
chore: fix duplicate (patch) suffix in Renovate k8s group name

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,7 +59,7 @@
         "sigs.k8s.io/custom-metrics-apiserver",
       ],
       matchUpdateTypes: ["patch", "digest"],
-      groupName: "Kubernetes Dependencies (patch)",
+      groupName: "Kubernetes Dependencies",
     },
     {
       matchManagers: ["gomod"],


### PR DESCRIPTION
Renovate auto-appends the update type to PR titles when separateMinorPatch is active. Using "Kubernetes Dependencies (patch)" as the group name caused PR titles like "update kubernetes dependencies (patch) (patch)".

Use the same group name for both minor and patch+digest rules. separateMinorPatch ensures separate PRs regardless.

I hope this fixes the issue, bit hard to tell.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7841
