### PR TITLE
fix: throttle LastActiveTime status updates on steady-state polls (#7998)

### DIFF
--- a/pkg/scaling/executor/scale_scaledobjects.go
+++ b/pkg/scaling/executor/scale_scaledobjects.go
@@ -22,6 +22,13 @@ import (
 	"strings"
 	"time"
 
+	// lastActiveTimeRefreshInterval is the minimum interval between LastActiveTime
+	// status updates on steady-state ScaledObjects. Updating it on every poll
+	// forces a status patch on each polling interval even when nothing else
+	// changed, causing constant etcd write pressure and watch churn.
+	lastActiveTimeRefreshInterval = time.Minute
+
+
 	"github.com/go-logr/logr"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -77,7 +84,12 @@ func (e *scaleExecutor) RequestScale(ctx context.Context, scaledObject *kedav1al
 			logger.V(1).Info("Some triggers defined in ScaledObject are not working correctly")
 		default:
 			// triggers are active, but we didn't need to scale (replica count > 0)
-			result.LastActiveTime = &metav1.Time{Time: time.Now()}
+			// Refresh LastActiveTime only if it is unset or stale, to avoid
+			// writing a redundant status patch on every polling cycle.
+			if scaledObject.Status.LastActiveTime == nil ||
+				time.Since(scaledObject.Status.LastActiveTime.Time) >= lastActiveTimeRefreshInterval {
+				result.LastActiveTime = &metav1.Time{Time: time.Now()}
+			}
 		}
 	} else {
 		// isActive == false


### PR DESCRIPTION
### Problem

When a `ScaledObject` is in steady state (triggers active, replica count unchanged, conditions unchanged), `RequestScale` unconditionally refreshes `result.LastActiveTime` to `time.Now()` on every polling cycle. This forces `handleResult`'s `equality.Semantic.DeepEqual(original, current)` check to always fail, writing a status patch on every polling interval (default every 30s) even when nothing else changed.

This creates constant etcd write pressure and watch churn for all active ScaledObjects.

### Fix

Throttle the `LastActiveTime` refresh in the steady-state (`default`) case of `RequestScale`: only set `result.LastActiveTime` when the current value is nil or older than `lastActiveTimeRefreshInterval` (1 minute). This reduces redundant status patches from every poll to at most once per minute while preserving the cooldown semantics (the 1-minute staleness is well within the default 5-minute cooldown period).

### Changes

- `pkg/scaling/executor/scale_scaledobjects.go`: Add `lastActiveTimeRefreshInterval` constant (1 minute). Modify the steady-state `default` case to check staleness before refreshing `LastActiveTime`.

Closes #7998