### PR TITLE
RabbitMQ scaler: fix empty queue handling during fast drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Event Hub Scaler**: Fix authentication failures caused by appending a duplicate `EntityPath` when `eventHubName` is provided ([#7926](https://github.com/kedacore/keda/issues/7926))
 - **Dynatrace Scaler**: Handle all documented DQL query states (`NOT_STARTED`, `FAILED`, `CANCELLED`, `RESULT_GONE`) in both the execute and poll paths; `NOT_STARTED` on either path now triggers a poll retry instead of an immediate error, and terminal error states produce descriptive messages instead of `unknown state: X` ([#7986](https://github.com/kedacore/keda/pull/7986))
 - **Github Runner Scaler**: Fix per-repository ETag job cache returning another concurrent workflow run's jobs, inflating the computed queue length when a repository has multiple simultaneous queued/in_progress runs ([#7949](https://github.com/kedacore/keda/issues/7949))
-- **RabbitMQ Scaler**: Fix rabbitmq empty queue handling during fast drain ([#8033](https://github.com/kedacore/keda/pull/8033))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Event Hub Scaler**: Fix authentication failures caused by appending a duplicate `EntityPath` when `eventHubName` is provided ([#7926](https://github.com/kedacore/keda/issues/7926))
 - **Dynatrace Scaler**: Handle all documented DQL query states (`NOT_STARTED`, `FAILED`, `CANCELLED`, `RESULT_GONE`) in both the execute and poll paths; `NOT_STARTED` on either path now triggers a poll retry instead of an immediate error, and terminal error states produce descriptive messages instead of `unknown state: X` ([#7986](https://github.com/kedacore/keda/pull/7986))
 - **Github Runner Scaler**: Fix per-repository ETag job cache returning another concurrent workflow run's jobs, inflating the computed queue length when a repository has multiple simultaneous queued/in_progress runs ([#7949](https://github.com/kedacore/keda/issues/7949))
+- **RabbitMQ Scaler**: Fix rabbitmq empty queue handling during fast drain ([#8033](https://github.com/kedacore/keda/pull/8033))
 
 ### Deprecations
 

--- a/pkg/scalers/rabbitmq_scaler.go
+++ b/pkg/scalers/rabbitmq_scaler.go
@@ -719,13 +719,16 @@ func (s *rabbitMQScaler) GetMetricsAndActivity(ctx context.Context, metricName s
 		isActive = (ratio > s.metadata.ActivationValue) || ((publishRate > 0) && (deliverGetRate == 0))
 	case rabbitModeExpectedQueueConsumptionTime:
 		eta := float64(0)
-		if deliverGetRate == 0 {
+		switch {
+		case messages == 0:
+			eta = 0
+		case deliverGetRate == 0:
 			eta = float64(s.metadata.ActivationValue)
-		} else {
+		default:
 			eta = ((publishRate - deliverGetRate) / deliverGetRate) + (float64(messages) / deliverGetRate)
 		}
 		metric = GenerateMetricInMili(metricName, eta)
-		isActive = (eta > s.metadata.ActivationValue) || (deliverGetRate == 0)
+		isActive = (eta > s.metadata.ActivationValue) || (deliverGetRate == 0 && messages > 0)
 	}
 
 	return []external_metrics.ExternalMetricValue{metric}, isActive, nil

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -515,6 +515,72 @@ func TestGetQueueInfo(t *testing.T) {
 	}
 }
 
+var testExpectedQueueConsumptionTimeTestData = []struct {
+	name          string
+	response      string
+	expectedMilli int64
+	isActive      bool
+}{
+	// empty idle queue: nothing to consume and nobody consuming - must be
+	// inactive with a zero metric so the workload can scale to zero
+	{name: "empty idle queue", response: `{"messages": 0, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 0}, "deliver_get_details": {"rate": 0}}, "name": "evaluate_trials"}`, expectedMilli: 0, isActive: false},
+	// queue just drained, delivery rate still decaying: empty queue wins
+	{name: "empty queue with decaying delivery rate", response: `{"messages": 0, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 0}, "deliver_get_details": {"rate": 2}}, "name": "evaluate_trials"}`, expectedMilli: 0, isActive: false},
+	// backlog with no consumers: consumption time cannot be estimated, report
+	// the activation value and activate so consumers get scaled up
+	{name: "backlog without consumers", response: `{"messages": 10, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 3}, "deliver_get_details": {"rate": 0}}, "name": "evaluate_trials"}`, expectedMilli: 1000, isActive: true},
+	// steady state: eta = (publish-deliver)/deliver + messages/deliver = (3-2)/2 + 10/2 = 5.5
+	{name: "backlog with consumers", response: `{"messages": 10, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 3}, "deliver_get_details": {"rate": 2}}, "name": "evaluate_trials"}`, expectedMilli: 5500, isActive: true},
+	// draining after publish stopped: eta = (0-2)/2 + 4/2 = 1, not above activation
+	{name: "draining backlog", response: `{"messages": 4, "messages_unacknowledged": 0, "message_stats": {"publish_details": {"rate": 0}, "deliver_get_details": {"rate": 2}}, "name": "evaluate_trials"}`, expectedMilli: 1000, isActive: false},
+}
+
+func TestExpectedQueueConsumptionTime(t *testing.T) {
+	for _, testData := range testExpectedQueueConsumptionTimeTestData {
+		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(testData.response))
+		}))
+
+		resolvedEnv := map[string]string{host: apiStub.URL}
+
+		metadata := map[string]string{
+			"queueName":       "evaluate_trials",
+			"hostFromEnv":     host,
+			"protocol":        "http",
+			"mode":            "ExpectedQueueConsumptionTime",
+			"value":           "1",
+			"activationValue": "1",
+		}
+
+		s, err := NewRabbitMQScaler(
+			&scalersconfig.ScalerConfig{
+				ResolvedEnv:       resolvedEnv,
+				TriggerMetadata:   metadata,
+				AuthParams:        map[string]string{},
+				GlobalHTTPTimeout: 1000 * time.Millisecond,
+			},
+		)
+		if err != nil {
+			t.Fatal("Expect success", err)
+		}
+
+		metrics, active, err := s.GetMetricsAndActivity(context.TODO(), "Metric")
+		if err != nil {
+			t.Fatal("Expect success", err)
+		}
+
+		if got := metrics[0].Value.MilliValue(); got != testData.expectedMilli {
+			t.Error(testData.name, ": expect metric =", testData.expectedMilli, "milli but got", got)
+		}
+		if active != testData.isActive {
+			t.Error(testData.name, ": expect isActive =", testData.isActive, "but got", active)
+		}
+
+		apiStub.Close()
+	}
+}
+
 var testRegexQueueInfoTestData = []getQueueInfoTestData{
 	// sum queue length
 	{response: `{"items":[{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}, "deliver_get_details": {"rate": 0}}, "name": "evaluate_trials"},{"messages": 4, "messages_unacknowledged": 1, "message_stats": {"publish_details": {"rate": 0}, "deliver_get_details": {"rate": 0}}, "name": "evaluate_trial2"}]}`, responseStatus: http.StatusOK, isActive: true, extraMetadata: map[string]string{"queueLength": "10", "useRegex": "true", "operation": "sum"}},

--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -539,6 +539,7 @@ func TestExpectedQueueConsumptionTime(t *testing.T) {
 	for _, testData := range testExpectedQueueConsumptionTimeTestData {
 		var apiStub = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
+			// nosemgrep: no-direct-write-to-responsewriter
 			_, _ = w.Write([]byte(testData.response))
 		}))
 


### PR DESCRIPTION
When fixing slow consumer rabbitmq test flake in https://github.com/kedacore/keda/pull/7981, this eventually exposed a bug in actual rabbitmq scaler.

When user configures `mode: ExpectedQueueConsumptionTime` and something drains the queue very fast and KEDA/HPA polls with a delay, the delivery rate can report `0`, meaning nothing is draining the queue, but at the same time, the queue is empty so there is nothing to be drained. The scaler checked only the drain rate, never the queue lengths.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/pull/7981
