### PR TITLE
CI: defer cleanup in file_based_auth so the ClusterTriggerAuthentication cannot leak

### DIFF
--- a/tests/internals/file_based_auth/file_based_auth_test.go
+++ b/tests/internals/file_based_auth/file_based_auth_test.go
@@ -172,11 +172,12 @@ func TestFileBasedAuthentication(t *testing.T) {
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
+	// Deferred because this test's ClusterTriggerAuthentication is cluster-scoped and so outlives
+	// the namespace, and testScaledObjectWithFileAuth can end the test early with a Fatalf.
+	defer DeleteKubernetesResources(t, testNamespace, data, templates)
+
 	// test scaled object creation with file-based auth
 	testScaledObjectWithFileAuth(t)
-
-	// cleanup
-	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 
 func getTemplateData() (templateData, []Template) {


### PR DESCRIPTION
`TestFileBasedAuthentication` cleans up as its last statement:

```go
testScaledObjectWithFileAuth(t)

// cleanup
DeleteKubernetesResources(t, testNamespace, data, templates)
```

`testScaledObjectWithFileAuth` has two `t.Fatalf` calls in it - one when the `ClusterTriggerAuthentication` is missing, one when setting the metric value fails. Either ends the test through `runtime.Goexit`, and the cleanup statement never runs.

That costs more here than a leaked namespace would. The template list includes a **cluster-scoped** `ClusterTriggerAuthentication` named `file-auth`, and no namespace teardown reclaims it. It survives for the rest of the run, visible to every later test that lists or counts trigger authentications, under a name generic enough to collide.

Deferring it means `Goexit` unwinds through the cleanup on its way out, so the resource goes away on the failure paths too - which are exactly the paths where it currently does not.

### One thing I noticed but did not change

Nine lines into `testScaledObjectWithFileAuth`:

```go
scaledObject, err := kedaKc.ScaledObjects(testNamespace).Get(context.Background(), scaledObjectName, metav1.GetOptions{})
if err != nil {
    t.Logf("ScaledObject not found (expected in e2e environment): %v", err)
    return
}
```

`CreateKubernetesResources` applied `scaledObjectTemplate` before this runs, so the ScaledObject is always there and the comment's "expected in e2e environment" does not hold. If that `Get` ever does fail, the test logs and returns green, having checked nothing. It looks like it wants to be a failure rather than a skip, but changing it makes the test able to fail for the first time, so it seemed better kept out of a cleanup fix. Happy to send it separately if you agree with the reading.

Part of the test isolation work tracked in #7991.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
