### PR TITLE
General: Fix typos in comments and make help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ pkg/scalers/liiklus/mocks/mock_liiklus.go:
 
 ##@ Build
 
-build: update-mod generate fmt vet manager adapter webhooks ## Build Operator (manager), Metrics Server (adapter) and Admision Web Hooks (webhooks) binaries.
+build: update-mod generate fmt vet manager adapter webhooks ## Build Operator (manager), Metrics Server (adapter) and Admission Web Hooks (webhooks) binaries.
 
 update-mod:
 	go mod tidy

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -600,7 +600,7 @@ func ValidateAndCompileScalingModifiers(so *ScaledObject) (*vm.Program, error) {
 	}
 
 	// cast return value of formula to float if necessary to avoid wrong value return
-	// type (ternary operator doesnt return float)
+	// type (ternary operator doesn't return float)
 	so.Spec.Advanced.ScalingModifiers.Formula = castToFloatIfNecessary(sm.Formula)
 
 	// validate formula if not empty

--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -144,7 +144,7 @@ func getMetricHandler() http.HandlerFunc {
 	}
 }
 
-// getMetricInterceptor returns a metrics inceptor that records metrics between the adapter and opertaor
+// getMetricInterceptor returns a metrics interceptor that records metrics between the adapter and operator
 func getMetricInterceptor() *grpcprom.ClientMetrics {
 	metricsNamespace := "keda_internal_metricsservice"
 

--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -626,7 +626,7 @@ func buildRegexFromConfig(config helper.TestConfig) (string, error) {
 		}
 
 		if len(supportedTests) > 0 {
-			// go regex doesn't support negative lookaheads, so we need to explicily include the tests we want to run
+			// go regex doesn't support negative lookaheads, so we need to explicitly include the tests we want to run
 			regexParts = append(regexParts, fmt.Sprintf("%s/(%s)/.*", category, strings.Join(supportedTests, "|")))
 		}
 		// if there's no tests for that category, we don't need to add anything to the regex

--- a/tests/secret-providers/aws_identity_assume_role/aws_identity_assume_role_test.go
+++ b/tests/secret-providers/aws_identity_assume_role/aws_identity_assume_role_test.go
@@ -170,7 +170,7 @@ func TestSqsScaler(t *testing.T) {
 	// for a role that can be assumed
 	testScaleWithExplicitRoleArnUsingRoleAssumtion(t, kc, data, sqsClient, queueWorkload1.QueueUrl)
 	// test scaling using correct identity provided via podIdentity.RoleArn
-	// for a role to be used with web indentity (workload-2 role allows it)
+	// for a role to be used with web identity (workload-2 role allows it)
 	testScaleWithExplicitRoleArnUsingWebIdentityRole(t, kc, data, sqsClient, queueWorkload2.QueueUrl)
 	// test scaling using correct identity provided via workload
 	testScaleWithWorkloadArn(t, kc, data, sqsClient, queueWorkload1.QueueUrl)


### PR DESCRIPTION
Five spelling fixes. One is visible in `make help`:

- `Makefile`: "Admision Web Hooks" -> "Admission Web Hooks" in the `build` target's help text

The rest are comments:

- `cmd/adapter/main.go`: "a metrics inceptor … the adapter and opertaor" -> "a metrics interceptor … the adapter and operator" (two typos on one line)
- `apis/keda/v1alpha1/scaledobject_webhook.go`: "doesnt" -> "doesn't"
- `tests/run-all.go`: "explicily" -> "explicitly"
- `tests/secret-providers/aws_identity_assume_role/…`: "web indentity" -> "web identity"

No behaviour changes, so no docs request is needed. Happy to take a `skip-changelog` or `kind/chore` label, whichever you prefer.