### PR TITLE
CI: Exclude mutable main references from digest pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -127,6 +127,18 @@
       pinDigests: false,
       groupName: "DevContainer",
     },
+
+    // Internal main references deliberately follow the latest KEDA build.
+    {
+      matchPackageNames: [
+        "kedacore/keda",
+        "ghcr.io/kedacore/keda",
+        "ghcr.io/kedacore/keda-admission-webhooks",
+        "ghcr.io/kedacore/keda-metrics-apiserver",
+      ],
+      matchCurrentValue: "main",
+      pinDigests: false,
+    },
   ],
   customManagers: [
     // Versions in Go source files annotated with // renovate: comments.


### PR DESCRIPTION
Exclude mutable internal `main` references from Renovate digest pinning.

The matching reusable workflows and Kustomize images are intended to follow the latest KEDA build; adding a commit SHA or image digest freezes that behavior and produces update churn on every main commit. Versioned external images and versioned `keda-tools` images remain eligible for digest pinning.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #

Relates to #8043