### PR TITLE
Selenium Grid Scaler: Safely parse capabilities and limit response body

### DIFF
--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -302,7 +302,7 @@ func (s *seleniumGridScaler) getSessionsQueueLength(ctx context.Context, logger 
 		return -1, -1, err
 	}
 	if len(b) > maxSeleniumGridResponseSize {
-		err = fmt.Errorf("Selenium Grid response body exceeds the %d byte limit", maxSeleniumGridResponseSize)
+		err = fmt.Errorf("selenium Grid response body exceeds the %d byte limit", maxSeleniumGridResponseSize)
 		logger.Error(err, "Selenium Grid response body is too large")
 		return -1, -1, err
 	}

--- a/pkg/scalers/selenium_grid_scaler.go
+++ b/pkg/scalers/selenium_grid_scaler.go
@@ -25,6 +25,8 @@ type seleniumGridScaler struct {
 	logger     logr.Logger
 }
 
+const maxSeleniumGridResponseSize = 10 * 1024 * 1024
+
 type seleniumGridScalerMetadata struct {
 	triggerIndex int
 
@@ -294,9 +296,14 @@ func (s *seleniumGridScaler) getSessionsQueueLength(ctx context.Context, logger 
 	}
 
 	defer res.Body.Close()
-	b, err := io.ReadAll(res.Body)
+	b, err := io.ReadAll(io.LimitReader(res.Body, maxSeleniumGridResponseSize+1))
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Error when reading Selenium Grid response body: %s", err))
+		return -1, -1, err
+	}
+	if len(b) > maxSeleniumGridResponseSize {
+		err = fmt.Errorf("Selenium Grid response body exceeds the %d byte limit", maxSeleniumGridResponseSize)
+		logger.Error(err, "Selenium Grid response body is too large")
 		return -1, -1, err
 	}
 	newRequestNodes, onGoingSession, err := getCountFromSeleniumResponse(b, s.metadata.BrowserName, s.metadata.BrowserVersion, s.metadata.SessionBrowserName, s.metadata.PlatformName, s.metadata.NodeMaxSessions, s.metadata.EnableManagedDownloads, s.metadata.Capabilities, logger)
@@ -309,10 +316,13 @@ func (s *seleniumGridScaler) getSessionsQueueLength(ctx context.Context, logger 
 
 func getCapability(capability map[string]any, key string) string {
 	value, ok := capability[key]
-	if ok {
-		return value.(string)
+	if !ok || value == nil {
+		return ""
 	}
-	return ""
+	if s, ok := value.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", value)
 }
 
 func getBrowserName(capability map[string]any) string {
@@ -355,14 +365,21 @@ func countMatchingSessions(sessions Sessions, browserName string, browserVersion
 func managedDownloadsEnabled(stereotype map[string]any, capabilities map[string]any) bool {
 	// First lets check if user wanted a Node with managed downloads enabled
 	value1, ok1 := capabilities[EnableManagedDownloadsCapability]
-	if !ok1 || !value1.(bool) {
+	if !ok1 || value1 == nil {
 		// User didn't ask. So lets move on to the next matching criteria
+		return true
+	}
+	enabled1, ok := value1.(bool)
+	if !ok || !enabled1 {
 		return true
 	}
 	// User wants managed downloads enabled to be done on this Node, let's check the stereotype
 	value2, ok2 := stereotype[EnableManagedDownloadsCapability]
-	// Try to match what the user requested
-	return ok2 && value2.(bool)
+	if !ok2 || value2 == nil {
+		return false
+	}
+	enabled2, ok := value2.(bool)
+	return ok && enabled2
 }
 
 func extensionCapabilitiesMatch(stereotype map[string]any, capabilities map[string]any) bool {

--- a/pkg/scalers/selenium_grid_scaler_test.go
+++ b/pkg/scalers/selenium_grid_scaler_test.go
@@ -3760,3 +3760,59 @@ func Test_GetMetricsAndActivity_IncludeOngoingSessions(t *testing.T) {
 		})
 	}
 }
+
+func Test_getCapabilityAndManagedDownloadsSafeTypes(t *testing.T) {
+	// Numeric / boolean / nil capabilities should not panic
+	capMap := map[string]any{
+		"browserVersion": float64(128),
+		"browserName":    "chrome",
+		"nilField":       nil,
+		"boolField":      true,
+	}
+
+	if got := getCapability(capMap, "browserVersion"); got != "128" {
+		t.Errorf("getCapability(browserVersion) = %v, want 128", got)
+	}
+	if got := getCapability(capMap, "browserName"); got != "chrome" {
+		t.Errorf("getCapability(browserName) = %v, want chrome", got)
+	}
+	if got := getCapability(capMap, "nilField"); got != "" {
+		t.Errorf("getCapability(nilField) = %v, want empty", got)
+	}
+	if got := getCapability(capMap, "missingField"); got != "" {
+		t.Errorf("getCapability(missingField) = %v, want empty", got)
+	}
+
+	// Non-boolean managed downloads should not panic
+	if got := managedDownloadsEnabled(map[string]any{EnableManagedDownloadsCapability: "invalid"}, map[string]any{}); !got {
+		t.Errorf("managedDownloadsEnabled() = false, want true")
+	}
+	if got := managedDownloadsEnabled(map[string]any{}, map[string]any{EnableManagedDownloadsCapability: "invalid"}); !got {
+		t.Errorf("managedDownloadsEnabled() = false, want true")
+	}
+	if got := managedDownloadsEnabled(map[string]any{EnableManagedDownloadsCapability: "invalid"}, map[string]any{EnableManagedDownloadsCapability: true}); got {
+		t.Errorf("managedDownloadsEnabled() = true, want false")
+	}
+	if got := managedDownloadsEnabled(map[string]any{EnableManagedDownloadsCapability: true}, map[string]any{EnableManagedDownloadsCapability: true}); !got {
+		t.Errorf("managedDownloadsEnabled() = false, want true")
+	}
+}
+
+func Test_getSessionsQueueLengthRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// nosemgrep: no-direct-write-to-responsewriter
+		_, _ = w.Write(make([]byte, maxSeleniumGridResponseSize+2))
+	}))
+	defer server.Close()
+
+	s := &seleniumGridScaler{
+		metadata:   &seleniumGridScalerMetadata{URL: server.URL},
+		httpClient: server.Client(),
+	}
+
+	_, _, err := s.getSessionsQueueLength(context.Background(), logr.Discard())
+	if err == nil {
+		t.Fatal("getSessionsQueueLength() error = nil, want response-size error")
+	}
+}


### PR DESCRIPTION
### What this PR does
Prevents potential panics and unbounded allocations in the Selenium Grid Scaler.

### Details
1. Replaces direct type assertions (`value.(string)` in `getCapability` and `value.(bool)` in `managedDownloadsEnabled`) with safe type checking to prevent unhandled panics if capabilities or stereotype data contains non-string types (e.g. numeric browser version `128`), nulls, or non-boolean values.
2. Wraps `res.Body` with `io.LimitReader(res.Body, 10*1024*1024)` to protect against memory exhaustion from oversized responses.
3. Adds unit test coverage for non-string / numeric / null capability parsing.