### PR TITLE
CI: improve AMP test workspace cleanup logic

### DIFF
--- a/tests/scalers/aws/aws_managed_prometheus/aws_managed_prometheus_test.go
+++ b/tests/scalers/aws/aws_managed_prometheus/aws_managed_prometheus_test.go
@@ -138,9 +138,15 @@ func TestScaler(t *testing.T) {
 	t.Log("--- setting up ---")
 
 	ampClient := createAMPClient()
-	workspaceOutput, err := ampClient.CreateWorkspace(context.Background(), nil)
-	assert.NoError(t, err, "aws prometheus workspace creation has failed")
+	workspaceAlias := "keda-e2e-amp-" + testName
+	workspaceOutput, err := ampClient.CreateWorkspace(context.Background(), &amp.CreateWorkspaceInput{Alias: &workspaceAlias})
+	require.NoError(t, err, "aws prometheus workspace creation has failed")
+	require.NotNil(t, workspaceOutput.WorkspaceId, "aws prometheus workspace creation returned no workspace ID")
 	workspaceID = *workspaceOutput.WorkspaceId
+	t.Cleanup(func() {
+		_, err := ampClient.DeleteWorkspace(context.Background(), &amp.DeleteWorkspaceInput{WorkspaceId: &workspaceID})
+		assert.NoError(t, err, "aws prometheus workspace deletion has failed")
+	})
 
 	kc := GetKubernetesClient(t)
 
@@ -149,16 +155,10 @@ func TestScaler(t *testing.T) {
 	t.Log(secretTemplate)
 	t.Log("--- assert ---")
 	expectedReplicaCountNumber := 2 // as mentioned above, as the AMP returns 100 and the threshold set to 50, the expected replica count is 100 / 50 = 2
-	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
+	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, expectedReplicaCountNumber, 60, 1),
 		"replica count should be %d after 1 minute", expectedReplicaCountNumber)
 
 	t.Log("--- cleaning up ---")
-	deleteWSInput := amp.DeleteWorkspaceInput{
-		WorkspaceId: &workspaceID,
-	}
-	input := &deleteWSInput
-	_, err = ampClient.DeleteWorkspace(context.Background(), input)
-	assert.NoError(t, err, "aws prometheus workspace deletion has failed")
 	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 
@@ -174,6 +174,7 @@ func getTemplateData() (templateData, []Template) {
 			WorkspaceID:        workspaceID,
 		}, []Template{
 			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "secretTemplate", Config: secretTemplate},
 			{Name: "triggerAuthenticationTemplate", Config: triggerAuthenticationTemplate},
 			{Name: "scaledObjectTemplate", Config: scaledObjectTemplate},
 		}

--- a/tests/scalers/aws/aws_managed_prometheus_pod_identity/aws_managed_prometheus_pod_identity_test.go
+++ b/tests/scalers/aws/aws_managed_prometheus_pod_identity/aws_managed_prometheus_pod_identity_test.go
@@ -123,9 +123,15 @@ func TestScaler(t *testing.T) {
 	t.Log("--- setting up ---")
 
 	ampClient := createAMPClient()
-	workspaceOutput, err := ampClient.CreateWorkspace(context.Background(), nil)
-	assert.NoError(t, err, "aws prometheus workspace creation has failed")
+	workspaceAlias := "keda-e2e-amp-" + testName
+	workspaceOutput, err := ampClient.CreateWorkspace(context.Background(), &amp.CreateWorkspaceInput{Alias: &workspaceAlias})
+	require.NoError(t, err, "aws prometheus workspace creation has failed")
+	require.NotNil(t, workspaceOutput.WorkspaceId, "aws prometheus workspace creation returned no workspace ID")
 	workspaceID = *workspaceOutput.WorkspaceId
+	t.Cleanup(func() {
+		_, err := ampClient.DeleteWorkspace(context.Background(), &amp.DeleteWorkspaceInput{WorkspaceId: &workspaceID})
+		assert.NoError(t, err, "aws prometheus workspace deletion has failed")
+	})
 
 	kc := GetKubernetesClient(t)
 
@@ -134,16 +140,10 @@ func TestScaler(t *testing.T) {
 
 	t.Log("--- assert ---")
 	expectedReplicaCountNumber := 2 // as mentioned above, as the AMP returns 100 and the threshold set to 50, the expected replica count is 100 / 50 = 2
-	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, 0, 60, 1),
+	assert.Truef(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, expectedReplicaCountNumber, 60, 1),
 		"replica count should be %d after 1 minute", expectedReplicaCountNumber)
 
 	t.Log("--- cleaning up ---")
-	deleteWSInput := amp.DeleteWorkspaceInput{
-		WorkspaceId: &workspaceID,
-	}
-	input := &deleteWSInput
-	_, err = ampClient.DeleteWorkspace(context.Background(), input)
-	assert.NoError(t, err, "aws prometheus workspace deletion has failed")
 	DeleteKubernetesResources(t, testNamespace, data, templates)
 }
 


### PR DESCRIPTION
past two days, amp e2e tests were failing
```
SUITE                                        09-07/12:24  09-07/08:51  09-06/16:36  09-06/16:18
aws_managed_prometheus_test.go               ❌           ❌           ❌           ✅
aws_managed_prometheus_pod_identity_test.go  ❌           ❌           ❌           ✅
```

the reason was quota for AMP workspaces was hit due to leaking failed runs (25 max workspaces in the environment). The workspaces were cleaned up manually but I'd like to improve the test and add gc too. This PR improves tests cleanup, previously the workspace deletion logic was not executed if test assertion failed.

for gc see also: https://github.com/kedacore/testing-infrastructure/pull/211