### PR TITLE
RabbitMQ scaler: close test HTTP servers

### DIFF
--- a/pkg/scalers/rabbitmq_scaler_test.go
+++ b/pkg/scalers/rabbitmq_scaler_test.go
@@ -494,6 +494,7 @@ func TestGetQueueInfo(t *testing.T) {
 
 		ctx := context.TODO()
 		_, active, err := s.GetMetricsAndActivity(ctx, "Metric")
+		apiStub.Close()
 
 		if testData.responseStatus == http.StatusOK {
 			if err != nil {
@@ -720,6 +721,7 @@ func TestGetQueueInfoWithRegex(t *testing.T) {
 
 		ctx := context.TODO()
 		_, active, err := s.GetMetricsAndActivity(ctx, "Metric")
+		apiStub.Close()
 
 		if testData.responseStatus == http.StatusOK {
 			if err != nil {
@@ -804,6 +806,7 @@ func TestGetPageSizeWithRegex(t *testing.T) {
 
 		ctx := context.TODO()
 		_, active, err := s.GetMetricsAndActivity(ctx, "Metric")
+		apiStub.Close()
 
 		if err != nil {
 			t.Error("Expect success", err)
@@ -925,6 +928,7 @@ func TestRegexQueueMissingError(t *testing.T) {
 
 		ctx := context.TODO()
 		_, _, err = s.GetMetricsAndActivity(ctx, "Metric")
+		apiStub.Close()
 		if err != nil && !testData.isError {
 			t.Error("Expected success but got error", err)
 		}


### PR DESCRIPTION
### Description

Close each RabbitMQ test HTTP server immediately after the scaler request finishes. The four affected tests created a server inside a loop without ever closing it, allowing a handler to outlive its owning test and call `t.Error` after that test completed.

This addresses the flake observed in the `validate` job of #7985, where the resulting panic was attributed to an unrelated Splunk test. Closing synchronously after `GetMetricsAndActivity` returns preserves the existing assertions while ensuring every iteration releases its listener before proceeding.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Tests have been added or updated where appropriate
- [x] All tests and static analysis pass locally
- [x] This change is limited to the issue scope

Fixes #8034
