### PR TITLE
CI: make the mysql readiness probe mean mysql is reachable

### DIFF
--- a/tests/scalers/mysql/mysql_test.go
+++ b/tests/scalers/mysql/mysql_test.go
@@ -200,10 +200,8 @@ spec:
             protocol: TCP
             containerPort: 3600
         readinessProbe:
-          # -h 127.0.0.1 forces TCP, and the database is the one the entrypoint creates from
-          # MYSQL_DATABASE. During first-time initialisation the entrypoint runs a temporary server
-          # with networking disabled, so a probe over the local socket reports ready before the
-          # database exists and before port 3306 accepts connections.
+          # don't use mysqladmin ping over unix socket as this can report premature readiness
+          # instead use mysql over TCP with real query to cover (1) network socket availability and (2) database initialization
           exec:
             command:
             - sh

--- a/tests/scalers/mysql/mysql_test.go
+++ b/tests/scalers/mysql/mysql_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
@@ -201,11 +200,16 @@ spec:
             protocol: TCP
             containerPort: 3600
         readinessProbe:
+          # -h 127.0.0.1 forces TCP, and the database is the one the entrypoint creates from
+          # MYSQL_DATABASE. During first-time initialisation the entrypoint runs a temporary server
+          # with networking disabled, so a probe over the local socket reports ready before the
+          # database exists and before port 3306 accepts connections.
           exec:
             command:
             - sh
             - -c
-            - "mysqladmin ping -u root -p{{.MySQLRootPassword}}"
+            - "mysql -h 127.0.0.1 -u{{.MySQLUsername}} -p{{.MySQLPassword}} -e 'SELECT 1' {{.MySQLDatabase}}"
+          periodSeconds: 2
 `
 
 	mysqlServiceTemplate = `
@@ -249,9 +253,9 @@ func setupMySQL(t *testing.T, kc *kubernetes.Clientset, data templateData, templ
 	// Deploy mysql
 	KubectlApplyWithTemplate(t, data, "mysqlDeploymentTemplate", mysqlDeploymentTemplate)
 	KubectlApplyWithTemplate(t, data, "mysqlServiceTemplate", mysqlServiceTemplate)
-	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, "mysql", testNamespace, 1, 30, 2), "mysql is not in a ready state")
-	// Wait 30 sec which would be enought for mysql to be accessible
-	time.Sleep(30 * time.Second)
+	// A larger budget than the readiness probe used to need: it now only passes once mysqld has
+	// finished initialising and is serving over TCP, which is what this waits for.
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, "mysql", testNamespace, 1, 60, 2), "mysql is not in a ready state")
 
 	// Create table that used by the job and the worker
 	createTableSQL := fmt.Sprintf("CREATE TABLE %s.task_instance (id INT AUTO_INCREMENT PRIMARY KEY,state VARCHAR(10));", mySQLDatabase)


### PR DESCRIPTION
Setup waits for mysql's deployment to report a ready replica, and then sleeps anyway:

```go
require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, "mysql", testNamespace, 1, 30, 2), "mysql is not in a ready state")
// Wait 30 sec which would be enought for mysql to be accessible
time.Sleep(30 * time.Second)
```

The sleep is covering for the readiness probe, which is `mysqladmin ping -u root -p...` over the local socket. On first start the official image's entrypoint brings up a **temporary server with networking disabled** to create `MYSQL_DATABASE` and `MYSQL_USER` - and that server answers `ping`. So the pod reports ready while the database does not exist yet, while port 3306 is not listening, and while the server is about to be shut down and restarted for real. Thirty seconds was a guess at how long the rest of that would take.

Two consequences beyond this test's setup: the Service gets an endpoint that refuses TCP connections, so KEDA's first scaler polls fail with connection errors, and the `CREATE TABLE` immediately after the sleep can hit a server that is mid-restart.

The probe now runs a query over TCP against the database the entrypoint creates:

```
mysql -h 127.0.0.1 -u<user> -p<pass> -e 'SELECT 1' <database>
```

`-h 127.0.0.1` is the load-bearing part - it forces TCP rather than the socket, so the probe cannot pass during the skip-networking phase. Naming the database and using the application user means it cannot pass until initialisation has actually finished. That is exactly the condition the `CREATE TABLE` below and the scaler both depend on, so the sleep is no longer covering anything and is removed.

Because ready now arrives after real initialisation rather than during it, the readiness wait has to cover that time itself: its budget goes from 60s to 120s. Total worst case is still comparable to the old 60s wait plus 30s sleep, and unlike the sleep the budget is only spent when mysql genuinely never comes up. The probe period is 2s so readiness is picked up promptly instead of on the default 10s cycle.

Unrelated but worth flagging rather than fixing here: the container declares `containerPort: 3600` where 3306 was surely meant. It is only declarative - the Service targets `targetPort: 3306` and works - so nothing depends on it, but it will mislead the next person to read this manifest.

Verified locally that the template still renders to valid YAML and that the probe command comes out as intended after substitution, since a broken manifest here would only show up once the e2e job reached this scaler.

Part of the e2e determinism work tracked in #7991.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
