### PR TITLE
Selenium Grid Scaler: add includeOngoingSessions trigger param

### DIFF
--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -42,6 +42,7 @@ type seleniumGridScalerMetadata struct {
 	NodeMaxSessions        int64  `keda:"name=nodeMaxSessions,          order=triggerMetadata, default=1"`
 	EnableManagedDownloads bool   `keda:"name=enableManagedDownloads,   order=triggerMetadata, default=true"`
 	Capabilities           string `keda:"name=capabilities,             order=triggerMetadata, optional"`
+	IncludeOngoingSessions bool   `keda:"name=includeOngoingSessions,   order=triggerMetadata, default=true"`
 
 	TargetValue int64
 }
@@ -204,9 +205,33 @@ func (s *seleniumGridScaler) GetMetricsAndActivity(ctx context.Context, metricNa
 		return []external_metrics.ExternalMetricValue{}, false, fmt.Errorf("error requesting selenium grid endpoint: %w", err)
 	}
 
-	metric := GenerateMetricInMili(metricName, float64(newRequestNodes+onGoingSessions))
+	// The metric returned to KEDA represents the number of Nodes (Job pods) the Grid needs.
+	// On-going sessions are work the Grid is already serving, so whether they belong in the
+	// metric depends on whether the consumer subtracts already-running work for us:
+	//
+	//   * ScaledObjects (HPA), and ScaledJobs using the "default" or "custom" strategy, deduct
+	//     the running Job count from the desired scale ("custom" deducts
+	//     customScalingRunningJobPercentage of it). On-going sessions are served by running
+	//     Jobs, so they cancel out in that deduction: the metric must report queued requests
+	//     PLUS on-going sessions for the arithmetic to resolve to the number of *new* Nodes to
+	//     create. This is the default.
+	//
+	//   * ScaledJobs using "accurate" deduct the pending Job count, and "eager" deducts the
+	//     running and pending Job counts (bounded by maxScale). These strategies do not re-add
+	//     running work, so counting on-going sessions here double-counts work already in
+	//     progress and causes runaway Job creation that never scales back down (see
+	//     SeleniumHQ/docker-selenium#3167). Set includeOngoingSessions=false for these, so the
+	//     metric reports only the new Nodes required to drain the session queue.
+	//
+	// See pkg/scaling/executor/scale_jobs.go for how the executor computes effective max scale.
+	count := newRequestNodes
+	if s.metadata.IncludeOngoingSessions {
+		count += onGoingSessions
+	}
 
-	return []external_metrics.ExternalMetricValue{metric}, (newRequestNodes + onGoingSessions) > s.metadata.ActivationThreshold, nil
+	metric := GenerateMetricInMili(metricName, float64(count))
+
+	return []external_metrics.ExternalMetricValue{metric}, count > s.metadata.ActivationThreshold, nil
 }
 
 func buildSeleniumGridMetricName(meta *seleniumGridScalerMetadata) string {

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -1,6 +1,9 @@
 package scalers
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -3210,6 +3213,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				BrowserVersion:         "",
 				PlatformName:           "",
@@ -3234,6 +3238,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "MicrosoftEdge",
 				SessionBrowserName:     "msedge",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				BrowserVersion:         "",
 				PlatformName:           "",
@@ -3257,6 +3262,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "",
 				SessionBrowserName:     "",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				BrowserVersion:         "",
 				PlatformName:           "",
@@ -3287,6 +3293,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				Password:               "password",
 				BrowserName:            "MicrosoftEdge",
 				SessionBrowserName:     "msedge",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				BrowserVersion:         "",
 				PlatformName:           "",
@@ -3315,6 +3322,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "MicrosoftEdge",
 				SessionBrowserName:     "msedge",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				BrowserVersion:         "",
 				PlatformName:           "",
@@ -3347,6 +3355,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "MicrosoftEdge",
 				SessionBrowserName:     "msedge",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				BrowserVersion:         "",
 				PlatformName:           "",
@@ -3374,6 +3383,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				BrowserVersion:         "91.0",
 				UnsafeSsl:              false,
@@ -3401,6 +3411,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				ActivationThreshold:    10,
 				BrowserVersion:         "91.0",
@@ -3444,6 +3455,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				ActivationThreshold:    10,
 				BrowserVersion:         "91.0",
@@ -3473,6 +3485,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				URL:                    "http://selenium-hub:4444/graphql",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				ActivationThreshold:    10,
 				BrowserVersion:         "91.0",
@@ -3509,6 +3522,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				Password:               "password",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				ActivationThreshold:    10,
 				BrowserVersion:         "91.0",
@@ -3546,6 +3560,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				Password:               "password",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				ActivationThreshold:    10,
 				BrowserVersion:         "91.0",
@@ -3583,6 +3598,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				AccessToken:            "my-access-token",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				ActivationThreshold:    10,
 				BrowserVersion:         "91.0",
@@ -3619,6 +3635,7 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 				AccessToken:            "my-access-token",
 				BrowserName:            "chrome",
 				SessionBrowserName:     "chrome",
+				IncludeOngoingSessions: true,
 				TargetValue:            1,
 				ActivationThreshold:    10,
 				BrowserVersion:         "91.0",
@@ -3639,6 +3656,106 @@ func Test_parseSeleniumGridScalerMetadata(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseSeleniumGridScalerMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GetMetricsAndActivity_IncludeOngoingSessions(t *testing.T) {
+	// Grid with 2 queued chrome requests and 1 on-going chrome session on a fully
+	// occupied Node. getCountFromSeleniumResponse yields newRequestNodes=2, onGoingSessions=1.
+	response := []byte(`{
+		"data": {
+			"grid": { "sessionCount": 1, "maxSession": 1, "totalSlots": 1 },
+			"nodesInfo": {
+				"nodes": [
+					{
+						"id": "node-1",
+						"status": "UP",
+						"sessionCount": 1,
+						"maxSession": 1,
+						"slotCount": 1,
+						"stereotypes": "[{\"slots\": 1, \"stereotype\": {\"browserName\": \"chrome\"}}]",
+						"sessions": [
+							{
+								"id": "session-1",
+								"capabilities": "{\"browserName\": \"chrome\"}",
+								"slot": { "id": "slot-1", "stereotype": "{\"browserName\": \"chrome\"}" }
+							}
+						]
+					}
+				]
+			},
+			"sessionsInfo": {
+				"sessionQueueRequests": [
+					"{\"browserName\": \"chrome\"}",
+					"{\"browserName\": \"chrome\"}"
+				]
+			}
+		}
+	}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// nosemgrep: no-direct-write-to-responsewriter
+		_, _ = w.Write(response)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name                   string
+		includeOngoingSessions string
+		wantMetric             int64
+	}{
+		{
+			name:                   "omitted defaults to including on-going sessions",
+			includeOngoingSessions: "",
+			wantMetric:             3,
+		},
+		{
+			name:                   "explicit true includes on-going sessions",
+			includeOngoingSessions: "true",
+			wantMetric:             3,
+		},
+		{
+			name:                   "false excludes on-going sessions",
+			includeOngoingSessions: "false",
+			wantMetric:             2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			triggerMetadata := map[string]string{
+				"url":         server.URL,
+				"browserName": "chrome",
+			}
+			if tt.includeOngoingSessions != "" {
+				triggerMetadata["includeOngoingSessions"] = tt.includeOngoingSessions
+			}
+
+			meta, err := parseSeleniumGridScalerMetadata(&scalersconfig.ScalerConfig{
+				TriggerMetadata: triggerMetadata,
+			})
+			if err != nil {
+				t.Fatalf("parseSeleniumGridScalerMetadata() error = %v", err)
+			}
+
+			s := &seleniumGridScaler{
+				metadata:   meta,
+				httpClient: http.DefaultClient,
+				logger:     logr.Discard(),
+			}
+
+			metrics, active, err := s.GetMetricsAndActivity(context.Background(), "s0-selenium-grid-chrome")
+			if err != nil {
+				t.Fatalf("GetMetricsAndActivity() error = %v", err)
+			}
+			if !active {
+				t.Errorf("GetMetricsAndActivity() active = false, want true")
+			}
+			if got := metrics[0].Value.MilliValue() / 1000; got != tt.wantMetric {
+				t.Errorf("GetMetricsAndActivity() metric = %v, want %v", got, tt.wantMetric)
 			}
 		})
 	}

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -5441,6 +5441,12 @@
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "includeOngoingSessions",
+                    "type": "string",
+                    "default": "true",
+                    "metadataVariableReadable": true
                 }
             ]
         },

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -3580,6 +3580,10 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
+        - name: includeOngoingSessions
+          type: string
+          default: "true"
+          metadataVariableReadable: true
     - type: solace-direct-messaging
       parameters:
         - name: solaceSempBaseURL


### PR DESCRIPTION
The Selenium Grid scaler reports queued session requests **plus on-going sessions** as its scaling metric. That total is only correct when the consumer deducts already-running work: ScaledObjects (HPA), and ScaledJobs using the `default` or `custom` strategy, subtract the *running* Job count from the desired scale, so on-going sessions cancel out in the subtraction and the arithmetic resolves to the number of new Nodes to create.

The `accurate` strategy instead subtracts the *pending* Job count, and `eager` subtracts running + pending (bounded by `maxScale`). Because these never re-add running work, on-going sessions are counted again on every polling cycle — producing runaway Node creation that never scales back down. This is exactly what surfaced when the Selenium Grid Helm chart switched its default ScaledJob strategy from `default` to `accurate` (SeleniumHQ/docker-selenium#3167).

This change adds an `includeOngoingSessions` trigger metadata option (`bool`, default `true`) that controls whether on-going sessions are counted toward the metric:

```yaml
triggers:
  - type: selenium-grid
    metadata:
      url: http://selenium-hub:4444/graphql
      browserName: chrome
      includeOngoingSessions: "false"   # required for accurate / eager
```

The recommended value follows directly from which Job count each strategy deducts in `GetEffectiveMaxScale` (`pkg/scaling/executor/scale_jobs.go`):

| ScaledJob strategy | Core deducts | `includeOngoingSessions` | Metric emitted |
|---|---|---|---|
| `default` | running Job count | `true` (default) | queued requests + on-going sessions |
| `custom` | `customScalingRunningJobPercentage` of running Job count | `true` (default) | queued requests + on-going sessions |
| `accurate` | pending Job count | **`false`** | queued requests only |
| `eager` | running + pending Job count (bounded by `maxScale`) | **`false`** | queued requests only |
| _ScaledObject (HPA)_ | running replicas via HPA | `true` (default) | queued requests + on-going sessions |

Defaulting to `true` keeps current behaviour, so existing deployments are unaffected and this is backward compatible.

### Why a trigger param rather than reading the ScaledJob strategy

An earlier revision of this PR derived the behaviour automatically from the owning ScaledJob's `spec.scalingStrategy.strategy`. That was dropped in favour of an explicit param, for two reasons:

1. **It matches how other scalers expose the same choice** — whether in-progress work counts toward the metric: AWS SQS `scaleOnInFlight` / `scaleOnDelayed`, RabbitMQ `excludeUnacknowledged`, Beanstalkd `includeDelayed`, Temporal `includeRunningWorkflowCount`. All are plain booleans on trigger metadata.
2. **It keeps the change inside the scaler.** Auto-detection required threading the strategy through `WithTriggersSpec`, `ScalerConfig` and `scalers_builder`, which would have made this the first scaler to branch its metric on owner-object spec. `ScalableObjectType` — the only owner context in `ScalerConfig` today — feeds logging and one Prometheus label, but never behaviour.

The trade-off, stated plainly: unlike auto-detection, the param can be set inconsistently with the ScaledJob strategy, which reproduces the bug it fixes. This is the same characteristic `scaleOnInFlight` has on SQS + ScaledJob, so it is handled the same way — in the docs.

> [!NOTE]
> `custom` is a spectrum. Leaving `includeOngoingSessions` at `true` is correct for the common `customScalingRunningJobPercentage: "1"` configuration (the recommended equivalent of `default`). A running percentage well below `1` deducts less running work, in which case the total-desired value slightly over-provisions.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md) <!-- backward compatible; new optional field defaults to prior behavior -->
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(https://github.com/kedacore/keda-docs/pull/1858)* <!-- TODO: document includeOngoingSessions, incl. setting it to false for accurate/eager -->
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to SeleniumHQ/docker-selenium#3167
