### PR TITLE
CI: wait for the first job instead of sleeping one polling interval

### DIFF
--- a/tests/internals/scaled_job_conditions/scaled_job_conditions_test.go
+++ b/tests/internals/scaled_job_conditions/scaled_job_conditions_test.go
@@ -24,6 +24,10 @@ var _ = godotenv.Load("../../.env")
 
 const (
 	testName = "scaledjob-conditions-test"
+
+	// Reached only if the executor never creates a job for an active ScaledJob, which is a failure
+	// rather than slowness, so the budget is loose enough that a busy cluster cannot hit it.
+	jobCreationTimeout = 2 * time.Minute
 )
 
 var (
@@ -376,10 +380,21 @@ func testReadyConditionUnknown(t *testing.T, kc *kubernetes.Clientset) {
 		}),
 		"ScaledJob should have ReadyCondition=Unknown and ActiveCondition=True")
 
-	// Verify that at least some jobs were created
-	time.Sleep(5 * time.Second)
-	jobCount, _ := GetScaledJobCount(kc, scaledJobNs, testNs)
-	assert.Greater(t, jobCount, int64(0), "at least one job should be created when one trigger is active")
+	// Verify that at least some jobs were created. The ScaledJob polls every 5s, so this is waiting
+	// for the first evaluation after the active condition above, not for a fixed amount of time.
+	ctx, cancel := context.WithTimeout(context.Background(), jobCreationTimeout)
+	defer cancel()
+
+	var jobCount int64
+	err := KedaEventually(ctx, func(_ context.Context) (bool, error) {
+		var countErr error
+		jobCount, countErr = GetScaledJobCount(kc, scaledJobNs, testNs)
+		if countErr != nil {
+			return false, countErr
+		}
+		return jobCount > 0, nil
+	}, IntervalShort)
+	assert.NoErrorf(t, err, "at least one job should be created when one trigger is active, last count was %d", jobCount)
 }
 
 // Helper function to wait for ScaledJob conditions


### PR DESCRIPTION
The ScaledJobs in this test set `pollingInterval: 5`, and the check that jobs were created sleeps for exactly that long before counting:

```go
// Verify that at least some jobs were created
time.Sleep(5 * time.Second)
jobCount, _ := GetScaledJobCount(kc, scaledJobNs, testNs)
assert.Greater(t, jobCount, int64(0), "at least one job should be created when one trigger is active")
```

That budgets the executor a single evaluation to notice the active trigger and create a job, with nothing left over. One late tick - a busy operator, a slow RabbitMQ query, a contended node - and the assertion reports that KEDA failed to scale when all it did was arrive a second late. The discarded error compounds it: a failed `List` leaves `jobCount` at zero, so an API blip is reported as a scaling bug.

Now polls for the first job, with a two minute budget. Nothing is spent waiting when a job appears promptly, which is the normal case, and the timeout is only reached when no job is ever created - which is a genuine failure worth reporting, with the last observed count in the message.

The wait immediately above this already established `ActiveCondition=True`, so the executor has been shown to have an active trigger before the count starts; only the job creation itself is being waited on.

Small ordering note: the condition returns its error rather than hiding it behind a `false`, which is strictly better than today either way - currently the error is discarded entirely - and becomes properly resilient to a transient `List` failure once #8025 lands. The two PRs touch different files and can merge in either order.

Part of the e2e determinism work tracked in #7991.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
