### PR TITLE
General: Accept pod-level cpu/memory requests in ScaledObject validation

### DIFF
--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -541,15 +541,18 @@ func verifyCPUMemoryScalers(incomingSo *ScaledObject, action string, dryRun bool
 				}
 			}
 			containerName := trigger.Metadata["containerName"]
-			for _, container := range podSpec.Containers {
-				if containerName != "" && container.Name != containerName {
-					continue
-				}
+			resourceType := corev1.ResourceName(trigger.Type)
 
-				if trigger.Type == cpuString || trigger.Type == memoryString {
+			// Pod-level requests (KEP-2837) cover every container in the pod and are what the HPA
+			// uses as the utilization denominator, so the per-container check must be skipped.
+			if podSpec.Resources == nil || !isWorkloadResourceSet(*podSpec.Resources, resourceType) {
+				for _, container := range podSpec.Containers {
+					if containerName != "" && container.Name != containerName {
+						continue
+					}
+
 					// Fail if neither pod's container spec has particular resource limit specified, nor a default limit is
 					// specified in LimitRange in the same namespace as the deployment
-					resourceType := corev1.ResourceName(trigger.Type)
 					if !isWorkloadResourceSet(container.Resources, resourceType) &&
 						!isContainerResourceLimitSet(context.Background(), incomingSo.Namespace, resourceType) {
 						err := fmt.Errorf("the scaledobject has a %v trigger but the container %s doesn't have the %v request defined", resourceType, container.Name, resourceType)

--- a/apis/keda/v1alpha1/scaledobject_webhook.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook.go
@@ -543,9 +543,11 @@ func verifyCPUMemoryScalers(incomingSo *ScaledObject, action string, dryRun bool
 			containerName := trigger.Metadata["containerName"]
 			resourceType := corev1.ResourceName(trigger.Type)
 
-			// Pod-level requests (KEP-2837) cover every container in the pod and are what the HPA
-			// uses as the utilization denominator, so the per-container check must be skipped.
-			if podSpec.Resources == nil || !isWorkloadResourceSet(*podSpec.Resources, resourceType) {
+			// The HPA uses the pod-level request (KEP-2837) only for Resource metrics; a containerName
+			// trigger yields a ContainerResource metric, which ignores it and needs the container request.
+			podLevelRequestApplies := containerName == "" && podSpec.Resources != nil && isWorkloadResourceSet(*podSpec.Resources, resourceType)
+
+			if !podLevelRequestApplies {
 				for _, container := range podSpec.Containers {
 					if containerName != "" && container.Name != containerName {
 						continue

--- a/apis/keda/v1alpha1/scaledobject_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook_test.go
@@ -600,6 +600,135 @@ var _ = It("shouldn't validate the so creation with cpu and memory when stateful
 	}).Should(HaveOccurred())
 })
 
+// The following tests cover cpu/memory requests declared at pod level (KEP-2837) instead of on the
+// containers. The HPA uses the pod-level request as the utilization denominator, so such a workload
+// is valid and must be accepted. See github.com/kedacore/keda/issues/8113
+var _ = It("should validate the so creation with cpu and memory when deployment has pod-level requests", func() {
+
+	namespaceName := "deployment-has-pod-level-requests"
+	namespace := createNamespace(namespaceName)
+	workload := createDeployment(namespaceName, false, false)
+	workload.Spec.Template.Spec.Resources = &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+			v1.ResourceMemory: *resource.NewQuantity(100*1024*1024, resource.BinarySI),
+		},
+	}
+	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", true, map[string]string{}, "")
+
+	err := k8sClient.Create(context.Background(), namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), workload)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return k8sClient.Create(context.Background(), so)
+	}).ShouldNot(HaveOccurred())
+})
+
+var _ = It("should validate the so creation with cpu when deployment has pod-level requests and the trigger sets containerName", func() {
+
+	namespaceName := "deployment-pod-level-requests-container-name"
+	namespace := createNamespace(namespaceName)
+	workload := createDeployment(namespaceName, false, false)
+	workload.Spec.Template.Spec.Resources = &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI),
+		},
+	}
+	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
+	so.Spec.Triggers = []ScaleTriggers{
+		{
+			Type: "cpu",
+			Metadata: map[string]string{
+				"value":         "10",
+				"containerName": "test",
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), workload)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return k8sClient.Create(context.Background(), so)
+	}).ShouldNot(HaveOccurred())
+})
+
+// A pod-level request only satisfies the trigger for the resource it declares, so a memory trigger
+// must still be rejected when only cpu is declared at pod level.
+var _ = It("shouldn't validate the so creation with cpu and memory when deployment has pod-level cpu request only", func() {
+
+	namespaceName := "deployment-pod-level-cpu-request-only"
+	namespace := createNamespace(namespaceName)
+	workload := createDeployment(namespaceName, false, false)
+	workload.Spec.Template.Spec.Resources = &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI),
+		},
+	}
+	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", true, map[string]string{}, "")
+
+	err := k8sClient.Create(context.Background(), namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), workload)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return k8sClient.Create(context.Background(), so)
+	}).Should(HaveOccurred())
+})
+
+// Regression guard: container-level requests must keep satisfying the check when the pod-level
+// resources are present but declare nothing.
+var _ = It("should validate the so creation with cpu and memory when deployment has container requests and empty pod-level resources", func() {
+
+	namespaceName := "deployment-container-requests-empty-pod-level"
+	namespace := createNamespace(namespaceName)
+	workload := createDeployment(namespaceName, true, true)
+	workload.Spec.Template.Spec.Resources = &v1.ResourceRequirements{}
+	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", true, map[string]string{}, "")
+
+	err := k8sClient.Create(context.Background(), namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), workload)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return k8sClient.Create(context.Background(), so)
+	}).ShouldNot(HaveOccurred())
+})
+
+var _ = It("should validate the so creation with cpu and memory when statefulset has pod-level requests", func() {
+
+	namespaceName := "statefulset-has-pod-level-requests"
+	namespace := createNamespace(namespaceName)
+	workload := createStatefulSet(namespaceName, false, false)
+	workload.Spec.Template.Spec.Resources = &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+			v1.ResourceMemory: *resource.NewQuantity(100*1024*1024, resource.BinarySI),
+		},
+	}
+	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "StatefulSet", true, map[string]string{}, "")
+
+	err := k8sClient.Create(context.Background(), namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), workload)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return k8sClient.Create(context.Background(), so)
+	}).ShouldNot(HaveOccurred())
+})
+
 var _ = It("should validate the so creation without cpu and memory when custom resources", func() {
 
 	namespaceName := "crd-not-resources"

--- a/apis/keda/v1alpha1/scaledobject_webhook_test.go
+++ b/apis/keda/v1alpha1/scaledobject_webhook_test.go
@@ -627,7 +627,10 @@ var _ = It("should validate the so creation with cpu and memory when deployment 
 	}).ShouldNot(HaveOccurred())
 })
 
-var _ = It("should validate the so creation with cpu when deployment has pod-level requests and the trigger sets containerName", func() {
+// A trigger that sets containerName produces an HPA ContainerResource metric, whose denominator is
+// the named container's own request. The HPA ignores pod-level requests in that case, so validation
+// must keep rejecting a container that declares none.
+var _ = It("shouldn't validate the so creation with cpu when the trigger sets containerName and only pod-level requests are declared", func() {
 
 	namespaceName := "deployment-pod-level-requests-container-name"
 	namespace := createNamespace(namespaceName)
@@ -640,7 +643,36 @@ var _ = It("should validate the so creation with cpu when deployment has pod-lev
 	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
 	so.Spec.Triggers = []ScaleTriggers{
 		{
-			Type: "cpu",
+			Type:       "cpu",
+			MetricType: v2.UtilizationMetricType,
+			Metadata: map[string]string{
+				"value":         "10",
+				"containerName": "test",
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), namespace)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = k8sClient.Create(context.Background(), workload)
+	Expect(err).ToNot(HaveOccurred())
+
+	Eventually(func() error {
+		return k8sClient.Create(context.Background(), so)
+	}).Should(MatchError(ContainSubstring("the container test doesn't have the cpu request defined")))
+})
+
+var _ = It("should validate the so creation with cpu when the trigger sets containerName and that container declares requests", func() {
+
+	namespaceName := "deployment-container-requests-container-name"
+	namespace := createNamespace(namespaceName)
+	workload := createDeployment(namespaceName, true, true)
+	so := createScaledObject(soName, namespaceName, workloadName, "apps/v1", "Deployment", false, map[string]string{}, "")
+	so.Spec.Triggers = []ScaleTriggers{
+		{
+			Type:       "cpu",
+			MetricType: v2.UtilizationMetricType,
 			Metadata: map[string]string{
 				"value":         "10",
 				"containerName": "test",
@@ -681,7 +713,7 @@ var _ = It("shouldn't validate the so creation with cpu and memory when deployme
 
 	Eventually(func() error {
 		return k8sClient.Create(context.Background(), so)
-	}).Should(HaveOccurred())
+	}).Should(MatchError(ContainSubstring("the scaledobject has a memory trigger")))
 })
 
 // Regression guard: container-level requests must keep satisfying the check when the pod-level


### PR DESCRIPTION
`verifyCPUMemoryScalers` reads only `podSpec.Containers`, so a ScaledObject with a `cpu` or `memory` trigger is rejected when the scale target declares its requests at pod level (`podSpec.Resources`, KEP-2837) instead of on the containers. The apply fails with `the scaledobject has a cpu trigger but the container app doesn't have the cpu request defined`, even though the HPA that KEDA generates computes utilization correctly from that request.

**What changed.** The check now reads `podSpec.Resources` once per trigger, before the per-container loop, and skips the loop when the pod-level request for that resource applies. It reuses the existing `isWorkloadResourceSet` helper, which already accepts a `corev1.ResourceRequirements` by value, so there are no new imports and no new module dependencies.

**The shortcut is deliberately limited to triggers without `containerName`.** A trigger that sets `containerName` makes `cpuMemoryScaler.GetMetricSpecForScaling` emit a `ContainerResource` metric, and upstream `calculateRequests` in `replica_calculator.go` uses pod-level requests only when no container is named. Accepting a pod-level request there would replace an admission rejection with a runtime `ScalingActive=False`, so that path keeps requiring the named container to declare its own request.

**Downstream already supports the widened case.** Since kubernetes/kubernetes#132430 (v1.34) the HPA controller uses the pod-level request as the utilization denominator for `type: Resource` metrics. Only KEDA's admission check blocked it. An `argoproj.io/v1alpha1.Rollout` with the same pod spec and the same trigger is accepted today and scales correctly, with `averageValue: 333m` against a 200m pod-level request reported as `166%`.

Three points a reviewer may want settled up front:

- **No version gating is needed.** `PodSpec.Resources` exists in the `k8s.io/api v0.36.4` types already vendored here. When the `PodLevelResources` feature gate is off the field is empty, so the added condition is inert on clusters that do not support the feature.
- **This only widens acceptance.** Nothing that validated before is rejected now. The container-level path and the `LimitRange` fallback are untouched, and the spec `should validate the so creation with cpu and memory when deployment has container requests and empty pod-level resources` guards that.
- **It removes an inconsistency rather than adding permissiveness.** Every scale target kind other than `apps/v1.Deployment` and `apps/v1.StatefulSet` reaches the `default` branch of the GVK switch and skips this validation entirely, so pod-level-only specs are already accepted for those kinds today.

**Tests.** Six specs were added to `apis/keda/v1alpha1/scaledobject_webhook_test.go`:

- pod-level requests on a Deployment, and the same on a StatefulSet, are accepted
- a `containerName` trigger against a container with no requests is still rejected, even with pod-level requests set
- a `containerName` trigger against a container that does declare requests is accepted
- a pod-level cpu-only spec still rejects the `memory` trigger, asserted on the admission message
- container-level requests with a non-nil but empty `podSpec.Resources` are still accepted

`go test ./apis/keda/v1alpha1/...` reports `91 Passed | 0 Failed`. Reverting either half of the webhook change fails specs from this set.

**Known adjacent issue, left out of scope.** `isWorkloadResourceSet` treats an explicit `requests: {cpu: 0}` alongside a positive limit as satisfied, which the HPA cannot compute a utilization from. That helper predates this PR and `should not validate ScaledObject creation when deployment only provides cpu resource limits` currently asserts the accepting behavior, so changing it belongs in its own issue rather than here.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)* https://github.com/kedacore/keda-docs/pull/1856
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #8113

Relates to https://github.com/kedacore/keda-docs/pull/1856
