### PR TITLE
General: Ignore StreamMetricSpec updates that carry no metric specs

### DIFF
--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -283,9 +283,16 @@ func (c *ScalersCache) GetMetricsAndActivityForScaler(ctx context.Context, index
 //
 // The identity check and the write are performed under the same lock so the
 // validated cache cannot silently become stale between the two operations. It
-// reports whether the update was applied (false if the cache is closed, the
-// index is out of range, or the identity does not match).
+// reports whether the update was applied (false if the update carries no metric
+// specs, the cache is closed, the index is out of range, or the identity does
+// not match).
 func (c *ScalersCache) UpdateMetricSpecForScaler(index int, specs []v2.MetricSpec, uid types.UID, generation int64) bool {
+	// Empty updates are rejected so that CachedMetricSpecs is never a non-nil empty
+	// slice.
+	if len(specs) == 0 {
+		return false
+	}
+
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -442,11 +442,24 @@ func TestScalersCache_UpdateMetricSpecForScaler_InvalidIndex(t *testing.T) {
 	scaler := newFakeScaler(nil)
 	c := newCacheWithScaler(scaler)
 
-	if c.UpdateMetricSpecForScaler(-1, []v2.MetricSpec{}, testCacheUID, testCacheGeneration) {
+	// Non-empty specs, so the rejection can only come from the index check and
+	// not from the empty-update guard.
+	specs := []v2.MetricSpec{{
+		External: &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{Name: "updated-metric"},
+		},
+		Type: "External",
+	}}
+
+	if c.UpdateMetricSpecForScaler(-1, specs, testCacheUID, testCacheGeneration) {
 		t.Fatal("UpdateMetricSpecForScaler should report false for a negative index")
 	}
-	if c.UpdateMetricSpecForScaler(5, []v2.MetricSpec{}, testCacheUID, testCacheGeneration) {
+	if c.UpdateMetricSpecForScaler(5, specs, testCacheUID, testCacheGeneration) {
 		t.Fatal("UpdateMetricSpecForScaler should report false for an out-of-range index")
+	}
+
+	if got := c.GetMetricSpecForScaling(context.Background()); len(got) != 1 || got[0].External.Metric.Name != "fake" {
+		t.Fatalf("cache specs must be untouched on an invalid index, got %+v", got)
 	}
 }
 
@@ -470,6 +483,56 @@ func TestScalersCache_UpdateMetricSpecForScaler_IdentityMismatch(t *testing.T) {
 
 	if got := c.GetMetricSpecForScaling(context.Background()); len(got) != 1 || got[0].External.Metric.Name != "fake" {
 		t.Fatalf("cache specs must be untouched on identity mismatch, got %+v", got)
+	}
+}
+
+// A scaler that streams no metric specs must not be able to wedge the
+// ScaledObject: caching a non-nil empty slice would satisfy the "use the cache"
+// checks while yielding no metric specs at all, so the HPA could not be built
+// and the pull-based fallback would stay suppressed indefinitely.
+func TestScalersCache_UpdateMetricSpecForScaler_RejectsEmptySpecs(t *testing.T) {
+	scaler := newFakeScaler(nil)
+	c := newCacheWithScaler(scaler)
+
+	for _, specs := range [][]v2.MetricSpec{nil, {}} {
+		if c.UpdateMetricSpecForScaler(0, specs, testCacheUID, testCacheGeneration) {
+			t.Fatalf("UpdateMetricSpecForScaler should report false for %d specs", len(specs))
+		}
+	}
+
+	if got := c.GetMetricSpecForScaling(context.Background()); len(got) != 1 || got[0].External.Metric.Name != "fake" {
+		t.Fatalf("expected the scaler's own specs, got %+v", got)
+	}
+
+	got, err := c.GetMetricSpecForScalingForScaler(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].External.Metric.Name != "fake" {
+		t.Fatalf("expected the scaler's own specs, got %+v", got)
+	}
+}
+
+func TestScalersCache_UpdateMetricSpecForScaler_EmptyUpdateKeepsCachedSpecs(t *testing.T) {
+	scaler := newFakeScaler(nil)
+	c := newCacheWithScaler(scaler)
+
+	streamed := []v2.MetricSpec{{
+		External: &v2.ExternalMetricSource{
+			Metric: v2.MetricIdentifier{Name: "streamed-metric"},
+		},
+		Type: "External",
+	}}
+	if !c.UpdateMetricSpecForScaler(0, streamed, testCacheUID, testCacheGeneration) {
+		t.Fatal("UpdateMetricSpecForScaler should report true for a valid update")
+	}
+
+	if c.UpdateMetricSpecForScaler(0, nil, testCacheUID, testCacheGeneration) {
+		t.Fatal("UpdateMetricSpecForScaler should report false for an empty update")
+	}
+
+	if got := c.GetMetricSpecForScaling(context.Background()); len(got) != 1 || got[0].External.Metric.Name != "streamed-metric" {
+		t.Fatalf("expected the last non-empty streamed specs to be kept, got %+v", got)
 	}
 }
 

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -179,6 +179,14 @@ func (h *scaleHandler) watchMetricSpecUpdates(ctx context.Context, scaledObjectN
 				return
 			}
 
+			// UpdateMetricSpecForScaler also rejects these, but a scaler that
+			// streams no metric specs is a scaler bug worth surfacing rather
+			// than dropping silently.
+			if len(specs) == 0 {
+				logger.V(1).Info("ignoring streamed metric spec update with no metric specs")
+				continue
+			}
+
 			scalersCache, err := h.getScalersCacheForScaledObject(ctx, scaledObjectName, scaledObjectNamespace)
 			if err != nil {
 				if ctx.Err() != nil {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

`buildMetricSpecs` always returns a non-nil slice, and `cloneMetricSpecs` only maps nil to nil, so a streamed update with an empty `metricSpecs` list was cached as a non-nil empty slice. That value satisfies the `CachedMetricSpecs != nil` checks the read paths use to prefer the cache over the scaler, while contributing no metric specs at all.

The ScaledObject was then unable to build its HPA, reporting "no metric specs returned from scalers" on every reconcile. Because the cached value also short-circuits `GetMetricSpecForScalingForScaler` before its existing refresh-and-retry safety net, KEDA stopped calling `GetMetricSpec` and could not discover that the scaler was healthy again. Recovery depended entirely on the scaler streaming a non-empty update, which a send-on-change implementation has no reason to do.

Reject empty updates in `UpdateMetricSpecForScaler`, the single write point for `CachedMetricSpecs`, so the field is never a non-nil empty slice. Keeping the last known specs means a scaler that transiently reports no metrics cannot wedge the ScaledObject. The existing boolean return value makes the watcher skip the reconcile enqueue for a rejected update.

Fixes #8115

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

