### PR TITLE
CI: Force KEDA resources deletion after e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ e2e-test-clean-crds: ## Delete all scaled objects and jobs across all namespaces
 
 .PHONY: e2e-test-clean
 e2e-test-clean: get-cluster-context ## Delete all namespaces labeled with type=e2e
+	# Remove finalizers/resources left behind if KEDA was uninstalled before its CRs were finalized,
+	# otherwise the namespace deletion below gets stuck in "Terminating"
+	./tests/force-clean-keda-resources.sh
 	kubectl delete ns -l type=e2e
 	# Clean up the strimzi CRDs, helm will not update them on Strimzi install if they already exist
 	# and we get stranded on old versions when we try to upgrade

--- a/tests/force-clean-keda-resources.sh
+++ b/tests/force-clean-keda-resources.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+# Removes finalizers from every KEDA custom resource left in the cluster and
+# deletes the external metrics apiservice, in case KEDA was removed before its
+# resources were properly finalized (e.g. operator deleted mid e2e run),
+# leaving namespaces stuck in "Terminating".
+
+set -euo pipefail
+
+echo "Force cleaning up leftover KEDA resources"
+
+while read -r namespace
+do
+    resources=$(kubectl get so,sj,ta,cloudeventsource -n "$namespace" -o name --ignore-not-found=true)
+    if [[ -n "$resources" ]]
+    then
+        while read -r resource
+        do
+            kubectl patch "$resource" -n "$namespace" --type=merge -p '{"metadata":{"finalizers":null}}' || true
+            kubectl delete "$resource" -n "$namespace" --ignore-not-found=true --timeout=60s || true
+        done <<< "$resources"
+    fi
+done < <(kubectl get namespaces -o jsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}")
+
+cluster_resources=$(kubectl get cta,clustercloudeventsource -o name --ignore-not-found=true)
+if [[ -n "$cluster_resources" ]]
+then
+    while read -r resource
+    do
+        kubectl patch "$resource" --type=merge -p '{"metadata":{"finalizers":null}}' || true
+        kubectl delete "$resource" --ignore-not-found=true --timeout=60s || true
+    done <<< "$cluster_resources"
+fi
+
+echo "Removing external metrics apiservice if present"
+kubectl delete apiservice v1beta1.external.metrics.k8s.io --ignore-not-found=true --timeout=60s


### PR DESCRIPTION
As from time to time, e2e cluster is stuck because of dangling KEDA resources stuck by finalicers, this PR enforces the deletion of KEDA resources

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


