### PR TITLE
CI: use server-side apply for Argo Rollouts

### DIFF
--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -69,7 +69,7 @@ func TestSetupArgoRollouts(t *testing.T) {
 	}
 	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, ArgoRolloutsNamespace)
-	cmdWithNamespace := fmt.Sprintf("kubectl apply -n %s -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml",
+	cmdWithNamespace := fmt.Sprintf("kubectl apply --server-side -n %s -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml",
 		ArgoRolloutsNamespace)
 	_, err := ExecuteCommand(cmdWithNamespace)
 


### PR DESCRIPTION
The Argo Rollouts CRDs now exceed the annotation size limit used by client-side apply. Use server-side apply so the e2e setup does not store the complete CRD manifests in the last-applied-configuration annotation (which doesn't work anymore).

This follows the Argo Rollouts fix documented in https://github.com/argoproj/argo-rollouts/pull/4687.

I will create a follow-up PR to pin the version using renovate.


### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
