### PR TITLE
CI: assert what the nil identity id tests claim to check

### DIFF
--- a/tests/internals/trigger_authentication_validation/trigger_authentication_validation_test.go
+++ b/tests/internals/trigger_authentication_validation/trigger_authentication_validation_test.go
@@ -142,8 +142,10 @@ func testTriggerAuthenticationWithNilID(t *testing.T, _ *kubernetes.Clientset, d
 
 	KubectlApplyWithTemplate(t, data, "triggerAuthWorkloadNilITemplate", triggerAuthWorkloadNilIDTemplate)
 
-	triggerauthentication, _ := kedaKc.TriggerAuthentications(testNamespace).Get(context.Background(), triggerAuthWorkloadNilIDName, v1.GetOptions{})
-	assert.NotNil(t, triggerauthentication)
+	// Asserting on the error rather than on the returned object: the generated client returns a
+	// non-nil zero value alongside a NotFound, so a nil check passes whether or not it was created.
+	_, err := kedaKc.TriggerAuthentications(testNamespace).Get(context.Background(), triggerAuthWorkloadNilIDName, v1.GetOptions{})
+	assert.NoErrorf(t, err, "TriggerAuthentication %s should have been created without an identity id - %s", triggerAuthWorkloadNilIDName, err)
 }
 
 // expect clustertriggerauthentication should not be created with empty identity id
@@ -161,7 +163,9 @@ func testClusterTriggerAuthenticationWithNilID(t *testing.T, _ *kubernetes.Clien
 	kedaKc := GetKedaKubernetesClient(t)
 
 	KubectlApplyWithTemplate(t, data, "clusterTriggerAuthWorkloadNilIDTemplate", clusterTriggerAuthWorkloadNilIDTemplate)
+	// Cluster-scoped, so deleting the test namespace does not remove it.
+	defer KubectlDeleteWithTemplate(t, data, "clusterTriggerAuthWorkloadNilIDTemplate", clusterTriggerAuthWorkloadNilIDTemplate)
 
-	clustertriggerauthentication, _ := kedaKc.ClusterTriggerAuthentications().Get(context.Background(), clusterTriggerAuthWorkloadNilIDTemplate, v1.GetOptions{})
-	assert.NotNil(t, clustertriggerauthentication)
+	_, err := kedaKc.ClusterTriggerAuthentications().Get(context.Background(), clusterTriggerAuthWorkloadNilIDName, v1.GetOptions{})
+	assert.NoErrorf(t, err, "ClusterTriggerAuthentication %s should have been created without an identity id - %s", clusterTriggerAuthWorkloadNilIDName, err)
 }


### PR DESCRIPTION
`testTriggerAuthenticationWithNilID` and `testClusterTriggerAuthenticationWithNilID` cannot fail. Both discard the error from the clientset `Get` and then assert the returned object is not nil:

```go
triggerauthentication, _ := kedaKc.TriggerAuthentications(testNamespace).Get(context.Background(), triggerAuthWorkloadNilIDName, v1.GetOptions{})
assert.NotNil(t, triggerauthentication)
```

The generated client returns a non-nil zero value alongside a `NotFound`, so `assert.NotNil` holds whether or not the resource was created. Both tests exist to prove a trigger authentication *can* be created without `identityId`, and neither currently proves it.

The cluster-scoped one has a second bug on the same line: it passes `clusterTriggerAuthWorkloadNilIDTemplate` - the YAML document - where the resource name belongs, instead of `clusterTriggerAuthWorkloadNilIDName`. That lookup could never have succeeded, and only the vacuous `NotNil` hid it.

Both now assert on the error, which is the thing that actually distinguishes "created" from "rejected".

One related fix in the same two tests: the `ClusterTriggerAuthentication` is now deleted afterwards. `getTemplateData` returns an empty template list, so `DeleteKubernetesResources` only removes the test namespace, and a cluster-scoped object outlives it - so this test has been leaving a `ClusterTriggerAuthentication` behind on every run, pass or fail. Anything later in the same cluster that lists or counts them saw it.

Part of the e2e wait and assertion cleanup tracked in #7991.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
