### PR TITLE
General: scaler scheme: recurse on nested pointers and propagate 'optional'

### DIFF
--- a/schema/generate_scaler_schema.go
+++ b/schema/generate_scaler_schema.go
@@ -131,7 +131,7 @@ func aggregateSchemaStruct(scalerSelectors map[string]string, kedaScalerStructs 
 	sort.Strings(sortedScalerNames)
 
 	for _, creatorName := range sortedScalerCreatorNames {
-		metadataFields := generateMetadataFields(kedaScalerStructs[creatorName], otherReferenceKedaTagStructs)
+		metadataFields := generateMetadataFields(kedaScalerStructs[creatorName], otherReferenceKedaTagStructs, false)
 		if len(metadataFields) == 0 {
 			fmt.Printf("Error generating metadata fields with creator %s: %s\n", creatorName, err)
 			continue
@@ -219,7 +219,7 @@ func aggregateSchemaStruct(scalerSelectors map[string]string, kedaScalerStructs 
 }
 
 // generateMetadataFields is a function that generates the metadata fields of a scaler struct
-func generateMetadataFields(structType *ast.StructType, otherReferenceKedaTagStructs map[string]*ast.StructType) []Parameters {
+func generateMetadataFields(structType *ast.StructType, otherReferenceKedaTagStructs map[string]*ast.StructType, parentOptional bool) []Parameters {
 	scalerMetadata := []Parameters{}
 
 	// get the tag of each field and generate the metadata
@@ -235,21 +235,21 @@ func generateMetadataFields(structType *ast.StructType, otherReferenceKedaTagStr
 		}
 
 		if !hasSubstruct {
+			if parentOptional {
+				for i := range metadataList {
+					metadataList[i].Optional = true
+				}
+			}
 			scalerMetadata = append(scalerMetadata, metadataList...)
 			continue
 		}
 
 		// If the field has a substruct, try to find substruct from reference structs.
-		// Handle both *ast.Ident (same package) and *ast.SelectorExpr (e.g. gcp.AuthMetadata).
-		var subStructName string
-		switch t := commentGroup.Type.(type) {
-		case *ast.Ident:
-			subStructName = t.Name
-		case *ast.SelectorExpr:
-			subStructName = t.Sel.Name
-		}
+		// A substruct field is only recognized by its bare `keda:"optional"` tag, so its
+		// fields are always parsed as optional at runtime.
+		subStructName := subStructTypeName(commentGroup.Type)
 		if subStructName != "" && otherReferenceKedaTagStructs[subStructName] != nil {
-			subStructMetadataField := generateMetadataFields(otherReferenceKedaTagStructs[subStructName], otherReferenceKedaTagStructs)
+			subStructMetadataField := generateMetadataFields(otherReferenceKedaTagStructs[subStructName], otherReferenceKedaTagStructs, true)
 			if len(subStructMetadataField) > 0 {
 				scalerMetadata = append(scalerMetadata, subStructMetadataField...)
 			}
@@ -257,6 +257,21 @@ func generateMetadataFields(structType *ast.StructType, otherReferenceKedaTagStr
 	}
 
 	return scalerMetadata
+}
+
+// subStructTypeName resolves the type name of a substruct field: *ast.Ident (same package),
+// *ast.SelectorExpr (other package, e.g. gcp.AuthMetadata) or *ast.StarExpr wrapping either
+// (pointer substructs, e.g. *authentication.Config).
+func subStructTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	case *ast.StarExpr:
+		return subStructTypeName(t.X)
+	}
+	return ""
 }
 
 // generateMetadatas is a function that generates the metadata field from tag

--- a/schema/generated/scalers-schema.json
+++ b/schema/generated/scalers-schema.json
@@ -224,6 +224,162 @@
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
+                    "name": "authModes",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "authMode",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "bearerToken",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "token",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "username",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "cert",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "ca",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "oauthTokenURI",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scopes",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scope",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientID",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientSecret",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "endpointParams",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthHeader",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthValue",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "apiKey",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "method",
+                    "type": "string",
+                    "optional": true,
+                    "default": "header",
+                    "allowedValue": [
+                        "header",
+                        "query"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "keyParamName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
                     "name": "dbName",
                     "type": "string",
                     "metadataVariableReadable": true,
@@ -919,6 +1075,7 @@
                 {
                     "name": "consumerGroup",
                     "type": "string",
+                    "optional": true,
                     "default": "$Default",
                     "metadataVariableReadable": true
                 },
@@ -3332,77 +3489,92 @@
                 {
                     "name": "username",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "password",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "key",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "ca",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "oauthTokenURI",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "scopes",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "scope",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "clientID",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "clientSecret",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "endpointParams",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "customAuthHeader",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "customAuthValue",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "apiKey",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "method",
                     "type": "string",
+                    "optional": true,
                     "default": "header",
                     "allowedValue": [
                         "header",
@@ -3549,6 +3721,162 @@
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "authModes",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "authMode",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "bearerToken",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "token",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "username",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "cert",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "ca",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "oauthTokenURI",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scopes",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scope",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientID",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientSecret",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "endpointParams",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthHeader",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthValue",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "apiKey",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "method",
+                    "type": "string",
+                    "optional": true,
+                    "default": "header",
+                    "allowedValue": [
+                        "header",
+                        "query"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "keyParamName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
                 }
             ]
         },
@@ -4223,6 +4551,162 @@
                     "metadataVariableReadable": true
                 },
                 {
+                    "name": "authModes",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "authMode",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "bearerToken",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "token",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "username",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "cert",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "ca",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "oauthTokenURI",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scopes",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scope",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientID",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientSecret",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "endpointParams",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthHeader",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthValue",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "apiKey",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "method",
+                    "type": "string",
+                    "optional": true,
+                    "default": "header",
+                    "allowedValue": [
+                        "header",
+                        "query"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "keyParamName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
                     "name": "query",
                     "type": "string",
                     "metadataVariableReadable": true
@@ -4264,6 +4748,162 @@
         {
             "type": "prometheus",
             "parameters": [
+                {
+                    "name": "authModes",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "authMode",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "bearerToken",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "token",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "username",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "cert",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "ca",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "oauthTokenURI",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scopes",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scope",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientID",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientSecret",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "endpointParams",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthHeader",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthValue",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "apiKey",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "method",
+                    "type": "string",
+                    "optional": true,
+                    "default": "header",
+                    "allowedValue": [
+                        "header",
+                        "query"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "keyParamName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
                 {
                     "name": "serverAddress",
                     "type": "string",
@@ -4457,6 +5097,162 @@
                     "type": "string",
                     "optional": true,
                     "metadataVariableReadable": true
+                },
+                {
+                    "name": "authModes",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "authMode",
+                    "type": "string",
+                    "optional": true,
+                    "allowedValue": [
+                        "apiKey",
+                        "basic",
+                        "tls",
+                        "bearer",
+                        "custom",
+                        "oauth"
+                    ],
+                    "exclusiveSet": [
+                        "bearer",
+                        "basic",
+                        "oauth"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "bearerToken",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "token",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "username",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "password",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "cert",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "key",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "ca",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "oauthTokenURI",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scopes",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "scope",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientID",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "clientSecret",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "endpointParams",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthHeader",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "customAuthValue",
+                    "type": "string",
+                    "optional": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "apiKey",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "method",
+                    "type": "string",
+                    "optional": true,
+                    "default": "header",
+                    "allowedValue": [
+                        "header",
+                        "query"
+                    ],
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
+                },
+                {
+                    "name": "keyParamName",
+                    "type": "string",
+                    "optional": true,
+                    "metadataVariableReadable": true,
+                    "triggerAuthenticationVariableReadable": true
                 }
             ]
         },
@@ -4603,31 +5399,37 @@
                 {
                     "name": "oauthTokenURI",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "scopes",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "scope",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "clientID",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "clientSecret",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "endpointParams",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 }
             ]
@@ -4673,6 +5475,7 @@
                 {
                     "name": "address",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4680,6 +5483,7 @@
                 {
                     "name": "addresses",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4687,6 +5491,7 @@
                 {
                     "name": "username",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4694,6 +5499,7 @@
                 {
                     "name": "password",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4701,6 +5507,7 @@
                 {
                     "name": "sentinelUsername",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4708,6 +5515,7 @@
                 {
                     "name": "sentinelPassword",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4715,6 +5523,7 @@
                 {
                     "name": "sentinelMaster",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4722,6 +5531,7 @@
                 {
                     "name": "host",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4729,6 +5539,7 @@
                 {
                     "name": "hosts",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4736,6 +5547,7 @@
                 {
                     "name": "port",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4743,6 +5555,7 @@
                 {
                     "name": "ports",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4750,32 +5563,38 @@
                 {
                     "name": "unsafeSsl",
                     "type": "string",
+                    "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
                 },
                 {
                     "name": "Cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "key",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "keyPassword",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "ca",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 }
             ]
@@ -4821,6 +5640,7 @@
                 {
                     "name": "address",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4828,6 +5648,7 @@
                 {
                     "name": "addresses",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4835,6 +5656,7 @@
                 {
                     "name": "username",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4842,6 +5664,7 @@
                 {
                     "name": "password",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4849,6 +5672,7 @@
                 {
                     "name": "sentinelUsername",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4856,6 +5680,7 @@
                 {
                     "name": "sentinelPassword",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4863,6 +5688,7 @@
                 {
                     "name": "sentinelMaster",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4870,6 +5696,7 @@
                 {
                     "name": "host",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4877,6 +5704,7 @@
                 {
                     "name": "hosts",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4884,6 +5712,7 @@
                 {
                     "name": "port",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4891,6 +5720,7 @@
                 {
                     "name": "ports",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4898,32 +5728,38 @@
                 {
                     "name": "unsafeSsl",
                     "type": "string",
+                    "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
                 },
                 {
                     "name": "Cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "key",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "keyPassword",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "ca",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 }
             ]
@@ -4969,6 +5805,7 @@
                 {
                     "name": "address",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4976,6 +5813,7 @@
                 {
                     "name": "addresses",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4983,6 +5821,7 @@
                 {
                     "name": "username",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4990,6 +5829,7 @@
                 {
                     "name": "password",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -4997,6 +5837,7 @@
                 {
                     "name": "sentinelUsername",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5004,6 +5845,7 @@
                 {
                     "name": "sentinelPassword",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5011,6 +5853,7 @@
                 {
                     "name": "sentinelMaster",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5018,6 +5861,7 @@
                 {
                     "name": "host",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5025,6 +5869,7 @@
                 {
                     "name": "hosts",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5032,6 +5877,7 @@
                 {
                     "name": "port",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5039,6 +5885,7 @@
                 {
                     "name": "ports",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5046,32 +5893,38 @@
                 {
                     "name": "unsafeSsl",
                     "type": "string",
+                    "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
                 },
                 {
                     "name": "Cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "key",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "keyPassword",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "ca",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 }
             ]
@@ -5117,6 +5970,7 @@
                 {
                     "name": "address",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5124,6 +5978,7 @@
                 {
                     "name": "addresses",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5131,6 +5986,7 @@
                 {
                     "name": "username",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5138,6 +5994,7 @@
                 {
                     "name": "password",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5145,6 +6002,7 @@
                 {
                     "name": "sentinelUsername",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5152,6 +6010,7 @@
                 {
                     "name": "sentinelPassword",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5159,6 +6018,7 @@
                 {
                     "name": "sentinelMaster",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5166,6 +6026,7 @@
                 {
                     "name": "host",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5173,6 +6034,7 @@
                 {
                     "name": "hosts",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5180,6 +6042,7 @@
                 {
                     "name": "port",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5187,6 +6050,7 @@
                 {
                     "name": "ports",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5194,32 +6058,38 @@
                 {
                     "name": "unsafeSsl",
                     "type": "string",
+                    "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
                 },
                 {
                     "name": "Cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "key",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "keyPassword",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "ca",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
@@ -5283,6 +6153,7 @@
                 {
                     "name": "address",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5290,6 +6161,7 @@
                 {
                     "name": "addresses",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5297,6 +6169,7 @@
                 {
                     "name": "username",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5304,6 +6177,7 @@
                 {
                     "name": "password",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5311,6 +6185,7 @@
                 {
                     "name": "sentinelUsername",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5318,6 +6193,7 @@
                 {
                     "name": "sentinelPassword",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5325,6 +6201,7 @@
                 {
                     "name": "sentinelMaster",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5332,6 +6209,7 @@
                 {
                     "name": "host",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5339,6 +6217,7 @@
                 {
                     "name": "hosts",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5346,6 +6225,7 @@
                 {
                     "name": "port",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5353,6 +6233,7 @@
                 {
                     "name": "ports",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5360,32 +6241,38 @@
                 {
                     "name": "unsafeSsl",
                     "type": "string",
+                    "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
                 },
                 {
                     "name": "Cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "key",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "keyPassword",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "ca",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
@@ -5449,6 +6336,7 @@
                 {
                     "name": "address",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5456,6 +6344,7 @@
                 {
                     "name": "addresses",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5463,6 +6352,7 @@
                 {
                     "name": "username",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5470,6 +6360,7 @@
                 {
                     "name": "password",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5477,6 +6368,7 @@
                 {
                     "name": "sentinelUsername",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5484,6 +6376,7 @@
                 {
                     "name": "sentinelPassword",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5491,6 +6384,7 @@
                 {
                     "name": "sentinelMaster",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5498,6 +6392,7 @@
                 {
                     "name": "host",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5505,6 +6400,7 @@
                 {
                     "name": "hosts",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5512,6 +6408,7 @@
                 {
                     "name": "port",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5519,6 +6416,7 @@
                 {
                     "name": "ports",
                     "type": "string",
+                    "optional": true,
                     "metadataVariableReadable": true,
                     "envVariableReadable": true,
                     "triggerAuthenticationVariableReadable": true
@@ -5526,32 +6424,38 @@
                 {
                     "name": "unsafeSsl",
                     "type": "string",
+                    "optional": true,
                     "default": "false",
                     "metadataVariableReadable": true
                 },
                 {
                     "name": "Cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "cert",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "key",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "keyPassword",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {
                     "name": "ca",
                     "type": "string",
+                    "optional": true,
                     "triggerAuthenticationVariableReadable": true
                 },
                 {

--- a/schema/generated/scalers-schema.yaml
+++ b/schema/generated/scalers-schema.yaml
@@ -150,6 +150,117 @@ scalers:
           type: string
           metadataVariableReadable: true
           triggerAuthenticationVariableReadable: true
+        - name: authModes
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: authMode
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: bearerToken
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: token
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: username
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: password
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: cert
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: key
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: ca
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: oauthTokenURI
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scopes
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scope
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientID
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientSecret
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: endpointParams
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthHeader
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthValue
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: apiKey
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: method
+          type: string
+          optional: true
+          default: header
+          allowedValue:
+            - header
+            - query
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: keyParamName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
         - name: dbName
           type: string
           metadataVariableReadable: true
@@ -601,6 +712,7 @@ scalers:
           triggerAuthenticationVariableReadable: true
         - name: consumerGroup
           type: string
+          optional: true
           default: $Default
           metadataVariableReadable: true
         - name: storageConnection
@@ -2187,49 +2299,64 @@ scalers:
           triggerAuthenticationVariableReadable: true
         - name: username
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: password
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: key
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: ca
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: oauthTokenURI
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: scopes
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: scope
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: clientID
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: clientSecret
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: endpointParams
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: customAuthHeader
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: customAuthValue
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: apiKey
           type: string
+          optional: true
           metadataVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: method
           type: string
+          optional: true
           default: header
           allowedValue:
             - header
@@ -2329,6 +2456,117 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
+        - name: authModes
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: authMode
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: bearerToken
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: token
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: username
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: password
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: cert
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: key
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: ca
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: oauthTokenURI
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scopes
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scope
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientID
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientSecret
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: endpointParams
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthHeader
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthValue
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: apiKey
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: method
+          type: string
+          optional: true
+          default: header
+          allowedValue:
+            - header
+            - query
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: keyParamName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
     - type: mongodb
       parameters:
         - name: connectionString
@@ -2772,6 +3010,117 @@ scalers:
         - name: prometheusAddress
           type: string
           metadataVariableReadable: true
+        - name: authModes
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: authMode
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: bearerToken
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: token
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: username
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: password
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: cert
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: key
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: ca
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: oauthTokenURI
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scopes
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scope
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientID
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientSecret
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: endpointParams
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthHeader
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthValue
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: apiKey
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: method
+          type: string
+          optional: true
+          default: header
+          allowedValue:
+            - header
+            - query
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: keyParamName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
         - name: query
           type: string
           metadataVariableReadable: true
@@ -2797,6 +3146,117 @@ scalers:
           metadataVariableReadable: true
     - type: prometheus
       parameters:
+        - name: authModes
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: authMode
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: bearerToken
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: token
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: username
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: password
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: cert
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: key
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: ca
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: oauthTokenURI
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scopes
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scope
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientID
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientSecret
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: endpointParams
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthHeader
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthValue
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: apiKey
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: method
+          type: string
+          optional: true
+          default: header
+          allowedValue:
+            - header
+            - query
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: keyParamName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
         - name: serverAddress
           type: string
           metadataVariableReadable: true
@@ -2925,6 +3385,117 @@ scalers:
           type: string
           optional: true
           metadataVariableReadable: true
+        - name: authModes
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: authMode
+          type: string
+          optional: true
+          allowedValue:
+            - apiKey
+            - basic
+            - tls
+            - bearer
+            - custom
+            - oauth
+          exclusiveSet:
+            - bearer
+            - basic
+            - oauth
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: bearerToken
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: token
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: username
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: password
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: cert
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: key
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: ca
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: oauthTokenURI
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scopes
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: scope
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientID
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: clientSecret
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: endpointParams
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthHeader
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: customAuthValue
+          type: string
+          optional: true
+          triggerAuthenticationVariableReadable: true
+        - name: apiKey
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: method
+          type: string
+          optional: true
+          default: header
+          allowedValue:
+            - header
+            - query
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
+        - name: keyParamName
+          type: string
+          optional: true
+          metadataVariableReadable: true
+          triggerAuthenticationVariableReadable: true
     - type: rabbitmq
       parameters:
         - name: queueName
@@ -3022,21 +3593,27 @@ scalers:
           triggerAuthenticationVariableReadable: true
         - name: oauthTokenURI
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: scopes
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: scope
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: clientID
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: clientSecret
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: endpointParams
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
     - type: redis
       parameters:
@@ -3065,77 +3642,94 @@ scalers:
           triggerAuthenticationVariableReadable: true
         - name: address
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: addresses
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: username
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: password
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelUsername
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelPassword
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelMaster
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: host
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: hosts
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: port
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: ports
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: unsafeSsl
           type: string
+          optional: true
           default: "false"
           metadataVariableReadable: true
         - name: Cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: key
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: keyPassword
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: ca
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
     - type: redis-cluster
       parameters:
@@ -3164,77 +3758,94 @@ scalers:
           triggerAuthenticationVariableReadable: true
         - name: address
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: addresses
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: username
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: password
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelUsername
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelPassword
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelMaster
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: host
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: hosts
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: port
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: ports
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: unsafeSsl
           type: string
+          optional: true
           default: "false"
           metadataVariableReadable: true
         - name: Cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: key
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: keyPassword
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: ca
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
     - type: redis-sentinel
       parameters:
@@ -3263,77 +3874,94 @@ scalers:
           triggerAuthenticationVariableReadable: true
         - name: address
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: addresses
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: username
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: password
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelUsername
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelPassword
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelMaster
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: host
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: hosts
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: port
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: ports
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: unsafeSsl
           type: string
+          optional: true
           default: "false"
           metadataVariableReadable: true
         - name: Cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: key
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: keyPassword
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: ca
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
     - type: redis-cluster-streams
       parameters:
@@ -3362,77 +3990,94 @@ scalers:
           metadataVariableReadable: true
         - name: address
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: addresses
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: username
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: password
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelUsername
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelPassword
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelMaster
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: host
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: hosts
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: port
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: ports
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: unsafeSsl
           type: string
+          optional: true
           default: "false"
           metadataVariableReadable: true
         - name: Cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: key
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: keyPassword
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: ca
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: activationLagCount
           type: string
@@ -3473,77 +4118,94 @@ scalers:
           metadataVariableReadable: true
         - name: address
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: addresses
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: username
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: password
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelUsername
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelPassword
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelMaster
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: host
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: hosts
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: port
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: ports
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: unsafeSsl
           type: string
+          optional: true
           default: "false"
           metadataVariableReadable: true
         - name: Cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: key
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: keyPassword
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: ca
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: activationLagCount
           type: string
@@ -3584,77 +4246,94 @@ scalers:
           metadataVariableReadable: true
         - name: address
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: addresses
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: username
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: password
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelUsername
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelPassword
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: sentinelMaster
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: host
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: hosts
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: port
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: ports
           type: string
+          optional: true
           metadataVariableReadable: true
           envVariableReadable: true
           triggerAuthenticationVariableReadable: true
         - name: unsafeSsl
           type: string
+          optional: true
           default: "false"
           metadataVariableReadable: true
         - name: Cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: cert
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: key
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: keyPassword
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: ca
           type: string
+          optional: true
           triggerAuthenticationVariableReadable: true
         - name: activationLagCount
           type: string


### PR DESCRIPTION
followup to https://github.com/kedacore/keda/pull/8074, recurse on nested pointer structures and also propagate `optional` field annotation to child substructs because if a parent is optional, then the children are also optional.

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/8065
