### PR TITLE
General: Rebuild scalers with the caller's context on refresh

### DIFF
--- a/controllers/keda/hpa_test.go
+++ b/controllers/keda/hpa_test.go
@@ -97,7 +97,7 @@ var _ = Describe("hpa", func() {
 		scalersCache := cache.ScalersCache{
 			Scalers: []cache.ScalerBuilder{{
 				Scaler: emptyScaler,
-				Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+				Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 					return emptyScaler, &scalersconfig.ScalerConfig{}, nil
 				},
 			}},
@@ -127,7 +127,7 @@ var _ = Describe("hpa", func() {
 		scalersCache := cache.ScalersCache{
 			Scalers: []cache.ScalerBuilder{{
 				Scaler: emptyScaler,
-				Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+				Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 					return emptyScaler, &scalersconfig.ScalerConfig{}, nil
 				},
 			}},
@@ -194,7 +194,7 @@ func setupTest(health map[string]v1alpha1.HealthStatus, scaler *mock_scalers.Moc
 	scalersCache := cache.ScalersCache{
 		Scalers: []cache.ScalerBuilder{{
 			Scaler: scaler,
-			Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+			Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 				return scaler, &scalersconfig.ScalerConfig{}, nil
 			},
 		}},

--- a/controllers/keda/scaledobject_controller_test.go
+++ b/controllers/keda/scaledobject_controller_test.go
@@ -98,7 +98,7 @@ var _ = Describe("ScaledObjectController", func() {
 
 					testScalers = append(testScalers, cache.ScalerBuilder{
 						Scaler: s,
-						Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+						Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 							scaler, err := scalers.NewPrometheusScaler(config)
 							return scaler, config, err
 						},
@@ -155,7 +155,7 @@ var _ = Describe("ScaledObjectController", func() {
 				scalersCache := cache.ScalersCache{
 					Scalers: []cache.ScalerBuilder{{
 						Scaler: s,
-						Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+						Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 							return s, config, nil
 						},
 					}},
@@ -199,7 +199,7 @@ var _ = Describe("ScaledObjectController", func() {
 
 					testScalers = append(testScalers, cache.ScalerBuilder{
 						Scaler: s,
-						Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+						Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 							return s, config, nil
 						},
 					})

--- a/pkg/scaling/cache/scalers_cache.go
+++ b/pkg/scaling/cache/scalers_cache.go
@@ -93,7 +93,7 @@ func (c *ScalersCache) acquireReader() (release func(), err error) {
 type ScalerBuilder struct {
 	Scaler            scalers.Scaler
 	ScalerConfig      scalersconfig.ScalerConfig
-	Factory           func() (scalers.Scaler, *scalersconfig.ScalerConfig, error)
+	Factory           func(ctx context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error)
 	CachedMetricSpecs []v2.MetricSpec
 }
 
@@ -315,7 +315,7 @@ func (c *ScalersCache) refreshScaler(ctx context.Context, index int) (scalers.Sc
 
 	oldSb := c.Scalers[index]
 
-	newScaler, sConfig, err := oldSb.Factory()
+	newScaler, sConfig, err := oldSb.Factory(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scaling/cache/scalers_cache_test.go
+++ b/pkg/scaling/cache/scalers_cache_test.go
@@ -151,7 +151,7 @@ func newCacheWithScaler(s scalers.Scaler) *ScalersCache {
 		Scalers: []ScalerBuilder{{
 			Scaler:       s,
 			ScalerConfig: scalersconfig.ScalerConfig{},
-			Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+			Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 				return s, &scalersconfig.ScalerConfig{}, nil
 			},
 		}},
@@ -512,5 +512,35 @@ func TestScalersCache_GetMetricSpecForScalingForScaler_UsesCachedSpecs(t *testin
 	}
 	if specsAgain[0].External.Metric.Selector.MatchLabels["owner"] != "cache" {
 		t.Fatalf("expected selector owner=cache on second read, got %q", specsAgain[0].External.Metric.Selector.MatchLabels["owner"])
+	}
+}
+
+func TestScalersCache_RefreshScalerUsesCallerContext(t *testing.T) {
+	// The cache may be built while serving an HPA metrics read, so the Factory
+	// must not depend on the context that was live at build time: the apiserver
+	// cancels it once the response is written, long before the next refresh.
+	buildCtx, cancelBuild := context.WithCancel(context.Background())
+	scaler := newFakeScaler(nil)
+	cache := newCacheWithScaler(scaler)
+
+	var gotCtx context.Context
+	cache.Scalers[0].Factory = func(ctx context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		gotCtx = ctx
+		return scaler, &scalersconfig.ScalerConfig{}, nil
+	}
+	cancelBuild()
+
+	refreshCtx := context.Background()
+	if _, err := cache.refreshScaler(refreshCtx, 0); err != nil {
+		t.Fatalf("refreshScaler() error = %v", err)
+	}
+	if gotCtx != refreshCtx {
+		t.Fatalf("Factory received ctx %v, want the refreshScaler caller ctx", gotCtx)
+	}
+	if err := gotCtx.Err(); err != nil {
+		t.Fatalf("Factory received a cancelled ctx: %v", err)
+	}
+	if err := buildCtx.Err(); err == nil {
+		t.Fatal("test setup: build-time ctx should be cancelled")
 	}
 }

--- a/pkg/scaling/scale_handler_test.go
+++ b/pkg/scaling/scale_handler_test.go
@@ -84,7 +84,7 @@ func TestGetScaledObjectMetrics_DirectCall(t *testing.T) {
 	scaler := mock_scalers.NewMockScaler(ctrl)
 	// we are going to query metrics directly
 	scalerConfig := scalersconfig.ScalerConfig{TriggerUseCachedMetrics: false}
-	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler, &scalerConfig, nil
 	}
 
@@ -177,7 +177,7 @@ func TestGetScaledObjectMetrics_FromCache(t *testing.T) {
 	scaler := mock_scalers.NewMockScaler(ctrl)
 	// we are going to use cache for metrics values
 	scalerConfig := scalersconfig.ScalerConfig{TriggerUseCachedMetrics: true}
-	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler, &scalerConfig, nil
 	}
 
@@ -292,8 +292,8 @@ func TestGetScaledObjectMetrics_InParallel(t *testing.T) {
 		}
 	}
 
-	scalerFactoryFn := func(index int) func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
-		return func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	scalerFactoryFn := func(index int) func(context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		return func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 			return scalerCollection[index], scalerConfigFn(index), nil
 		}
 	}
@@ -400,7 +400,7 @@ func TestCheckScaledObjectScalersWithError(t *testing.T) {
 	scaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).Return([]external_metrics.ExternalMetricValue{}, false, errors.New("some error"))
 	scaler.EXPECT().Close(gomock.Any())
 
-	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
 		scaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).Return([]external_metrics.ExternalMetricValue{}, false, errors.New("some error"))
 		scaler.EXPECT().Close(gomock.Any())
@@ -461,7 +461,7 @@ func TestCheckScaledObjectScalersWithTriggerAuthError(t *testing.T) {
 	scaler := mock_scalers.NewMockScaler(ctrl)
 	scaler.EXPECT().Close(gomock.Any())
 
-	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
 		scaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).Return([]external_metrics.ExternalMetricValue{}, false, errors.New("some error"))
 		scaler.EXPECT().Close(gomock.Any())
@@ -588,17 +588,17 @@ func TestCheckScaledObjectFindFirstActiveNotIgnoreOthers(t *testing.T) {
 	metricsSpecs := []v2.MetricSpec{createMetricSpec(1, "metric-name")}
 	metricValue := scalers.GenerateMetricInMili("metric-name", float64(10))
 
-	activeFactory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	activeFactory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
 		scaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Return(metricsSpecs)
 		scaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).Return([]external_metrics.ExternalMetricValue{metricValue}, true, nil)
 		scaler.EXPECT().Close(gomock.Any())
 		return scaler, &scalersconfig.ScalerConfig{}, nil
 	}
-	activeScaler, _, err := activeFactory()
+	activeScaler, _, err := activeFactory(context.Background())
 	assert.Nil(t, err)
 
-	failingFactory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	failingFactory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		scaler := mock_scalers.NewMockScaler(ctrl)
 		scaler.EXPECT().GetMetricsAndActivity(gomock.Any(), gomock.Any()).Return([]external_metrics.ExternalMetricValue{}, false, errors.New("some error"))
 		scaler.EXPECT().Close(gomock.Any())
@@ -675,7 +675,7 @@ func TestClearScalersCache_PreservesMetricsCacheRecords(t *testing.T) {
 		closed <- struct{}{}
 		return nil
 	})
-	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler, &scalersconfig.ScalerConfig{}, nil
 	}
 
@@ -817,12 +817,12 @@ func TestGetScaledObjectMetrics_ErrorDoesNotClearOtherTriggersCachedRecord(t *te
 
 	cachedScaler := mock_scalers.NewMockScaler(ctrl)
 	cachedScalerConfig := scalersconfig.ScalerConfig{TriggerUseCachedMetrics: true}
-	cachedFactory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	cachedFactory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return cachedScaler, &cachedScalerConfig, nil
 	}
 	failingScaler := mock_scalers.NewMockScaler(ctrl)
 	failingScalerConfig := scalersconfig.ScalerConfig{}
-	failingFactory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	failingFactory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return failingScaler, &failingScalerConfig, nil
 	}
 
@@ -1115,7 +1115,7 @@ func TestGetScaledJobState(t *testing.T) {
 	scalerCache := cache.ScalersCache{
 		Scalers: []cache.ScalerBuilder{{
 			Scaler: createScaler(ctrl, int64(20), int64(2), true, metricName),
-			Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+			Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 				return createScaler(ctrl, int64(20), int64(2), true, metricName), &scalersconfig.ScalerConfig{}, nil
 			},
 		}},
@@ -1157,22 +1157,22 @@ func TestGetScaledJobState(t *testing.T) {
 		scaledJob := createScaledJob(scalerTestData.MinReplicaCount, scalerTestData.MaxReplicaCount, scalerTestData.MultipleScalersCalculation)
 		scalersToTest := []cache.ScalerBuilder{{
 			Scaler: createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+			Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 				return createScaler(ctrl, scalerTestData.Scaler1QueueLength, scalerTestData.Scaler1AverageValue, scalerTestData.Scaler1IsActive, scalerTestData.MetricName), &scalersconfig.ScalerConfig{}, nil
 			},
 		}, {
 			Scaler: createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+			Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 				return createScaler(ctrl, scalerTestData.Scaler2QueueLength, scalerTestData.Scaler2AverageValue, scalerTestData.Scaler2IsActive, scalerTestData.MetricName), &scalersconfig.ScalerConfig{}, nil
 			},
 		}, {
 			Scaler: createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+			Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 				return createScaler(ctrl, scalerTestData.Scaler3QueueLength, scalerTestData.Scaler3AverageValue, scalerTestData.Scaler3IsActive, scalerTestData.MetricName), &scalersconfig.ScalerConfig{}, nil
 			},
 		}, {
 			Scaler: createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive, scalerTestData.MetricName),
-			Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+			Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 				return createScaler(ctrl, scalerTestData.Scaler4QueueLength, scalerTestData.Scaler4AverageValue, scalerTestData.Scaler4IsActive, scalerTestData.MetricName), &scalersconfig.ScalerConfig{}, nil
 			},
 		}}
@@ -1217,7 +1217,7 @@ func TestGetScaledJobStateIfQueueEmptyButMinReplicaCountGreaterZero(t *testing.T
 	scaledJobSingle := createScaledJob(1, 100, "") // testing default = max
 	scalerSingle := []cache.ScalerBuilder{{
 		Scaler: createScaler(ctrl, int64(0), int64(1), true, metricName),
-		Factory: func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		Factory: func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 			return createScaler(ctrl, int64(0), int64(1), true, metricName), &scalersconfig.ScalerConfig{}, nil
 		},
 	}}
@@ -1408,10 +1408,10 @@ func TestScalingModifiersFormula(t *testing.T) {
 	// dont use cached metrics
 	scalerConfig1 := scalersconfig.ScalerConfig{TriggerUseCachedMetrics: false, TriggerName: triggerName1, TriggerIndex: 0}
 	scalerConfig2 := scalersconfig.ScalerConfig{TriggerUseCachedMetrics: false, TriggerName: triggerName2, TriggerIndex: 1}
-	factory1 := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory1 := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler1, &scalerConfig1, nil
 	}
-	factory2 := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory2 := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler2, &scalerConfig2, nil
 	}
 
@@ -1790,7 +1790,7 @@ func TestGetScaledJobMetrics_CacheClosedIsBenign(t *testing.T) {
 
 	scaler := mock_scalers.NewMockScaler(ctrl)
 	scaler.EXPECT().GetMetricSpecForScaling(gomock.Any()).Return(metricsSpecs)
-	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler, &scalersconfig.ScalerConfig{}, nil
 	}
 
@@ -1835,7 +1835,7 @@ func TestGetScaledObjectState_CacheClosedIsBenign(t *testing.T) {
 	recorder := events.NewFakeRecorder(10)
 
 	scaler := mock_scalers.NewMockScaler(ctrl)
-	factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+	factory := func(_ context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 		return scaler, &scalersconfig.ScalerConfig{}, nil
 	}
 

--- a/pkg/scaling/scalers_builder.go
+++ b/pkg/scaling/scalers_builder.go
@@ -46,7 +46,7 @@ func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alp
 	for i, t := range withTriggers.Spec.Triggers {
 		triggerIndex, trigger := i, t
 
-		factory := func() (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
+		factory := func(ctx context.Context) (scalers.Scaler, *scalersconfig.ScalerConfig, error) {
 			if podTemplateSpec != nil {
 				resolvedEnv, err = resolver.ResolveContainerEnv(ctx, h.client, logger, &podTemplateSpec.Spec, containerName, withTriggers.Namespace, h.authClientSet.SecretLister)
 				if err != nil {
@@ -90,7 +90,7 @@ func (h *scaleHandler) buildScalers(ctx context.Context, withTriggers *kedav1alp
 		}
 
 		// nosemgrep: invalid-usage-of-modified-variable
-		scaler, config, err := factory()
+		scaler, config, err := factory(ctx)
 		if err != nil {
 			h.recorder.Eventf(withTriggers, nil, corev1.EventTypeWarning, eventreason.KEDAScalerFailed, eventreason.KEDAScalerFailed, "%s", err.Error())
 			logger.Error(err, "error resolving auth params", "triggerIndex", triggerIndex)


### PR DESCRIPTION
## Problem

A `ScaledObject` authenticated with `boundServiceAccountToken` can permanently stop refreshing its token. Once the token expires, every poll logs
`error trying to create bound service account token ... client rate limiter Wait returned an error: context canceled`
followed by a misleading metadata error such as `BearerToken is required`, and the object stays pinned to its fallback replicas until `keda-operator` is restarted.

## Root cause

`ScalerBuilder.Factory` takes no context, so the closure created in `pkg/scaling/scalers_builder.go:49` captures the `ctx` that was passed to `buildScalers`. `refreshScaler` (`pkg/scaling/cache/scalers_cache.go:318`) receives a live `ctx` but only uses it to `Close()` the old scaler; the rebuild runs `oldSb.Factory()` under the captured build-time context, and the same closure is re-stored (`scalers_cache.go:326`), so every later refresh inherits it.

When the cache is (re)built while serving an HPA metrics read, that build-time context is the gRPC request context (`pkg/metricsservice/server.go:50` -> `GetScaledObjectMetrics` -> `getScalersCacheForScaledObject` -> `performGetScalersCache` -> `buildScalers`, `pkg/scaling/scale_handler.go:585`). The apiserver cancels it as soon as the response is written. About an hour later the token expires, `refreshScaler` rebuilds the scaler under the dead context, `CreateToken` fails, and the scaler is constructed with an empty token. Any trigger that uses `boundServiceAccountToken` is affected since a full scaler rebuild is the only way to mint a fresh token.

## Fix

Make `Factory` take a `context.Context` and pass the caller's context through:

- `pkg/scaling/cache/scalers_cache.go`: `Factory func(ctx context.Context) (...)`; `refreshScaler` calls `oldSb.Factory(ctx)`.
- `pkg/scaling/scalers_builder.go`: the factory closure takes `ctx` as a parameter instead of closing over the enclosing one; the initial build still passes `buildScalers`' own `ctx`.
- Test-only `Factory` literals updated to the new signature in `pkg/scaling/cache/scalers_cache_test.go`, `pkg/scaling/scale_handler_test.go`, `controllers/keda/hpa_test.go` and `controllers/keda/scaledobject_controller_test.go`.

No behaviour change for the initial build; only the refresh path now runs under a live context. `ScalerBuilder` lives in `pkg/scaling/cache` and is not part of the public API.

Credit to @leejones for the diagnosis and the proposed patch in #8112; this PR applies that patch together with a regression test.

## How tested

Throwaway test on `main` (28360844f) mirroring the closure in `scalers_builder.go`: the factory captures a build-time context, that context is cancelled, then `refreshScaler` is called with a live `context.Background()`:

```
--- FAIL: TestRepro_RefreshScalerRunsUnderBuildTimeContext (0.00s)
    repro_tmp_test.go:27: refreshScaler with a live caller ctx failed: context canceled
FAIL	github.com/kedacore/keda/v2/pkg/scaling/cache	0.041s
```

New regression test `TestScalersCache_RefreshScalerUsesCallerContext` (`pkg/scaling/cache/scalers_cache_test.go`) records the context a hand-built `Factory` receives from `refreshScaler` and asserts it is the caller's (live) context, not the cancelled build-time one. It covers the cache plumbing; the real closure in `scalers_builder.go` is not driven by any existing test (nothing calls `buildScalers` in unit tests). Against unfixed production code the test does not compile (the old `Factory` has no context parameter); with the fix:

```
=== RUN   TestScalersCache_RefreshScalerUsesCallerContext
--- PASS: TestScalersCache_RefreshScalerUsesCallerContext (0.00s)
ok  	github.com/kedacore/keda/v2/pkg/scaling/cache	0.047s
ok  	github.com/kedacore/keda/v2/pkg/scaling	1.008s
```

Repo-wide: `gofmt -l controllers/ pkg/` clean, `go build ./...` ok, `go vet ./...` clean, `go test -count=1 ./controllers/... ./pkg/scaling/...` (envtest 1.36) ok, `golangci-lint run ./controllers/... ./pkg/scaling/...` (v2.13.2, repo config): 0 issues. The first revision only ran vet/lint over `./pkg/scaling/...` and missed the `controllers/keda` test literals; fixed in this revision.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

## Links

Fixes https://github.com/kedacore/keda/issues/8112
Relates to https://github.com/kedacore/keda/issues/5428

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.

