### PR TITLE
CI: enable dynatrace e2e tests when licensing issue is resolved

### DIFF
--- a/tests/scalers/dynatrace/dynatrace_test.go
+++ b/tests/scalers/dynatrace/dynatrace_test.go
@@ -131,7 +131,6 @@ spec:
 )
 
 func TestDynatraceScaler(t *testing.T) {
-	t.Skip("Disabled - Dynatrace tenant access is currently unavailable due to licensing; see https://github.com/kedacore/keda/issues/6995 for details")
 	// setup
 	t.Log("--- setting up ---")
 	require.NotEmpty(t, dynatraceToken, "DYNATRACE_METRICS_TOKEN env variable is required for dynatrace tests")

--- a/tests/scalers/dynatrace_dql/dynatrace_dql_test.go
+++ b/tests/scalers/dynatrace_dql/dynatrace_dql_test.go
@@ -132,7 +132,6 @@ spec:
 )
 
 func TestDynatraceDQLScaler(t *testing.T) {
-	t.Skip("Disabled - Dynatrace tenant access is currently unavailable due to licensing; see https://github.com/kedacore/keda/issues/6995 for details")
 	// setup
 	t.Log("--- setting up ---")
 	require.NotEmpty(t, dynatraceToken, "DYNATRACE_METRICS_TOKEN env variable is required for dynatrace tests")


### PR DESCRIPTION
On hold, must wait for external resolution, reverting https://github.com/kedacore/keda/pull/8142

Relates to https://github.com/kedacore/keda/issues/6995
