### PR TITLE
CI: keep waiting when a KedaEventually condition cannot be observed

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -1304,16 +1304,27 @@ func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace str
 // KedaEventually checks if the provided conditionFunc eventually returns true
 // (and no error) within the context's deadline. It polls the conditionFunc
 // at the given interval until the condition is met or the context times out.
+// An error from conditionFunc is treated as an attempt that could not observe
+// the condition, so polling continues; the error is only reported if the
+// deadline arrives while the most recent attempt is still failing. Callers may
+// therefore return errors directly instead of hiding them behind a false.
 func KedaEventually(ctx context.Context, conditionFunc wait.ConditionWithContextFunc, interval time.Duration) error {
 	if interval <= 0 {
 		return fmt.Errorf("polling interval must be positive, got %v", interval)
 	}
 
+	// A condition that returns an error has not been shown to be false, only that it could not be
+	// observed this time, so the error is remembered and the wait carries on. It is reported if the
+	// deadline arrives while the most recent attempt is still failing, which is when it becomes the
+	// likely explanation. A later attempt that observes the condition clears it, so a transient
+	// failure early in a long wait does not end up blamed for a condition that simply stayed false.
+	var lastErr error
+
 	ok, err := conditionFunc(ctx)
-	if err != nil {
-		return fmt.Errorf("eventually check failed on initial check: %w", err)
-	}
-	if ok {
+	switch {
+	case err != nil:
+		lastErr = err
+	case ok:
 		return nil
 	}
 
@@ -1323,14 +1334,15 @@ func KedaEventually(ctx context.Context, conditionFunc wait.ConditionWithContext
 	for {
 		select {
 		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("eventually check failed: context deadline exceeded, last attempt errored: %w", lastErr)
+			}
 			return fmt.Errorf("eventually check failed: context deadline exceeded before condition was met")
 
 		case <-ticker.C:
 			ok, err := conditionFunc(ctx)
-			if err != nil {
-				return fmt.Errorf("eventually check failed during polling: %w", err)
-			}
-			if ok {
+			lastErr = err
+			if err == nil && ok {
 				return nil
 			}
 		}


### PR DESCRIPTION
`KedaEventually` returns as soon as its condition returns an error, both on the initial check and on any poll:

```go
ok, err := conditionFunc(ctx)
if err != nil {
    return fmt.Errorf("eventually check failed during polling: %w", err)
}
```

For a wait, that is the wrong reading of an error. A failed read has not shown the condition to be false, only that it could not be observed this time, and the usual causes in a cluster under load - a connection reset, a scrape against a pod that is still coming up, an API server timeout - clear on their own well inside the wait budget. Ending the wait on the first one turns a recoverable blip into a test failure.

An error is now treated as an attempt that observed nothing, and polling continues. The error is reported if the deadline arrives while the most recent attempt is still failing, so a genuine outage still explains itself instead of producing a bare deadline message. An attempt that does observe the condition clears the remembered error, so a transient failure early in a long wait is not blamed for a condition that simply stayed false.

### This changes no behaviour today

None of the five current callers returns a non-nil error - every one of them already converts failures into `false, nil`:

```go
if scrapeErr != nil {
    t.Logf("error scraping: %v", scrapeErr)
    return false, nil
}
```

That workaround only exists because of the behaviour this PR fixes, and it costs the caller the error text on timeout. The value of the change is forward-looking: conditions can now return errors directly, which is what the remaining hand-rolled polling loops in `helper.go` need before they can be converted onto this primitive (#7991).

### On the missing unit test

This is pure logic and would be worth a table test, but there is nowhere for it to run today. `helper.go` is behind the `e2e` build tag, so `make test` does not compile it, and `getRegularTestFiles` in `tests/run-all.go` collects any `_test.go` under `tests/` outside `utils` and `sequential` - so a `tests/helper/helper_test.go` would be picked up and executed as an e2e test. Worth noting that the filter's comment says it excludes "helper files" but nothing in it actually does. Happy to add coverage if you would like that filter tightened first, in a separate PR.

`KedaConsistently` has the same shape and is deliberately left alone: for a "stays true throughout" check, an unobservable condition is not obviously benign, and changing it is a separate judgement call.

Part of the e2e determinism work tracked in #7991.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
