### PR TITLE
CI: pin e2e keda images

### DIFF
--- a/.github/workflows/template-main-e2e-test.yml
+++ b/.github/workflows/template-main-e2e-test.yml
@@ -34,6 +34,7 @@ jobs:
           AZURE_RUN_WORKLOAD_IDENTITY_TESTS: true
           GCP_RUN_IDENTITY_TESTS: true
           ENABLE_OPENTELEMETRY: true
+          VERSION: ${{ github.sha }}
         run: make e2e-test
 
       - name: Delete all e2e related namespaces


### PR DESCRIPTION
Recently there were couple of failures for OTel and prom e2e tests
```
SUITE                                   08-16  08-15  08-14  08-13
opentelemetry_metrics_test.go              ❌     ✅     ✅     ❌
prometheus_metrics_test.go                 ✅     ✅     ✅     ❌
```

in all three cases, the reason is rather silly:
* the tests assert `keda_build_info` and `git_commit`
* but the tests pull `:main` image tag
* mid execution, other pipeline can push to the `:main` image tag resulting in test failure

```
2026-08-16T01:58:25.4333739Z     opentelemetry_metrics_test.go:***06: --- testing build info metric ---
2026-08-16T01:58:25.4334046Z     opentelemetry_metrics_test.go:***5:
2026-08-16T01:58:25.4334612Z            Error Trace:    /__w/keda/keda/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go:***5
2026-08-16T01:58:25.4335162Z                                        /__w/keda/keda/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go:***0***
2026-08-16T01:58:25.4335701Z                                        /__w/keda/keda/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go:***89
2026-08-16T01:58:25.4336230Z                                        /__w/keda/keda/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go:675
2026-08-16T01:58:25.4336501Z            Error:          Not equal:
2026-08-16T01:58:25.4337093Z                            expected: "4b7a***69b5***8dec85eb95cdbfa***eb76***b5a7***496"
2026-08-16T01:58:25.4337527Z                            actual  : "a***8cbeff840de7877e0b7a0a97cb7ebfe***bf595a"
2026-08-16T01:58:25.4337783Z
2026-08-16T01:58:25.4338041Z                            Diff:
2026-08-16T01:58:25.4338316Z                            --- Expected
2026-08-16T01:58:25.4338578Z                            +++ Actual
2026-08-16T01:58:25.4338862Z                            @@ -*** +*** @@
2026-08-16T01:58:25.4339220Z                            -4b7a***69b5***8dec85eb95cdbfa***eb76***b5a7***496
2026-08-16T01:58:25.4339561Z                            +a***8cbeff840de7877e0b7a0a97cb7ebfe***bf595a
2026-08-16T01:58:25.4340170Z            Test:           TestOpenTelemetryMetrics
2026-08-16T01:58:25.4340569Z            Messages:       values do not match for label git_commit
```
when pinning the e2e image to a non-floating tag, these types of flakes should go away too