### PR TITLE
Solr Scaler: fail on non-200 instead of reporting an empty queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Event Hub Scaler**: Fix authentication failures caused by appending a duplicate `EntityPath` when `eventHubName` is provided ([#7926](https://github.com/kedacore/keda/issues/7926))
 - **Dynatrace Scaler**: Handle all documented DQL query states (`NOT_STARTED`, `FAILED`, `CANCELLED`, `RESULT_GONE`) in both the execute and poll paths; `NOT_STARTED` on either path now triggers a poll retry instead of an immediate error, and terminal error states produce descriptive messages instead of `unknown state: X` ([#7986](https://github.com/kedacore/keda/pull/7986))
 - **Github Runner Scaler**: Fix per-repository ETag job cache returning another concurrent workflow run's jobs, inflating the computed queue length when a repository has multiple simultaneous queued/in_progress runs ([#7949](https://github.com/kedacore/keda/issues/7949))
+- **Solr Scaler**: Fix a non-200 response being reported as a queue length of 0, which scaled the workload to zero during a Solr outage, an auth rejection or a missing collection instead of surfacing the error ([#8036](https://github.com/kedacore/keda/issues/8036))
 
 ### Deprecations
 

--- a/pkg/scalers/solr_scaler.go
+++ b/pkg/scalers/solr_scaler.go
@@ -120,9 +120,21 @@ func (s *solrScaler) getItemCount(ctx context.Context) (float64, error) {
 		return -1, err
 	}
 
+	// Solr reports failures as JSON when wt=json, and those bodies unmarshal cleanly into
+	// solrResponse leaving numFound at 0. Without this check an auth rejection, a missing
+	// collection or an outage would look like an empty queue and scale the workload to zero.
+	if resp.StatusCode != http.StatusOK {
+		// Redacted() strips any password embedded in the configured host so it cannot reach the
+		// ScaledObject status or the operator log.
+		return -1, fmt.Errorf("the solr API returned error. url: %s status: %d response: %s", baseURL.Redacted(), resp.StatusCode, string(body))
+	}
+
 	err = json.Unmarshal(body, &SolrResponse1)
 	if err != nil {
 		return -1, fmt.Errorf("%w, make sure you enter username, password and collection values correctly in the yaml file", err)
+	}
+	if SolrResponse1 == nil {
+		return -1, fmt.Errorf("the solr API returned a body that decoded to null. url: %s", baseURL.Redacted())
 	}
 	itemCount = float64(SolrResponse1.Response.NumFound)
 	return itemCount, nil

--- a/pkg/scalers/solr_scaler_test.go
+++ b/pkg/scalers/solr_scaler_test.go
@@ -3,6 +3,7 @@ package scalers
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
@@ -75,5 +76,71 @@ func TestSolrGetMetricSpecForScaling(t *testing.T) {
 		if metricName != testData.name {
 			t.Errorf("Wrong External metric source name: %s, expected: %s", metricName, testData.name)
 		}
+	}
+}
+
+// Solr reports failures as JSON when wt=json, and those bodies unmarshal cleanly into solrResponse
+// with numFound left at 0. Without a status check the scaler reported a healthy queue length of 0
+// and scaled the workload to zero during an outage or an auth rejection.
+func TestSolrGetItemCountErrorsOnNon200(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"server error", http.StatusInternalServerError, `{"responseHeader":{"status":500},"error":{"msg":"no servers hosting shard","code":500}}`},
+		{"unauthorized", http.StatusUnauthorized, `{"responseHeader":{"status":401},"error":{"msg":"require authentication","code":401}}`},
+		{"collection missing", http.StatusNotFound, `{"responseHeader":{"status":404},"error":{"msg":"no such collection","code":404}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				// nosemgrep: no-direct-write-to-responsewriter
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			s, err := NewSolrScaler(&scalersconfig.ScalerConfig{
+				TriggerMetadata: map[string]string{
+					"host": server.URL, "collection": "my_core", "query": "*:*", "targetQueryValue": "1",
+				},
+				AuthParams: map[string]string{"username": "u", "password": "p"},
+			})
+			if err != nil {
+				t.Fatalf("failed to create solr scaler: %v", err)
+			}
+
+			count, err := s.(*solrScaler).getItemCount(context.Background())
+			if err == nil {
+				t.Errorf("expected an error for HTTP %d, got count %v and nil error", tc.status, count)
+			}
+			if count != -1 {
+				t.Errorf("expected the sentinel count -1 on error, got %v", count)
+			}
+		})
+	}
+}
+
+// A literal JSON null body leaves the *solrResponse nil, which used to panic on dereference.
+func TestSolrGetItemCountHandlesNullBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// nosemgrep: no-direct-write-to-responsewriter
+		_, _ = w.Write([]byte("null"))
+	}))
+	defer server.Close()
+
+	s, err := NewSolrScaler(&scalersconfig.ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"host": server.URL, "collection": "my_core", "query": "*:*", "targetQueryValue": "1",
+		},
+		AuthParams: map[string]string{"username": "u", "password": "p"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create solr scaler: %v", err)
+	}
+
+	if _, err := s.(*solrScaler).getItemCount(context.Background()); err == nil {
+		t.Error("expected an error for a null response body, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

The Solr scaler scaled workloads to zero during a backend outage instead of surfacing an error.

## Problem

`getItemCount` in `pkg/scalers/solr_scaler.go` never checked `resp.StatusCode` before decoding the body. Because the query sets `wt=json`, Solr returns its errors as JSON too:

```json
{"responseHeader":{"status":500},"error":{"msg":"no servers hosting shard","code":500}}
```

The `solrResponse` struct only declares `response.numFound`, so an error body unmarshals cleanly, unknown fields are dropped, and `NumFound` stays at its zero value. `getItemCount` therefore returned `(0, nil)`, which KEDA reads as a healthy queue length of zero — so a 500 from a down shard, a 401 from rotated credentials, or a 404 from a renamed collection all scaled the workload to zero exactly when its backend was failing.

A literal `null` response body additionally left the decoded `*solrResponse` nil and panicked on dereference.

## Solution

Check the status code before decoding and return a descriptive error including the response body, matching the convention already used in `datadog_scaler.go`, `dynatrace_scaler.go` and `azure_pipelines_scaler.go`. Guard the decoded pointer against a `null` body.

## Testing

- `TestSolrGetItemCountErrorsOnNon200` covers 500, 401 and 404
- `TestSolrGetItemCountHandlesNullBody` covers the nil dereference

Both fail without the fix. On `main` the first returns `count 0, nil error` for every status:

```
expected an error for HTTP 500, got count 0 and nil error
expected an error for HTTP 401, got count 0 and nil error
expected an error for HTTP 404, got count 0 and nil error
```

and the second panics with `runtime error: invalid memory address or nil pointer dereference`.

`go build ./...`, `go vet`, `make golangci` (0 issues), `gofmt`, the full unit suite and `go test -race ./pkg/scalers/` all pass.

## Breaking Changes

None. A previously silent misread now surfaces as a scaler error.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #8036

Relates to #
