### PR TITLE
Prometheus Scaler: Add support for OAuth2 client credentials authentication

### DIFF
--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -91,7 +91,7 @@ var _ = Describe("ScaledObjectController", func() {
 						TriggerIndex:            i,
 					}
 
-					s, err := scalers.NewPrometheusScaler(config)
+					s, err := scalers.NewPrometheusScaler(context.Background(), config)
 					if err != nil {
 						Fail(err.Error())
 					}
@@ -99,7 +99,7 @@ var _ = Describe("ScaledObjectController", func() {
 					testScalers = append(testScalers, cache.ScalerBuilder{
 						Scaler: s,
 						Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
-							scaler, err := scalers.NewPrometheusScaler(config)
+							scaler, err := scalers.NewPrometheusScaler(context.Background(), config)
 							return scaler, config, err
 						},
 					})
@@ -142,7 +142,7 @@ var _ = Describe("ScaledObjectController", func() {
 					AuthParams:              nil,
 				}
 
-				s, err := scalers.NewPrometheusScaler(config)
+				s, err := scalers.NewPrometheusScaler(context.Background(), config)
 				if err != nil {
 					Fail(err.Error())
 				}
@@ -192,7 +192,7 @@ var _ = Describe("ScaledObjectController", func() {
 						AuthParams:              nil,
 					}
 
-					s, err := scalers.NewPrometheusScaler(config)
+					s, err := scalers.NewPrometheusScaler(context.Background(), config)
 					if err != nil {
 						Fail(err.Error())
 					}

--- a/pkg/scalers/authentication/authentication_helpers.go
+++ b/pkg/scalers/authentication/authentication_helpers.go
@@ -1,6 +1,7 @@
 package authentication
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -9,6 +10,8 @@ import (
 	libs "github.com/dysnix/predictkube-libs/external/configs"
 	"github.com/dysnix/predictkube-libs/external/http_transport"
 	pConfig "github.com/prometheus/common/config"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
@@ -22,7 +25,54 @@ type AuthClientSet struct {
 
 const (
 	AuthModesKey = "authModes"
+
+	// InsecureOAuthWarningMessage is emitted when OAuth is configured without a client secret and without mTLS,
+	// which leaves the client effectively unauthenticated.
+	InsecureOAuthWarningMessage = "OAuth is configured without clientSecret and without mTLS (RFC 8705). Add a clientSecret or enable mTLS to ensure secure authentication."
+
+	// unusedClientSecret satisfies Go's OAuth library, which requires a non-empty secret,
+	// for the mTLS client authentication flow (RFC 8705) that does not use one.
+	unusedClientSecret = "unused"
 )
+
+// InsecureOAuthWarning returns a warning message when OAuth is enabled without a client secret and without mTLS,
+// and an empty string otherwise.
+// Such a configuration is accepted so that mTLS client authentication (RFC 8705) can be terminated by a proxy,
+// but it cannot be distinguished from a missing secret, so callers should surface this.
+func (c *Config) InsecureOAuthWarning() string {
+	if c.EnabledOAuth() && c.ClientSecret == "" && !c.EnabledTLS() {
+		return InsecureOAuthWarningMessage
+	}
+	return ""
+}
+
+// OAuthTokenSource returns an [oauth2.TokenSource] that performs the client credentials
+// flow using the Config's OAuth settings.
+// The returned source caches the token and refreshes it only once it expires,
+// so it should be created once per scaler and reused across requests rather than rebuilt per request.
+//
+// tokenClient is used for the requests to the token endpoint, so that they share the scaler's timeout and TLS settings.
+// It must not be a client whose transport is wrapped by the returned token source, as token requests would then recurse back into it.
+func (c *Config) OAuthTokenSource(ctx context.Context, tokenClient *http.Client) oauth2.TokenSource {
+	clientSecret := c.ClientSecret
+	if clientSecret == "" {
+		clientSecret = unusedClientSecret
+	}
+
+	cfg := clientcredentials.Config{
+		ClientID:       c.ClientID,
+		ClientSecret:   clientSecret,
+		TokenURL:       c.OauthTokenURI,
+		Scopes:         c.Scopes,
+		EndpointParams: c.EndpointParams,
+	}
+
+	if tokenClient != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, tokenClient)
+	}
+
+	return cfg.TokenSource(ctx)
+}
 
 // CreateHTTPRoundTripper builds an http.RoundTripper using the auth settings from the given Config (TLS, basic, bearer).
 func CreateHTTPRoundTripper(roundTripperType TransportType, auth *Config, conf ...*HTTPTransport) (rt http.RoundTripper, err error) {

--- a/pkg/scalers/authentication/authentication_helpers.go
+++ b/pkg/scalers/authentication/authentication_helpers.go
@@ -29,10 +29,6 @@ const (
 	// InsecureOAuthWarningMessage is emitted when OAuth is configured without a client secret and without mTLS,
 	// which leaves the client effectively unauthenticated.
 	InsecureOAuthWarningMessage = "OAuth is configured without clientSecret and without mTLS (RFC 8705). Add a clientSecret or enable mTLS to ensure secure authentication."
-
-	// unusedClientSecret satisfies Go's OAuth library, which requires a non-empty secret,
-	// for the mTLS client authentication flow (RFC 8705) that does not use one.
-	unusedClientSecret = "unused"
 )
 
 // InsecureOAuthWarning returns a warning message when OAuth is enabled without a client secret and without mTLS,
@@ -54,17 +50,16 @@ func (c *Config) InsecureOAuthWarning() string {
 // tokenClient is used for the requests to the token endpoint, so that they share the scaler's timeout and TLS settings.
 // It must not be a client whose transport is wrapped by the returned token source, as token requests would then recurse back into it.
 func (c *Config) OAuthTokenSource(ctx context.Context, tokenClient *http.Client) oauth2.TokenSource {
-	clientSecret := c.ClientSecret
-	if clientSecret == "" {
-		clientSecret = unusedClientSecret
-	}
-
 	cfg := clientcredentials.Config{
 		ClientID:       c.ClientID,
-		ClientSecret:   clientSecret,
+		ClientSecret:   c.ClientSecret,
 		TokenURL:       c.OauthTokenURI,
 		Scopes:         c.Scopes,
 		EndpointParams: c.EndpointParams,
+	}
+
+	if c.ClientSecret == "" {
+		cfg.AuthStyle = oauth2.AuthStyleInParams
 	}
 
 	if tokenClient != nil {

--- a/pkg/scalers/authentication/authentication_helpers_test.go
+++ b/pkg/scalers/authentication/authentication_helpers_test.go
@@ -1,0 +1,174 @@
+package authentication
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestInsecureOAuthWarning(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      *Config
+		wantWarning bool
+	}{
+		{
+			name:        "oauth with client secret",
+			config:      &Config{Modes: []Type{OAuthType}, OAuth: OAuth{ClientSecret: "secret"}},
+			wantWarning: false,
+		},
+		{
+			name:        "oauth without client secret but with mTLS",
+			config:      &Config{Modes: []Type{OAuthType, TLSAuthType}},
+			wantWarning: false,
+		},
+		{
+			name:        "oauth without client secret and without mTLS",
+			config:      &Config{Modes: []Type{OAuthType}},
+			wantWarning: true,
+		},
+		{
+			name:        "oauth not enabled",
+			config:      &Config{Modes: []Type{BearerAuthType}},
+			wantWarning: false,
+		},
+		{
+			// Scalers embed the Config as an optional pointer, so it may be nil.
+			name:        "no auth config at all",
+			config:      nil,
+			wantWarning: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := test.config.InsecureOAuthWarning()
+			if test.wantWarning {
+				assert.Equal(t, InsecureOAuthWarningMessage, msg)
+			} else {
+				assert.Empty(t, msg)
+			}
+		})
+	}
+}
+
+// newTokenServer returns a token endpoint handing out client credentials tokens,
+// the number of requests it has served and the form values of the most recent request.
+func newTokenServer(t *testing.T) (*httptest.Server, *atomic.Int64, *url.Values) {
+	t.Helper()
+
+	var requests atomic.Int64
+	lastForm := &url.Values{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if !assert.NoError(t, r.ParseForm()) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		*lastForm = r.Form
+		if username, password, ok := r.BasicAuth(); ok {
+			lastForm.Set("client_id", username)
+			lastForm.Set("client_secret", password)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		// expires_in keeps the token valid for the duration of the test,
+		// so that a second request to the endpoint can only come from a cache miss.
+		_, err := w.Write([]byte(`{"access_token":"fake_token","token_type":"Bearer","expires_in":3600}`))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &requests, lastForm
+}
+
+func TestOAuthTokenSource(t *testing.T) {
+	t.Parallel()
+
+	server, requests, lastForm := newTokenServer(t)
+
+	config := &Config{
+		Modes: []Type{OAuthType},
+		OAuth: OAuth{
+			OauthTokenURI:  server.URL,
+			ClientID:       "my-client",
+			ClientSecret:   "my-secret",
+			Scopes:         []string{"scope-a", "scope-b"},
+			EndpointParams: url.Values{"audience": []string{"my-audience"}},
+		},
+	}
+
+	tokenSource := config.OAuthTokenSource(t.Context(), server.Client())
+
+	token, err := tokenSource.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "fake_token", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+
+	assert.Equal(t, "client_credentials", lastForm.Get("grant_type"))
+	assert.Equal(t, "my-client", lastForm.Get("client_id"))
+	assert.Equal(t, "my-secret", lastForm.Get("client_secret"))
+	assert.Equal(t, "scope-a scope-b", lastForm.Get("scope"))
+	assert.Equal(t, "my-audience", lastForm.Get("audience"))
+	assert.Equal(t, int64(1), requests.Load())
+
+	// A cached, unexpired token must not trigger another request to the token endpoint.
+	_, err = tokenSource.Token()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), requests.Load(), "token should be cached until it expires")
+}
+
+func TestOAuthTokenSourceWithoutClientSecret(t *testing.T) {
+	server, _, lastForm := newTokenServer(t)
+
+	config := &Config{
+		Modes: []Type{OAuthType, TLSAuthType},
+		OAuth: OAuth{
+			OauthTokenURI: server.URL,
+			ClientID:      "my-client",
+		},
+	}
+
+	_, err := config.OAuthTokenSource(t.Context(), server.Client()).Token()
+	require.NoError(t, err)
+
+	// mTLS client authentication (RFC 8705) carries no secret,
+	// but Go's OAuth library requires a non-empty one, so a placeholder is sent instead.
+	assert.Equal(t, "my-client", lastForm.Get("client_id"))
+	assert.Equal(t, unusedClientSecret, lastForm.Get("client_secret"))
+}
+
+func TestOAuthTokenSourceUsesGivenClient(t *testing.T) {
+	t.Parallel()
+
+	server, requests, _ := newTokenServer(t)
+
+	config := &Config{
+		Modes: []Type{OAuthType},
+		OAuth: OAuth{OauthTokenURI: server.URL, ClientID: "my-client", ClientSecret: "my-secret"},
+	}
+
+	// A client whose transport always fails proves the token request is routed through the client passed in,
+	// rather than through http.DefaultClient.
+	failing := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, assert.AnError
+	})}
+
+	_, err := config.OAuthTokenSource(t.Context(), failing).Token()
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, int64(0), requests.Load())
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/pkg/scalers/authentication/authentication_helpers_test.go
+++ b/pkg/scalers/authentication/authentication_helpers_test.go
@@ -61,13 +61,22 @@ func TestInsecureOAuthWarning(t *testing.T) {
 	}
 }
 
+// tokenRequest records what the token endpoint received on its most recent request.
+type tokenRequest struct {
+	// form holds the request's form values, with any credentials from the Authorization header folded in,
+	// so that assertions on client_id and client_secret hold for both OAuth auth styles.
+	form url.Values
+	// authorization is the raw Authorization header, empty when the request carried none.
+	authorization string
+}
+
 // newTokenServer returns a token endpoint handing out client credentials tokens,
-// the number of requests it has served and the form values of the most recent request.
-func newTokenServer(t *testing.T) (*httptest.Server, *atomic.Int64, *url.Values) {
+// the number of requests it has served and the most recent request it received.
+func newTokenServer(t *testing.T) (*httptest.Server, *atomic.Int64, *tokenRequest) {
 	t.Helper()
 
 	var requests atomic.Int64
-	lastForm := &url.Values{}
+	last := &tokenRequest{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests.Add(1)
@@ -75,10 +84,10 @@ func newTokenServer(t *testing.T) (*httptest.Server, *atomic.Int64, *url.Values)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		*lastForm = r.Form
+		*last = tokenRequest{form: r.Form, authorization: r.Header.Get("Authorization")}
 		if username, password, ok := r.BasicAuth(); ok {
-			lastForm.Set("client_id", username)
-			lastForm.Set("client_secret", password)
+			last.form.Set("client_id", username)
+			last.form.Set("client_secret", password)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -89,13 +98,13 @@ func newTokenServer(t *testing.T) (*httptest.Server, *atomic.Int64, *url.Values)
 	}))
 	t.Cleanup(server.Close)
 
-	return server, &requests, lastForm
+	return server, &requests, last
 }
 
 func TestOAuthTokenSource(t *testing.T) {
 	t.Parallel()
 
-	server, requests, lastForm := newTokenServer(t)
+	server, requests, last := newTokenServer(t)
 
 	config := &Config{
 		Modes: []Type{OAuthType},
@@ -115,11 +124,11 @@ func TestOAuthTokenSource(t *testing.T) {
 	assert.Equal(t, "fake_token", token.AccessToken)
 	assert.Equal(t, "Bearer", token.TokenType)
 
-	assert.Equal(t, "client_credentials", lastForm.Get("grant_type"))
-	assert.Equal(t, "my-client", lastForm.Get("client_id"))
-	assert.Equal(t, "my-secret", lastForm.Get("client_secret"))
-	assert.Equal(t, "scope-a scope-b", lastForm.Get("scope"))
-	assert.Equal(t, "my-audience", lastForm.Get("audience"))
+	assert.Equal(t, "client_credentials", last.form.Get("grant_type"))
+	assert.Equal(t, "my-client", last.form.Get("client_id"))
+	assert.Equal(t, "my-secret", last.form.Get("client_secret"))
+	assert.Equal(t, "scope-a scope-b", last.form.Get("scope"))
+	assert.Equal(t, "my-audience", last.form.Get("audience"))
 	assert.Equal(t, int64(1), requests.Load())
 
 	// A cached, unexpired token must not trigger another request to the token endpoint.
@@ -129,7 +138,7 @@ func TestOAuthTokenSource(t *testing.T) {
 }
 
 func TestOAuthTokenSourceWithoutClientSecret(t *testing.T) {
-	server, _, lastForm := newTokenServer(t)
+	server, _, last := newTokenServer(t)
 
 	config := &Config{
 		Modes: []Type{OAuthType, TLSAuthType},
@@ -142,10 +151,12 @@ func TestOAuthTokenSourceWithoutClientSecret(t *testing.T) {
 	_, err := config.OAuthTokenSource(t.Context(), server.Client()).Token()
 	require.NoError(t, err)
 
-	// mTLS client authentication (RFC 8705) carries no secret,
-	// but Go's OAuth library requires a non-empty one, so a placeholder is sent instead.
-	assert.Equal(t, "my-client", lastForm.Get("client_id"))
-	assert.Equal(t, unusedClientSecret, lastForm.Get("client_secret"))
+	// mTLS client authentication (RFC 8705) identifies the client by its certificate,
+	// so the token request must carry the client ID but no second client authentication method:
+	// neither a client_secret parameter nor an Authorization header.
+	assert.Equal(t, "my-client", last.form.Get("client_id"))
+	assert.Empty(t, last.form.Get("client_secret"))
+	assert.Empty(t, last.authorization)
 }
 
 func TestOAuthTokenSourceUsesGivenClient(t *testing.T) {

--- a/pkg/scalers/prometheus_scaler.go
+++ b/pkg/scalers/prometheus_scaler.go
@@ -13,10 +13,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"golang.org/x/oauth2"
 	v2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/kedacore/keda/v2/pkg/eventreason"
 	"github.com/kedacore/keda/v2/pkg/metricscollector"
 	"github.com/kedacore/keda/v2/pkg/scalers/authentication"
 	"github.com/kedacore/keda/v2/pkg/scalers/aws"
@@ -73,7 +76,7 @@ type promQueryResult struct {
 }
 
 // NewPrometheusScaler creates a new prometheusScaler
-func NewPrometheusScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
+func NewPrometheusScaler(ctx context.Context, config *scalersconfig.ScalerConfig) (Scaler, error) {
 	metricType, err := GetMetricTargetType(config)
 	if err != nil {
 		return nil, fmt.Errorf("error getting scaler metric type: %w", err)
@@ -106,6 +109,22 @@ func NewPrometheusScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 				return nil, err
 			}
 			httpClient.Transport = transport
+		}
+
+		if meta.PrometheusAuth.EnabledOAuth() {
+			if msg := meta.PrometheusAuth.InsecureOAuthWarning(); msg != "" {
+				logger.Info(msg)
+				if config.Recorder != nil {
+					config.Recorder.Eventf(config.ScaledObject, nil, corev1.EventTypeWarning, eventreason.KEDAScalersInfo, eventreason.KEDAScalersInfo, "%s", msg)
+				}
+			}
+
+			baseTransport := httpClient.Transport
+			tokenSource := meta.PrometheusAuth.OAuthTokenSource(ctx, &http.Client{
+				Timeout:   httpClientTimeout,
+				Transport: baseTransport,
+			})
+			httpClient.Transport = &oauth2.Transport{Source: tokenSource, Base: baseTransport}
 		}
 	} else {
 		// could be the case of azure managed prometheus. Try and get the round-tripper.

--- a/pkg/scalers/prometheus_scaler_test.go
+++ b/pkg/scalers/prometheus_scaler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"golang.org/x/oauth2"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -115,6 +117,20 @@ var testPrometheusAuthMetadata = []prometheusAuthMetadataTestData{
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "custom"}, map[string]string{"customAuthHeader": "header\n", "customAuthValue": "value\n"}, "", false},
 
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "tls,basic"}, map[string]string{"username": "user", "password": "pass"}, "", true},
+	// success oauth
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "oauth"}, map[string]string{"oauthTokenURI": "http://localhost:8080/token", "clientID": "client", "clientSecret": "secret"}, "", false},
+	// success oauth with scopes and endpointParams
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "oauth"}, map[string]string{"oauthTokenURI": "http://localhost:8080/token", "clientID": "client", "clientSecret": "secret", "scopes": "scope-a,scope-b", "endpointParams": "audience=aud"}, "", false},
+	// success oauth without clientSecret, mTLS client authentication (RFC 8705) does not use one
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "oauth,tls"}, map[string]string{"oauthTokenURI": "http://localhost:8080/token", "clientID": "client", "cert": "ceert", "key": "keey"}, "", false},
+	// fail oauth with no oauthTokenURI
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "oauth"}, map[string]string{"clientID": "client", "clientSecret": "secret"}, "", true},
+	// fail oauth with no clientID
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "oauth"}, map[string]string{"oauthTokenURI": "http://localhost:8080/token", "clientSecret": "secret"}, "", true},
+	// fail oauth combined with bearer, they are mutually exclusive
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "oauth,bearer"}, map[string]string{"oauthTokenURI": "http://localhost:8080/token", "clientID": "client", "clientSecret": "secret", "bearerToken": "tooooken"}, "", true},
+	// fail oauth combined with basic, they are mutually exclusive
+	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "oauth,basic"}, map[string]string{"oauthTokenURI": "http://localhost:8080/token", "clientID": "client", "clientSecret": "secret", "username": "user", "password": "pass"}, "", true},
 	// pod identity and other auth modes enabled together
 	{map[string]string{"serverAddress": "http://localhost:9090", "metricName": "http_requests_total", "threshold": "100", "query": "up", "authModes": "basic"}, map[string]string{"username": "user", "password": "pass"}, "azure-workload", true},
 	// azure workload identity
@@ -170,7 +186,8 @@ func TestPrometheusScalerAuthParams(t *testing.T) {
 				if (meta.PrometheusAuth.EnabledBearerAuth() && !strings.Contains(testData.metadata["authModes"], "bearer")) ||
 					(meta.PrometheusAuth.EnabledBasicAuth() && !strings.Contains(testData.metadata["authModes"], "basic")) ||
 					(meta.PrometheusAuth.EnabledTLS() && !strings.Contains(testData.metadata["authModes"], "tls")) ||
-					(meta.PrometheusAuth.EnabledCustomAuth() && !strings.Contains(testData.metadata["authModes"], "custom")) {
+					(meta.PrometheusAuth.EnabledCustomAuth() && !strings.Contains(testData.metadata["authModes"], "custom")) ||
+					(meta.PrometheusAuth.EnabledOAuth() && !strings.Contains(testData.metadata["authModes"], "oauth")) {
 					t.Error("wrong auth mode detected")
 				}
 			}
@@ -443,6 +460,88 @@ func TestPrometheusScalerExecutePromQueryParameters(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestPrometheusScaler_ExecutePromQuery_WithOAuth(t *testing.T) {
+	t.Parallel()
+
+	var tokenRequests atomic.Int64
+	tokenForm := &url.Values{}
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequests.Add(1)
+		require.NoError(t, r.ParseForm())
+		*tokenForm = r.Form
+		if username, password, ok := r.BasicAuth(); ok {
+			tokenForm.Set("client_id", username)
+			tokenForm.Set("client_secret", password)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"access_token":"fake_access_token","token_type":"Bearer","expires_in":3600}`))
+		assert.NoError(t, err)
+	}))
+	defer tokenServer.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !assert.Equal(t, "Bearer fake_access_token", r.Header.Get("Authorization")) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "vector",
+				"result": []map[string]any{
+					{"metric": map[string]string{}, "value": []any{1686063687, "42"}},
+				},
+			},
+		}))
+	}))
+	defer server.Close()
+
+	config := &scalersconfig.ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"serverAddress": server.URL,
+			"query":         "up",
+			"threshold":     "100",
+			"authModes":     "oauth",
+		},
+		AuthParams: map[string]string{
+			"oauthTokenURI":  tokenServer.URL,
+			"clientID":       "my-client",
+			"clientSecret":   "my-secret",
+			"scopes":         "scope-a,scope-b",
+			"endpointParams": "audience=my-audience",
+		},
+	}
+
+	scaler, err := NewPrometheusScaler(t.Context(), config)
+	require.NoError(t, err)
+
+	s, ok := scaler.(*prometheusScaler)
+	require.True(t, ok, "Scaler must be a Prometheus Scaler")
+	_, ok = s.httpClient.Transport.(*oauth2.Transport)
+	require.True(t, ok, "HTTP transport must be OAuth2")
+
+	got, err := s.ExecutePromQuery(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, float64(42), got)
+
+	assert.Equal(t, "client_credentials", tokenForm.Get("grant_type"))
+	assert.Equal(t, "my-client", tokenForm.Get("client_id"))
+	assert.Equal(t, "my-secret", tokenForm.Get("client_secret"))
+	assert.Equal(t, "scope-a scope-b", tokenForm.Get("scope"))
+	assert.Equal(t, "my-audience", tokenForm.Get("audience"))
+	assert.Equal(t, int64(1), tokenRequests.Load())
+
+	// The token is acquired once and reused for subsequent queries,
+	// rather than being re-fetched on every polling interval.
+	got, err = s.ExecutePromQuery(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, float64(42), got)
+	assert.Equal(t, int64(1), tokenRequests.Load(), "token should be reused across queries")
+}
+
 func TestPrometheusScaler_ExecutePromQuery_WithGcpNativeAuthentication(t *testing.T) {
 	fakeGoogleOAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"token_type": "Bearer", "access_token": "fake_access_token"}`)
@@ -572,7 +671,7 @@ h+VRH7M7/22LuSxeKoQaRqeBRbvGup/oHGr9Ks/sVi0EQRUqwB45QLNiF1bi
 			require.NotNil(t, tt.config, "you must provide a config generator func")
 			config := tt.config(t, baseConfig)
 
-			scaler, err := NewPrometheusScaler(config)
+			scaler, err := NewPrometheusScaler(t.Context(), config)
 			require.NoError(t, err)
 
 			s, ok := scaler.(*prometheusScaler)

--- a/pkg/scalers/pulsar_scaler.go
+++ b/pkg/scalers/pulsar_scaler.go
@@ -151,8 +151,7 @@ func NewPulsarScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
 
 	client := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
 
-	if pulsarMetadata.PulsarAuth.EnabledOAuth() && pulsarMetadata.PulsarAuth.ClientSecret == "" && !pulsarMetadata.PulsarAuth.EnabledTLS() {
-		msg := "OAuth is configured without clientSecret and without mTLS (RFC 8705). Add a clientSecret or enable mTLS to ensure secure authentication."
+	if msg := pulsarMetadata.PulsarAuth.InsecureOAuthWarning(); msg != "" {
 		logger.Info(msg)
 		if config.Recorder != nil {
 			config.Recorder.Eventf(config.ScaledObject, nil, corev1.EventTypeWarning, eventreason.KEDAScalersInfo, eventreason.KEDAScalersInfo, "%s", msg)

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -247,7 +247,7 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 	case "predictkube":
 		return scalers.NewPredictKubeScaler(ctx, config)
 	case "prometheus":
-		return scalers.NewPrometheusScaler(config)
+		return scalers.NewPrometheusScaler(ctx, config)
 	case "pulsar":
 		return scalers.NewPulsarScaler(config)
 	case "rabbitmq":

--- a/tests/scalers/prometheus/prometheus_oauth/prometheus_oauth_test.go
+++ b/tests/scalers/prometheus/prometheus_oauth/prometheus_oauth_test.go
@@ -1,0 +1,523 @@
+//go:build e2e
+// +build e2e
+
+package prometheus_oauth_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/kedacore/keda/v2/tests/helper"
+	prometheus "github.com/kedacore/keda/v2/tests/scalers/prometheus"
+)
+
+// Load environment variables from .env file
+var _ = godotenv.Load("../../../.env")
+
+const (
+	testName = "prometheus-oauth-test"
+)
+
+var (
+	testNamespace        = fmt.Sprintf("%s-ns", testName)
+	deploymentName       = fmt.Sprintf("%s-deployment", testName)
+	monitoredAppName     = fmt.Sprintf("%s-monitored-app", testName)
+	scaledObjectName     = fmt.Sprintf("%s-so", testName)
+	prometheusServerName = fmt.Sprintf("%s-server", testName)
+	oauthProxyName       = fmt.Sprintf("%s-oauth-proxy", testName)
+	enforcementJobName   = fmt.Sprintf("%s-oauth-proxy-enforcement", testName)
+	triggerAuthName      = fmt.Sprintf("%s-ta", testName)
+	triggerSecretName    = fmt.Sprintf("%s-ta-secret", testName)
+	oauthClientID        = "keda-prometheus"
+	oauthClientSecret    = "keda-prometheus-secret"
+	oauthAccessToken     = "e2e-access-token"
+	minReplicaCount      = 0
+	maxReplicaCount      = 2
+)
+
+type templateData struct {
+	TestNamespace           string
+	DeploymentName          string
+	MonitoredAppName        string
+	ScaledObjectName        string
+	PrometheusServerName    string
+	OAuthProxyName          string
+	EnforcementJobName      string
+	TriggerAuthName         string
+	TriggerSecretName       string
+	OAuthClientID           string
+	Base64ClientSecret      string
+	Base64ClientCredentials string
+	OAuthAccessToken        string
+	MinReplicaCount         int
+	MaxReplicaCount         int
+}
+
+const (
+	// oauthProxyConfigMapTemplate serves two endpoints:
+	// 1. A token endpoint handing out a static access token to the expected client credentials.
+	// 2. A reverse proxy in front of Prometheus that only forwards requests carrying that access token.
+	//
+	// Together they verify that KEDA acquires a token with the configured credentials and presents it on the query request.
+	oauthProxyConfigMapTemplate = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.OAuthProxyName}}
+  namespace: {{.TestNamespace}}
+data:
+  default.conf: |
+    server {
+      listen 8080;
+
+      location = /healthz {
+        access_log off;
+        return 200;
+      }
+
+      location = /token {
+        if ($request_method != POST) {
+          return 405;
+        }
+        # Only the expected client credentials are issued a token, so a scaler that sends
+        # the wrong ones cannot reach Prometheus. Requiring them in the Authorization header
+        # also pins the client authentication style: golang.org/x/oauth2 prefers HTTP Basic
+        # (RFC 6749 2.3.1) and only falls back to credentials in the request body once a
+        # request has failed, so a fallback shows up as a failing test rather than passing
+        # unnoticed.
+        if ($http_authorization != "Basic {{.Base64ClientCredentials}}") {
+          return 401;
+        }
+        default_type application/json;
+        return 200 '{"access_token":"{{.OAuthAccessToken}}","token_type":"Bearer","expires_in":3600}';
+      }
+
+      location / {
+        if ($http_authorization != "Bearer {{.OAuthAccessToken}}") {
+          return 401;
+        }
+        proxy_pass http://{{.PrometheusServerName}}.{{.TestNamespace}}.svc;
+      }
+    }
+`
+
+	oauthProxyDeploymentTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{.OAuthProxyName}}
+  name: {{.OAuthProxyName}}
+  namespace: {{.TestNamespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.OAuthProxyName}}
+  template:
+    metadata:
+      labels:
+        app: {{.OAuthProxyName}}
+    spec:
+      containers:
+      - name: nginx
+        image: ghcr.io/nginx/nginx-unprivileged:1.26
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/conf.d
+          readOnly: true
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: {{.OAuthProxyName}}
+`
+
+	oauthProxyServiceTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{.OAuthProxyName}}
+  name: {{.OAuthProxyName}}
+  namespace: {{.TestNamespace}}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: {{.OAuthProxyName}}
+`
+
+	// oauthProxyEnforcementJobTemplate asserts that the proxy really is a gate before the scaler
+	// is pointed at it. Without this, a proxy that forwarded everything, or a token endpoint that
+	// issued tokens to anyone, would let the scaling assertions pass without any authentication
+	// taking place. It also confirms the proxy is serving, so that the scaler's first poll is not
+	// racing the proxy becoming reachable.
+	oauthProxyEnforcementJobTemplate = `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.EnforcementJobName}}
+  namespace: {{.TestNamespace}}
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      containers:
+      - name: curl
+        image: docker.io/curlimages/curl
+        command:
+        - sh
+        - -e
+        - -c
+        - |
+          proxy="http://{{.OAuthProxyName}}.{{.TestNamespace}}.svc:8080"
+          query="$proxy/api/v1/query?query=up"
+
+          status() {
+            curl -s --max-time 10 -o /dev/null -w '%{http_code}' "$@"
+          }
+
+          # The token endpoint issues a token to the expected client credentials only.
+          test "$(status -X POST -H 'Authorization: Basic {{.Base64ClientCredentials}}' "$proxy/token")" = 200
+          test "$(status -X POST -H 'Authorization: Basic d3JvbmctY2xpZW50Ondyb25nLXNlY3JldA==' "$proxy/token")" = 401
+          test "$(status -X POST "$proxy/token")" = 401
+
+          # Prometheus is reachable with that access token only.
+          test "$(status -H 'Authorization: Bearer {{.OAuthAccessToken}}' "$query")" = 200
+          test "$(status -H 'Authorization: Bearer wrong-access-token' "$query")" = 401
+          test "$(status "$query")" = 401
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          # The image declares its user by name, which the kubelet cannot verify as non-root,
+          # so the uid behind that name is given explicitly.
+          runAsUser: 100
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      restartPolicy: Never
+`
+
+	triggerSecretTemplate = `apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.TriggerSecretName}}
+  namespace: {{.TestNamespace}}
+type: Opaque
+data:
+  clientSecret: {{.Base64ClientSecret}}
+`
+
+	triggerAuthTemplate = `apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{.TriggerAuthName}}
+  namespace: {{.TestNamespace}}
+spec:
+  oauth2:
+    type: clientCredentials
+    clientId: {{.OAuthClientID}}
+    clientSecret:
+      valueFrom:
+        secretKeyRef:
+          name: {{.TriggerSecretName}}
+          key: clientSecret
+    tokenUrl: http://{{.OAuthProxyName}}.{{.TestNamespace}}.svc:8080/token
+    scopes:
+    - {{.OAuthClientID}}
+`
+
+	deploymentTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-app
+  name: {{.DeploymentName}}
+  namespace: {{.TestNamespace}}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+        type: keda-testing
+    spec:
+      containers:
+      - name: prom-test-app
+        image: ghcr.io/kedacore/tests-prometheus:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+`
+
+	monitoredAppDeploymentTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{.MonitoredAppName}}
+  name: {{.MonitoredAppName}}
+  namespace: {{.TestNamespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.MonitoredAppName}}
+  template:
+    metadata:
+      labels:
+        app: {{.MonitoredAppName}}
+        type: {{.MonitoredAppName}}
+    spec:
+      containers:
+      - name: prom-test-app
+        image: ghcr.io/kedacore/tests-prometheus:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+`
+
+	monitoredAppServiceTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{.MonitoredAppName}}
+  name: {{.MonitoredAppName}}
+  namespace: {{.TestNamespace}}
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    type: {{.MonitoredAppName}}
+`
+
+	// The scaler reaches Prometheus through the token gated proxy, so scaling can only
+	// happen once the OAuth client credentials flow has succeeded.
+	scaledObjectTemplate = `apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  minReplicaCount: {{.MinReplicaCount}}
+  maxReplicaCount: {{.MaxReplicaCount}}
+  pollingInterval: 3
+  cooldownPeriod:  1
+  triggers:
+  - type: prometheus
+    metadata:
+      serverAddress: http://{{.OAuthProxyName}}.{{.TestNamespace}}.svc:8080
+      threshold: '20'
+      activationThreshold: '20'
+      query: sum(rate(http_requests_total{app="{{.MonitoredAppName}}"}[2m]))
+      authModes: "oauth"
+    authenticationRef:
+      name: {{.TriggerAuthName}}
+`
+
+	generateLowLevelLoadJobTemplate = `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-low-level-requests-job
+  namespace: {{.TestNamespace}}
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/kedacore/tests-hey
+        name: test
+        command: ["/bin/sh"]
+        args: ["-c", "for i in $(seq 1 60);do echo $i;/hey -c 5 -n 30 http://{{.MonitoredAppName}}.{{.TestNamespace}}.svc;sleep 1;done"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      restartPolicy: Never
+  activeDeadlineSeconds: 100
+  backoffLimit: 2
+`
+
+	generateLoadJobTemplate = `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: generate-requests-job
+  namespace: {{.TestNamespace}}
+spec:
+  template:
+    spec:
+      containers:
+      - image: ghcr.io/kedacore/tests-hey
+        name: test
+        command: ["/bin/sh"]
+        args: ["-c", "for i in $(seq 1 60);do echo $i;/hey -c 5 -n 80 http://{{.MonitoredAppName}}.{{.TestNamespace}}.svc;sleep 1;done"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      restartPolicy: Never
+  activeDeadlineSeconds: 100
+  backoffLimit: 2
+`
+)
+
+// TestPrometheusOAuthScaler verifies that the Prometheus scaler authenticates with an OAuth2 client credentials TriggerAuthentication.
+// Prometheus sits behind a proxy that rejects every request without a valid access token,
+// so the scaler can only observe the metric, and therefore only scale, when the token has been acquired and presented.
+func TestPrometheusOAuthScaler(t *testing.T) {
+	kc := GetKubernetesClient(t)
+	data, templates := getTemplateData()
+
+	t.Cleanup(func() {
+		prometheus.Uninstall(t, prometheusServerName, testNamespace, nil)
+		DeleteKubernetesResources(t, testNamespace, data, templates)
+	})
+
+	// Prometheus is installed first, so that its service can be resolved by the proxy.
+	prometheus.Install(t, kc, prometheusServerName, testNamespace, nil)
+
+	KubectlApplyMultipleWithTemplate(t, data, proxyTemplates())
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, oauthProxyName, testNamespace, 1, 60, 3),
+		"oauth proxy replica count should be 1 after 3 minutes")
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, monitoredAppName, testNamespace, 1, 60, 3),
+		"monitored app replica count should be 1 after 3 minutes")
+
+	t.Log("--- verifying oauth proxy enforcement ---")
+	KubectlApplyWithTemplate(t, data, "oauthProxyEnforcementJobTemplate", oauthProxyEnforcementJobTemplate)
+	require.True(t, WaitForJobSuccess(t, kc, enforcementJobName, testNamespace, 30, 5),
+		"oauth proxy should issue a token to the expected client credentials only, and gate Prometheus behind it")
+
+	// The scaler is created once the proxy is known to be serving,
+	// so that its first poll does not race the proxy becoming reachable.
+	KubectlApplyMultipleWithTemplate(t, data, scalerTemplates())
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", minReplicaCount)
+
+	testActivation(t, kc, data)
+	testScaleOut(t, kc, data)
+	testScaleIn(t, kc)
+}
+
+func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing activation ---")
+	KubectlReplaceWithTemplate(t, data, "generateLowLevelLoadJobTemplate", generateLowLevelLoadJobTemplate)
+
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, minReplicaCount, 60)
+}
+
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
+	KubectlReplaceWithTemplate(t, data, "generateLoadJobTemplate", generateLoadJobTemplate)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 60, 3),
+		"replica count should be %d after 3 minutes", maxReplicaCount)
+}
+
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing scale in ---")
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 60, 5),
+		"replica count should be %d after 5 minutes", minReplicaCount)
+}
+
+func getTemplateData() (templateData, []Template) {
+	return templateData{
+		TestNamespace:           testNamespace,
+		DeploymentName:          deploymentName,
+		MonitoredAppName:        monitoredAppName,
+		ScaledObjectName:        scaledObjectName,
+		PrometheusServerName:    prometheusServerName,
+		OAuthProxyName:          oauthProxyName,
+		EnforcementJobName:      enforcementJobName,
+		TriggerAuthName:         triggerAuthName,
+		TriggerSecretName:       triggerSecretName,
+		OAuthClientID:           oauthClientID,
+		Base64ClientSecret:      base64.StdEncoding.EncodeToString([]byte(oauthClientSecret)),
+		Base64ClientCredentials: basicClientCredentials(),
+		OAuthAccessToken:        oauthAccessToken,
+		MinReplicaCount:         minReplicaCount,
+		MaxReplicaCount:         maxReplicaCount,
+	}, append(proxyTemplates(), scalerTemplates()...)
+}
+
+// proxyTemplates are the token endpoint and the gated Prometheus, everything the scaler
+// authenticates against.
+func proxyTemplates() []Template {
+	return []Template{
+		{Name: "oauthProxyConfigMapTemplate", Config: oauthProxyConfigMapTemplate},
+		{Name: "oauthProxyDeploymentTemplate", Config: oauthProxyDeploymentTemplate},
+		{Name: "oauthProxyServiceTemplate", Config: oauthProxyServiceTemplate},
+		{Name: "monitoredAppDeploymentTemplate", Config: monitoredAppDeploymentTemplate},
+		{Name: "monitoredAppServiceTemplate", Config: monitoredAppServiceTemplate},
+	}
+}
+
+// scalerTemplates are the KEDA resources and their scale target,
+// applied only once the proxy they authenticate against is known to be enforcing.
+func scalerTemplates() []Template {
+	return []Template{
+		{Name: "triggerSecretTemplate", Config: triggerSecretTemplate},
+		{Name: "triggerAuthTemplate", Config: triggerAuthTemplate},
+		{Name: "deploymentTemplate", Config: deploymentTemplate},
+		{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
+	}
+}
+
+// basicClientCredentials is the credential the scaler is expected to present to the token
+// endpoint. golang.org/x/oauth2 URL encodes both halves before base64 encoding them, so the
+// expected value is derived the same way rather than hardcoded.
+func basicClientCredentials() string {
+	credentials := url.QueryEscape(oauthClientID) + ":" + url.QueryEscape(oauthClientSecret)
+	return base64.StdEncoding.EncodeToString([]byte(credentials))
+}


### PR DESCRIPTION
Add support for `authModes: oauth` to the Prometheus scaler, enabling
queries to be authenticated using OAuth2 client credentials from a
TriggerAuthentication.

This is mainly based on the RabbitMQ and Pulsar implementations.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] ~~When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)~~
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] ~~A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*~~
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to https://github.com/kedacore/keda-docs/pull/1843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OAuth 2.0 client-credentials authentication for Prometheus scalers.
  - Supports scopes, endpoint parameters, custom HTTP clients, token reuse, and mutual TLS without a client secret.
  - Prometheus scaling now uses OAuth bearer tokens for authenticated queries.

- **Bug Fixes**
  - Added warnings for insecure OAuth configurations without a client secret and TLS.

- **Tests**
  - Added coverage for OAuth authentication, token handling, authorization, and end-to-end scaling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->