### PR TITLE
chore: use Dependencies: prefix for Renovate PR titles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
     ":prHourlyLimitNone",
   ],
   commitBodyTable: true,
+  commitMessagePrefix: "Dependencies:",
   labels: ["dependencies", "kind/dependencies"],
   osvVulnerabilityAlerts: true,
   packageRules: [


### PR DESCRIPTION
CI now enforces PR titles in "Component: Description" format but renovate's default "fix(deps): ..."/"chore(deps): ..." titles fail that check.

git-cliff's changelog rendering already splits titles on the first colon and groups by the kind/ label rather than the commit type, so switching prefixes doesn't affect changelog generation.

### Changes
- Prefix all Renovate commit messages/PR titles with "Dependencies:"
	- this overwrites the default semantic commits, see https://docs.renovatebot.com/semantic-commits/#semantic-commit-messages


### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #7841 
