### PR TITLE
Test: Fix e2e races in cron, disruption and validation tests

### DIFF
--- a/tests/internals/scaled_job_validation/scaled_job_validation_test.go
+++ b/tests/internals/scaled_job_validation/scaled_job_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
 )
@@ -126,7 +127,7 @@ func testTriggersWithEmptyArray(t *testing.T, data templateData) {
 	t.Log("--- triggers with empty array ---")
 
 	err := KubectlApplyWithErrors(t, data, "emptyTriggersSjTemplate", emptyTriggersSjTemplate)
-	assert.Errorf(t, err, "can deploy the scaledJob - %s", err)
+	require.Errorf(t, err, "can deploy the scaledJob - %s", err)
 	assert.Contains(t, err.Error(), "spec.triggers in body should have at least 1 items")
 }
 

--- a/tests/internals/scaled_object_validation/scaled_object_validation_test.go
+++ b/tests/internals/scaled_object_validation/scaled_object_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
 )
@@ -262,11 +263,11 @@ func testScaledWorkloadByOtherScaledObject(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
+	require.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
 
 	data.ScaledObjectName = scaledObject2Name
 	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the workload '%s' of type 'apps/v1.Deployment' is already managed by the ScaledObject '%s", deploymentName, scaledObject1Name))
 
 	data.ScaledObjectName = scaledObject1Name
@@ -280,12 +281,12 @@ func testManagedHpaByOtherScaledObject(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", customHpaScaledObjectTemplate)
-	assert.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
+	require.NoErrorf(t, err, "cannot deploy the scaledObject - %s", err)
 
 	data.ScaledObjectName = scaledObject2Name
 	data.DeploymentName = fmt.Sprintf("%s-other-deployment", testName)
 	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", customHpaScaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the HPA '%s' is already managed by the ScaledObject '%s", hpaName, scaledObject1Name))
 
 	data.ScaledObjectName = scaledObject1Name
@@ -297,11 +298,11 @@ func testScaledWorkloadByOtherHpa(t *testing.T, data templateData) {
 
 	data.HpaName = hpaName
 	err := KubectlApplyWithErrors(t, data, "hpaTemplate", hpaTemplate)
-	assert.NoErrorf(t, err, "cannot deploy the hpa - %s", err)
+	require.NoErrorf(t, err, "cannot deploy the hpa - %s", err)
 
 	data.ScaledObjectName = scaledObject1Name
 	err = KubectlApplyWithErrors(t, data, "scaledObjectTemplate", scaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the workload '%s' of type 'apps/v1.Deployment' is already managed by the hpa '%s", deploymentName, hpaName))
 
 	KubectlDeleteWithTemplate(t, data, "hpaTemplate", hpaTemplate)
@@ -327,7 +328,7 @@ func testMissingCPU(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", cpuScaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the scaledobject has a cpu trigger but the container %s doesn't have the cpu request defined", deploymentName))
 }
 
@@ -336,7 +337,7 @@ func testMissingMemory(t *testing.T, data templateData) {
 
 	data.ScaledObjectName = scaledObject1Name
 	err := KubectlApplyWithErrors(t, data, "scaledObjectTemplate", memoryScaledObjectTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("the scaledobject has a memory trigger but the container %s doesn't have the memory request defined", deploymentName))
 }
 
@@ -404,7 +405,7 @@ func testTriggersWithEmptyArray(t *testing.T, data templateData) {
 	t.Log("--- triggers with empty array ---")
 
 	err := KubectlApplyWithErrors(t, data, "emptyTriggersTemplate", emptyTriggersTemplate)
-	assert.Errorf(t, err, "can deploy the scaledObject - %s", err)
+	require.Errorf(t, err, "can deploy the scaledObject - %s", err)
 	assert.Contains(t, err.Error(), "spec.triggers in body should have at least 1 items")
 }
 

--- a/tests/scalers/cron/cron_test.go
+++ b/tests/scalers/cron/cron_test.go
@@ -24,9 +24,8 @@ var (
 	deploymentName   = fmt.Sprintf("%s-deployment", testName)
 	scaledObjectName = fmt.Sprintf("%s-so", testName)
 
-	now   = time.Now().Local()
-	start = (now.Minute() + 1) % 60
-	end   = (start + 1) % 60
+	start int
+	end   int
 )
 
 type templateData struct {
@@ -92,6 +91,12 @@ spec:
 func TestScaler(t *testing.T) {
 	// setup
 	t.Log("--- setting up ---")
+
+	// Compute the cron schedule just before creating resources so the
+	// trigger window does not expire during setup.
+	now := time.Now().Local()
+	start = (now.Minute() + 1) % 60
+	end = (start + 1) % 60
 
 	// Create kubernetes resources
 	kc := GetKubernetesClient(t)

--- a/tests/sequential/broken_scaledobject_tolerancy/broken_scaledobject_tolerancy_test.go
+++ b/tests/sequential/broken_scaledobject_tolerancy/broken_scaledobject_tolerancy_test.go
@@ -161,26 +161,26 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 2 replicas
 	replicas := 2
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 
 	// scale monitored deployment to 4 replicas
 	replicas = 4
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 }
 
 func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to 2 replicas
 	replicas := 2
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 
 	// scale monitored deployment to 0 replicas
 	replicas = 0
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
-	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 10, 6),
-		fmt.Sprintf("replica count should be %d after 1 minute", replicas))
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, replicas, 60, 5),
+		fmt.Sprintf("replica count should be %d after 5 minutes", replicas))
 }

--- a/tests/sequential/disruption/disruption_test.go
+++ b/tests/sequential/disruption/disruption_test.go
@@ -151,6 +151,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount - 2 replicas
 	replicas := maxReplicaCount - 2
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	var wg sync.WaitGroup
@@ -167,6 +169,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount - 1 replicas
 	replicas = maxReplicaCount - 1
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)
@@ -182,6 +186,8 @@ func testScaleOut(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to maxReplicaCount replicas
 	replicas = maxReplicaCount
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before metrics-server disruption")
 	saveLogs(t, kc, msLogName, msLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, msLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)
@@ -199,6 +205,8 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to minReplicaCount + 1 replicas
 	replicas := minReplicaCount + 1
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator/metrics-server disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	saveLogs(t, kc, msLogName, msLabelSelector, kedaNamespace)
@@ -217,6 +225,8 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
 	// scale monitored deployment to minReplicaCount replicas
 	replicas = minReplicaCount
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, int64(replicas), testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredDeploymentName, testNamespace, replicas, 60, 5),
+		"monitored deployment should be ready before operator disruption")
 	saveLogs(t, kc, operatorLogName, operatorLabelSelector, kedaNamespace)
 	DeletePodsInNamespaceBySelector(t, kc, operatorLabelSelector, kedaNamespace)
 	wg.Add(scaledObjectCount)


### PR DESCRIPTION
We're observing flaky E2E tests in our downstream OpenShift CI environment which I could basically completely fix by replacing fixed waits with actual waits for the desired state and a few cherry-picks of recent commits here.

I understand that this is not really a problem here in upstream but think the fixes are sensible and make also sense here as well.

Verified downstream in https://github.com/openshift/kedacore-keda/pull/64


### Changes

- **cron**: the trigger's start/end minute window was computed at package init, before any test setup ran. On a slow setup the window could already be closed by the time the test polled for it.
	- Compute it in TestScaler, right before the resources that use it are created.
- **disruption**: the test killed the KEDA operator/metrics-server pods right after scaling the monitored deployment, without waiting for the new pods to be running. KubernetesScaleDeployment only sets spec.replicas and returns immediately, so the operator could be killed before the pods it needs to observe on recovery exist yet.
	- Wait for the monitored deployment to reach the target replica count before each disruption.
- **broken_scaledobject_tolerancy**: the first reconcile of a broken ScaledObject competes with other reconciles for workers and can take longer than 60s.
	- Raise the scale wait to 300s (60x5), matching the budget already used at 26 other call sites of the same helper.

Also, this one isn't a timeout increase but a simple bug fix - due to the few line changes I'm including them here as well:
- **scaled_object_validation** / **scaled_job_validation**: a transient API error on an earlier setup step could leave err == nil where the test expected an error from a later step, and the next line unconditionally called err.Error(), panicking the test goroutine.
	- Use require instead of assert at those call sites so a failure stops the test cleanly instead of crashing the run.




### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Relates to #7991
