### PR TITLE
CI: three internals tests cannot report a failure

### DIFF
--- a/tests/internals/file_based_auth/file_based_auth_test.go
+++ b/tests/internals/file_based_auth/file_based_auth_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
@@ -202,27 +203,22 @@ func testScaledObjectWithFileAuth(t *testing.T) {
 	kc := GetKubernetesClient(t)
 	kedaKc := GetKedaKubernetesClient(t)
 
-	// Verify ScaledObject was created successfully
+	// Setup applies scaledObjectTemplate unconditionally, so a missing ScaledObject is a failure and
+	// not an environment to skip: returning here passed the whole test without reaching a single one
+	// of the scaling assertions below.
 	scaledObject, err := kedaKc.ScaledObjects(testNamespace).Get(context.Background(), scaledObjectName, metav1.GetOptions{})
-	if err != nil {
-		t.Logf("ScaledObject not found (expected in e2e environment): %v", err)
-		return
-	}
-	assert.NotNil(t, scaledObject)
+	require.NoErrorf(t, err, "scaledobject %s/%s should exist", testNamespace, scaledObjectName)
 
-	// Verify the authenticationRef exists
-	if len(scaledObject.Spec.Triggers) > 0 {
-		assert.NotNil(t, scaledObject.Spec.Triggers[0].AuthenticationRef)
-		assert.Equal(t, "file-auth", scaledObject.Spec.Triggers[0].AuthenticationRef.Name)
-		assert.Equal(t, "ClusterTriggerAuthentication", scaledObject.Spec.Triggers[0].AuthenticationRef.Kind)
-	}
+	// Verify the authenticationRef exists. Asserted rather than guarded by a length check, which
+	// skipped these three silently when the trigger the template defines was not there.
+	require.NotEmpty(t, scaledObject.Spec.Triggers, "scaledobject should have one trigger")
+	require.NotNil(t, scaledObject.Spec.Triggers[0].AuthenticationRef, "trigger should reference an authentication")
+	assert.Equal(t, "file-auth", scaledObject.Spec.Triggers[0].AuthenticationRef.Name)
+	assert.Equal(t, "ClusterTriggerAuthentication", scaledObject.Spec.Triggers[0].AuthenticationRef.Kind)
 
 	// Verify ClusterTriggerAuthentication has the filePath
 	clusterTriggerAuth, err := kedaKc.ClusterTriggerAuthentications().Get(context.Background(), "file-auth", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("ClusterTriggerAuthentication not found: %v", err)
-	}
-	assert.NotNil(t, clusterTriggerAuth)
+	require.NoError(t, err, "clustertriggerauthentication file-auth should exist")
 	assert.Equal(t, "creds.json", clusterTriggerAuth.Spec.FilePath)
 
 	// Check app is scaled to 0

--- a/tests/internals/force_activation/force_activation_test.go
+++ b/tests/internals/force_activation/force_activation_test.go
@@ -113,8 +113,12 @@ func TestScaler(t *testing.T) {
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
-	// assert that the deployment did not scale down after one minute
-	WaitForDeploymentReplicaCountChange(t, kc, deploymentName, testNamespace, 0, 60)
+	// The trigger is inactive to start with - the monitored deployment has no pods - so KEDA takes
+	// this deployment to idleReplicaCount. Waiting for that is what gives the force-activation
+	// assertion something to prove: the deployment is created with two replicas, which is the very
+	// count that assertion looks for, so without this it is satisfied before anything is forced.
+	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
+		"replica count should be 0 before activation is forced")
 
 	// test activation
 	testForceActivation(t, kc)

--- a/tests/internals/scaled_job_validation/scaled_job_validation_test.go
+++ b/tests/internals/scaled_job_validation/scaled_job_validation_test.go
@@ -116,11 +116,13 @@ func TestScaledJobValidations(t *testing.T) {
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
+	// Deferred because the checks below end the test early when they fail, which would otherwise
+	// leave this namespace behind for whatever runs next.
+	defer DeleteKubernetesResources(t, testNamespace, data, templates)
+
 	testTriggersWithEmptyArray(t, data)
 
 	testScaledJobWithExcludedLabels(t, data)
-
-	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 
 func testTriggersWithEmptyArray(t *testing.T, data templateData) {
@@ -140,9 +142,11 @@ func testScaledJobWithExcludedLabels(t *testing.T, data templateData) {
 	err = KubectlApplyWithErrors(t, data, "scaledJobTemplateWithExcludedLabels", scaledJobTemplateWithExcludedLabels)
 	assert.NoError(t, err, "scaledJob should be deployed")
 
+	// Required rather than asserted: the label checks below read fields off this job, so a wait that
+	// timed out would panic here instead of reporting that no job was created.
 	job, err := WaitForJobCreation(t, GetKubernetesClient(t), data.ExcludedLabelsSjName, data.TestNamespace, 10, 5)
-	assert.NoError(t, err, "job should be created")
-	assert.NotNil(t, job, "job should be created")
+	require.NoError(t, err, "job should be created")
+	require.NotNil(t, job, "job should be created")
 
 	// Ensure that foo.bar/environment and foo.bar/version labels are not propagated
 	assert.Equal(t, "", job.Labels["foo.bar/environment"], "job should not have the 'foo.bar/environment' label")


### PR DESCRIPTION
Three tests in `tests/internals` are green for reasons unrelated to what they are checking. Found while auditing the wait and assertion patterns tracked in #7991.

### `force_activation` passes whether or not force-activation works

The deployment is created with two replicas:

```yaml
spec:
  replicas: 2
```

and the test forces activation, then asserts the count reaches two:

```go
upsertScaledObjectAnnotation(t)

assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 2, 60, testScaleOutWaitMin), ...)
```

So the assertion is satisfied by the replicas the deployment started with, before the annotation has done anything. The line that was supposed to establish the starting state is this one:

```go
// assert that the deployment did not scale down after one minute
WaitForDeploymentReplicaCountChange(t, kc, deploymentName, testNamespace, 0, 60)
```

That helper's signature is `(..., iterations, intervalSeconds int)`, so this passes `iterations: 0` and its loop body never executes. It returns immediately, having neither waited nor asserted anything, and its result is discarded too.

The trigger is inactive to begin with — the monitored deployment has `replicas: 0`, so the `kubernetes-workload` trigger sees no pods — and the ScaledObject sets `idleReplicaCount: 0`. KEDA therefore takes the deployment to zero, which is the state the test needs to start from. That is now what it waits for, and it is asserted.

### `file_based_auth` excuses its own failure

```go
scaledObject, err := kedaKc.ScaledObjects(testNamespace).Get(...)
if err != nil {
    t.Logf("ScaledObject not found (expected in e2e environment): %v", err)
    return
}
```

Setup applies `scaledObjectTemplate` unconditionally, so a ScaledObject that cannot be read is a failure, not an environment to tolerate. Worse, the `return` is from the function containing every scaling assertion in the test, so this path reports success having checked nothing at all.

Two smaller instances of the same thing in the same function: a `if len(scaledObject.Spec.Triggers) > 0` guard silently skipped three assertions when the trigger the template defines was absent, and `assert.NotNil` on the results of two client `Get` calls cannot fail, since the generated clientset returns a non-nil zero value alongside an error — the pattern fixed in #8024.

### `scaled_job_validation` panics instead of failing

```go
job, err := WaitForJobCreation(...)
assert.NoError(t, err, "job should be created")
assert.NotNil(t, job, "job should be created")

assert.Equal(t, "", job.Labels["foo.bar/environment"], ...)
```

`assert` records the failure and carries on, so a wait that timed out reaches `job.Labels` with a nil job and panics. Now `require`.

That introduces an early exit into a test whose cleanup was a plain statement at the end of `TestScaledJobValidations`, so `DeleteKubernetesResources` is now deferred — the same reasoning as #8027. This also covers the `require.Errorf` added to this file by #8063, which had the same exposure.

### Notes

No product behaviour is involved and no assertion has been weakened; two vacuous `assert.NotNil` calls were removed because a real check now stands in their place. Verified with `make fmt`, `make vet`, `make golangci` (0 issues) and `go vet -tags e2e ./tests/...`.

This is independent of #8085 and of #8111, which share no files with it, so they can merge in any order.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
