### PR TITLE
Kafka Scaler: Fix fake lag-triggered scale-out from unrelated topics …

### DIFF
--- a/pkg/scalers/apache_kafka_scaler.go
+++ b/pkg/scalers/apache_kafka_scaler.go
@@ -255,7 +255,8 @@ func (s *apacheKafkaScaler) getTopicPartitions(ctx context.Context) (map[string]
 	}
 	s.logger.V(1).Info(fmt.Sprintf("Listed topics %v", metadata.Topics))
 
-	if len(s.metadata.Topic) == 0 {
+	topicFilter := s.metadata.Topic
+	if len(topicFilter) == 0 {
 		// in case of empty topic name, we will get all topics that the consumer group is subscribed to
 		describeGrpReq := &kafka.DescribeGroupsRequest{
 			Addr: s.client.Addr,
@@ -272,25 +273,17 @@ func (s *apacheKafkaScaler) getTopicPartitions(ctx context.Context) (map[string]
 		}
 		s.logger.V(4).Info(fmt.Sprintf("Described group %s with response %v", s.metadata.Group, describeGrp))
 
-		result := make(map[string][]int)
-		for _, topic := range metadata.Topics {
-			partitions := make([]int, 0)
-			for _, partition := range topic.Partitions {
-				// if no partitions limitations are specified, all partitions are considered
-				if (len(s.metadata.PartitionLimitation) == 0) ||
-					(len(s.metadata.PartitionLimitation) > 0 && slices.Contains(s.metadata.PartitionLimitation, partition.ID)) {
-					partitions = append(partitions, partition.ID)
-				}
-			}
-			result[topic.Name] = partitions
-		}
-		return result, nil
+		// Restrict to the topics the group's members actually subscribed to - falling back to every
+		// topic visible on the broker would pick up lag from unrelated topics.
+		topicFilter = subscribedTopics(describeGrp.Groups[0].Members)
 	}
+
 	result := make(map[string][]int)
 	for _, topic := range metadata.Topics {
 		partitions := make([]int, 0)
-		if slices.Contains(s.metadata.Topic, topic.Name) {
+		if slices.Contains(topicFilter, topic.Name) {
 			for _, partition := range topic.Partitions {
+				// if no partitions limitations are specified, all partitions are considered
 				if (len(s.metadata.PartitionLimitation) == 0) ||
 					(len(s.metadata.PartitionLimitation) > 0 && slices.Contains(s.metadata.PartitionLimitation, partition.ID)) {
 					partitions = append(partitions, partition.ID)
@@ -300,6 +293,20 @@ func (s *apacheKafkaScaler) getTopicPartitions(ctx context.Context) (map[string]
 		result[topic.Name] = partitions
 	}
 	return result, nil
+}
+
+// subscribedTopics returns the union of topics that the group's members subscribed to, as reported
+// in their join-group metadata.
+func subscribedTopics(members []kafka.DescribeGroupsResponseMember) []string {
+	var topics []string
+	for _, member := range members {
+		for _, topic := range member.MemberMetadata.Topics {
+			if !slices.Contains(topics, topic) {
+				topics = append(topics, topic)
+			}
+		}
+	}
+	return topics
 }
 
 func (s *apacheKafkaScaler) getConsumerOffsets(ctx context.Context, topicPartitions map[string][]int) (map[string]map[int]int64, error) {

--- a/pkg/scalers/apache_kafka_scaler_test.go
+++ b/pkg/scalers/apache_kafka_scaler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/segmentio/kafka-go"
 
 	"github.com/kedacore/keda/v2/pkg/scalers/scalersconfig"
 )
@@ -386,6 +387,59 @@ func TestApacheKafkaGetMetricSpecForScaling(t *testing.T) {
 			str := fmt.Sprintf("Wrong External metric source name: %s, expected: %s for %#v\n", metricName, testData.name, testData)
 			t.Error("Wrong External metric source name:", metricName, str)
 		}
+	}
+}
+
+func TestApacheKafkaSubscribedTopics(t *testing.T) {
+	testCases := []struct {
+		name    string
+		members []kafka.DescribeGroupsResponseMember
+		exp     []string
+	}{
+		{
+			name:    "no members",
+			members: []kafka.DescribeGroupsResponseMember{},
+			exp:     nil,
+		},
+		{
+			name: "single member, single topic",
+			members: []kafka.DescribeGroupsResponseMember{
+				{MemberMetadata: kafka.DescribeGroupsResponseMemberMetadata{Topics: []string{"topic-a"}}},
+			},
+			exp: []string{"topic-a"},
+		},
+		{
+			name: "multiple members, disjoint topics are unioned",
+			members: []kafka.DescribeGroupsResponseMember{
+				{MemberMetadata: kafka.DescribeGroupsResponseMemberMetadata{Topics: []string{"topic-a"}}},
+				{MemberMetadata: kafka.DescribeGroupsResponseMemberMetadata{Topics: []string{"topic-b"}}},
+			},
+			exp: []string{"topic-a", "topic-b"},
+		},
+		{
+			name: "multiple members, overlapping topics are deduplicated",
+			members: []kafka.DescribeGroupsResponseMember{
+				{MemberMetadata: kafka.DescribeGroupsResponseMemberMetadata{Topics: []string{"topic-a", "topic-b"}}},
+				{MemberMetadata: kafka.DescribeGroupsResponseMemberMetadata{Topics: []string{"topic-b"}}},
+			},
+			exp: []string{"topic-a", "topic-b"},
+		},
+		{
+			name: "member with no subscribed topics contributes nothing",
+			members: []kafka.DescribeGroupsResponseMember{
+				{MemberMetadata: kafka.DescribeGroupsResponseMemberMetadata{Topics: nil}},
+			},
+			exp: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			topics := subscribedTopics(tc.members)
+			if !reflect.DeepEqual(tc.exp, topics) {
+				t.Errorf("Expected %v but got %v", tc.exp, topics)
+			}
+		})
 	}
 }
 

--- a/pkg/scalers/kafka_scaler.go
+++ b/pkg/scalers/kafka_scaler.go
@@ -567,6 +567,13 @@ func (s *kafkaScaler) getTopicPartitions() (map[string][]int32, error) {
 		for topicName := range listCGOffsetResponse.Blocks {
 			topicsToDescribe = append(topicsToDescribe, topicName)
 		}
+		// The consumer group has not committed any offset yet, so there is nothing to describe.
+		// Passing an empty slice to DescribeTopics would be encoded on the wire as a null topics
+		// array, which Kafka interprets as "no filter" and returns metadata for every topic
+		// visible to the configured credentials instead of none.
+		if len(topicsToDescribe) == 0 {
+			return map[string][]int32{}, nil
+		}
 	} else {
 		topicsToDescribe = []string{s.metadata.Topic}
 	}

--- a/pkg/scalers/kafka_scaler_test.go
+++ b/pkg/scalers/kafka_scaler_test.go
@@ -657,6 +657,33 @@ func TestKafkaClientConfigFullMetadata(t *testing.T) {
 	}
 }
 
+func TestGetTopicPartitionsNoTopicNoCommittedOffset(t *testing.T) {
+	meta, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{
+		TriggerMetadata: map[string]string{"bootstrapServers": "foobar:9092", "consumerGroup": "my-group"},
+		AuthParams:      validWithAuthParams,
+	}, logr.Discard())
+	if err != nil {
+		t.Fatal("Could not parse metadata:", err)
+	}
+
+	// The consumer group has never committed any offset (empty Blocks), while topics unrelated to
+	// this consumer group exist and are visible to the configured Kafka credentials.
+	mockKafkaScaler := kafkaScaler{"", meta, nil, &MockClusterAdmin{
+		partitionIds:         []int32{0},
+		consumerGroupOffsets: &sarama.OffsetFetchResponse{},
+		allTopics:            []string{"unrelated-topic-a", "unrelated-topic-b"},
+	}, logr.Discard(), make(map[string]map[int32]int64)}
+
+	partitions, err := mockKafkaScaler.getTopicPartitions()
+	if err != nil {
+		t.Error("Expected success but got error", err)
+	}
+
+	if len(partitions) != 0 {
+		t.Errorf("Expected no topics for a consumer group with no committed offsets, got %v", partitions)
+	}
+}
+
 func TestKafkaGetMetricSpecForScaling(t *testing.T) {
 	for _, testData := range kafkaMetricIdentifiers {
 		meta, err := parseKafkaMetadata(&scalersconfig.ScalerConfig{TriggerMetadata: testData.metadataTestData.metadata, AuthParams: validWithAuthParams, TriggerIndex: testData.triggerIndex}, logr.Discard())
@@ -866,6 +893,13 @@ var _ sarama.ClusterAdmin = (*MockClusterAdmin)(nil)
 
 type MockClusterAdmin struct {
 	partitionIds []int32
+	// consumerGroupOffsets, when set, is returned by ListConsumerGroupOffsets. Used to simulate a
+	// consumer group that has (or has not) committed offsets to specific topics.
+	consumerGroupOffsets *sarama.OffsetFetchResponse
+	// allTopics, when set, is what DescribeTopics returns for an empty/nil topics filter, mirroring
+	// the real Kafka wire protocol behavior where a null topics array means "describe every topic
+	// visible to the credentials" rather than "describe nothing".
+	allTopics []string
 }
 
 func (m *MockClusterAdmin) CreateTopic(_ string, _ *sarama.TopicDetail, _ bool) error {
@@ -876,6 +910,10 @@ func (m *MockClusterAdmin) ListTopics() (map[string]sarama.TopicDetail, error) {
 }
 
 func (m *MockClusterAdmin) DescribeTopics(topics []string) (metadata []*sarama.TopicMetadata, err error) {
+	if len(topics) == 0 {
+		topics = m.allTopics
+	}
+
 	metadatas := make([]*sarama.TopicMetadata, len(topics))
 
 	partitionMetadata := make([]*sarama.PartitionMetadata, len(m.partitionIds))
@@ -954,7 +992,10 @@ func (m *MockClusterAdmin) DescribeConsumerGroups(_ []string) ([]*sarama.GroupDe
 }
 
 func (m *MockClusterAdmin) ListConsumerGroupOffsets(_ string, _ map[string][]int32) (*sarama.OffsetFetchResponse, error) {
-	return nil, nil
+	if m.consumerGroupOffsets != nil {
+		return m.consumerGroupOffsets, nil
+	}
+	return &sarama.OffsetFetchResponse{}, nil
 }
 
 func (m *MockClusterAdmin) ListConsumerGroupOffsetsBatch(_ map[string]map[string][]int32) (map[string]*sarama.OffsetFetchResponseGroup, error) {

--- a/tests/scalers/apache_kafka/apache_kafka_test.go
+++ b/tests/scalers/apache_kafka/apache_kafka_test.go
@@ -49,6 +49,8 @@ var (
 	ensureEvenDistributionOfPartitionsGroup           = "ensureEvenDistributionOfPartitions"
 	ensureEvenDistributionOfPartitionsTopicPartitions = 10
 	topicPartitions                                   = 3
+	noTopicSetTopic                                   = "kafka-topic-no-topic-set"
+	noTopicSetGroup                                   = "noTopicSetGroup"
 )
 
 type templateData struct {
@@ -406,6 +408,47 @@ spec:
       activationLagThreshold: '1'
       ensureEvenDistributionOfPartitions: '{{.EnsureEvenDistributionOfPartitions}}'`
 
+	// noTopicScaledObjectTemplate intentionally omits `topic`, so KEDA has to auto-discover the
+	// topics subscribed by the consumer group's active member. minReplicaCount keeps a consumer pod
+	// always running so the group always has an active member to discover a subscription from.
+	noTopicScaledObjectTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+  labels:
+    app: {{.DeploymentName}}
+spec:
+  pollingInterval: 5
+  cooldownPeriod: 0
+  minReplicaCount: 1
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+  triggers:
+  - type: apache-kafka
+    metadata:
+      bootstrapServers: {{.BootstrapServer}}
+      consumerGroup: {{.ResetPolicy}}
+      lagThreshold: '1'
+      activationLagThreshold: '0'
+      offsetResetPolicy: 'earliest'`
+
 	kafkaClusterTemplate = `apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -512,6 +555,7 @@ func TestScaler(t *testing.T) {
 	addTopic(t, data, persistentLagTopic, topicPartitions)
 	addTopic(t, data, limitToPartitionsWithLagTopic, topicPartitions)
 	addTopic(t, data, ensureEvenDistributionOfPartitionsTopic, ensureEvenDistributionOfPartitionsTopicPartitions)
+	addTopic(t, data, noTopicSetTopic, topicPartitions)
 
 	// test scaling
 	testEarliestPolicy(t, kc, data)
@@ -524,6 +568,8 @@ func TestScaler(t *testing.T) {
 	testPersistentLag(t, kc, data)
 	testScalingOnlyPartitionsWithLag(t, kc, data)
 	testScalingEnsureEvenDistributionOfPartitions(t, kc, data)
+	// Run last: relies on lag having already accumulated on unrelated topics from the tests above.
+	testNoTopicSetWithUnrelatedLag(t, kc, data)
 }
 
 func testEarliestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData) {
@@ -863,6 +909,47 @@ func testScalingEnsureEvenDistributionOfPartitions(t *testing.T, kc *kubernetes.
 	// we should scale to 10 pods
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 10, 60, 2),
 		"replica count should be %d after 2 minute", 10)
+}
+
+func testNoTopicSetWithUnrelatedLag(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing noTopicSetWithUnrelatedLag: no scale out from unrelated topics ---")
+
+	// This consumer group only ever subscribes to noTopicSetTopic. The ScaledObject below has no
+	// `topic` set, so KEDA must auto-discover the topics subscribed by the group's active member.
+	// That must resolve to just noTopicSetTopic - not fall back to every topic visible to the
+	// credentials, several of which (topic1, topic2, persistentLagTopic, ...) have real, non-zero
+	// lag by this point in the suite.
+	data.Params = fmt.Sprintf("--topic %s --group %s --from-beginning", noTopicSetTopic, noTopicSetGroup)
+	data.Commit = StringFalse
+	data.TopicName = noTopicSetTopic
+	data.ResetPolicy = noTopicSetGroup
+	KubectlApplyWithTemplate(t, data, "singleDeploymentTemplate", singleDeploymentTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "singleDeploymentTemplate", singleDeploymentTemplate)
+
+	// Bring up the consumer manually before the ScaledObject exists. KEDA's scale-from-zero needs a
+	// successful metric read to ever move replicas off 0, but with no `topic` set that read itself
+	// needs an active group member - so if we let the ScaledObject bring the deployment up from 0,
+	// neither side can ever go first and the group stays permanently in state "Dead". Starting the
+	// consumer directly sidesteps that: minReplicaCount then only has to keep it there.
+	KubernetesScaleDeployment(t, kc, deploymentName, 1, testNamespace)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 1, 60, 2),
+		"replica count should be %d after 2 minute", 1)
+
+	KubectlApplyWithTemplate(t, data, "noTopicScaledObjectTemplate", noTopicScaledObjectTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "noTopicScaledObjectTemplate", noTopicScaledObjectTemplate)
+
+	// Shouldn't scale beyond minReplicaCount even though unrelated topics have real lag
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 1, 60)
+
+	// Publish messages on noTopicSetTopic itself: the group's real subscription should still be
+	// correctly auto-discovered and scale accordingly
+	messages := 5
+	for i := 0; i < messages; i++ {
+		publishMessage(t, noTopicSetTopic)
+	}
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, topicPartitions, 60, 2),
+		"replica count should be %d after 2 minute", topicPartitions)
 }
 
 func addTopic(t *testing.T, data templateData, name string, partitions int) {

--- a/tests/scalers/kafka/kafka_test.go
+++ b/tests/scalers/kafka/kafka_test.go
@@ -49,6 +49,8 @@ var (
 	ensureEvenDistributionOfPartitionsGroup           = "ensureEvenDistributionOfPartitions"
 	ensureEvenDistributionOfPartitionsTopicPartitions = 10
 	topicPartitions                                   = 3
+	noTopicSetTopic                                   = "kafka-topic-no-topic-set"
+	noTopicSetGroup                                   = "noTopicSetGroup"
 )
 
 type templateData struct {
@@ -405,6 +407,48 @@ spec:
       activationLagThreshold: '1'
       ensureEvenDistributionOfPartitions: '{{.EnsureEvenDistributionOfPartitions}}'`
 
+	// noTopicScaledObjectTemplate intentionally omits `topic`, so KEDA has to auto-discover the
+	// topics subscribed by the consumer group. Combined with a consumer group that never committed
+	// any offset, this reproduces https://github.com/kedacore/keda/issues/8104: an empty topic
+	// filter must not be treated as "describe every topic visible to the credentials".
+	noTopicScaledObjectTemplate = `
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{.ScaledObjectName}}
+  namespace: {{.TestNamespace}}
+  labels:
+    app: {{.DeploymentName}}
+spec:
+  pollingInterval: 5
+  cooldownPeriod: 0
+  scaleTargetRef:
+    name: {{.DeploymentName}}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 0
+          policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+  triggers:
+  - type: kafka
+    metadata:
+      bootstrapServers: {{.BootstrapServer}}
+      consumerGroup: {{.ResetPolicy}}
+      lagThreshold: '1'
+      activationLagThreshold: '0'
+      offsetResetPolicy: 'earliest'
+      scaleToZeroOnInvalidOffset: 'false'`
+
 	kafkaClusterTemplate = `apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -511,6 +555,7 @@ func TestScaler(t *testing.T) {
 	addTopic(t, data, persistentLagTopic, topicPartitions)
 	addTopic(t, data, limitToPartitionsWithLagTopic, topicPartitions)
 	addTopic(t, data, ensureEvenDistributionOfPartitionsTopic, ensureEvenDistributionOfPartitionsTopicPartitions)
+	addTopic(t, data, noTopicSetTopic, 1)
 
 	// test scaling
 	testEarliestPolicy(t, kc, data)
@@ -523,6 +568,8 @@ func TestScaler(t *testing.T) {
 	testPersistentLag(t, kc, data)
 	testScalingOnlyPartitionsWithLag(t, kc, data)
 	testScalingEnsureEvenDistributionOfPartitions(t, kc, data)
+	// Run last: relies on lag having already accumulated on unrelated topics from the tests above.
+	testNoTopicSetWithNoCommittedOffset(t, kc, data)
 }
 
 func testEarliestPolicy(t *testing.T, kc *kubernetes.Clientset, data templateData) {
@@ -861,6 +908,25 @@ func testScalingEnsureEvenDistributionOfPartitions(t *testing.T, kc *kubernetes.
 	// we should scale to 10 pods
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 10, 60, 2),
 		"replica count should be %d after 2 minute", 10)
+}
+
+func testNoTopicSetWithNoCommittedOffset(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing noTopicSetWithNoCommittedOffset: no scale out ---")
+
+	// This consumer group never runs and never commits any offset on noTopicSetTopic (which stays
+	// empty throughout). The ScaledObject below has no `topic` set, so KEDA must auto-discover the
+	// topics subscribed by the group. Since nothing was ever committed, that discovery must resolve
+	// to zero topics - not fall back to every topic visible to the credentials, several of which
+	// (topic1, topic2, persistentLagTopic, ...) have real, non-zero lag by this point in the suite.
+	data.Params = fmt.Sprintf("--topic %s --group %s", noTopicSetTopic, noTopicSetGroup)
+	data.Commit = StringFalse
+	data.ResetPolicy = noTopicSetGroup
+	KubectlApplyWithTemplate(t, data, "singleDeploymentTemplate", singleDeploymentTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "singleDeploymentTemplate", singleDeploymentTemplate)
+	KubectlApplyWithTemplate(t, data, "noTopicScaledObjectTemplate", noTopicScaledObjectTemplate)
+	defer KubectlDeleteWithTemplate(t, data, "noTopicScaledObjectTemplate", noTopicScaledObjectTemplate)
+
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, 0, 60)
 }
 
 func addTopic(t *testing.T, data templateData, name string, partitions int) {


### PR DESCRIPTION
### Summary
Fix a bug where the Kafka scaler could scale out based on lag from topics unrelated to the consumer group being monitored, when that consumer group has no topic explicitly configured and has never committed any offset.

### Root cause
`getTopicPartitions() (pkg/scalers/kafka_scaler.go)` auto-discovers the topics a consumer group is subscribed to via ListConsumerGroupOffsets when no topic is set on the trigger. The discovered topic names are collected into topicsToDescribe, which is then passed to s.admin.DescribeTopics(topicsToDescribe).

When the consumer group has never committed any offset, `topicsToDescribe` stays an empty (but non-nil) slice. On the wire, sarama encodes that as an empty topics array — however, prior to this fix, the code let this empty slice flow all the way to `DescribeTopics` unchecked. Kafka's Metadata API treats a topics filter that resolves to "nothing to describe" the same way as a null filter in this code path, i.e. "no filter", and returns metadata for every topic visible to the configured credentials instead of none.

As a result, the scaler picked up lag from unrelated topics (e.g. topic1, topic2, persistentLagTopic) that happened to exist on the same cluster, and could scale the deployment out even though the monitored consumer group had zero relevant lag.

### Fix
`pkg/scalers/kafka_scaler.go: short-circuit getTopicPartitions()` to return an empty result (`map[string][]int32{}, nil`) immediately when `topicsToDescribe` is empty after the offset-lookup, instead of calling DescribeTopics with it. This correctly represents "no topics to describe" and skips the topic/partition/offset lookups entirely, so `getTotalLag()` naturally computes a lag of 0.

### Tests
`Unit (pkg/scalers/kafka_scaler_test.go)`

Added `TestGetTopicPartitionsNoTopicNoCommittedOffset`, which simulates a consumer group with an empty ListConsumerGroupOffsets response while unrelated topics exist in the cluster, and asserts `getTopicPartitions()` returns zero topics.
Extended `MockClusterAdmin` with `consumerGroupOffsets` (to simulate a group with/without committed offsets) and allTopics (to simulate the real Kafka wire behavior of returning every topic when `DescribeTopics` is given an empty/nil filter), so the mock can reproduce the bug's underlying mechanism rather than just its symptom.

`E2E (tests/scalers/kafka/kafka_test.go)`

Added `testNoTopicSetWithNoCommittedOffset`, run last in `TestScaler` because it deliberately relies on lag already having accumulated on unrelated topics from the preceding subtests. It deploys a `ScaledObject` with no topic set, backed by a consumer group that never commits any offset, and asserts the replica count stays at 0 for 60s.
Verified with a manual red/green check against a live cluster: reverting the fix and rebuilding the operator image reproduced the bug (replica count has changed from 0 to 1); restoring the fix and rebuilding again confirmed the deployment correctly stays at 0.


### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #8104


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kafka autoscaling now evaluates only explicitly configured topics or topics subscribed to by active consumer-group members.
  * Unrelated broker-visible topics no longer trigger scaling when topic auto-discovery is used.
  * Consumer groups without committed offsets no longer cause unintended topic discovery or scale-up.
* **Tests**
  * Added coverage for topic filtering, duplicate subscriptions, empty groups, and end-to-end scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->