### PR TITLE
General: Copy the Anti-Spam policy into contributing.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,7 @@ If a rule here conflicts with `CONTRIBUTING.md`, follow `CONTRIBUTING.md` and fl
 
 ## Zero-spam & PR authorization policy
 
-- **Require an issue:** DO NOT create a Pull Request unless there is an existing, open, and approved GitHub Issue that explicitly requests this work. Drive-by PRs, speculative refactors, "found a typo" PRs, and unsolicited feature work are not accepted.
-- **Require assignment:** DO NOT start work on an issue unless it is assigned to the human user driving you. An unassigned issue is not an invitation to start coding. If the human has not been assigned, ask them to request assignment from a maintainer first and wait.
-- **Respect claimed issues**: If someone has commented that they intend to work on the issue, or has been assigned to it, do not open a competing PR, push commits, or start a draft PR. However, if there has been no visible progress for an extended period, it is acceptable to politely ask whether they are still actively working on it before taking further action.
-- **Stay inside the issue's scope:** Implement only what the issue describes. If you discover related problems, mention them in the PR description or open a separate issue. Do not silently expand the scope.
-- **One issue, one PR:** Do not bundle multiple issues into a single PR, and do not split a single issue across multiple PRs without coordinating in the issue first.
-- **No PR for chores that already have automation:** Dependency bumps (Renovate/Dependabot), changelog regeneration, generated-file refreshes, and similar housekeeping are handled by bots or release tooling. Do not open PRs that duplicate that work.
+Follow the [Anti-Spam & PR authorization policy](CONTRIBUTING.md#anti-spam--pr-authorization-policy) in `CONTRIBUTING.md`. In short: require an approved issue and assignment before opening a PR, respect claimed issues, stay in scope, one issue per PR, and do not duplicate bot-managed chores.
 
 ## Pull request rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ There are many areas we can use contributions - ranging from code, documentation
 **Table of contents**
 
 - [Project governance](#project-governance)
+- [Anti-Spam & PR authorization policy](#anti-spam--pr-authorization-policy)
 - [Getting Help](#getting-help)
 - [Making Breaking Changes](#making-breaking-changes)
 - [Contributing Scalers](#contributing-scalers)
@@ -31,6 +32,17 @@ There are many areas we can use contributions - ranging from code, documentation
 ## Project governance
 
 You can learn about the governance of KEDA [here](https://github.com/kedacore/governance).
+
+## Anti-Spam & PR authorization policy
+
+To keep review load manageable and respect everyone's time, we ask contributors to follow these rules:
+
+- **Require an issue:** Do not open a Pull Request unless there is an existing, open GitHub Issue that explicitly requests the work. Drive-by PRs, speculative refactors, typo-only PRs, and unsolicited feature work are not accepted.
+- **Require assignment:** Do not start work on an issue unless you have been assigned to it. An unassigned issue is not an invitation to start coding. Comment on the issue and ask a maintainer to assign you before you begin.
+- **Respect claimed issues:** If someone has commented that they intend to work on an issue, or has been assigned to it, do not open a competing PR. If there has been no visible progress for an extended period, it is fine to politely ask whether they are still actively working on it before taking further action.
+- **Stay inside the issue's scope:** Implement only what the issue describes. If you discover related problems, mention them in the PR description or open a separate issue — do not silently expand the scope.
+- **One issue, one PR:** Do not bundle multiple issues into a single PR, and do not split a single issue across multiple PRs without coordinating in the issue first.
+- **No PR for chores that already have automation:** Dependency bumps (Renovate/Dependabot), changelog regeneration, generated-file refreshes, and similar housekeeping are handled by bots or release tooling. Do not open PRs that duplicate that work.
 
 ## Getting Help
 


### PR DESCRIPTION

I move Anti-Spam & PR authorization policy from Agents.md file to CONTRIBUTING.md 

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Fixes https://github.com/kedacore/keda/issues/8091

