### PR TITLE
Kafka: Add Azure Workload Identity SASL OAUTHBEARER support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Add optional `StreamMetricSpec` server-streaming RPC to external scaler gRPC proto, allowing external-push scalers to dynamically update HPA target values without modifying the ScaledObject ([#7793](https://github.com/kedacore/keda/issues/7793))
 - **General**: Introduce new ClickHouse Scaler ([#7418](https://github.com/kedacore/keda/issues/7418))
 - **General**: Introduce new GCP Spanner Scaler ([#7891](https://github.com/kedacore/keda/issues/7891))
+- **Kafka**: Support Azure AD Workload Identity as a SASL OAUTHBEARER token provider ([#5757](https://github.com/kedacore/keda/issues/5757))
 
 #### Experimental
 

--- a/pkg/scalers/kafka/kafka_scaler_oauth_token_provider.go
+++ b/pkg/scalers/kafka/kafka_scaler_oauth_token_provider.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/IBM/sarama"
 	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -105,4 +107,47 @@ func (m *mskTokenProvider) Token() (*sarama.AccessToken, error) {
 
 func (m *mskTokenProvider) String() string {
 	return "MSK"
+}
+
+type azureADWorkloadIdentityTokenProvider struct {
+	sync.Mutex
+	expireAt   *time.Time
+	token      string
+	credential azcore.TokenCredential
+	scopes     []string
+	extensions map[string]string
+}
+
+func OAuthAzureADWorkloadIdentityTokenProvider(credential azcore.TokenCredential, scopes []string, extensions map[string]string) TokenProvider {
+	return &azureADWorkloadIdentityTokenProvider{
+		credential: credential,
+		scopes:     scopes,
+		extensions: extensions,
+	}
+}
+
+func (a *azureADWorkloadIdentityTokenProvider) Token() (*sarama.AccessToken, error) {
+	a.Lock()
+	defer a.Unlock()
+
+	if a.expireAt != nil && time.Now().Before(*a.expireAt) {
+		return &sarama.AccessToken{Token: a.token, Extensions: a.extensions}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	token, err := a.credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: a.scopes})
+	if err != nil {
+		return nil, err
+	}
+
+	a.expireAt = &token.ExpiresOn
+	a.token = token.Token
+
+	return &sarama.AccessToken{Token: token.Token, Extensions: a.extensions}, nil
+}
+
+func (a *azureADWorkloadIdentityTokenProvider) String() string {
+	return "AzureADWorkloadIdentity"
 }

--- a/pkg/scalers/kafka/kafka_scaler_oauth_token_provider_test.go
+++ b/pkg/scalers/kafka/kafka_scaler_oauth_token_provider_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+type fakeTokenCredential struct {
+	calls int
+	token azcore.AccessToken
+	err   error
+}
+
+func (f *fakeTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	f.calls++
+	return f.token, f.err
+}
+
+func TestAzureADWorkloadIdentityTokenProviderReturnsToken(t *testing.T) {
+	cred := &fakeTokenCredential{token: azcore.AccessToken{Token: "test-token", ExpiresOn: time.Now().Add(time.Hour)}}
+	provider := OAuthAzureADWorkloadIdentityTokenProvider(cred, []string{"scope"}, map[string]string{"logicalCluster": "lkc-1"})
+
+	token, err := provider.Token()
+	if err != nil {
+		t.Fatal("Expected success but got error", err)
+	}
+	if token.Token != "test-token" {
+		t.Errorf("Expected token to be %v but got %v", "test-token", token.Token)
+	}
+	if token.Extensions["logicalCluster"] != "lkc-1" {
+		t.Errorf("Expected extensions to be carried through, got %v", token.Extensions)
+	}
+	if provider.String() != "AzureADWorkloadIdentity" {
+		t.Errorf("Expected provider name to be AzureADWorkloadIdentity but got %v", provider.String())
+	}
+}
+
+func TestAzureADWorkloadIdentityTokenProviderCachesUntilExpiry(t *testing.T) {
+	cred := &fakeTokenCredential{token: azcore.AccessToken{Token: "cached-token", ExpiresOn: time.Now().Add(time.Hour)}}
+	provider := OAuthAzureADWorkloadIdentityTokenProvider(cred, []string{"scope"}, nil)
+
+	if _, err := provider.Token(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Token(); err != nil {
+		t.Fatal(err)
+	}
+
+	if cred.calls != 1 {
+		t.Errorf("Expected credential to be called once due to caching but got %v calls", cred.calls)
+	}
+}
+
+func TestAzureADWorkloadIdentityTokenProviderRefreshesAfterExpiry(t *testing.T) {
+	cred := &fakeTokenCredential{token: azcore.AccessToken{Token: "expiring-token", ExpiresOn: time.Now().Add(-time.Minute)}}
+	provider := OAuthAzureADWorkloadIdentityTokenProvider(cred, []string{"scope"}, nil)
+
+	if _, err := provider.Token(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.Token(); err != nil {
+		t.Fatal(err)
+	}
+
+	if cred.calls != 2 {
+		t.Errorf("Expected credential to be called twice since the cached token was already expired, got %v calls", cred.calls)
+	}
+}
+
+func TestAzureADWorkloadIdentityTokenProviderPropagatesError(t *testing.T) {
+	cred := &fakeTokenCredential{err: errors.New("boom")}
+	provider := OAuthAzureADWorkloadIdentityTokenProvider(cred, []string{"scope"}, nil)
+
+	if _, err := provider.Token(); err == nil {
+		t.Fatal("Expected error but got success")
+	}
+}

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -35,7 +35,9 @@ import (
 	v2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/metrics/pkg/apis/external_metrics"
 
+	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	awsutils "github.com/kedacore/keda/v2/pkg/scalers/aws"
+	"github.com/kedacore/keda/v2/pkg/scalers/azure"
 	"github.com/kedacore/keda/v2/pkg/scalers/kafka"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 	kedautil "github.com/kedacore/keda/v2/pkg/util"
@@ -87,7 +89,7 @@ type kafkaMetadata struct {
 	Username string `keda:"name=username,order=authParams,optional"`
 	Password string `keda:"name=password,order=authParams,optional"`
 
-	SaslTokenProvider     string `keda:"name=saslTokenProvider,order=triggerMetadata;authParams,optional,enum=bearer;aws_msk_iam"`
+	SaslTokenProvider     string `keda:"name=saslTokenProvider,order=triggerMetadata;authParams,optional,enum=bearer;aws_msk_iam;azure_workload_identity"`
 	ScopesStr             string `keda:"name=scopes,order=authParams,optional"`
 	OAuthTokenEndpointURI string `keda:"name=oauthTokenEndpointUri,order=authParams,optional"`
 	OAuthExtensionsStr    string `keda:"name=oauthExtensions,order=authParams,optional"`
@@ -107,6 +109,7 @@ type kafkaMetadata struct {
 	keytabPath         string
 	kerberosConfigPath string
 	awsAuthorization   awsutils.AuthorizationMetadata
+	podIdentity        v1alpha1.AuthPodIdentity
 	scopes             []string
 	oauthExtensions    map[string]string
 
@@ -259,16 +262,8 @@ func (m *kafkaMetadata) parseOAuthParams() error {
 		if m.OAuthTokenEndpointURI == "" {
 			return errors.New("no oauth token endpoint uri given")
 		}
-		m.scopes = strings.Split(m.ScopesStr, ",")
-		m.oauthExtensions = make(map[string]string)
-		if m.OAuthExtensionsStr != "" {
-			for ext := range strings.SplitSeq(m.OAuthExtensionsStr, ",") {
-				kv := strings.Split(ext, "=")
-				if len(kv) != 2 {
-					return errors.New("invalid OAuthBearer extension, must be of format key=value")
-				}
-				m.oauthExtensions[kv[0]] = kv[1]
-			}
+		if err := m.parseScopesAndExtensions(); err != nil {
+			return err
 		}
 
 	case KafkaSASLOAuthTokenProviderAWSMSKIAM:
@@ -278,9 +273,29 @@ func (m *kafkaMetadata) parseOAuthParams() error {
 		if m.AWSRegion == "" {
 			return errors.New("no awsRegion given")
 		}
+
+	case KafkaSASLOAuthTokenProviderAzureWorkloadIdentity:
+		if err := m.parseScopesAndExtensions(); err != nil {
+			return err
+		}
 	}
 
 	m.tokenProvider = tokenProvider
+	return nil
+}
+
+func (m *kafkaMetadata) parseScopesAndExtensions() error {
+	m.scopes = strings.Split(m.ScopesStr, ",")
+	m.oauthExtensions = make(map[string]string)
+	if m.OAuthExtensionsStr != "" {
+		for ext := range strings.SplitSeq(m.OAuthExtensionsStr, ",") {
+			kv := strings.Split(ext, "=")
+			if len(kv) != 2 {
+				return errors.New("invalid OAuthBearer extension, must be of format key=value")
+			}
+			m.oauthExtensions[kv[0]] = kv[1]
+		}
+	}
 	return nil
 }
 
@@ -323,8 +338,9 @@ type kafkaSaslOAuthTokenProvider string
 
 // supported SASL OAuth token provider types
 const (
-	KafkaSASLOAuthTokenProviderBearer    kafkaSaslOAuthTokenProvider = "bearer"
-	KafkaSASLOAuthTokenProviderAWSMSKIAM kafkaSaslOAuthTokenProvider = "aws_msk_iam"
+	KafkaSASLOAuthTokenProviderBearer                kafkaSaslOAuthTokenProvider = "bearer"
+	KafkaSASLOAuthTokenProviderAWSMSKIAM             kafkaSaslOAuthTokenProvider = "aws_msk_iam"
+	KafkaSASLOAuthTokenProviderAzureWorkloadIdentity kafkaSaslOAuthTokenProvider = "azure_workload_identity"
 )
 
 const (
@@ -351,7 +367,7 @@ func NewKafkaScaler(ctx context.Context, config *scalersconfig.ScalerConfig) (Sc
 		return nil, fmt.Errorf("error parsing kafka metadata: %w", err)
 	}
 
-	client, admin, err := getKafkaClients(ctx, kafkaMetadata)
+	client, admin, err := getKafkaClients(ctx, kafkaMetadata, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -411,6 +427,14 @@ func parseKafkaMetadata(config *scalersconfig.ScalerConfig, logger logr.Logger) 
 		meta.awsAuthorization = auth
 	}
 
+	if meta.saslType == KafkaSASLTypeOAuthbearer && meta.tokenProvider == KafkaSASLOAuthTokenProviderAzureWorkloadIdentity {
+		if config.PodIdentity.Provider != v1alpha1.PodIdentityProviderAzureWorkload {
+			return meta, fmt.Errorf("pod identity provider %q is required when using the %q SASL OAuth token provider, got %q",
+				v1alpha1.PodIdentityProviderAzureWorkload, KafkaSASLOAuthTokenProviderAzureWorkloadIdentity, config.PodIdentity.Provider)
+		}
+		meta.podIdentity = config.PodIdentity
+	}
+
 	meta.triggerIndex = config.TriggerIndex
 	return meta, nil
 }
@@ -439,8 +463,8 @@ func saveToFile(content string) (string, error) {
 	return tempFile.Name(), nil
 }
 
-func getKafkaClients(ctx context.Context, metadata kafkaMetadata) (sarama.Client, sarama.ClusterAdmin, error) {
-	config, err := getKafkaClientConfig(ctx, metadata)
+func getKafkaClients(ctx context.Context, metadata kafkaMetadata, logger logr.Logger) (sarama.Client, sarama.ClusterAdmin, error) {
+	config, err := getKafkaClientConfig(ctx, metadata, logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting kafka client config: %w", err)
 	}
@@ -470,7 +494,7 @@ func getKafkaClients(ctx context.Context, metadata kafkaMetadata) (sarama.Client
 	return client, admin, nil
 }
 
-func getKafkaClientConfig(ctx context.Context, metadata kafkaMetadata) (*sarama.Config, error) {
+func getKafkaClientConfig(ctx context.Context, metadata kafkaMetadata, logger logr.Logger) (*sarama.Config, error) {
 	config := sarama.NewConfig()
 	config.Version = metadata.version
 	config.Metadata.Full = metadata.FullMetadata
@@ -522,6 +546,12 @@ func getKafkaClientConfig(ctx context.Context, metadata kafkaMetadata) (*sarama.
 				return nil, fmt.Errorf("error getting AWS config: %w", err)
 			}
 			config.Net.SASL.TokenProvider = kafka.OAuthMSKTokenProvider(awsAuth)
+		case KafkaSASLOAuthTokenProviderAzureWorkloadIdentity:
+			cred, err := azure.NewChainedCredential(logger, metadata.podIdentity)
+			if err != nil {
+				return nil, fmt.Errorf("error getting Azure credential: %w", err)
+			}
+			config.Net.SASL.TokenProvider = kafka.OAuthAzureADWorkloadIdentityTokenProvider(cred, metadata.scopes, metadata.oauthExtensions)
 		}
 	}
 

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/IBM/sarama"
 	"github.com/go-logr/logr"
 
+	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kafka_oauth "github.com/kedacore/keda/v2/pkg/scalers/kafka"
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
@@ -358,6 +360,8 @@ var parseKafkaOAuthbearerAuthParamsTestDataset = []parseKafkaOAuthbearerAuthPara
 	{map[string]string{}, map[string]string{"sasl": "oauthbearer", "saslTokenProvider": "aws_msk_iam", "tls": "enable", "awsRegion": ""}, true, true},
 	// failure, SASL OAUTHBEARER MSK + TLS + no credentials
 	{map[string]string{}, map[string]string{"sasl": "oauthbearer", "saslTokenProvider": "aws_msk_iam", "tls": "enable", "awsRegion": "eu-west-1"}, true, true},
+	// failure, SASL OAUTHBEARER + TLS bad saslTokenProvider type
+	{map[string]string{}, map[string]string{"sasl": "oauthbearer", "saslTokenProvider": "foo", "username": "admin", "password": "admin", "scopes": "scope", "oauthTokenEndpointUri": "https://website.com", "tls": "disable"}, true, false},
 }
 
 var kafkaMetricIdentifiers = []kafkaMetricIdentifier{
@@ -607,7 +611,7 @@ func TestKafkaClientsOAuthTokenProvider(t *testing.T) {
 				t.Fatal("Could not parse metadata:", err)
 			}
 
-			cfg, err := getKafkaClientConfig(context.TODO(), meta)
+			cfg, err := getKafkaClientConfig(context.TODO(), meta, logr.Discard())
 			if err != nil {
 				t.Error("Expected success but got error", err)
 			}
@@ -623,6 +627,72 @@ func TestKafkaClientsOAuthTokenProvider(t *testing.T) {
 
 			if tokenProvider.String() != tt.expectedTokenProvider {
 				t.Errorf("Expected token provider to be %v but got %v", tt.expectedTokenProvider, tokenProvider.String())
+			}
+		})
+	}
+}
+
+func TestKafkaClientsOAuthTokenProviderAzureWorkloadIdentity(t *testing.T) {
+	tokenFile := filepath.Join(t.TempDir(), "azure-federated-token")
+	if err := os.WriteFile(tokenFile, []byte("dummy-federated-token"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AZURE_TENANT_ID", "11111111-1111-1111-1111-111111111111")
+	t.Setenv("AZURE_CLIENT_ID", "22222222-2222-2222-2222-222222222222")
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", tokenFile)
+
+	metadata := map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic", "partitionLimitation": "1,2"}
+	authParams := map[string]string{"sasl": "oauthbearer", "saslTokenProvider": "azure_workload_identity", "scopes": "api://example/.default"}
+
+	meta, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{
+		TriggerMetadata: metadata,
+		AuthParams:      authParams,
+		PodIdentity:     v1alpha1.AuthPodIdentity{Provider: v1alpha1.PodIdentityProviderAzureWorkload},
+	}, logr.Discard())
+	if err != nil {
+		t.Fatal("Could not parse metadata:", err)
+	}
+
+	cfg, err := getKafkaClientConfig(context.TODO(), meta, logr.Discard())
+	if err != nil {
+		t.Fatal("Expected success but got error", err)
+	}
+
+	if !cfg.Net.SASL.Enable {
+		t.Error("Expected SASL to be enabled on client")
+	}
+
+	tokenProvider, ok := cfg.Net.SASL.TokenProvider.(kafka_oauth.TokenProvider)
+	if !ok {
+		t.Fatal("Expected token provider to be set on client")
+	}
+
+	if tokenProvider.String() != "AzureADWorkloadIdentity" {
+		t.Errorf("Expected token provider to be AzureADWorkloadIdentity but got %v", tokenProvider.String())
+	}
+}
+
+func TestKafkaOAuthbearerAzureWorkloadIdentityRequiresMatchingPodIdentity(t *testing.T) {
+	metadata := map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group", "topic": "my-topic"}
+	authParams := map[string]string{"sasl": "oauthbearer", "saslTokenProvider": "azure_workload_identity", "scopes": "api://example/.default"}
+
+	testCases := []struct {
+		name        string
+		podIdentity v1alpha1.AuthPodIdentity
+	}{
+		{"no pod identity", v1alpha1.AuthPodIdentity{}},
+		{"mismatched pod identity", v1alpha1.AuthPodIdentity{Provider: v1alpha1.PodIdentityProviderAwsEKS}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{
+				TriggerMetadata: metadata,
+				AuthParams:      authParams,
+				PodIdentity:     tc.podIdentity,
+			}, logr.Discard())
+			if err == nil {
+				t.Fatal("Expected error when pod identity is not azure-workload but got success")
 			}
 		})
 	}
@@ -645,7 +715,7 @@ func TestKafkaClientConfigFullMetadata(t *testing.T) {
 				t.Fatal("Could not parse metadata:", err)
 			}
 
-			cfg, err := getKafkaClientConfig(context.TODO(), meta)
+			cfg, err := getKafkaClientConfig(context.TODO(), meta, logr.Discard())
 			if err != nil {
 				t.Error("Expected success but got error", err)
 			}

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -611,7 +611,7 @@ func TestKafkaClientsOAuthTokenProvider(t *testing.T) {
 				t.Fatal("Could not parse metadata:", err)
 			}
 
-			cfg, err := getKafkaClientConfig(context.TODO(), meta, logr.Discard())
+			cfg, err := getKafkaClientConfig(t.Context(), meta, logr.Discard())
 			if err != nil {
 				t.Error("Expected success but got error", err)
 			}
@@ -653,7 +653,7 @@ func TestKafkaClientsOAuthTokenProviderAzureWorkloadIdentity(t *testing.T) {
 		t.Fatal("Could not parse metadata:", err)
 	}
 
-	cfg, err := getKafkaClientConfig(context.TODO(), meta, logr.Discard())
+	cfg, err := getKafkaClientConfig(t.Context(), meta, logr.Discard())
 	if err != nil {
 		t.Fatal("Expected success but got error", err)
 	}
@@ -715,7 +715,7 @@ func TestKafkaClientConfigFullMetadata(t *testing.T) {
 				t.Fatal("Could not parse metadata:", err)
 			}
 
-			cfg, err := getKafkaClientConfig(context.TODO(), meta, logr.Discard())
+			cfg, err := getKafkaClientConfig(t.Context(), meta, logr.Discard())
 			if err != nil {
 				t.Error("Expected success but got error", err)
 			}

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2992,7 +2992,8 @@
                     "optional": true,
                     "allowedValue": [
                         "bearer",
-                        "aws_msk_iam"
+                        "aws_msk_iam",
+                        "azure_workload_identity"
                     ],
                     "metadataVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1962,6 +1962,7 @@ scalers:
           allowedValue:
             - bearer
             - aws_msk_iam
+            - azure_workload_identity
           metadataVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: scopes


### PR DESCRIPTION
## What this PR does

The kafka scaler supports SASL OAUTHBEARER, but only with two token providers: `bearer` (plain OAuth2 client credentials) and `aws_msk_iam` (AWS credentials).

There is no way to use Azure AD Workload Identity. This is a problem for anyone who wants to connect to Confluent Cloud from an AKS pod using the pod's own federated identity, without a client secret.

This PR adds a third token provider, `azure_workload_identity`. It reuses `azure.NewChainedCredential`, the same credential chain other KEDA scalers already use (for example `azure_eventhub.go` and `azure_data_explorer.go`). It does not add any new Azure auth logic.

Related issue: #5757 (the original report there turned out to be a different problem with `oauthExtensions`, already fixed. But it is the closest tracked issue for OAUTHBEARER + Confluent Cloud problems, so I am linking it here too).

## How to use it

Set `saslTokenProvider: azure_workload_identity` on the trigger, together with a `podIdentity` of type `azure-workload` on the `TriggerAuthentication`. The scaler will then get tokens from the pod's federated identity instead of asking for a client secret.

## Changes

- `pkg/scalers/kafka/kafka_scaler_oauth_token_provider.go`: new `azureADWorkloadIdentityTokenProvider`. It caches the token and refreshes it when it is close to expiry, the same way the existing `aws_msk_iam` provider does.
- `pkg/scalers/kafka_scaler.go`: new `azure_workload_identity` enum value, validation that `podIdentity` is set to `azure-workload` when this provider is used, and wiring to build the credential and pass it to the token provider.
- `pkg/scalers/kafka_scaler_test.go` and new `pkg/scalers/kafka/kafka_scaler_oauth_token_provider_test.go`: unit tests for parsing, wiring, caching, and error cases.
- `CHANGELOG.md`: entry under Unreleased.
- `schema/generated/scalers-schema.json` / `.yaml`: regenerated so the new enum value shows up there too.

## Documentation

Docs PR: kedacore/keda-docs#1847 (also draft, waiting on this PR to settle first, as required by [CONTRIBUTING.md](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#including-documentation-changes)).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/scalers/... ./pkg/scalers/kafka/...`
- [x] `go test ./pkg/scalers/... ./pkg/scalers/kafka/... -run Kafka -v`
- [x] `go test ./pkg/scalers/kafka/... -v`
- [ ] e2e test (not added yet, opening as draft to get feedback first on whether this approach is the right one)

This is a draft because I want feedback on the approach before adding an e2e test.
