### PR TITLE
CI: wait for pods to be ready, not merely running

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -492,27 +492,39 @@ func WaitForPodsCompleted(t *testing.T, kc *kubernetes.Clientset, selector, name
 	return false
 }
 
-// Waits until all the pods in the namespace have a running status.
+// isPodReady reports whether the pod's Ready condition is true. The Running phase only means the
+// pod's containers have been created, so it is reached before a readiness probe first succeeds and
+// before the pod is reachable through a Service.
+func isPodReady(pod corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// Waits until all the pods in the namespace are ready.
 func WaitForAllPodRunningInNamespace(t *testing.T, kc *kubernetes.Clientset, namespace string, iterations, intervalSeconds int) bool {
 	for i := 0; i < iterations; i++ {
 		pods, err := kc.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			t.Logf("cannot list pods in namespace %s - %s", namespace, err)
 		} else {
-			runningCount := 0
+			readyCount := 0
 			for _, pod := range pods.Items {
-				if pod.Status.Phase != corev1.PodRunning {
+				if !isPodReady(pod) {
 					break
 				}
-				runningCount++
+				readyCount++
 			}
 
-			t.Logf("Waiting for pods in namespace to be in 'Running' status. Namespace - %s, Current - %d, Target - %d",
-				namespace, runningCount, len(pods.Items))
+			t.Logf("Waiting for pods in namespace to be ready. Namespace - %s, Current - %d, Target - %d",
+				namespace, readyCount, len(pods.Items))
 
-			// Both callers create the pods they are waiting on, so an empty namespace means the
-			// list arrived before they were scheduled rather than that everything is running.
-			if len(pods.Items) > 0 && runningCount == len(pods.Items) {
+			// Every caller creates the pods it is waiting on, so an empty namespace means the
+			// list arrived before they were scheduled rather than that everything is ready.
+			if len(pods.Items) > 0 && readyCount == len(pods.Items) {
 				return true
 			}
 		}
@@ -531,6 +543,8 @@ func WaitForRunningPodCount(t *testing.T, kc *kubernetes.Clientset, scaledJobNam
 		if err != nil {
 			t.Logf("cannot list pods - %s", err)
 		} else {
+			// Phase rather than readiness on purpose: these are ScaledJob pods, and the callers are
+			// counting how many the executor started, not whether each one is serving traffic.
 			runningPodCount := 0
 			for _, pod := range pods.Items {
 				if pod.Status.Phase == corev1.PodRunning {
@@ -612,12 +626,8 @@ func WaitForPodReady(t *testing.T, kc *kubernetes.Clientset, podName, namespace 
 		} else {
 			t.Logf("Waiting for pod to be in ready state. Pod - %s, Current Phase - %s", podName, pod.Status.Phase)
 
-			// A pod can be in the Running phase without all containers being ready.
-			// Check the Ready condition to ensure the pod is actually ready.
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-					return true
-				}
+			if isPodReady(*pod) {
+				return true
 			}
 		}
 		time.Sleep(time.Duration(intervalSeconds) * time.Second)


### PR DESCRIPTION
`WaitForAllPodRunningInNamespace` accepts every pod in the `Running` phase:

```go
if pod.Status.Phase != corev1.PodRunning {
    break
}
```

`Running` only means a pod's containers have been created. A pod reaches it before its readiness probe first succeeds, and therefore before the endpoints controller adds it to a Service. Any caller that waits here and then talks to the workload is racing the probe, and all three do:

- `arangodb` creates a database and then a collection in the cluster it just waited for
- `cloudevent_source` posts to the receiver it just waited for
- `splunk_observability` waits on nginx before driving load through it

Under upstream CI the probe usually wins that race. On slower or more contended clusters it does not, and the failure surfaces later as a connection refused from inside the test body rather than as a timeout in the wait, which makes it read like a product bug.

Now checks the `Ready` condition. `WaitForPodReady` a hundred lines further down this same file already does, with a comment spelling out the distinction, and `IsPodReady` in `pkg/fallback` does too - `fallback.go` even pairs them as `pod.Status.Phase == v1.PodRunning && IsPodReady(&pod)`. Rather than write the scan a third time, it is extracted into one unexported helper that both callers in this file now use.

### Why this is not a new constraint on callers

The phase check already rejected `Succeeded`, so a namespace holding a completed pod could never satisfy this wait to begin with. Readiness rejects the same set, plus running-but-unready - which is the point. `arangodb` is the only caller whose namespace eventually holds `Job` pods, and both Jobs are applied after this call returns (`helper.go:104` and `:107`, versus the wait at `:100`), so nothing completed is present while it polls.

The name still says "Running" and now understates what it checks, though readiness does imply running so it is not wrong. I left it alone deliberately: renaming touches three call sites, and one of them is in `splunk_observability_test.go`, which has two open PRs against it (#8012, #7997). Happy to rename in a follow-up once those land.

`WaitForRunningPodCount` keeps its phase check, now with a comment recording why, since the two helpers sitting next to each other and disagreeing invites the question: its callers count how many pods a ScaledJob's executor started, and a job pod's readiness is not the quantity being measured.

On merge order: this touches `helper.go`, as do #8023 and #8025, but all three edit different functions. I verified they merge together cleanly and that the combined result builds and passes `go vet`, so they can land in any order.

Part of the e2e determinism work tracked in #7991.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
