### PR TITLE
General: guard the event handler cache and fix a deadlock in the emit loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ### Fixes
 
 - **General**: Add controller-runtime cache field indexes for ScaledObject admission validation so `verifyScaledObjects` and `verifyHpas` look up duplicate scaleTargetRef and HPA-name conflicts via indexed Lists rather than full-namespace scans, eliminating the webhook OOM under high-scale creation bursts ([#7681](https://github.com/kedacore/keda/pull/7681))
+- **General**: Fix concurrent map access and a lock-ordering deadlock in the CloudEventSource event emitter, which could terminate the operator with a runtime throw or wedge every reconciler that emits events ([#8039](https://github.com/kedacore/keda/issues/8039))
 - **General**: Fix CVE-2026-42151, CVE-2026-42154, CVE-2026-40179 ([#7868](https://github.com/kedacore/keda/issues/7868))
 - **General**: Fix `pollingInterval` and `cooldownPeriod` relevance warnings incorrectly firing when `idleReplicaCount` is set to a value greater than 0, since idle mode keeps both settings relevant ([#7984](https://github.com/kedacore/keda/pull/7984))
 - **General**: Fix `ScaledJob` removal event using `namespace/name` in place of the namespace, which malformed the emitted CloudEvent's subject and the `namespace` label on the CloudEventSource metrics ([#7967](https://github.com/kedacore/keda/issues/7967))

--- a/pkg/eventemitter/eventemitter.go
+++ b/pkg/eventemitter/eventemitter.go
@@ -389,10 +389,6 @@ func (e *EventEmitter) emitEventByHandler(eventData eventdata.EventData) {
 	}
 
 	if eventData.HandlerKey == "" {
-		// Both locks are taken once, before the loop, and in the same order as createEventHandlers
-		// (handlers then filters). Taking the filter lock per iteration with a deferred unlock kept
-		// the reader held across iterations, so a waiting writer would block the next RLock and
-		// deadlock the event loop against the reconcilers.
 		e.eventHandlersCacheLock.RLock()
 		defer e.eventHandlersCacheLock.RUnlock()
 		e.eventFilterCacheLock.RLock()

--- a/pkg/eventemitter/eventemitter.go
+++ b/pkg/eventemitter/eventemitter.go
@@ -365,10 +365,22 @@ func (e *EventEmitter) enqueueEventData(eventData eventdata.EventData) {
 // 1. If there is a new EventData, call all handlers for emitting.
 // 2. Once there is an error when emitting event, record the handler's key and reqeueu this EventData.
 // 3. If the maximum number of retries has been exceeded, discard this event.
+// getEventHandler looks a handler up under the cache read lock. The map is mutated by
+// createEventHandlers and clearEventHandlersCache on the reconciler goroutines, so an unguarded
+// read here races with them and trips Go's "concurrent map read and map write" fatal error, which
+// no recover() can catch.
+func (e *EventEmitter) getEventHandler(key string) (EventDataHandler, bool) {
+	e.eventHandlersCacheLock.RLock()
+	defer e.eventHandlersCacheLock.RUnlock()
+
+	handler, found := e.eventHandlersCache[key]
+	return handler, found
+}
+
 func (e *EventEmitter) emitEventByHandler(eventData eventdata.EventData) {
 	if eventData.RetryTimes >= maxRetryTimes {
 		e.log.Error(eventData.Err, "Failed to emit Event multiple times. Will drop this event and need to check if event endpoint works well", "CloudEventSource", eventData.ObjectName)
-		handler, found := e.eventHandlersCache[eventData.HandlerKey]
+		handler, found := e.getEventHandler(eventData.HandlerKey)
 		if found {
 			e.log.V(1).Info("Set handler failure status. 1", "handler", eventData.HandlerKey)
 			handler.SetActiveStatus(metav1.ConditionFalse)
@@ -377,9 +389,16 @@ func (e *EventEmitter) emitEventByHandler(eventData eventdata.EventData) {
 	}
 
 	if eventData.HandlerKey == "" {
+		// Both locks are taken once, before the loop, and in the same order as createEventHandlers
+		// (handlers then filters). Taking the filter lock per iteration with a deferred unlock kept
+		// the reader held across iterations, so a waiting writer would block the next RLock and
+		// deadlock the event loop against the reconcilers.
+		e.eventHandlersCacheLock.RLock()
+		defer e.eventHandlersCacheLock.RUnlock()
+		e.eventFilterCacheLock.RLock()
+		defer e.eventFilterCacheLock.RUnlock()
+
 		for key, handler := range e.eventHandlersCache {
-			e.eventFilterCacheLock.RLock()
-			defer e.eventFilterCacheLock.RUnlock()
 			// Filter Event
 			identifierKey := getPrefixIdentifierFromKey(key)
 
@@ -401,7 +420,7 @@ func (e *EventEmitter) emitEventByHandler(eventData eventdata.EventData) {
 		}
 	} else {
 		e.log.Info("Failed to emit event", "handler", eventData.HandlerKey, "retry times", fmt.Sprintf("%d/%d", eventData.RetryTimes, maxRetryTimes), "error", eventData.Err)
-		handler, found := e.eventHandlersCache[eventData.HandlerKey]
+		handler, found := e.getEventHandler(eventData.HandlerKey)
 		if found && handler.GetActiveStatus() == metav1.ConditionTrue {
 			go handler.EmitEvent(eventData, e.emitErrorHandle)
 		}
@@ -413,7 +432,7 @@ func (e *EventEmitter) emitErrorHandle(eventData eventdata.EventData, err error)
 
 	if eventData.RetryTimes >= maxRetryTimes {
 		e.log.V(1).Info("Failed to emit Event multiple times. Will set handler failure status.", "handler", eventData.HandlerKey, "retry times", eventData.RetryTimes)
-		handler, found := e.eventHandlersCache[eventData.HandlerKey]
+		handler, found := e.getEventHandler(eventData.HandlerKey)
 		if found {
 			handler.SetActiveStatus(metav1.ConditionFalse)
 		}

--- a/pkg/eventemitter/eventemitter.go
+++ b/pkg/eventemitter/eventemitter.go
@@ -365,7 +365,7 @@ func (e *EventEmitter) enqueueEventData(eventData eventdata.EventData) {
 // 1. If there is a new EventData, call all handlers for emitting.
 // 2. Once there is an error when emitting event, record the handler's key and reqeueu this EventData.
 // 3. If the maximum number of retries has been exceeded, discard this event.
-// getEventHandler looks a handler up under the cache read lock. The map is mutated by
+// getEventHandler looks up a handler under the cache read lock. The map is mutated by
 // createEventHandlers and clearEventHandlersCache on the reconciler goroutines, so an unguarded
 // read here races with them and trips Go's "concurrent map read and map write" fatal error, which
 // no recover() can catch.


### PR DESCRIPTION
## Summary

Fixes an unrecoverable crash and a deadlock in the CloudEventSource event emitter.

## Problem

Two concurrency defects in `pkg/eventemitter/eventemitter.go`.

**1. `eventHandlersCache` is read without its lock.** The map is guarded by `eventHandlersCacheLock`, and the writers take it correctly (`createEventHandlers`, `clearEventHandlersCache`). But four reads take no lock at all — lines 371, 380, 404 (`emitEventByHandler`) and 416 (`emitErrorHandle`). `Emit` and `checkIfEventHandlersExist` *do* take `RLock`, so the omission looks accidental.

These run on the `startEventLoop` goroutine and on the handler callback goroutines, while the writers run on the CloudEventSource reconciler goroutine. Any CloudEventSource create, update or delete that overlaps event emission is a concurrent map read and write — a Go runtime **throw**, not a panic, so `recover()` cannot catch it and the operator process dies. Same class as the map races already fixed in `pkg/fallback` (#7838 / #7843).

**2. `defer RUnlock` inside a loop deadlocks the emit loop against the reconcilers.**

```go
for key, handler := range e.eventHandlersCache {
    e.eventFilterCacheLock.RLock()
    defer e.eventFilterCacheLock.RUnlock()   // released only at function return
```

The deferred unlock keeps the read lock held into the next iteration. With two or more registered CloudEventSources:

1. The event loop acquires `RLock` in iteration 1 and holds it.
2. `createEventHandlers` takes `eventHandlersCacheLock.Lock()`, then blocks on `eventFilterCacheLock.Lock()`.
3. Iteration 2 calls `RLock()` again — Go's `sync.RWMutex` bars new readers while a writer waits, so the event loop blocks while still holding the lock the writer needs.

Neither goroutine proceeds. The writer still holds `eventHandlersCacheLock`, so `Emit` blocks forever too — and `Emit` is called synchronously from the ScaledObject, ScaledJob, TriggerAuthentication and ClusterTriggerAuthentication reconcilers. Those workers wedge one by one while the operator keeps passing its liveness probe.

## Solution

Take both locks once before the loop, in the same order `createEventHandlers` uses (handlers then filters, so the acquisition order is consistent and cannot invert), and route the point lookups through a small guarded `getEventHandler` helper.

## Testing

`go test -race ./pkg/eventemitter/` passes. `go build ./...`, `go vet`, `make golangci` (0 issues), `gofmt` and the full unit suite are clean.

Both defects are timing-dependent, so I have not written a test that reproduces them deterministically — I did not want to add a flaky or sleep-based test. What is directly verifiable is the structure: the four unguarded reads against the lock-holding writers, and the deferred unlock inside the loop body.

## Breaking Changes

None.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #8039

Relates to #
