### PR TITLE
CI: wait for the status CheckKubectlGetResult reads

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -1289,16 +1289,35 @@ func generateCA(t *testing.T) {
 	}
 }
 
-// CheckKubectlGetResult runs `kubectl get` with parameters and compares output with expected value
+// The fields this reads are written by the operator as it reconciles the resource that references
+// the authentication, so they lag the apply or delete that triggered the change. A minute is many
+// times a reconcile and is only reached when the operator has genuinely stopped updating them.
+const kubectlGetResultTimeout = time.Minute
+
+// CheckKubectlGetResult runs `kubectl get` with parameters and waits for the output to match the
+// expected value.
 func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace string, otherparameter string, expected string) {
-	time.Sleep(1 * time.Second) // wait a second for recource deployment finished
 	kctlGetCmd := fmt.Sprintf(`kubectl get %s/%s -n %s %s"`, kind, name, namespace, otherparameter)
 	t.Log("Running kubectl cmd:", kctlGetCmd)
-	output, err := ExecuteCommand(kctlGetCmd)
-	assert.NoErrorf(t, err, "cannot get rollout info - %s", err)
 
-	unqoutedOutput := strings.ReplaceAll(string(output), "\"", "")
-	assert.Equal(t, expected, unqoutedOutput)
+	ctx, cancel := context.WithTimeout(context.Background(), kubectlGetResultTimeout)
+	defer cancel()
+
+	lastRead := "<nothing read>"
+	err := KedaEventually(ctx, func(_ context.Context) (bool, error) {
+		output, cmdErr := ExecuteCommand(kctlGetCmd)
+		if cmdErr != nil {
+			// Retried rather than reported, so that a command that fails while the resource is
+			// still being created does not end the wait.
+			lastRead = fmt.Sprintf("<command failed: %s>", cmdErr)
+			return false, nil
+		}
+
+		lastRead = strings.ReplaceAll(string(output), "\"", "")
+		return lastRead == expected, nil
+	}, IntervalShort)
+
+	assert.NoErrorf(t, err, "%s/%s %s: expected %q, last read %q", kind, name, otherparameter, expected, lastRead)
 }
 
 // KedaEventually checks if the provided conditionFunc eventually returns true


### PR DESCRIPTION
`CheckKubectlGetResult` slept for one second and then read once, with no retry:

```go
func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace string, otherparameter string, expected string) {
	time.Sleep(1 * time.Second) // wait a second for recource deployment finished
	kctlGetCmd := fmt.Sprintf(`kubectl get %s/%s -n %s %s"`, kind, name, namespace, otherparameter)
	...
	assert.Equal(t, expected, unqoutedOutput)
}
```

All 12 of its call sites use it to read a field the operator writes as it reconciles, right after the `kubectl apply` or `kubectl delete` that triggers that reconcile:

- `internals/update_ta` reads `.status.scaledobjects` and `.status.scaledjobs` on a `TriggerAuthentication` and a `ClusterTriggerAuthentication`, 8 call sites executed twice;
- `internals/status_update` reads `.status.triggersTypes` and `.status.authenticationsTypes` on a `ScaledObject` and a `ScaledJob`, 4 call sites.

Whether one second is enough is a race, and it is a race the suite already loses: in the e2e run on #7996, `update_ta` passed only "after two attempts" while every other test in `internals` passed on the first. Two of the call sites also expect the field to be empty after the referencing resource is deleted, and an empty read is indistinguishable from a read that arrived before the operator got there.

This polls for the expected value instead, up to a minute, and reports what it read last if the value never appears - previously a mismatch was reported without saying whether the field was empty, stale or holding a different set. A failing `kubectl` is retried rather than reported, so a command that fails while the resource is still being created no longer ends the wait.

The wait is bounded at a minute because these fields are written during a single reconcile; a minute is many times that, and is only reached when the operator has genuinely stopped updating them. Nothing else changes: the command construction, the quote stripping and the comparison are all as they were, and the assertion stays non-fatal.

One incidental improvement: `KedaEventually` reads immediately and only then starts polling, so where the status is already up to date this is now faster than before, removing a guaranteed second from each of the 20 times the suite calls this.

Part of the e2e wait cleanup tracked in #7991, following #7974, #7975, #7992 and #7996.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
