### PR TITLE
CI: mongodb and selenium activation tests watch a window instead of sleeping through it

### DIFF
--- a/tests/scalers/mongodb/mongodb_test.go
+++ b/tests/scalers/mongodb/mongodb_test.go
@@ -189,9 +189,39 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, mongoPod string) {
 
 	_, err := ExecuteCommand(fmt.Sprintf("kubectl exec %s -n %s -- mongosh --eval '%s'", mongoPod, mongoNamespace, insertCmd))
 	assert.NoErrorf(t, err, "cannot insert mongo records - %s", err)
-	time.Sleep(time.Second * 60)
-	assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 0, 60, 1),
-		"job count should be 0 after 1 minute")
+	assertNoScaledJobsDuring(t, kc, activationWindow)
+}
+
+// Two documents match the query and activationQueryValue is 4, so the ScaledJob must not create a
+// job. The window is three of the ScaledJob's 20s polling intervals, so the scaler has evaluated the
+// trigger against the inserted documents more than once before the test moves on. It is a window
+// rather than a sleep followed by a count because successfulJobsHistoryLimit is 0: a job that was
+// wrongly created and finished inside the window would have been removed by the time a single count
+// ran, and would have consumed a document that the scale-out test expects to still be there.
+const activationWindow = 60 * time.Second
+
+func assertNoScaledJobsDuring(t *testing.T, kc *kubernetes.Clientset, window time.Duration) {
+	t.Logf("Asserting that no job is created for %s for %s", scaledJobName, window)
+
+	ctx, cancel := context.WithTimeout(context.Background(), window)
+	defer cancel()
+
+	err := KedaConsistently(ctx, func(ctx context.Context) (bool, error) {
+		jobs, err := kc.BatchV1().Jobs(testNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("scaledjob.keda.sh/name=%s", scaledJobName),
+		})
+		if err != nil {
+			// KedaConsistently fails on a condition error, and a list that could not be made says
+			// nothing about the jobs, so it is logged as an attempt that saw nothing to object to.
+			t.Logf("cannot list jobs in namespace %s - %s", testNamespace, err)
+			return true, nil
+		}
+		if len(jobs.Items) != 0 {
+			return false, fmt.Errorf("%d job(s) exist for %s", len(jobs.Items), scaledJobName)
+		}
+		return true, nil
+	}, IntervalShort)
+	assert.NoErrorf(t, err, "job count should stay 0 for %s", window)
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, mongoPod string) {

--- a/tests/scalers/selenium/selenium_test.go
+++ b/tests/scalers/selenium/selenium_test.go
@@ -4,6 +4,7 @@
 package selenium_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -11,6 +12,8 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/kedacore/keda/v2/tests/helper"
@@ -602,11 +605,73 @@ func testActivation(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	data.WithVersion = false
 	KubectlApplyWithTemplate(t, data, "jobTemplate", jobTemplate)
 
-	// Instead of waiting a minute with every one, we sleep the time and check them later
-	time.Sleep(time.Second * 60)
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, chromeDeploymentName, testNamespace, minReplicaCount, 5)
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, firefoxDeploymentName, testNamespace, minReplicaCount, 5)
-	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, edgeDeploymentName, testNamespace, minReplicaCount, 5)
+	// The job's session requests queue at the hub, since no browser node is running, and on their
+	// own they do not exceed activationThreshold, so none of the three ScaledObjects may scale.
+	// Nothing is queued until the job's pod is running, so that is waited for first: a window
+	// that opened before it would be measuring the scaler against an empty queue.
+	require.True(t, waitForJobPodRunning(t, kc, data.JobName), "the %s job's pod should be running", data.JobName)
+	assertNoBrowserScalesDuring(t, kc, activationWindow)
+}
+
+// A minute is twelve of the ScaledObjects' 5s polling intervals, so the scaler has evaluated the
+// queued sessions many times over before the test moves on. It replaces a 60s sleep followed by a 5s
+// check per browser, which could only see the replica count at the end and not whether it had moved
+// and come back in between.
+const activationWindow = time.Minute
+
+// The image is pulled with imagePullPolicy: Always, so this has to absorb a pull on every run.
+const jobPodRunningTimeout = 2 * time.Minute
+
+func waitForJobPodRunning(t *testing.T, kc *kubernetes.Clientset, jobName string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), jobPodRunningTimeout)
+	defer cancel()
+
+	err := KedaEventually(ctx, func(ctx context.Context) (bool, error) {
+		pods, err := kc.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("app=%s", jobName),
+		})
+		if err != nil {
+			return false, fmt.Errorf("cannot list pods of job %s - %w", jobName, err)
+		}
+
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				return true, nil
+			}
+		}
+		t.Logf("Waiting for a pod of job %s to be running. Pods - %d", jobName, len(pods.Items))
+		return false, nil
+	}, IntervalShort)
+	if err != nil {
+		t.Log(err)
+		return false
+	}
+	return true
+}
+
+func assertNoBrowserScalesDuring(t *testing.T, kc *kubernetes.Clientset, window time.Duration) {
+	deployments := []string{chromeDeploymentName, firefoxDeploymentName, edgeDeploymentName}
+	t.Logf("Asserting that %v stay at %d replicas for %s", deployments, minReplicaCount, window)
+
+	ctx, cancel := context.WithTimeout(context.Background(), window)
+	defer cancel()
+
+	err := KedaConsistently(ctx, func(ctx context.Context) (bool, error) {
+		for _, name := range deployments {
+			deployment, err := kc.AppsV1().Deployments(testNamespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				// KedaConsistently fails on a condition error, and a read that could not be made says
+				// nothing about the replicas, so it is logged as an attempt that saw nothing to object to.
+				t.Logf("cannot get deployment %s/%s - %s", testNamespace, name, err)
+				continue
+			}
+			if replicas := deployment.Status.Replicas; replicas != int32(minReplicaCount) {
+				return false, fmt.Errorf("%s replica count has changed from %d to %d", name, minReplicaCount, replicas)
+			}
+		}
+		return true, nil
+	}, IntervalShort)
+	assert.NoErrorf(t, err, "no browser deployment should scale during activation")
 }
 
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {


### PR DESCRIPTION
The `mongodb` and `selenium` tests each check that an under-threshold load does **not** activate the scaler, and both did it the same way: sleep for 60 seconds, then read the count once. Part of #7991.

That reads the state at one instant and says nothing about the minute before it. Each is now a `KedaConsistently` window of the same length, checked every second, so a job or a replica that appears at any point in the window fails the test with the count it saw.

### `mongodb`

```go
time.Sleep(time.Second * 60)
assert.True(t, WaitForScaledJobCount(t, kc, scaledJobName, testNamespace, 0, 60, 1), ...)
```

The gap here is real, not theoretical. The ScaledJob has `successfulJobsHistoryLimit: 0`, so a job that was wrongly created and finished inside the sleep had already been removed by the time the count ran — and it would have consumed one of the two documents the scale-out test expects to still find. The window is three of the ScaledJob's 20s polling intervals, so the scaler has evaluated the trigger against the inserted documents several times before the test moves on.

### `selenium`

```go
// Instead of waiting a minute with every one, we sleep the time and check them later
time.Sleep(time.Second * 60)
AssertReplicaCountNotChangeDuringTimePeriod(t, kc, chromeDeploymentName, ..., minReplicaCount, 5)
AssertReplicaCountNotChangeDuringTimePeriod(t, kc, firefoxDeploymentName, ..., minReplicaCount, 5)
AssertReplicaCountNotChangeDuringTimePeriod(t, kc, edgeDeploymentName, ..., minReplicaCount, 5)
```

One 60s window now covers all three browser deployments together, which is what the comment was reaching for.

It also opens only once the activation job's pod is running. The sessions that job requests are what the scaler is being tested against, and they are not queued at the hub until the pod is up; the job image is pulled with `imagePullPolicy: Always`, so part of the previous minute was spent measuring the scaler against an empty queue. The pod wait has a 2-minute budget to absorb that pull.

### Notes

- Read errors inside the windows are logged and skipped rather than failing the assertion, following `AssertReplicaCountNotChangeDuringTimePeriod` in the helper: a read that could not be made is not an observation.
- Sleeps under `tests/scalers`: −2. Both tests run without external credentials.

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to #7991
