### PR TITLE
CI: replica-ready waits must observe the rollout, not just the count

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -601,12 +601,17 @@ func WaitForDeploymentReplicaReadyCount(t *testing.T, kc *kubernetes.Clientset, 
 		if err != nil {
 			t.Logf("cannot get deployment %s/%s - %s", namespace, name, err)
 		} else {
-			replicas := deployment.Status.ReadyReplicas
+			status := deployment.Status
 
-			t.Logf("Waiting for deployment replicas to hit target. Deployment - %s, Current  - %d, Target - %d",
-				name, replicas, target)
+			t.Logf("Waiting for deployment replicas to hit target. Deployment - %s, ObservedGeneration - %d/%d, ReadyReplicas - %d, UpdatedReplicas - %d, Target - %d",
+				name, status.ObservedGeneration, deployment.Generation, status.ReadyReplicas, status.UpdatedReplicas, target)
 
-			if replicas == int32(target) {
+			// ObservedGeneration rejects a status written before the current spec, and UpdatedReplicas
+			// rejects pods built from a previous template. Without both, a wait that follows a template
+			// change can be satisfied by the very pods that change is replacing.
+			if status.ObservedGeneration >= deployment.Generation &&
+				status.ReadyReplicas == int32(target) &&
+				status.UpdatedReplicas == int32(target) {
 				return true
 			}
 		}
@@ -677,12 +682,16 @@ func WaitForStatefulsetReplicaReadyCount(t *testing.T, kc *kubernetes.Clientset,
 		if err != nil {
 			t.Logf("cannot get statefulset %s/%s - %s", namespace, name, err)
 		} else {
-			replicas := statefulset.Status.ReadyReplicas
+			status := statefulset.Status
 
-			t.Logf("Waiting for statefulset replicas to hit target. Statefulset - %s, Current  - %d, Target - %d",
-				name, replicas, target)
+			t.Logf("Waiting for statefulset replicas to hit target. Statefulset - %s, ObservedGeneration - %d/%d, ReadyReplicas - %d, UpdatedReplicas - %d, Target - %d",
+				name, status.ObservedGeneration, statefulset.Generation, status.ReadyReplicas, status.UpdatedReplicas, target)
 
-			if replicas == int32(target) {
+			// Same reasoning as the deployment helper above: the generation rules out a stale status,
+			// and UpdatedReplicas rules out pods still running the previous revision.
+			if status.ObservedGeneration >= statefulset.Generation &&
+				status.ReadyReplicas == int32(target) &&
+				status.UpdatedReplicas == int32(target) {
 				return true
 			}
 		}


### PR DESCRIPTION
`WaitForDeploymentReplicaReadyCount` and `WaitForStatefulsetReplicaReadyCount` compare `ReadyReplicas` and nothing else:

```go
replicas := deployment.Status.ReadyReplicas
if replicas == int32(target) {
    return true
}
```

Two things satisfy that without the workload being in the state the caller is waiting for.

**A status that predates the spec being waited on.** Nothing checks that the controller has observed the current generation, so the first read after an apply can be answered from the previous status.

**Pods from the previous template.** `ReadyReplicas` counts every ready pod regardless of which ReplicaSet or revision it belongs to. A wait that follows a pod template change can be satisfied by exactly the pods that change is replacing - the test then proceeds against the workload it thought it had just replaced.

Both now check `ObservedGeneration` against the object's own `metadata.Generation`, and require `UpdatedReplicas` to reach the target as well.

`WaitForDeploymentRollout`, a couple of hundred lines further down this same file, already checks both - it just takes the generation as a parameter, which these two cannot do without changing a signature used at 696 call sites. Comparing status against `metadata.Generation` is equivalent for this purpose and is what `kubectl rollout status` does.

### This is stricter, so here is the blast radius

For a target of zero the wait now continues until the pods are actually gone, rather than returning as soon as they stop being ready. I checked the budgets before writing it: across all 696 call sites of these two helpers the **tightest budget anywhere is 60s**, and 146 of them wait for a literal zero. Sixty seconds covers pod deletion with room to spare even for a workload that sits out its full termination grace period.

For non-zero targets nothing changes in the common case. KEDA scaling a deployment bumps `metadata.Generation` by writing `spec.replicas`, and the controller observes that within milliseconds, so the generation check is satisfied immediately; with no template change, `UpdatedReplicas` and `ReadyReplicas` converge on the target together.

The log line now reports observed generation, ready replicas, updated replicas and the target on every poll, so a timeout says which of the three conditions was not met instead of just reporting a count.

Left alone deliberately: `WaitForReplicaSetReplicaReadyCount`, since a ReplicaSet has a single template and no rollout to observe, and `WaitForArgoRolloutReplicaReadyCount`, which reads through jsonpath rather than a typed status.

Part of the e2e determinism work tracked in #7991, and the last of the three wait-semantics fixes in it - the other two landed as #7996 and #8026.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991