### PR TITLE
General: Keep cached metric records of healthy triggers on scaler errors

### DIFF
--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -624,7 +624,7 @@ func (h *scaleHandler) performGetScalersCache(ctx context.Context, key string, s
 }
 
 // ClearScalersCache invalidates the scalers cache for the input scalableObject.
-// Metric records are kept, they are only deleted when the scalable object is stopped.
+// Metric records are kept; they are only deleted when the scalable object is stopped.
 func (h *scaleHandler) ClearScalersCache(ctx context.Context, scalableObject kedav1alpha1.ScalableObject) error {
 	withTriggers, err := kedav1alpha1.AsDuckWithTriggers(scalableObject)
 	if err != nil {

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -251,6 +251,7 @@ func (h *scaleHandler) DeleteScalableObject(ctx context.Context, scalableObject 
 			cancel()
 		}
 		h.scaleLoopContexts.Delete(key)
+		h.scaledObjectsMetricCache.Delete(key)
 		err := h.ClearScalersCache(ctx, scalableObject)
 		if err != nil {
 			log.Error(err, "error clearing scalers cache", "scalableObject", scalableObject, "key", key)
@@ -289,6 +290,7 @@ func (h *scaleHandler) startScaleLoop(ctx context.Context, withTriggers *kedav1a
 			tmr.Stop()
 		case <-ctx.Done():
 			logger.V(1).Info("Context canceled")
+			h.scaledObjectsMetricCache.Delete(withTriggers.GenerateIdentifier())
 			err := h.ClearScalersCache(ctx, scalableObject)
 			if err != nil {
 				logger.Error(err, "error clearing scalers cache")
@@ -621,7 +623,8 @@ func (h *scaleHandler) performGetScalersCache(ctx context.Context, key string, s
 	return h.scalerCaches[key], nil
 }
 
-// ClearScalersCache invalidates chache for the input scalableObject
+// ClearScalersCache invalidates the scalers cache for the input scalableObject.
+// Metric records are kept, they are only deleted when the scalable object is stopped.
 func (h *scaleHandler) ClearScalersCache(ctx context.Context, scalableObject kedav1alpha1.ScalableObject) error {
 	withTriggers, err := kedav1alpha1.AsDuckWithTriggers(scalableObject)
 	if err != nil {
@@ -629,8 +632,6 @@ func (h *scaleHandler) ClearScalersCache(ctx context.Context, scalableObject ked
 	}
 
 	key := withTriggers.GenerateIdentifier()
-
-	h.scaledObjectsMetricCache.Delete(key)
 
 	h.scalerCachesLock.Lock()
 	defer h.scalerCachesLock.Unlock()

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -748,7 +748,7 @@ func TestDeleteScalableObject_DeletesMetricsCacheRecords(t *testing.T) {
 
 	_, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	sh.scaleLoopContexts.Store(key, context.CancelFunc(cancel))
+	sh.scaleLoopContexts.Store(key, cancel)
 	metricCache.StoreRecords(key, map[string]metricscache.MetricsRecord{
 		metricName: {IsActive: true},
 	})

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -663,15 +662,19 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 	assert.Equal(t, []string{"metric-name"}, activeTriggers)
 }
 
-func TestClearScalersCache_DeletionCompletesBeforeReturn(t *testing.T) {
+func TestClearScalersCache_PreservesMetricsCacheRecords(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	recorder := events.NewFakeRecorder(1)
 
 	metricName := "survivor-metric"
 	metricValue := scalers.GenerateMetricInMili(metricName, float64(42))
 
+	closed := make(chan struct{}, 1)
 	scaler := mock_scalers.NewMockScaler(ctrl)
-	scaler.EXPECT().Close(gomock.Any())
+	scaler.EXPECT().Close(gomock.Any()).DoAndReturn(func(context.Context) error {
+		closed <- struct{}{}
+		return nil
+	})
 	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler, &scalersconfig.ScalerConfig{}, nil
 	}
@@ -697,7 +700,6 @@ func TestClearScalersCache_DeletionCompletesBeforeReturn(t *testing.T) {
 		scaledObjectsMetricCache: metricCache,
 	}
 
-	// Pre-populate cache
 	metricCache.StoreRecords(key, map[string]metricscache.MetricsRecord{
 		metricName: {IsActive: true, Metric: []external_metrics.ExternalMetricValue{metricValue}},
 	})
@@ -705,21 +707,185 @@ func TestClearScalersCache_DeletionCompletesBeforeReturn(t *testing.T) {
 	err := sh.ClearScalersCache(t.Context(), &scaledObject)
 	assert.NoError(t, err)
 
-	_, found := metricCache.ReadRecord(key, metricName)
-	assert.False(t, found, "cache entry must be deleted when ClearScalersCache returns")
-
-	// Store new metrics that should not be deleted
-	metricCache.StoreRecords(key, map[string]metricscache.MetricsRecord{
-		metricName: {IsActive: true, Metric: []external_metrics.ExternalMetricValue{metricValue}},
-	})
-
-	runtime.Gosched()
-	time.Sleep(50 * time.Millisecond)
+	sh.scalerCachesLock.RLock()
+	_, scalersCacheFound := sh.scalerCaches[key]
+	sh.scalerCachesLock.RUnlock()
+	assert.False(t, scalersCacheFound, "scalers cache entry must be removed")
 
 	record, found := metricCache.ReadRecord(key, metricName)
-	assert.True(t, found)
+	assert.True(t, found, "metric records must survive a scalers cache invalidation")
 	if found {
 		assert.Equal(t, metricValue, record.Metric[0])
+	}
+
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the scaler to be closed")
+	}
+}
+
+func TestDeleteScalableObject_DeletesMetricsCacheRecords(t *testing.T) {
+	recorder := events.NewFakeRecorder(1)
+
+	metricName := "some-metric"
+	scaledObject := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "delete-test", Namespace: "ns"},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "target"},
+		},
+	}
+	key := scaledObject.GenerateIdentifier()
+
+	metricCache := metricscache.NewMetricsCache()
+	sh := scaleHandler{
+		scaleLoopContexts:        &sync.Map{},
+		recorder:                 recorder,
+		scalerCaches:             map[string]*cache.ScalersCache{},
+		scalerCachesLock:         &sync.RWMutex{},
+		scaledObjectsMetricCache: metricCache,
+	}
+
+	_, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	sh.scaleLoopContexts.Store(key, context.CancelFunc(cancel))
+	metricCache.StoreRecords(key, map[string]metricscache.MetricsRecord{
+		metricName: {IsActive: true},
+	})
+
+	err := sh.DeleteScalableObject(t.Context(), &scaledObject)
+	assert.NoError(t, err)
+
+	_, found := metricCache.ReadRecord(key, metricName)
+	assert.False(t, found, "metric records must be deleted when the scalable object is deleted")
+}
+
+func TestStartScaleLoop_DeletesMetricsCacheRecordsOnShutdown(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	recorder := events.NewFakeRecorder(1)
+	mockClient := mock_client.NewMockClient(ctrl)
+
+	metricName := "some-metric"
+	scaledObject := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "shutdown-test", Namespace: "ns"},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "target"},
+		},
+	}
+	key := scaledObject.GenerateIdentifier()
+	withTriggers, err := kedav1alpha1.AsDuckWithTriggers(&scaledObject)
+	assert.NoError(t, err)
+
+	metricCache := metricscache.NewMetricsCache()
+	sh := scaleHandler{
+		client:                   mockClient,
+		scaleLoopContexts:        &sync.Map{},
+		recorder:                 recorder,
+		scalerCaches:             map[string]*cache.ScalersCache{},
+		scalerCachesLock:         &sync.RWMutex{},
+		scaledObjectsMetricCache: metricCache,
+	}
+
+	metricCache.StoreRecords(key, map[string]metricscache.MetricsRecord{
+		metricName: {IsActive: true},
+	})
+
+	// canceled context makes the loop exit after one iteration, the client error short-circuits checkScalers
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("context canceled"))
+	sh.startScaleLoop(ctx, withTriggers, &scaledObject, &sync.Mutex{})
+
+	_, found := metricCache.ReadRecord(key, metricName)
+	assert.False(t, found, "metric records must be deleted when the scale loop shuts down")
+}
+
+func TestGetScaledObjectMetrics_ErrorDoesNotClearOtherTriggersCachedRecord(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	recorder := events.NewFakeRecorder(10)
+	mockClient := mock_client.NewMockClient(ctrl)
+
+	cachedMetricName := "cached-metric"
+	failingMetricName := "failing-metric"
+	cachedMetricValue := scalers.GenerateMetricInMili(cachedMetricName, float64(10))
+
+	closed := make(chan struct{}, 3)
+	signalClose := func(context.Context) error {
+		closed <- struct{}{}
+		return nil
+	}
+
+	cachedScaler := mock_scalers.NewMockScaler(ctrl)
+	cachedScalerConfig := scalersconfig.ScalerConfig{TriggerUseCachedMetrics: true}
+	cachedFactory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		return cachedScaler, &cachedScalerConfig, nil
+	}
+	failingScaler := mock_scalers.NewMockScaler(ctrl)
+	failingScalerConfig := scalersconfig.ScalerConfig{}
+	failingFactory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		return failingScaler, &failingScalerConfig, nil
+	}
+
+	scaledObject := kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "multi-trigger", Namespace: "ns"},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "target"},
+		},
+	}
+	key := scaledObject.GenerateIdentifier()
+
+	scalerCache := &cache.ScalersCache{
+		ScaledObject: &scaledObject,
+		Scalers: []cache.ScalerBuilder{
+			{Scaler: cachedScaler, ScalerConfig: cachedScalerConfig, Factory: cachedFactory},
+			{Scaler: failingScaler, ScalerConfig: failingScalerConfig, Factory: failingFactory},
+		},
+		Recorder: recorder,
+	}
+
+	metricCache := metricscache.NewMetricsCache()
+	sh := scaleHandler{
+		client:                   mockClient,
+		scaleLoopContexts:        &sync.Map{},
+		globalHTTPTimeout:        time.Duration(1000),
+		recorder:                 recorder,
+		scalerCaches:             map[string]*cache.ScalersCache{key: scalerCache},
+		scalerCachesLock:         &sync.RWMutex{},
+		scaledObjectsMetricCache: metricCache,
+		rawMetricsSubscriptions:  map[string]*RawMetricSubscriptions{},
+		metricToSubscriptions:    map[metricMeta][]*RawMetricSubscriptions{},
+		subsLock:                 &sync.RWMutex{},
+	}
+
+	metricCache.StoreRecords(key, map[string]metricscache.MetricsRecord{
+		cachedMetricName: {IsActive: true, Metric: []external_metrics.ExternalMetricValue{cachedMetricValue}},
+	})
+
+	cachedScaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Return([]v2.MetricSpec{createMetricSpec(10, cachedMetricName)})
+	failingScaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Return([]v2.MetricSpec{createMetricSpec(10, failingMetricName)})
+	// initial attempt plus the retry after refreshScaler
+	failingScaler.EXPECT().GetMetricsAndActivity(gomock.Any(), failingMetricName).Return(nil, false, errors.New("scaler error")).Times(2)
+	// refreshScaler close plus the async scalers cache close
+	failingScaler.EXPECT().Close(gomock.Any()).DoAndReturn(signalClose).Times(2)
+	cachedScaler.EXPECT().Close(gomock.Any()).DoAndReturn(signalClose)
+
+	metrics, err := sh.GetScaledObjectMetrics(t.Context(), scaledObject.Name, scaledObject.Namespace, failingMetricName)
+	assert.Nil(t, metrics)
+	assert.Error(t, err)
+
+	record, found := metricCache.ReadRecord(key, cachedMetricName)
+	assert.True(t, found, "an error in one trigger must not clear the cached record of another trigger")
+	if found {
+		assert.Equal(t, cachedMetricValue, record.Metric[0])
+	}
+
+	// wait for the async scalers cache close
+	for range 3 {
+		select {
+		case <-closed:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for scalers to be closed")
+		}
 	}
 }
 

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -847,7 +847,7 @@ func TestGetScaledObjectMetrics_ErrorDoesNotClearOtherTriggersCachedRecord(t *te
 	sh := scaleHandler{
 		client:                   mockClient,
 		scaleLoopContexts:        &sync.Map{},
-		globalHTTPTimeout:        time.Duration(1000),
+		globalHTTPTimeout:        time.Microsecond,
 		recorder:                 recorder,
 		scalerCaches:             map[string]*cache.ScalersCache{key: scalerCache},
 		scalerCachesLock:         &sync.RWMutex{},


### PR DESCRIPTION
Follow-up to #8067. An error in one trigger still deleted the valid cached records of the ScaledObject's healthy triggers, and a concurrent store could still interleave with the clear.

This PR removes the metric records deletion from `ClearScalersCache`. Records are overwritten on every store anyway, so the error path has nothing to invalidate. They are now only deleted when the ScaledObject is stopped.

Little note;

> `TestClearScalersCache_DeletionCompletesBeforeReturn` from the other PR asserted the removed behavior and is rewritten as `TestClearScalersCache_PreservesMetricsCacheRecords`, keeping its guarantee that a later store cannot be wiped.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Tests have been added *(if applicable)*
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #8067 