### PR TITLE
fix: fall back to last known metric specs when scaler is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 ## History
 
 - [Unreleased](#unreleased)
+
+## Unreleased
+
+### Fixes
+
+- **General**: Fix fallback never activating when an external gRPC scaler is unreachable ([#8056](https://github.com/kedacore/keda/issues/8056))
 - [v2.20.2](#v2202)
 - [v2.20.1](#v2201)
 - [v2.20.0](#v2200)

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -235,7 +235,27 @@ func (c *ScalersCache) GetMetricSpecForScalingForScaler(ctx context.Context, ind
 		}
 	}
 
-	return metricSpecs, err
+	if err != nil {
+		// The scaler failed to return metric specs (e.g. an unreachable external gRPC
+		// scaler). Fall back to the last known specs so the caller can still evaluate
+		// metrics and, when those fail too, trigger fallback. Without this, the caller's
+		// metric loop never runs and the fallback failure counter is never incremented.
+		sb, _ = c.getScalerBuilder(index)
+		if sb.CachedMetricSpecs != nil {
+			return cloneMetricSpecs(sb.CachedMetricSpecs), nil
+		}
+		return nil, err
+	}
+
+	// Cache the freshly fetched specs so they can be reused if the scaler becomes
+	// unreachable on a later poll (see fallback handling in pkg/scaling/scale_handler.go).
+	c.mutex.Lock()
+	if !c.closed && index >= 0 && index < len(c.Scalers) {
+		c.Scalers[index].CachedMetricSpecs = cloneMetricSpecs(metricSpecs)
+	}
+	c.mutex.Unlock()
+
+	return metricSpecs, nil
 }
 
 // GetMetricsAndActivityForScaler returns metric value, activity and latency for a scaler identified by the metric name


### PR DESCRIPTION
### Problem

When an external (gRPC) scaler becomes unreachable at runtime, fallback configured on the ScaledObject never activates, no matter how long the outage lasts. The failure counter (Health in the ScaledObject status) stays at 0 for the whole outage.

### Root cause

`GetMetricSpecForScalingForScaler` in `pkg/scaling/cache/scalers_cache.go` returns an error and empty specs when the scaler cannot be reached. The caller in `getScaledObjectMetrics` / `getScalerState` iterates over the returned specs — when they're empty, the for-loop body never executes, so `processMetricsWithFallback` (which calls `GetMetricsWithFallback` → `IncrementFailure`) is never called. The fallback failure counter is never incremented, and fallback can never activate.

### Fix

Cache the last successfully fetched metric specs. When the scaler later becomes unreachable and `GetMetricSpecForScalingForScaler` fails, return the cached specs instead of the error. This lets the caller's per-spec loop execute, the (now-failing) metric-fetch path runs, and `processMetricsWithFallback` increments the fallback failure counter as intended.

### Changes

- `pkg/scaling/cache/scalers_cache.go`: After a successful spec fetch, store the specs in `CachedMetricSpecs`. On failure, if cached specs exist, return them.

Fixes #8056