### PR TITLE
General: extract shared AuthMetadata struct for GCP scalers to eliminate duplicate credential fields

### DIFF
--- a/pkg/scalers/gcp/gcp_common.go
+++ b/pkg/scalers/gcp/gcp_common.go
@@ -19,6 +19,16 @@ var (
 	ErrGoogleApplicationCrendentialsNotFound = errors.New("google application credentials not found")
 )
 
+// AuthMetadata holds the typed-config fields for GCP credential parameters.
+// It is embedded in every GCP scaler metadata struct so that TypedConfig
+// registers "credentials" and "credentialsFromEnvFile" as known parameters,
+// preventing spurious "unmatched input property" warnings when
+// KEDA_CHECK_UNEXPECTED_SCALERS_PARAMS is enabled.
+type AuthMetadata struct {
+	Credentials            string `keda:"name=credentials,            order=triggerMetadata;resolvedEnv, optional"`
+	CredentialsFromEnvFile string `keda:"name=credentialsFromEnvFile, order=triggerMetadata;resolvedEnv, optional"`
+}
+
 type AuthorizationMetadata struct {
 	GoogleApplicationCredentials     string
 	GoogleApplicationCredentialsFile string

--- a/pkg/scalers/gcp_cloud_tasks_scaler.go
+++ b/pkg/scalers/gcp_cloud_tasks_scaler.go
@@ -33,8 +33,7 @@ type gcpCloudTaskMetadata struct {
 	QueueName string `keda:"name=queueName, order=triggerMetadata"`
 	ProjectID string `keda:"name=projectID, order=triggerMetadata, deprecatedAnnounce=This scaler is deprecated. More info -> 'https://keda.sh/blog/2025-09-15-gcp-deprecations'"`
 
-	Credentials            string `keda:"name=credentials, order=triggerMetadata;resolvedEnv, optional"`
-	CredentialsFromEnvFile string `keda:"name=credentialsFromEnvFile, order=triggerMetadata;resolvedEnv, optional"`
+	gcp.AuthMetadata `keda:"optional"`
 
 	gcpAuthorization *gcp.AuthorizationMetadata
 	triggerIndex     int

--- a/pkg/scalers/gcp_cloud_tasks_scaler_test.go
+++ b/pkg/scalers/gcp_cloud_tasks_scaler_test.go
@@ -39,7 +39,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "myQueue",
 		ProjectID:       "myproject",
-		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
+		AuthMetadata:    gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,
@@ -76,7 +76,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "mysubscription",
 		ProjectID:       "myproject",
-		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
+		AuthMetadata:    gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,
@@ -89,7 +89,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "myQueue",
 		ProjectID:       "myProject",
-		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
+		AuthMetadata:    gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,
@@ -102,7 +102,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "myQueue",
 		ProjectID:       "myProject",
-		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
+		AuthMetadata:    gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,

--- a/pkg/scalers/gcp_cloud_tasks_scaler_test.go
+++ b/pkg/scalers/gcp_cloud_tasks_scaler_test.go
@@ -39,7 +39,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "myQueue",
 		ProjectID:       "myproject",
-		Credentials:     "{}",
+		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,
@@ -76,7 +76,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "mysubscription",
 		ProjectID:       "myproject",
-		Credentials:     "{}",
+		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,
@@ -89,7 +89,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "myQueue",
 		ProjectID:       "myProject",
-		Credentials:     "{}",
+		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,
@@ -102,7 +102,7 @@ var testGcpCloudTasksMetadata = []parseGcpCloudTasksMetadataTestData{
 		FilterDuration:  0,
 		QueueName:       "myQueue",
 		ProjectID:       "myProject",
-		Credentials:     "{}",
+		AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
 		gcpAuthorization: &gcp.AuthorizationMetadata{
 			GoogleApplicationCredentials: "{}",
 			PodIdentityProviderEnabled:   false,

--- a/pkg/scalers/gcp_pubsub_scaler.go
+++ b/pkg/scalers/gcp_pubsub_scaler.go
@@ -47,8 +47,7 @@ type pubsubMetadata struct {
 	SubscriptionName string        `keda:"name=subscriptionName, order=triggerMetadata;resolvedEnv, optional"`
 	TopicName        string        `keda:"name=topicName, order=triggerMetadata;resolvedEnv, optional"`
 
-	Credentials            string `keda:"name=credentials, order=triggerMetadata;resolvedEnv, optional"`
-	CredentialsFromEnvFile string `keda:"name=credentialsFromEnvFile, order=triggerMetadata;resolvedEnv, optional"`
+	gcp.AuthMetadata `keda:"optional"`
 
 	// a resource is one of subscription or topic
 	resourceType     string

--- a/pkg/scalers/gcp_spanner_scaler.go
+++ b/pkg/scalers/gcp_spanner_scaler.go
@@ -35,8 +35,7 @@ type spannerMetadata struct {
 	TargetValue     float64 `keda:"name=targetValue,            order=triggerMetadata, default=5"`
 	ActivationValue float64 `keda:"name=activationValue,        order=triggerMetadata, default=0"`
 
-	Credentials            string `keda:"name=credentials,            order=triggerMetadata;resolvedEnv, optional"`
-	CredentialsFromEnvFile string `keda:"name=credentialsFromEnvFile, order=triggerMetadata;resolvedEnv, optional"`
+	gcp.AuthMetadata `keda:"optional"`
 
 	gcpAuthorization *gcp.AuthorizationMetadata
 	metricName       string

--- a/pkg/scalers/gcp_stackdriver_scaler.go
+++ b/pkg/scalers/gcp_stackdriver_scaler.go
@@ -32,8 +32,7 @@ type stackdriverMetadata struct {
 	AlignmentAligner       string   `keda:"name=alignmentAligner, order=triggerMetadata, optional"`
 	AlignmentReducer       string   `keda:"name=alignmentReducer, order=triggerMetadata, optional"`
 
-	Credentials            string `keda:"name=credentials, order=triggerMetadata;resolvedEnv, optional"`
-	CredentialsFromEnvFile string `keda:"name=credentialsFromEnvFile, order=triggerMetadata;resolvedEnv, optional"`
+	gcp.AuthMetadata `keda:"optional"`
 
 	metricName       string
 	TriggerIndex     int

--- a/pkg/scalers/gcp_stackdriver_scaler_test.go
+++ b/pkg/scalers/gcp_stackdriver_scaler_test.go
@@ -49,7 +49,7 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 			Filter:                sdFilter,
 			TargetValue:           7,
 			ActivationTargetValue: 5,
-			AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
+			AuthMetadata:          gcp.AuthMetadata{Credentials: "{}"},
 			metricName:            "s0-gcp-stackdriver-myProject",
 			aggregation:           nil,
 			gcpAuthorization: &gcp.AuthorizationMetadata{
@@ -72,7 +72,7 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 			Filter:                sdFilter,
 			TargetValue:           5,
 			ActivationTargetValue: 0,
-			AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
+			AuthMetadata:          gcp.AuthMetadata{Credentials: "{}"},
 			metricName:            "s0-gcp-stackdriver-myProject",
 			aggregation:           nil,
 			gcpAuthorization: &gcp.AuthorizationMetadata{
@@ -96,7 +96,7 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 			Filter:                sdFilter,
 			TargetValue:           5,
 			ActivationTargetValue: 0,
-			AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
+			AuthMetadata:          gcp.AuthMetadata{Credentials: "{}"},
 			ValueIfNull:           func() *float64 { v := 1.5; return &v }(),
 			metricName:            "s0-gcp-stackdriver-myProject",
 			aggregation:           nil,

--- a/pkg/scalers/gcp_stackdriver_scaler_test.go
+++ b/pkg/scalers/gcp_stackdriver_scaler_test.go
@@ -49,7 +49,7 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 			Filter:                sdFilter,
 			TargetValue:           7,
 			ActivationTargetValue: 5,
-			Credentials:           "{}",
+			AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
 			metricName:            "s0-gcp-stackdriver-myProject",
 			aggregation:           nil,
 			gcpAuthorization: &gcp.AuthorizationMetadata{
@@ -72,7 +72,7 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 			Filter:                sdFilter,
 			TargetValue:           5,
 			ActivationTargetValue: 0,
-			Credentials:           "{}",
+			AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
 			metricName:            "s0-gcp-stackdriver-myProject",
 			aggregation:           nil,
 			gcpAuthorization: &gcp.AuthorizationMetadata{
@@ -96,7 +96,7 @@ var testStackdriverMetadata = []parseStackdriverMetadataTestData{
 			Filter:                sdFilter,
 			TargetValue:           5,
 			ActivationTargetValue: 0,
-			Credentials:           "{}",
+			AuthMetadata: gcp.AuthMetadata{Credentials: "{}"},
 			ValueIfNull:           func() *float64 { v := 1.5; return &v }(),
 			metricName:            "s0-gcp-stackdriver-myProject",
 			aggregation:           nil,

--- a/pkg/scalers/gcp_storage_scaler.go
+++ b/pkg/scalers/gcp_storage_scaler.go
@@ -33,8 +33,7 @@ type gcsMetadata struct {
 	BlobDelimiter               string `keda:"name=blobDelimiter,               order=triggerMetadata, optional"`
 	BlobPrefix                  string `keda:"name=blobPrefix,                  order=triggerMetadata, optional"`
 
-	Credentials            string `keda:"name=credentials, order=triggerMetadata;resolvedEnv, optional"`
-	CredentialsFromEnvFile string `keda:"name=credentialsFromEnvFile, order=triggerMetadata;resolvedEnv, optional"`
+	gcp.AuthMetadata `keda:"optional"`
 
 	gcpAuthorization *gcp.AuthorizationMetadata
 	metricName       string

--- a/schema/generate_scaler_schema.go
+++ b/schema/generate_scaler_schema.go
@@ -239,13 +239,17 @@ func generateMetadataFields(structType *ast.StructType, otherReferenceKedaTagStr
 			continue
 		}
 
-		// If the field has a substruct, try to find substruct from reference structs
-		s, ok := commentGroup.Type.(*ast.Ident)
-		if !ok {
-			continue
+		// If the field has a substruct, try to find substruct from reference structs.
+		// Handle both *ast.Ident (same package) and *ast.SelectorExpr (e.g. gcp.AuthMetadata).
+		var subStructName string
+		switch t := commentGroup.Type.(type) {
+		case *ast.Ident:
+			subStructName = t.Name
+		case *ast.SelectorExpr:
+			subStructName = t.Sel.Name
 		}
-		if otherReferenceKedaTagStructs[s.Name] != nil {
-			subStructMetadataField := generateMetadataFields(otherReferenceKedaTagStructs[s.Name], otherReferenceKedaTagStructs)
+		if subStructName != "" && otherReferenceKedaTagStructs[subStructName] != nil {
+			subStructMetadataField := generateMetadataFields(otherReferenceKedaTagStructs[subStructName], otherReferenceKedaTagStructs)
 			if len(subStructMetadataField) > 0 {
 				scalerMetadata = append(scalerMetadata, subStructMetadataField...)
 			}
@@ -450,7 +454,13 @@ func getAllKedaTagedStructs(dir string) (map[string]*ast.StructType, map[string]
 
 	for _, e := range entries {
 		if e.IsDir() {
-			getAllKedaTagedStructs(dir + "/" + e.Name())
+			subScalerStructs, subTagStructs := getAllKedaTagedStructs(dir + "/" + e.Name())
+			for k, v := range subScalerStructs {
+				kedaScalerStructs[k] = v
+			}
+			for k, v := range subTagStructs {
+				kedaTagStructs[k] = v
+			}
 			continue
 		}
 

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -908,6 +908,58 @@
                     "type": "string",
                     "default": "10000",
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "connection",
+                    "type": "string",
+                    "optional": true,
+                    "envVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "consumerGroup",
+                    "type": "string",
+                    "default": "$Default",
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "storageConnection",
+                    "type": "string",
+                    "optional": true,
+                    "envVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "storageAccountName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "blobContainer",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "eventHubNamespace",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "envVariableReadable": true
+                },
+                {
+                    "name": "eventHubName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "envVariableReadable": true
+                },
+                {
+                    "name": "checkpointStrategy",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
                 }
             ]
         },
@@ -3224,6 +3276,147 @@
                     "type": "string",
                     "default": "false",
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "authModes",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "authMode",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "bearerToken",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "token",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "username",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "cert",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "ca",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "oauthTokenURI",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scopes",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scope",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientID",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientSecret",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "endpointParams",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthHeader",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthValue",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "apiKey",
+                    "type": "string",
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "method",
+                    "type": "string",
+                    "default": "header",
+                    "allowedValue": [
+                        "header",
+                        "query"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "keyParamName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
                 }
             ]
         },
@@ -4405,6 +4598,36 @@
                     "name": "workloadIdentityResource",
                     "type": "string",
                     "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "oauthTokenURI",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scopes",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scope",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientID",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientSecret",
+                    "type": "string",
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "endpointParams",
+                    "type": "string",
                     "triggerAuthenticationVariableReadable": true
                 }
             ]

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -594,6 +594,42 @@ scalers:
           type: string
           default: "10000"
           metadataVariableReadable: true
+        - name: connection
+          type: string
+          optional: true
+          envVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: consumerGroup
+          type: string
+          default: $Default
+          metadataVariableReadable: true
+        - name: storageConnection
+          type: string
+          optional: true
+          envVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: storageAccountName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: blobContainer
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: eventHubNamespace
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          envVariableReadable: true
+        - name: eventHubName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          envVariableReadable: true
+        - name: checkpointStrategy
+          type: string
+          optional: true
+          metadataVariableReadable: true
     - type: azure-log-analytics
       parameters:
         - name: tenantId
@@ -2109,6 +2145,102 @@ scalers:
           type: string
           default: "false"
           metadataVariableReadable: true
+        - name: authModes
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: authMode
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: bearerToken
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: token
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: username
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: password
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: cert
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: key
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: ca
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: oauthTokenURI
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: scopes
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: scope
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: clientID
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: clientSecret
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: endpointParams
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthHeader
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthValue
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: apiKey
+          type: string
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: method
+          type: string
+          default: header
+          allowedValue:
+            - header
+            - query
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: keyParamName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
     - type: mssql
       parameters:
         - name: connectionString
@@ -2887,6 +3019,24 @@ scalers:
         - name: workloadIdentityResource
           type: string
           optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: oauthTokenURI
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: scopes
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: scope
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: clientID
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: clientSecret
+          type: string
+          triggerAuthenticationVariableReadable: true
+        - name: endpointParams
+          type: string
           triggerAuthenticationVariableReadable: true
     - type: redis
       parameters:


### PR DESCRIPTION
Closes #8065

## Description

All GCP scalers declared identical `Credentials` and `CredentialsFromEnvFile` fields in their metadata structs purely so that `TypedConfig` registers `credentialsFromEnv` / `credentialsFromEnvFile` as known parameter names, preventing false "unmatched input property" warnings when `KEDA_CHECK_UNEXPECTED_SCALERS_PARAMS` is enabled.

This PR moves the duplicate fields into a single `gcp.AuthMetadata` struct embedded in each scaler with `keda:"optional"`. `TypedConfig` processes it recursively via the `IsNested()` path.

## Bug fixes in schema/generate_scaler_schema.go

Recursive calls to `getAllKedaTagedStructs` were discarding their return values, so structs in subdirectories were silently ignored. `SelectorExpr` field types (e.g. `gcp.AuthMetadata`) were not handled when resolving nested struct references. As a side effect, `azure-eventhub` schema now correctly includes the `EventHubInfo` parameters that were previously missing.

## Testing

All existing GCP scaler unit tests pass. Verified that `KEDA_CHECK_UNEXPECTED_SCALERS_PARAMS=enabled` produces no warnings when `credentialsFromEnv` is passed via TriggerMetadata.

## Checklist
- [x] I have verified that my change is according to the deprecations & breaking changes policy
- [x] Tests have been added
- [x] make generate-scalers-schema has been run
- [x] Commits are signed with DCO