### PR TITLE
General: Introduce new Gitea Runner Scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **General**: Add optional `StreamMetricSpec` server-streaming RPC to external scaler gRPC proto, allowing external-push scalers to dynamically update HPA target values without modifying the ScaledObject ([#7793](https://github.com/kedacore/keda/issues/7793))
 - **General**: Introduce new ClickHouse Scaler ([#7418](https://github.com/kedacore/keda/issues/7418))
 - **General**: Introduce new GCP Spanner Scaler ([#7891](https://github.com/kedacore/keda/issues/7891))
+- **General**: Introduce new Gitea Runner Scaler ([#8086](https://github.com/kedacore/keda/issues/8086))
 
 #### Experimental
 

--- a/pkg/scalers/gitea_runner_scaler.go
+++ b/pkg/scalers/gitea_runner_scaler.go
@@ -1,0 +1,314 @@
+package scalers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-logr/logr"
+	v2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/metrics/pkg/apis/external_metrics"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+	kedautil "github.com/kedacore/keda/v2/pkg/util"
+)
+
+const (
+	giteaAdminJobPath = "/api/v1/admin/actions/jobs"
+	giteaOrgJobPath   = "/api/v1/orgs/%s/actions/jobs"
+	giteaRepoJobPath  = "/api/v1/repos/%s/%s/actions/jobs"
+	giteaUserJobPath  = "/api/v1/user/actions/jobs"
+
+	// Gitea clamps `limit` to MAX_RESPONSE_ITEMS (default 50) no matter what is
+	// requested, so this is the real page size rather than a preference.
+	giteaPageSize = 50
+
+	// Upper bound on pages walked in a single poll when label filtering is on.
+	// 20 pages x 50 = 1000 jobs, far above any queue that a scaler decision
+	// could still be meaningfully affected by: long before that the workload is
+	// pinned at maxReplicaCount. Hitting the cap is logged, never silent.
+	giteaMaxPages = 20
+)
+
+// giteaJob is one entry of the `jobs` array returned by Gitea's Actions jobs
+// endpoints. Only the fields the scaler actually reads are modelled.
+type giteaJob struct {
+	ID     int64    `json:"id"`
+	Name   string   `json:"name"`
+	Status string   `json:"status"`
+	Labels []string `json:"labels"`
+}
+
+// giteaJobsResponse is Gitea's envelope. Note this differs from Forgejo, which
+// returns a bare array — the two forges diverged on this API.
+type giteaJobsResponse struct {
+	Jobs       []giteaJob `json:"jobs"`
+	TotalCount int64      `json:"total_count"`
+}
+
+type giteaRunnerScaler struct {
+	metricType v2.MetricTargetType
+	metadata   *giteaRunnerMetadata
+	client     *http.Client
+	logger     logr.Logger
+}
+
+type giteaRunnerMetadata struct {
+	TriggerIndex int
+
+	Token   string `keda:"name=token, order=authParams;resolvedEnv"`
+	Address string `keda:"name=address, order=triggerMetadata"`
+
+	// Comma-separated runner labels. When empty the scaler counts every
+	// pending job, which is both correct and cheaper — see getJobCount.
+	Labels string `keda:"name=labels, order=triggerMetadata, optional"`
+
+	// Scope selectors, evaluated in the order repo > org > global > user.
+	Global bool   `keda:"name=global, order=triggerMetadata, optional"`
+	Owner  string `keda:"name=owner, order=triggerMetadata, optional"`
+	Org    string `keda:"name=org, order=triggerMetadata, optional"`
+	Repo   string `keda:"name=repo, order=triggerMetadata, optional"`
+
+	// Treat a job carrying no labels at all as matching only a scaler that
+	// itself declares no labels. Mirrors the github-runner scaler's option.
+	MatchUnlabeledJobsWithUnlabeledRunners bool `keda:"name=matchUnlabeledJobsWithUnlabeledRunners, order=triggerMetadata, default=false"`
+
+	// Jobs one runner replica absorbs.
+	TargetJobs int64 `keda:"name=targetJobs, order=triggerMetadata, default=1"`
+}
+
+func (m *giteaRunnerMetadata) labelList() []string {
+	if m.Labels == "" {
+		return nil
+	}
+	parts := strings.Split(m.Labels, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func parseGiteaRunnerMetadata(config *scalersconfig.ScalerConfig) (*giteaRunnerMetadata, error) {
+	meta := &giteaRunnerMetadata{}
+	meta.TriggerIndex = config.TriggerIndex
+
+	if err := config.TypedConfig(meta); err != nil {
+		return nil, fmt.Errorf("error parsing gitea metadata: %w", err)
+	}
+
+	meta.Address = strings.TrimSuffix(meta.Address, "/")
+
+	if meta.TargetJobs <= 0 {
+		return nil, fmt.Errorf("targetJobs must be a positive number, got %d", meta.TargetJobs)
+	}
+
+	if meta.Repo != "" && meta.Owner == "" {
+		return nil, fmt.Errorf("owner must be set when repo is set")
+	}
+
+	return meta, nil
+}
+
+// NewGiteaRunnerScaler creates a new Gitea Runner Scaler
+func NewGiteaRunnerScaler(config *scalersconfig.ScalerConfig) (Scaler, error) {
+	c := kedautil.CreateHTTPClient(config.GlobalHTTPTimeout, false)
+
+	metricType, err := GetMetricTargetType(config)
+	if err != nil {
+		return nil, fmt.Errorf("error getting scaler metric type: %w", err)
+	}
+
+	meta, err := parseGiteaRunnerMetadata(config)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Gitea Runner metadata: %w", err)
+	}
+
+	return &giteaRunnerScaler{
+		client:     c,
+		metricType: metricType,
+		metadata:   meta,
+		logger:     InitializeLogger(config, "gitea_runner_scaler"),
+	}, nil
+}
+
+func (s *giteaRunnerScaler) GetMetricsAndActivity(ctx context.Context, metricName string) ([]external_metrics.ExternalMetricValue, bool, error) {
+	count, err := s.getJobCount(ctx)
+	if err != nil {
+		return []external_metrics.ExternalMetricValue{}, false, err
+	}
+
+	metric := GenerateMetricInMili(metricName, float64(count))
+
+	return []external_metrics.ExternalMetricValue{metric}, count > 0, nil
+}
+
+func (s *giteaRunnerScaler) GetMetricSpecForScaling(_ context.Context) []v2.MetricSpec {
+	externalMetric := &v2.ExternalMetricSource{
+		Metric: v2.MetricIdentifier{
+			Name: GenerateMetricNameWithIndex(s.metadata.TriggerIndex, kedautil.NormalizeString("gitea")),
+		},
+		Target: GetMetricTarget(s.metricType, s.metadata.TargetJobs),
+	}
+	metricSpec := v2.MetricSpec{External: externalMetric, Type: externalMetricType}
+	return []v2.MetricSpec{metricSpec}
+}
+
+// getJobCount returns the number of jobs that are queued OR already running.
+//
+// Counting running work as well as queued work is deliberate and load-bearing.
+// A "how many jobs are waiting" metric collapses to zero the moment those jobs
+// are picked up, so the scaler would immediately tear down the very replicas
+// doing the work. Gitea lets both statuses be requested in one call — the
+// filter is a genuine OR — so this costs nothing extra.
+//
+// Two paths, and the difference matters for API load:
+//
+//   - No labels configured: total_count honours the status filter, so a single
+//     request with limit=1 yields the answer. One call per poll, no pagination.
+//   - Labels configured: Gitea ignores a `labels` query parameter entirely
+//     (verified against 1.27) so filtering must happen client-side, which means
+//     actually walking the pages.
+func (s *giteaRunnerScaler) getJobCount(ctx context.Context) (int64, error) {
+	labels := s.metadata.labelList()
+
+	if len(labels) == 0 && !s.metadata.MatchUnlabeledJobsWithUnlabeledRunners {
+		resp, err := s.fetchJobsPage(ctx, 1, 1)
+		if err != nil {
+			return 0, err
+		}
+		return resp.TotalCount, nil
+	}
+
+	var count int64
+	for page := 1; page <= giteaMaxPages; page++ {
+		resp, err := s.fetchJobsPage(ctx, page, giteaPageSize)
+		if err != nil {
+			return 0, err
+		}
+
+		for _, job := range resp.Jobs {
+			if canGiteaRunnerMatchLabels(job.Labels, labels, s.metadata.MatchUnlabeledJobsWithUnlabeledRunners) {
+				count++
+			}
+		}
+
+		// A short page is the last page.
+		if len(resp.Jobs) < giteaPageSize {
+			return count, nil
+		}
+
+		if page == giteaMaxPages {
+			s.logger.V(0).Info(
+				"Gitea job pagination hit its page cap; the reported count is a lower bound",
+				"pagesWalked", giteaMaxPages,
+				"jobsInspected", giteaMaxPages*giteaPageSize,
+				"totalCount", resp.TotalCount,
+				"matched", count,
+			)
+		}
+	}
+
+	return count, nil
+}
+
+func (s *giteaRunnerScaler) fetchJobsPage(ctx context.Context, page, limit int) (*giteaJobsResponse, error) {
+	uri, err := s.getJobsURL(page, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", uri.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("token %s", s.metadata.Token))
+
+	r, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := r.Body.Close(); closeErr != nil {
+			s.logger.Error(closeErr, "Failed to close response body")
+		}
+	}()
+
+	if r.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, r.Body)
+		return nil, fmt.Errorf("the Gitea REST API returned error. url: %s status: %d", uri.Path, r.StatusCode)
+	}
+
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &giteaJobsResponse{}
+	if err := json.Unmarshal(b, resp); err != nil {
+		return nil, fmt.Errorf("error unmarshalling Gitea jobs response: %w", err)
+	}
+
+	return resp, nil
+}
+
+// getJobsURL builds the endpoint for the configured scope. Gitea exposes the
+// same jobs resource at four access levels; the narrowest configured one wins.
+func (s *giteaRunnerScaler) getJobsURL(page, limit int) (*url.URL, error) {
+	var path string
+
+	switch {
+	case s.metadata.Owner != "" && s.metadata.Repo != "":
+		path = fmt.Sprintf(giteaRepoJobPath, url.PathEscape(s.metadata.Owner), url.PathEscape(s.metadata.Repo))
+	case s.metadata.Org != "":
+		path = fmt.Sprintf(giteaOrgJobPath, url.PathEscape(s.metadata.Org))
+	case s.metadata.Global:
+		path = giteaAdminJobPath
+	default:
+		path = giteaUserJobPath
+	}
+
+	u, err := url.Parse(s.metadata.Address + path)
+	if err != nil {
+		return nil, err
+	}
+
+	q := url.Values{}
+	// Repeated `status` keys are OR-ed by Gitea, and total_count honours them.
+	q.Add("status", "queued")
+	q.Add("status", "in_progress")
+	q.Add("page", fmt.Sprintf("%d", page))
+	q.Add("limit", fmt.Sprintf("%d", limit))
+	u.RawQuery = q.Encode()
+
+	return u, nil
+}
+
+// canGiteaRunnerMatchLabels reports whether a runner offering runnerLabels is
+// able to take a job requesting jobLabels — i.e. every label the job asks for
+// is one the runner provides. Mirrors the github-runner scaler's semantics so
+// the two behave the same way for users moving between forges.
+func canGiteaRunnerMatchLabels(jobLabels, runnerLabels []string, matchUnlabeled bool) bool {
+	if matchUnlabeled && len(jobLabels) == 0 {
+		return len(runnerLabels) == 0
+	}
+	for _, jobLabel := range jobLabels {
+		if !contains(runnerLabels, jobLabel) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *giteaRunnerScaler) Close(_ context.Context) error {
+	if s.client != nil {
+		s.client.CloseIdleConnections()
+	}
+	return nil
+}

--- a/pkg/scalers/gitea_runner_scaler_test.go
+++ b/pkg/scalers/gitea_runner_scaler_test.go
@@ -1,0 +1,347 @@
+package scalers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
+)
+
+var testGiteaRunnerAuthParams = map[string]string{
+	"token": "some-token",
+}
+
+type parseGiteaRunnerMetadataTestData struct {
+	testName      string
+	metadata      map[string]string
+	authParams    map[string]string
+	isError       bool
+	expectedError string
+	address       string
+	targetJobs    int64
+}
+
+var testGiteaRunnerMetadata = []parseGiteaRunnerMetadataTestData{
+	{"no address given", map[string]string{
+		"global": "true",
+	}, testGiteaRunnerAuthParams, true, "missing required parameter \"address\"", "", 0},
+	{"no token given", map[string]string{
+		"address": "https://gitea.example.com", "global": "true",
+	}, map[string]string{}, true, "missing required parameter \"token\"", "", 0},
+	{"repo without owner", map[string]string{
+		"address": "https://gitea.example.com", "repo": "my-repo",
+	}, testGiteaRunnerAuthParams, true, "owner must be set when repo is set", "", 0},
+	{"zero targetJobs", map[string]string{
+		"address": "https://gitea.example.com", "global": "true", "targetJobs": "0",
+	}, testGiteaRunnerAuthParams, true, "targetJobs must be a positive number", "", 0},
+	{"negative targetJobs", map[string]string{
+		"address": "https://gitea.example.com", "global": "true", "targetJobs": "-3",
+	}, testGiteaRunnerAuthParams, true, "targetJobs must be a positive number", "", 0},
+	{"minimal global", map[string]string{
+		"address": "https://gitea.example.com", "global": "true",
+	}, testGiteaRunnerAuthParams, false, "", "https://gitea.example.com", 1},
+	{"trailing slash is trimmed", map[string]string{
+		"address": "https://gitea.example.com/", "global": "true",
+	}, testGiteaRunnerAuthParams, false, "", "https://gitea.example.com", 1},
+	{"labels are optional", map[string]string{
+		"address": "https://gitea.example.com", "global": "true", "labels": "ubuntu-latest,self-hosted",
+	}, testGiteaRunnerAuthParams, false, "", "https://gitea.example.com", 1},
+	{"explicit targetJobs", map[string]string{
+		"address": "https://gitea.example.com", "global": "true", "targetJobs": "4",
+	}, testGiteaRunnerAuthParams, false, "", "https://gitea.example.com", 4},
+	{"repo scope", map[string]string{
+		"address": "https://gitea.example.com", "owner": "someone", "repo": "my-repo",
+	}, testGiteaRunnerAuthParams, false, "", "https://gitea.example.com", 1},
+}
+
+func TestGiteaRunnerParseMetadata(t *testing.T) {
+	for _, testData := range testGiteaRunnerMetadata {
+		t.Run(testData.testName, func(t *testing.T) {
+			meta, err := parseGiteaRunnerMetadata(&scalersconfig.ScalerConfig{
+				TriggerMetadata: testData.metadata,
+				AuthParams:      testData.authParams,
+			})
+
+			if testData.isError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), testData.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, testData.address, meta.Address)
+			assert.Equal(t, testData.targetJobs, meta.TargetJobs)
+		})
+	}
+}
+
+func TestGiteaRunnerLabelList(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   string
+		expected []string
+	}{
+		{"empty", "", nil},
+		{"single", "ubuntu-latest", []string{"ubuntu-latest"}},
+		{"multiple", "ubuntu-latest,self-hosted", []string{"ubuntu-latest", "self-hosted"}},
+		{"whitespace is trimmed", " ubuntu-latest , self-hosted ", []string{"ubuntu-latest", "self-hosted"}},
+		{"empty entries are dropped", "ubuntu-latest,,self-hosted,", []string{"ubuntu-latest", "self-hosted"}},
+		{"only separators", ",,,", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &giteaRunnerMetadata{Labels: tt.labels}
+			assert.Equal(t, tt.expected, meta.labelList())
+		})
+	}
+}
+
+func TestGiteaRunnerCanMatchLabels(t *testing.T) {
+	tests := []struct {
+		name           string
+		jobLabels      []string
+		runnerLabels   []string
+		matchUnlabeled bool
+		expected       bool
+	}{
+		{"exact match", []string{"ubuntu-latest"}, []string{"ubuntu-latest"}, false, true},
+		{"runner offers a superset", []string{"ubuntu-latest"}, []string{"ubuntu-latest", "self-hosted"}, false, true},
+		{"job needs a label the runner lacks", []string{"windows"}, []string{"ubuntu-latest"}, false, false},
+		{"job needs two, runner has one", []string{"ubuntu-latest", "gpu"}, []string{"ubuntu-latest"}, false, false},
+		{"unlabeled job matches any runner by default", []string{}, []string{"ubuntu-latest"}, false, true},
+		{"unlabeled job with strict matching needs an unlabeled runner", []string{}, []string{"ubuntu-latest"}, true, false},
+		{"unlabeled job and unlabeled runner with strict matching", []string{}, []string{}, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := canGiteaRunnerMatchLabels(tt.jobLabels, tt.runnerLabels, tt.matchUnlabeled)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGiteaRunnerJobsURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadata     *giteaRunnerMetadata
+		expectedPath string
+	}{
+		{"global uses the admin endpoint", &giteaRunnerMetadata{Address: "https://g.example.com", Global: true}, "/api/v1/admin/actions/jobs"},
+		{"org scope", &giteaRunnerMetadata{Address: "https://g.example.com", Org: "my-org"}, "/api/v1/orgs/my-org/actions/jobs"},
+		{"repo scope", &giteaRunnerMetadata{Address: "https://g.example.com", Owner: "someone", Repo: "my-repo"}, "/api/v1/repos/someone/my-repo/actions/jobs"},
+		{"user scope is the fallback", &giteaRunnerMetadata{Address: "https://g.example.com"}, "/api/v1/user/actions/jobs"},
+		{"repo scope beats org scope", &giteaRunnerMetadata{Address: "https://g.example.com", Org: "my-org", Owner: "someone", Repo: "my-repo"}, "/api/v1/repos/someone/my-repo/actions/jobs"},
+		{"org scope beats global", &giteaRunnerMetadata{Address: "https://g.example.com", Global: true, Org: "my-org"}, "/api/v1/orgs/my-org/actions/jobs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &giteaRunnerScaler{metadata: tt.metadata}
+			u, err := s.getJobsURL(1, 50)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPath, u.Path)
+
+			// Both statuses must be requested, or the scaler tears down replicas
+			// the moment their jobs start running.
+			assert.ElementsMatch(t, []string{"queued", "in_progress"}, u.Query()["status"])
+			assert.Equal(t, "1", u.Query().Get("page"))
+			assert.Equal(t, "50", u.Query().Get("limit"))
+		})
+	}
+}
+
+// newGiteaTestScaler wires a scaler to a test server and returns a pointer to
+// the request counter, so tests can assert on API call volume rather than just
+// the resulting number.
+func newGiteaTestScaler(t *testing.T, meta *giteaRunnerMetadata, handler http.HandlerFunc) (*giteaRunnerScaler, *int) {
+	t.Helper()
+
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	meta.Address = srv.URL
+	return &giteaRunnerScaler{
+		metadata: meta,
+		client:   srv.Client(),
+		logger:   logr.Discard(),
+	}, &requests
+}
+
+// writeGiteaJobs encodes a jobs response straight onto the ResponseWriter.
+// json.NewEncoder rather than w.Write to match the idiom used by the other
+// forge scaler tests.
+func writeGiteaJobs(t *testing.T, w http.ResponseWriter, jobs []giteaJob, total int64) {
+	t.Helper()
+	err := json.NewEncoder(w).Encode(giteaJobsResponse{Jobs: jobs, TotalCount: total})
+	require.NoError(t, err)
+}
+
+// The headline property of this scaler: with no label filter it answers in a
+// SINGLE request by reading total_count, and never walks pages.
+func TestGiteaRunnerCountUsesTotalCountWithoutLabels(t *testing.T) {
+	s, requests := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, TargetJobs: 1},
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "1", r.URL.Query().Get("limit"), "fast path should request a single row")
+			writeGiteaJobs(t, w, []giteaJob{{ID: 1}}, 137)
+		})
+
+	count, err := s.getJobCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(137), count, "count should come from total_count, not len(jobs)")
+	assert.Equal(t, 1, *requests, "no-label path must cost exactly one request")
+}
+
+func TestGiteaRunnerCountFiltersByLabel(t *testing.T) {
+	jobs := []giteaJob{
+		{ID: 1, Status: "queued", Labels: []string{"ubuntu-latest"}},
+		{ID: 2, Status: "in_progress", Labels: []string{"ubuntu-latest"}},
+		{ID: 3, Status: "queued", Labels: []string{"windows"}},
+		{ID: 4, Status: "queued", Labels: []string{"ubuntu-latest", "gpu"}},
+	}
+
+	s, requests := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, Labels: "ubuntu-latest", TargetJobs: 1},
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeGiteaJobs(t, w, jobs, int64(len(jobs)))
+		})
+
+	count, err := s.getJobCount(context.Background())
+	require.NoError(t, err)
+	// Jobs 1 and 2 match. Job 3 wants windows; job 4 also wants gpu.
+	assert.Equal(t, int64(2), count)
+	assert.Equal(t, 1, *requests, "a short page terminates pagination immediately")
+}
+
+func TestGiteaRunnerCountPaginates(t *testing.T) {
+	full := make([]giteaJob, giteaPageSize)
+	for i := range full {
+		full[i] = giteaJob{ID: int64(i), Status: "queued", Labels: []string{"ubuntu-latest"}}
+	}
+	lastPage := []giteaJob{{ID: 999, Status: "queued", Labels: []string{"ubuntu-latest"}}}
+
+	s, requests := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, Labels: "ubuntu-latest", TargetJobs: 1},
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("page") == "1" {
+				writeGiteaJobs(t, w, full, 51)
+				return
+			}
+			writeGiteaJobs(t, w, lastPage, 51)
+		})
+
+	count, err := s.getJobCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(giteaPageSize+1), count)
+	assert.Equal(t, 2, *requests)
+}
+
+// A server that always returns a full page must not loop forever.
+func TestGiteaRunnerCountRespectsPageCap(t *testing.T) {
+	full := make([]giteaJob, giteaPageSize)
+	for i := range full {
+		full[i] = giteaJob{ID: int64(i), Status: "queued", Labels: []string{"ubuntu-latest"}}
+	}
+
+	s, requests := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, Labels: "ubuntu-latest", TargetJobs: 1},
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeGiteaJobs(t, w, full, 100000)
+		})
+
+	count, err := s.getJobCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(giteaMaxPages*giteaPageSize), count)
+	assert.Equal(t, giteaMaxPages, *requests, "pagination must stop at the page cap")
+}
+
+func TestGiteaRunnerCountErrors(t *testing.T) {
+	t.Run("non-200 is an error", func(t *testing.T) {
+		s, _ := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, TargetJobs: 1},
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			})
+
+		_, err := s.getJobCount(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "403")
+	})
+
+	t.Run("malformed JSON is an error", func(t *testing.T) {
+		s, _ := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, TargetJobs: 1},
+			func(w http.ResponseWriter, _ *http.Request) {
+				require.NoError(t, json.NewEncoder(w).Encode("this is not an object"))
+			})
+
+		_, err := s.getJobCount(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error unmarshalling")
+	})
+}
+
+func TestGiteaRunnerSendsTokenHeader(t *testing.T) {
+	s, _ := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, Token: "s3cret", TargetJobs: 1},
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "token s3cret", r.Header.Get("Authorization"))
+			writeGiteaJobs(t, w, nil, 0)
+		})
+
+	_, err := s.getJobCount(context.Background())
+	require.NoError(t, err)
+}
+
+func TestGiteaRunnerGetMetricsAndActivity(t *testing.T) {
+	tests := []struct {
+		name           string
+		total          int64
+		expectedValue  int64
+		expectedActive bool
+	}{
+		{"idle", 0, 0, false},
+		{"one queued job activates", 1, 1, true},
+		{"many queued jobs", 42, 42, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := newGiteaTestScaler(t, &giteaRunnerMetadata{Global: true, TargetJobs: 1},
+				func(w http.ResponseWriter, _ *http.Request) {
+					writeGiteaJobs(t, w, nil, tt.total)
+				})
+
+			metrics, active, err := s.GetMetricsAndActivity(context.Background(), "gitea")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedActive, active)
+			require.Len(t, metrics, 1)
+			assert.Equal(t, tt.expectedValue, metrics[0].Value.Value())
+		})
+	}
+}
+
+func TestGiteaRunnerGetMetricSpecForScaling(t *testing.T) {
+	meta, err := parseGiteaRunnerMetadata(&scalersconfig.ScalerConfig{
+		TriggerMetadata: map[string]string{
+			"address": "https://gitea.example.com", "global": "true", "targetJobs": "2",
+		},
+		AuthParams:   testGiteaRunnerAuthParams,
+		TriggerIndex: 3,
+	})
+	require.NoError(t, err)
+
+	s := &giteaRunnerScaler{metadata: meta, metricType: "AverageValue", logger: logr.Discard()}
+	spec := s.GetMetricSpecForScaling(context.Background())
+
+	require.Len(t, spec, 1)
+	assert.Equal(t, fmt.Sprintf("s%d-gitea", 3), spec[0].External.Metric.Name)
+	assert.Equal(t, int64(2), spec[0].External.Target.AverageValue.Value())
+}

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -200,6 +200,8 @@ func buildScaler(ctx context.Context, client client.Client, triggerType string, 
 		return scalers.NewStackdriverScaler(ctx, config)
 	case "gcp-storage":
 		return scalers.NewGcsScaler(config)
+	case "gitea-runner":
+		return scalers.NewGiteaRunnerScaler(config)
 	case "github-runner":
 		return scalers.NewGitHubRunnerScaler(config)
 	case "graphite":

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -2535,6 +2535,64 @@
             ]
         },
         {
+            "type": "gitea-runner",
+            "parameters": [
+                {
+                    "name": "token",
+                    "type": "string",
+                    "envVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "address",
+                    "type": "string",
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "labels",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "global",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "owner",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "org",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "repo",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "matchUnlabeledJobsWithUnlabeledRunners",
+                    "type": "string",
+                    "default": "false",
+                    "metadataVariableReadable": true
+                },
+                {
+                    "name": "targetJobs",
+                    "type": "string",
+                    "default": "1",
+                    "metadataVariableReadable": true
+                }
+            ]
+        },
+        {
             "type": "graphite",
             "parameters": [
                 {

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -1656,6 +1656,43 @@ scalers:
           type: string
           optional: true
           triggerAuthenticationVariableReadable: true
+    - type: gitea-runner
+      parameters:
+        - name: token
+          type: string
+          envVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: address
+          type: string
+          metadataVariableReadable: true
+        - name: labels
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: global
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: owner
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: org
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: repo
+          type: string
+          optional: true
+          metadataVariableReadable: true
+        - name: matchUnlabeledJobsWithUnlabeledRunners
+          type: string
+          default: "false"
+          metadataVariableReadable: true
+        - name: targetJobs
+          type: string
+          default: "1"
+          metadataVariableReadable: true
     - type: graphite
       parameters:
         - name: serverAddress

--- a/tests/scalers/gitea_runner/gitea_runner_test.go
+++ b/tests/scalers/gitea_runner/gitea_runner_test.go
@@ -1,0 +1,413 @@
+//go:build e2e
+// +build e2e
+
+// Co-authored-by: Christopher Homberger <christopher.homberger@web.de>
+//
+// The Gitea bootstrap approach here — standing a real Gitea up in-cluster with
+// `gitea admin user create --access-token` rather than shipping a pre-seeded
+// database — comes from https://github.com/kedacore/keda/pull/6765.
+//
+// This version drives Gitea entirely through `kubectl exec` (the pattern already
+// used by the elasticsearch/loki/mongodb tests) instead of port-forwarding, so it
+// needs no additional vendored dependency and nothing outside the cluster.
+
+package gitea_runner_test
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/kedacore/keda/v2/tests/helper" // For helper methods
+)
+
+var _ = godotenv.Load("../../.env")
+
+const (
+	testName = "gitea-runner-test"
+
+	giteaUser = "test01"
+	giteaRepo = "scaler-test"
+
+	// Must match the label the workflow requests via `runs-on`.
+	runnerLabel = "ubuntu-latest"
+)
+
+var (
+	testNamespace   = fmt.Sprintf("%s-ns", testName)
+	secretName      = fmt.Sprintf("%s-secret", testName)
+	triggerAuthName = fmt.Sprintf("%s-auth", testName)
+	scaledJobName   = fmt.Sprintf("%s-sj", testName)
+
+	giteaAddress = fmt.Sprintf("http://gitea.%s.svc.cluster.local:3000", testNamespace)
+
+	maxReplicaCount = 2
+)
+
+type templateData struct {
+	TestNamespace   string
+	SecretName      string
+	TriggerAuthName string
+	ScaledJobName   string
+	ScaledJobLabel  string
+	GiteaAddress    string
+	GiteaPassword   string
+	GiteaToken      string
+	RunnerLabel     string
+	MaxReplicaCount int
+}
+
+const (
+	giteaDeploymentTemplate = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitea
+  namespace: {{ .TestNamespace }}
+  labels:
+    app: gitea
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitea
+  template:
+    metadata:
+      labels:
+        app: gitea
+    spec:
+      containers:
+        - name: gitea
+          image: gitea/gitea:1.27
+          ports:
+            - containerPort: 3000
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              mkdir -p /data/gitea/conf
+              cat > /data/gitea/conf/app.ini << 'EOF'
+              I_AM_BEING_UNSAFE_RUNNING_AS_ROOT = true
+              [security]
+              INSTALL_LOCK = true
+              PASSWORD_COMPLEXITY = off
+              [database]
+              DB_TYPE = sqlite3
+              PATH = /data/gitea.db
+              [repository]
+              ROOT = /data/repositories
+              [actions]
+              ENABLED = true
+              [server]
+              ROOT_URL = {{ .GiteaAddress }}
+              EOF
+              gitea migrate -c /data/gitea/conf/app.ini
+              gitea admin user create -c /data/gitea/conf/app.ini \
+                --username ` + giteaUser + ` --password '{{ .GiteaPassword }}' \
+                --email test01@gitea.local --admin --must-change-password=false
+              exec gitea web -c /data/gitea/conf/app.ini
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+`
+
+	giteaServiceTemplate = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitea
+  namespace: {{ .TestNamespace }}
+spec:
+  selector:
+    app: gitea
+  ports:
+    - port: 3000
+      targetPort: 3000
+`
+
+	secretTemplate = `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .SecretName }}
+  namespace: {{ .TestNamespace }}
+data:
+  token: {{ .GiteaToken }}
+`
+
+	triggerAuthenticationTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ .TriggerAuthName }}
+  namespace: {{ .TestNamespace }}
+spec:
+  secretTargetRef:
+    - parameter: token
+      name: {{ .SecretName }}
+      key: token
+`
+
+	// The scaled workload is deliberately trivial. This test proves the SCALER
+	// reads Gitea's queue correctly and drives Job creation; it is not a test of
+	// docker-in-docker or of the runner image.
+	scaledJobTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: {{ .ScaledJobName }}
+  namespace: {{ .TestNamespace }}
+spec:
+  jobTargetRef:
+    parallelism: 1
+    completions: 1
+    backoffLimit: 0
+    template:
+      metadata:
+        labels:
+          app: {{ .ScaledJobLabel }}
+      spec:
+        restartPolicy: Never
+        containers:
+          - name: worker
+            image: busybox:1.36
+            command: ["sh", "-c", "sleep 15"]
+  minReplicaCount: 0
+  maxReplicaCount: {{ .MaxReplicaCount }}
+  pollingInterval: 5
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  scalingStrategy:
+    strategy: accurate
+  triggers:
+    - type: gitea-runner
+      metadata:
+        address: {{ .GiteaAddress }}
+        global: "true"
+        labels: "{{ .RunnerLabel }}"
+      authenticationRef:
+        name: {{ .TriggerAuthName }}
+`
+)
+
+func TestGiteaRunnerScaler(t *testing.T) {
+	kc := GetKubernetesClient(t)
+
+	// Generated per run: no credential literal lives in this source file.
+	password := randomPassword(t)
+
+	data := getTemplateData("", password)
+	CreateKubernetesResources(t, kc, testNamespace, data, giteaTemplates())
+	defer DeleteKubernetesResources(t, testNamespace, data, giteaTemplates())
+
+	require.True(t, WaitForDeploymentReplicaReadyCount(t, kc, "gitea", testNamespace, 1, 12, 15),
+		"gitea should be ready within 3 minutes")
+
+	pod := giteaPodName(t)
+	token := mintToken(t, pod, password)
+	require.NotEmpty(t, token, "should have minted a Gitea API token")
+
+	seedRepo(t, pod, token)
+
+	data = getTemplateData(base64.StdEncoding.EncodeToString([]byte(token)), password)
+	KubectlApplyMultipleWithTemplate(t, data, scalerTemplates())
+	defer KubectlDeleteMultipleWithTemplate(t, data, scalerTemplates())
+
+	testNotActivated(t, kc)
+	testScaleOut(t, kc, pod, token)
+	testScaleIn(t, kc, pod, token)
+}
+
+func giteaTemplates() []Template {
+	return []Template{
+		{Name: "giteaDeploymentTemplate", Config: giteaDeploymentTemplate},
+		{Name: "giteaServiceTemplate", Config: giteaServiceTemplate},
+	}
+}
+
+func scalerTemplates() []Template {
+	return []Template{
+		{Name: "secretTemplate", Config: secretTemplate},
+		{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
+		{Name: "scaledJobTemplate", Config: scaledJobTemplate},
+	}
+}
+
+func getTemplateData(token, password string) templateData {
+	return templateData{
+		TestNamespace:   testNamespace,
+		SecretName:      secretName,
+		TriggerAuthName: triggerAuthName,
+		ScaledJobName:   scaledJobName,
+		ScaledJobLabel:  scaledJobName,
+		GiteaAddress:    giteaAddress,
+		GiteaPassword:   password,
+		GiteaToken:      token,
+		RunnerLabel:     runnerLabel,
+		MaxReplicaCount: maxReplicaCount,
+	}
+}
+
+// randomPassword generates the throwaway admin password for this test run, so
+// no credential literal is committed to the repository.
+func randomPassword(t *testing.T) string {
+	t.Helper()
+	buf := make([]byte, 24)
+	_, err := rand.Read(buf)
+	require.NoError(t, err, "should be able to generate a test password")
+	return "Aa1-" + base64.RawURLEncoding.EncodeToString(buf)
+}
+
+func giteaPodName(t *testing.T) string {
+	out, err := ExecuteCommand(fmt.Sprintf(
+		"kubectl get pod -n %s -l app=gitea -o jsonpath={.items[0].metadata.name}", testNamespace))
+	require.NoError(t, err, "should be able to find the gitea pod")
+	return strings.TrimSpace(string(out))
+}
+
+// giteaCurl runs curl inside the Gitea pod, so the test needs no port-forward
+// and no route from the test runner into the cluster.
+func giteaCurl(t *testing.T, pod, args string) string {
+	stdout, stderr, err := ExecCommandOnSpecificPodWithoutTTY(t, pod, testNamespace,
+		fmt.Sprintf("curl -sS --fail-with-body %s", args))
+	require.NoError(t, err, "curl inside gitea pod failed: %s", stderr)
+	return stdout
+}
+
+// mintToken creates an API token for the admin user. read:admin is the scope the
+// scaler needs for `global: true` — the /admin/* endpoints are not reachable with
+// a repo-scoped token.
+func mintToken(t *testing.T, pod, password string) string {
+	out := giteaCurl(t, pod, fmt.Sprintf(
+		`-X POST -u '%s:%s' -H 'Content-Type: application/json' `+
+			`-d '{"name":"keda-e2e","scopes":["read:admin","write:repository","write:user"]}' `+
+			`http://localhost:3000/api/v1/users/%s/tokens`,
+		giteaUser, password, giteaUser))
+
+	token := extractJSONString(out, "sha1")
+	t.Logf("minted Gitea token (%d chars)", len(token))
+	return token
+}
+
+// seedRepo creates a repository containing a single workflow that requests the
+// runner label under test. No runner is ever registered, so dispatched jobs stay
+// queued — which is exactly the state the scaler must report.
+func seedRepo(t *testing.T, pod, token string) {
+	auth := fmt.Sprintf("-H 'Authorization: token %s' -H 'Content-Type: application/json'", token)
+
+	giteaCurl(t, pod, fmt.Sprintf(
+		`-X POST %s -d '{"name":"%s","auto_init":true,"default_branch":"main"}' `+
+			`http://localhost:3000/api/v1/user/repos`, auth, giteaRepo))
+
+	workflow := "name: e2e\non: [workflow_dispatch]\njobs:\n  build:\n    runs-on: " + runnerLabel +
+		"\n    steps:\n      - run: echo hello\n"
+	encoded := base64.StdEncoding.EncodeToString([]byte(workflow))
+
+	giteaCurl(t, pod, fmt.Sprintf(
+		`-X POST %s -d '{"content":"%s","message":"add workflow","branch":"main"}' `+
+			`http://localhost:3000/api/v1/repos/%s/%s/contents/.gitea/workflows/e2e.yaml`,
+		auth, encoded, giteaUser, giteaRepo))
+
+	t.Log("seeded repository with a workflow requesting label", runnerLabel)
+}
+
+func dispatchWorkflow(t *testing.T, pod, token string) {
+	giteaCurl(t, pod, fmt.Sprintf(
+		`-X POST -H 'Authorization: token %s' -H 'Content-Type: application/json' `+
+			`-d '{"ref":"main"}' `+
+			`http://localhost:3000/api/v1/repos/%s/%s/actions/workflows/e2e.yaml/dispatches`,
+		token, giteaUser, giteaRepo))
+}
+
+// queuedJobs asks Gitea the same question the scaler asks, so a failure can be
+// attributed to either the scaler or the fixture rather than being ambiguous.
+func queuedJobs(t *testing.T, pod, token string) string {
+	out := giteaCurl(t, pod, fmt.Sprintf(
+		`-H 'Authorization: token %s' `+
+			`'http://localhost:3000/api/v1/admin/actions/jobs?status=queued&status=in_progress&limit=1'`,
+		token))
+	return extractJSONNumber(out, "total_count")
+}
+
+func testNotActivated(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing not activated ---")
+	// Nothing dispatched yet, so the queue is empty and no Job should appear.
+	// Job count, not replica count: a ScaledJob has no Deployment to inspect.
+	assert.True(t, WaitForJobCountUntilIteration(t, kc, testNamespace, 0, 6, 5),
+		"no jobs should be created while the Gitea queue is empty")
+}
+
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, pod, token string) {
+	t.Log("--- testing scale out ---")
+
+	for i := 0; i < maxReplicaCount; i++ {
+		dispatchWorkflow(t, pod, token)
+	}
+	t.Logf("dispatched %d workflow runs; gitea reports total_count=%s",
+		maxReplicaCount, queuedJobs(t, pod, token))
+
+	assert.True(t, WaitForJobCount(t, kc, testNamespace, maxReplicaCount, 60, 2),
+		fmt.Sprintf("job count should reach %d within 2 minutes", maxReplicaCount))
+}
+
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, pod, token string) {
+	t.Log("--- testing scale in ---")
+
+	// Deleting the repository clears its queued jobs, so the metric returns to 0.
+	giteaCurl(t, pod, fmt.Sprintf(
+		`-X DELETE -H 'Authorization: token %s' http://localhost:3000/api/v1/repos/%s/%s`,
+		token, giteaUser, giteaRepo))
+
+	t.Logf("repo deleted; gitea now reports total_count=%s", queuedJobs(t, pod, token))
+
+	assert.True(t, WaitForPodsCompleted(t, kc, fmt.Sprintf("app=%s", scaledJobName), testNamespace, 60, 2),
+		"in-flight jobs should complete rather than be killed")
+}
+
+// extractJSONString pulls a string field out of a JSON object without needing a
+// struct, keeping the exec-based fixture dependency-free.
+func extractJSONString(body, key string) string {
+	marker := fmt.Sprintf(`"%s":"`, key)
+	idx := strings.Index(body, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := body[idx+len(marker):]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+func extractJSONNumber(body, key string) string {
+	marker := fmt.Sprintf(`"%s":`, key)
+	idx := strings.Index(body, marker)
+	if idx < 0 {
+		return "?"
+	}
+	rest := body[idx+len(marker):]
+	end := strings.IndexAny(rest, ",}")
+	if end < 0 {
+		return "?"
+	}
+	return strings.TrimSpace(rest[:end])
+}


### PR DESCRIPTION
> **Made using AI.** Authored with Claude Code; reviewed and verified by me before submitting.

Adds a `gitea-runner` scaler for Gitea Actions.

### Why a separate scaler

**`forgejo-runner` does not work against Gitea.** It calls `/api/v1/admin/runners/jobs`, which returns **404** on Gitea (verified against 1.27.2) — go-gitea/gitea#32862, which requested that endpoint, is still open. It also expects a bare array where Gitea returns a `{jobs, total_count}` envelope, and it filters via a `labels` query parameter that Gitea **ignores entirely**. So even fixing the path would silently return the page cap rather than a real count — a wrong answer rather than an error.

**`github-runner` does work against Gitea** (thanks to @ChristopherHX's finding in #6765), because Gitea implements GitHub-compatible Actions endpoints. But it targets an API with no instance-wide jobs endpoint, so it enumerates repos → runs per repo → jobs per run, roughly `1 + 2R + W` requests per poll. Its `enableEtags` mitigation doesn't apply either, as Gitea sends no ETag on these endpoints.

**Gitea exposes what GitHub doesn't:** `/api/v1/admin/actions/jobs`, instance-wide, where `total_count` honours a status filter and repeated `status` parameters are OR-ed. With no label filter this scaler answers in **one request per poll**, regardless of queue size.

### Design notes

- **Counts `queued` AND `in_progress`.** A queued-only metric collapses to zero the moment jobs are picked up, tearing down the replicas doing the work. Gitea accepts both statuses in a single call, so this costs nothing.
- **Label filtering is client-side**, because Gitea has no server-side filter here. Page size is capped by `MAX_RESPONSE_ITEMS` (50 by default); pagination is bounded at 20 pages and **logs when the bound is hit**, so a lower-bound count is never silent.
- **Four scopes** mirroring the forgejo scaler: `global` (admin), `org`, `owner`+`repo`, and the token owner's own jobs.

### Verification

Validated against a live Gitea 1.27.2 — the no-label path returned the correct count (11,329) in exactly **one** request; the label path paginated and stopped at the cap as designed.

The e2e passes against k3d with a locally built KEDA, in ~79s, covering not-activated → scale-out → scale-in. The `0 → 0 → 0 → 2` job-count progression confirms the scaler reacts to the queue changing rather than to pre-existing state.

### On the e2e, and credit

The approach of standing a real Gitea up in-cluster and bootstrapping it with `gitea admin user create --access-token`, rather than shipping a pre-seeded database, is @ChristopherHX's from #6765 — he is credited as co-author on the commit, and I gave him a heads-up on that PR.

This version drives Gitea through `kubectl exec` (the pattern `elasticsearch`/`loki`/`mongodb` already use) instead of port-forwarding, so it needs **no additional vendored dependency** and nothing outside the cluster. That also addresses his own concern that the port-forward variant might be flaky in CI.

Happy to restructure if maintainers would rather see this land differently.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)* — **not applicable**: this PR touches only Go source, the CHANGELOG and the generated scaler schema; no deployment manifests are modified, so no charts PR is needed
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* — kedacore/keda-docs#1851
- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #8086

Relates to kedacore/keda-docs#1851

