### PR TITLE
CI: pin Argo Rollouts e2e dependency

### DIFF
--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -48,6 +48,8 @@ import (
 )
 
 const (
+	// renovate: datasource=github-releases depName=argoproj/argo-rollouts
+	ArgoRolloutsVersion            = "v1.9.1"
 	ArgoRolloutsNamespace          = "argo-rollouts"
 	AzureWorkloadIdentityNamespace = "azure-workload-identity-system"
 	AwsIdentityNamespace           = "aws-identity-system"

--- a/tests/utils/cleanup_test.go
+++ b/tests/utils/cleanup_test.go
@@ -72,7 +72,7 @@ func TestRemoveArgoRollouts(t *testing.T) {
 		t.Skip("skipping -- Argo Rollouts was not installed for this run")
 	}
 
-	_, err := ExecuteCommand(fmt.Sprintf("kubectl delete -n %s -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml", ArgoRolloutsNamespace))
+	_, err := ExecuteCommand(fmt.Sprintf("kubectl delete -n %s -f https://github.com/argoproj/argo-rollouts/releases/download/%s/install.yaml", ArgoRolloutsNamespace, ArgoRolloutsVersion))
 	require.NoErrorf(t, err, "cannot uninstall argo rollouts - %s", err)
 	DeleteNamespace(t, ArgoRolloutsNamespace)
 }

--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -69,8 +69,8 @@ func TestSetupArgoRollouts(t *testing.T) {
 	}
 	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, ArgoRolloutsNamespace)
-	cmdWithNamespace := fmt.Sprintf("kubectl apply -n %s -f https://github.com/argoproj/argo-rollouts/releases/latest/download/install.yaml",
-		ArgoRolloutsNamespace)
+	cmdWithNamespace := fmt.Sprintf("kubectl apply -n %s -f https://github.com/argoproj/argo-rollouts/releases/download/%s/install.yaml",
+		ArgoRolloutsNamespace, ArgoRolloutsVersion)
 	_, err := ExecuteCommand(cmdWithNamespace)
 
 	require.NoErrorf(t, err, "cannot install argo resources - %s", err)

--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -70,7 +70,7 @@ func TestSetupArgoRollouts(t *testing.T) {
 	KubeClient = GetKubernetesClient(t)
 	CreateNamespace(t, KubeClient, ArgoRolloutsNamespace)
 	cmdWithNamespace := fmt.Sprintf("kubectl apply --server-side -n %s -f https://github.com/argoproj/argo-rollouts/releases/download/%s/install.yaml",
-		ArgoRolloutsNamespace, ArgoRolloutsVersion)	
+		ArgoRolloutsNamespace, ArgoRolloutsVersion)
 	_, err := ExecuteCommand(cmdWithNamespace)
 
 	require.NoErrorf(t, err, "cannot install argo resources - %s", err)


### PR DESCRIPTION
Track the Argo Rollouts release with Renovate and use the pinned version for setup and cleanup. Keep the e2e setup compatible with the version used before Argo Rollouts 1.10.0 while the server-side apply fix is reviewed separately.

The server-side apply fix is proposed in https://github.com/kedacore/keda/pull/8094 and follows https://github.com/argoproj/argo-rollouts/pull/4687.

We already track the strimzi version in a similar way: https://github.com/kedacore/keda/blob/4921f2339156dab9bc15f906efd8ecf1f29e0961/tests/helper/helper.go#L67-L68

I will rebase this PR after #8094 merged to resolve the conflict.

### Checklist

- [ ] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Tests have been added *(if applicable)*
- [ ] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [ ] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

