### PR TITLE
CI: assert the e2e waits whose results are discarded

### DIFF
--- a/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
+++ b/tests/internals/polling_cooldown_so/polling_cooldown_so_test.go
@@ -217,8 +217,10 @@ func testPollingIntervalUp(t *testing.T, kc *kubernetes.Clientset, data template
 	data.MetricValue = 0
 	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
-	// wait some seconds to finish the job
-	WaitForJobCount(t, kc, namespace, 0, 15, 2)
+	// The job posting the metric value sets ttlSecondsAfterFinished: 0, so the count falling back to
+	// zero is what says the new value has been posted rather than merely requested.
+	assert.True(t, WaitForJobCount(t, kc, namespace, 0, 15, 2),
+		"the job posting the metric value should finish within 30 seconds")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, minReplicas, 18, 10),
 		"replica count should be %d after 3 minutes", minReplicas)
@@ -248,8 +250,10 @@ func testPollingIntervalDown(t *testing.T, kc *kubernetes.Clientset, data templa
 	data.MetricValue = 1
 	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
-	// wait some seconds to finish the job
-	WaitForJobCount(t, kc, namespace, 0, 15, 2)
+	// The job posting the metric value sets ttlSecondsAfterFinished: 0, so the count falling back to
+	// zero is what says the new value has been posted rather than merely requested.
+	assert.True(t, WaitForJobCount(t, kc, namespace, 0, 15, 2),
+		"the job posting the metric value should finish within 30 seconds")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 18, 10),
 		"replica count should be %d after 3 minutes", minReplicas)
@@ -284,8 +288,10 @@ func testCooldownPeriod(t *testing.T, kc *kubernetes.Clientset, data templateDat
 	data.MetricValue = 1
 	KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
 
-	// wait some seconds to finish the job
-	WaitForJobCount(t, kc, namespace, 0, 15, 2)
+	// The job posting the metric value sets ttlSecondsAfterFinished: 0, so the count falling back to
+	// zero is what says the new value has been posted rather than merely requested.
+	assert.True(t, WaitForJobCount(t, kc, namespace, 0, 15, 2),
+		"the job posting the metric value should finish within 30 seconds")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, namespace, maxReplicas, 18, 10),
 		"replica count should be %d after 3 minutes", 1)

--- a/tests/internals/scaled_job_conditions/scaled_job_conditions_test.go
+++ b/tests/internals/scaled_job_conditions/scaled_job_conditions_test.go
@@ -191,7 +191,8 @@ func TestScaledJobConditions(t *testing.T) {
 	RMQInstall(t, kc, rmqNamespace, user, password, vhost, WithoutOAuth())
 	// Create the existing queue
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, 0, 0)
-	WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1)
+	assert.True(t, WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1),
+		"the RabbitMQ publisher job should succeed, otherwise the queue this test scales on does not exist")
 
 	t.Cleanup(func() {
 		RMQUninstall(t, rmqNamespace, user, password, vhost, WithoutOAuth())

--- a/tests/internals/scaled_object_validation/scaled_object_validation_test.go
+++ b/tests/internals/scaled_object_validation/scaled_object_validation_test.go
@@ -373,7 +373,8 @@ spec:
 `
 
 	KubectlApplyWithTemplate(t, data, "deploymentTemplate", customDeploymentTemplate)
-	WaitForDeploymentReplicaReadyCount(t, GetKubernetesClient(t), data.DeploymentName, data.TestNamespace, 1, 10, 5)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, GetKubernetesClient(t), data.DeploymentName, data.TestNamespace, 1, 10, 5),
+		"deployment should be ready with the resource limits the checks below rely on")
 
 	t.Log("deployment was updated with resource limits")
 

--- a/tests/internals/scaling_strategies/eager_scaling_strategy/eager_scaling_strategy_test.go
+++ b/tests/internals/scaling_strategies/eager_scaling_strategy/eager_scaling_strategy_test.go
@@ -102,7 +102,8 @@ func TestScalingStrategy(t *testing.T) {
 	RMQInstall(t, kc, rmqNamespace, user, password, vhost, WithoutOAuth())
 	// Publish 0 messges but create the queue
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, 0, 0)
-	WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1)
+	assert.True(t, WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1),
+		"the RabbitMQ publisher job should succeed, otherwise the queue this test scales on is not what it expects")
 
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 	testEagerScaling(t, kc)
@@ -124,17 +125,20 @@ func getTemplateData() (templateData, []Template) {
 func testEagerScaling(t *testing.T, kc *kubernetes.Clientset) {
 	iterationCount := 20
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, 4, 0)
-	WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1)
+	assert.True(t, WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1),
+		"the RabbitMQ publisher job should succeed, otherwise the queue this test scales on is not what it expects")
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 4, iterationCount, 1),
 		"job count should be %d after %d iterations", 4, iterationCount)
 
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, 4, 0)
-	WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1)
+	assert.True(t, WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1),
+		"the RabbitMQ publisher job should succeed, otherwise the queue this test scales on is not what it expects")
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 8, iterationCount, 1),
 		"job count should be %d after %d iterations", 8, iterationCount)
 
 	RMQPublishMessages(t, rmqNamespace, connectionString, queueName, 8, 0)
-	WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1)
+	assert.True(t, WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1),
+		"the RabbitMQ publisher job should succeed, otherwise the queue this test scales on is not what it expects")
 	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 10, iterationCount, 1),
 		"job count should be %d after %d iterations", 10, iterationCount)
 }

--- a/tests/scalers/azure/azure_pipelines/azure_pipelines_test.go
+++ b/tests/scalers/azure/azure_pipelines/azure_pipelines_test.go
@@ -176,7 +176,8 @@ func TestScaler(t *testing.T) {
 	data, templates := getTemplateData()
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
-	WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2)
+	assert.True(t, WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2),
+		"pod count should be %d before scaling is exercised", minReplicaCount)
 
 	// test scaling poolId
 	testActivation(t, kc, connection)

--- a/tests/scalers/azure/azure_pipelines_aad_wi/azure_pipelines_aad_wi_test.go
+++ b/tests/scalers/azure/azure_pipelines_aad_wi/azure_pipelines_aad_wi_test.go
@@ -183,7 +183,8 @@ func TestScaler(t *testing.T) {
 	data, templates := getTemplateData()
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
-	WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2)
+	assert.True(t, WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2),
+		"pod count should be %d before scaling is exercised", minReplicaCount)
 
 	// test scaling poolId
 	testActivation(t, kc, connection)

--- a/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
+++ b/tests/scalers/azure/azure_pipelines_adv/azure_pipelines_adv_test.go
@@ -299,7 +299,8 @@ func TestScaler(t *testing.T) {
 	err := preSeedAgentPool(t, data)
 	require.NoError(t, err)
 
-	WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2)
+	assert.True(t, WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2),
+		"pod count should be %d before scaling is exercised", minReplicaCount)
 	// new demand tests (assumes pre-seeded template)
 
 	KubectlApplyWithTemplate(t, data, "demandScaledJobTemplate", demandScaledJobTemplate)

--- a/tests/scalers/external_push_scaler/external_push_scaler_test.go
+++ b/tests/scalers/external_push_scaler/external_push_scaler_test.go
@@ -234,12 +234,14 @@ func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	data.MetricValue = "0"
 	data.MetricsServerEndpoint = metricsServerEndpointFloat
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
-	WaitForJobSuccess(t, kc, "update-metric-value", testNamespace, 60, 2)
+	assert.True(t, WaitForJobSuccess(t, kc, "update-metric-value", testNamespace, 60, 2),
+		"the job setting the metric value should succeed")
 	KubectlDeleteWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
 	data.MetricValue = "0"
 	data.MetricsServerEndpoint = metricsServerEndpointInt
 	KubectlReplaceWithTemplate(t, data, "updateMetricTemplate", updateMetricTemplate)
-	WaitForJobSuccess(t, kc, "update-metric-value", testNamespace, 60, 2)
+	assert.True(t, WaitForJobSuccess(t, kc, "update-metric-value", testNamespace, 60, 2),
+		"the job setting the metric value should succeed")
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2),
 		"replica count should be 0 after 2 minutes")

--- a/tests/scalers/github_runner/github_runner_test.go
+++ b/tests/scalers/github_runner/github_runner_test.go
@@ -310,7 +310,8 @@ func TestScaler(t *testing.T) {
 	data, templates := getTemplateData()
 	CreateKubernetesResources(t, kc, testNamespace, data, templates)
 
-	WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2)
+	assert.True(t, WaitForPodCountInNamespace(t, kc, testNamespace, minReplicaCount, 60, 2),
+		"pod count should be %d before scaling is exercised", minReplicaCount)
 
 	// test scaling Scaled Job with App
 	KubectlApplyWithTemplate(t, data, "scaledGhaJobTemplate", scaledGhaJobTemplate)

--- a/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
+++ b/tests/sequential/opentelemetry_metrics/opentelemetry_metrics_test.go
@@ -745,7 +745,8 @@ func changeOtlpProtocolInOperator(t *testing.T, kc *kubernetes.Clientset, name s
 	_, err := kc.AppsV1().Deployments(namespace).Update(context.TODO(), operator, metav1.UpdateOptions{})
 
 	require.NoErrorf(t, err, "error change keda operator - %s", err)
-	WaitForDeploymentReplicaReadyCount(t, kc, operator.Name, "keda", 1, 60, 2)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, operator.Name, "keda", 1, 60, 2),
+		"the operator should be ready again after its OTLP protocol changed")
 }
 
 func fallbackHTTPProtocolInOperator(t *testing.T, kc *kubernetes.Clientset, name string, namespace string) {
@@ -769,7 +770,8 @@ func fallbackHTTPProtocolInOperator(t *testing.T, kc *kubernetes.Clientset, name
 	_, err := kc.AppsV1().Deployments(namespace).Update(context.TODO(), operator, metav1.UpdateOptions{})
 
 	require.NoErrorf(t, err, "error change keda operator - %s", err)
-	WaitForDeploymentReplicaReadyCount(t, kc, operator.Name, "keda", 1, 60, 2)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, operator.Name, "keda", 1, 60, 2),
+		"the operator should be ready again after its OTLP protocol changed")
 }
 
 func testScalerGrpcMetricValue(t *testing.T, kc *kubernetes.Clientset, data templateData) {
@@ -777,7 +779,8 @@ func testScalerGrpcMetricValue(t *testing.T, kc *kubernetes.Clientset, data temp
 	KubectlDeleteWithTemplate(t, data, "scaledObjectTemplate", scaledObjectTemplate)
 	KubectlApplyWithTemplate(t, data, "scaledObjectGrpcTemplate", scaledObjectGrpcTemplate)
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 0, testNamespace)
-	WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2),
+		"replica count should be 0 before the metric it produces is read")
 
 	// The deployment reaching zero does not mean the metric has caught up: the value only
 	// changes once the scaler re-polls and the operator's next push reaches the collector.
@@ -1134,7 +1137,8 @@ func testScalerActiveMetric(t *testing.T, kc *kubernetes.Clientset) {
 
 	t.Log("--- testing scaler active metric scaled down ---")
 	KubernetesScaleDeployment(t, kc, monitoredDeploymentName, 0, testNamespace)
-	WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 2),
+		"replica count should be 0 before the metric it produces is read")
 	families = waitForCollectorMetric(t, "keda_scaler_active", func(family *prommodel.MetricFamily) bool {
 		value, found := scaledObjectGaugeValue(family, scaledObjectName)
 		return found && value == 0


### PR DESCRIPTION
Nineteen `WaitFor*` calls across ten files throw away the bool they return:

```go
// wait some seconds to finish the job
WaitForJobCount(t, kc, namespace, 0, 15, 2)
```

A wait whose result nobody reads cannot fail. It can only delay the test, and when it times out the run carries on into assertions whose premise is no longer true — so the failure surfaces later, somewhere else, as something that looks unrelated. Every one of these nineteen establishes a state the next assertion depends on, which is what makes them worth checking rather than deleting.

Part of the audit tracked in #7991.

### The two that were hiding the most

**The RabbitMQ publisher job.** `eager_scaling_strategy` and `scaled_job_conditions` both publish messages and then discard the wait on that job:

```go
RMQPublishMessages(t, rmqNamespace, connectionString, queueName, 4, 0)
WaitForAllJobsSuccess(t, kc, rmqNamespace, 60, 1)
assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 4, iterationCount, 1), ...)
```

If publishing fails, the test goes on to assert scaling behaviour on a queue that was never filled, and reports the scaler as broken. Note this only became a real check after #7996 — before that, `WaitForAllJobsSuccess` returned true for an empty namespace, so it could be satisfied by a list that arrived before the job was created.

**The job that posts a new metric value.** In `polling_cooldown_so` the discarded wait is the only thing separating "the value was posted" from "the value was requested":

```go
data.MetricValue = 0
KubectlReplaceWithTemplate(t, data, "updateMetricsTemplate", updateMetricsTemplate)
WaitForJobCount(t, kc, namespace, 0, 15, 2)
```

That job sets `ttlSecondsAfterFinished: 0`, so the count returning to zero means it ran to completion and was collected. That is a reliable signal, which is why this one is worth asserting rather than replacing.

### The rest

- `opentelemetry_metrics` (4): two wait for the operator to come back after its OTLP protocol is changed, two for the scaled deployment to reach zero before the metric it produces is read.
- `external_push_scaler` (2): the job that sets the metric value before a scale assertion.
- `scaled_object_validation` (1): the deployment must be ready with the resource limits the CPU and memory checks then rely on.
- `azure_pipelines`, `azure_pipelines_aad_wi`, `azure_pipelines_adv`, `github_runner` (4): each waits for the namespace to hold `minReplicaCount` pods before exercising scaling. For `azure_pipelines` that is a real wait — its deployment starts at one replica and KEDA takes it to zero — while `github_runner` starts at zero.

### Notes

None of the conditions are new, so this asks nothing of the product that the suite did not already expect; it just makes the expectation visible when it is not met. I checked each site for whether the condition actually holds before asserting it rather than converting them mechanically.

The four pod-count waits are in tests that need Azure DevOps or GitHub credentials, so upstream `/run-e2e` will only cover part of this. The remaining fifteen are in `internals` and `sequential` and run without credentials.

Verified with `make fmt`, `make vet`, `make golangci` (0 issues) and `go vet -tags e2e ./tests/...`. Independent of #8085 and #8110 — no shared files, so any merge order works.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog), only when the change impacts end users
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991