### PR TITLE
CI: scan test dependencies with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,8 +10,10 @@
     ":gitSignOff",
     ":prHourlyLimitNone",
   ],
+  ignorePresets: [":ignoreModulesAndTests"],
   commitBodyTable: true,
   commitMessagePrefix: "Dependencies:",
+  ignorePaths: ["**/vendor/**"],
   labels: ["dependencies", "kind/dependencies"],
   osvVulnerabilityAlerts: true,
   packageRules: [


### PR DESCRIPTION
The renovate preset config:recommended also included a preset :ignoreModulesAndTests which caused our renovate regex comments to be ignored.
I noticed this in the renovate dashboard after the PR about tracking the argo rollouts version yesterday, the file wasn't referenced at the bottom of the dashboard.

We have no vendor here anymore but who knows, the default included way more but this was the only thing that made sense to keep in a go project.

### Dashboard Issue

See #2063 

<img width="490" height="470" alt="image" src="https://github.com/user-attachments/assets/fa5ba7cb-effe-438c-aa3d-022727def38c" />


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #8095 