### PR TITLE
CI: temporarily disable s390x e2e tests

### DIFF
--- a/.github/workflows/pr-e2e-checker.yml
+++ b/.github/workflows/pr-e2e-checker.yml
@@ -54,7 +54,12 @@ jobs:
                 per_page: 100,
               });
 
-              const payload = skip ? skipPayload : queuedPayload;
+              // Keep s390x skipped when the skip-e2e label is added or removed.
+              const payload = name === process.env.S390X_SMOKE_CHECK_NAME ? {
+                status: 'completed',
+                conclusion: 'skipped',
+                output: { title: name, summary: 'Temporarily disabled while IBM s390x runners are unavailable.' },
+              } : (skip ? skipPayload : queuedPayload);
               for (const run of runs) {
                 await github.rest.checks.update({
                   ...context.repo,

--- a/.github/workflows/pr-e2e-creator.yml
+++ b/.github/workflows/pr-e2e-creator.yml
@@ -61,21 +61,11 @@ jobs:
             {"summary": "skipped by maintainer"}
 
       - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Enqueue e2e
-        id: create-s390x
+        name: Skip s390x smoke tests during IBM outage
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ github.event.pull_request.head.sha }}
           name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          status: queued
-
-      - uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        name: Skip e2e
-        if: ${{ contains(github.event.pull_request.labels.*.name, env.SKIP_E2E_TAG )}}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.event.pull_request.head.sha }}
-          check_id: ${{ steps.create-s390x.outputs.check_id }}
-          conclusion: success
+          conclusion: skipped
           output: |
-            {"summary": "skipped by maintainer"}
+            {"summary": "Temporarily disabled while IBM s390x runners are unavailable."}

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -102,16 +102,16 @@ jobs:
           output: |
             {"summary": "🚧 Tests are running. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
-      - name: Set status in-progress
+      - name: Skip s390x smoke tests during IBM outage
         uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          status: in_progress
+          conclusion: skipped
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
-            {"summary": "🚧 Tests are running. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
+            {"summary": "Temporarily disabled while IBM s390x runners are unavailable."}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -172,18 +172,6 @@ jobs:
           output: |
             {"summary": "❌ Tests Failed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
 
-      - name: Set status failure
-        uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: steps.regex-validation.outcome != 'success'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ needs.triage.outputs.commit_sha }}
-          name: ${{ env.S390X_SMOKE_CHECK_NAME }}
-          conclusion: failure
-          details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
-          output: |
-            {"summary": "❌ Tests Failed. [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
-
       - name: Exit on failure
         if: steps.regex-validation.outcome != 'success'
         run: exit 1
@@ -226,18 +214,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.triage.outputs.commit_sha }}
           name: ${{ env.ARM_SMOKE_CHECK_NAME }}
-          conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
-          details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
-          output: |
-            {"summary": "${{ job.status == 'cancelled' && '🚫 Image build was cancelled.' || '❌ Image build failed.' }} [**View Logs**](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}})"}
-
-      - name: Set status cancelled or failure
-        uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
-        if: always() && (failure() || cancelled()) && steps.regex-validation.outcome != 'failure'
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ needs.triage.outputs.commit_sha }}
-          name: ${{ env.S390X_SMOKE_CHECK_NAME }}
           conclusion: ${{ job.status == 'cancelled' && 'cancelled' || 'failure' }}
           details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/${{job.check_run_id}}
           output: |
@@ -509,7 +485,8 @@ jobs:
     needs: [triage, build-test-images]
     runs-on: s390x
     name: Execute s390x smoke tests
-    if: needs.triage.outputs.run-e2e == 'true'
+    # Temporarily disabled while IBM s390x runners are unavailable.
+    if: ${{ false }}
     outputs:
       test-outcome: ${{ steps.test.outcome }}
     steps:
@@ -610,7 +587,7 @@ jobs:
           if-no-files-found: ignore
 
   report-reaction:
-    needs: [triage, run-e2e-test, run-arm-smoke-test, run-s390x-smoke-test]
+    needs: [triage, run-e2e-test, run-arm-smoke-test]
     runs-on: ubuntu-latest
     name: Report combined reaction
     if: ${{ always() && needs.triage.outputs.run-e2e == 'true' }}
@@ -618,8 +595,7 @@ jobs:
       - name: React to comment with success
         if: >-
           needs.run-e2e-test.outputs.test-outcome == 'success' &&
-          needs.run-arm-smoke-test.outputs.test-outcome == 'success' &&
-          needs.run-s390x-smoke-test.outputs.test-outcome == 'success'
+          needs.run-arm-smoke-test.outputs.test-outcome == 'success'
         uses: dkershner6/reaction-action@7aa897865eb9a5a1b9d6f1ab16bfcae1ce1b0334 # v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -629,8 +605,7 @@ jobs:
       - name: React to comment with failure
         if: >-
           needs.run-e2e-test.outputs.test-outcome != 'success' ||
-          needs.run-arm-smoke-test.outputs.test-outcome != 'success' ||
-          needs.run-s390x-smoke-test.outputs.test-outcome != 'success'
+          needs.run-arm-smoke-test.outputs.test-outcome != 'success'
         uses: dkershner6/reaction-action@7aa897865eb9a5a1b9d6f1ab16bfcae1ce1b0334 # v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -22,8 +22,6 @@ jobs:
             name: arm64
           - runner: ubuntu-latest
             name: amd64
-          - runner: s390x
-            name: s390x
     steps:
       - name: Maximize disk space
         if: ${{ matrix.name == 'amd64' }}
@@ -139,8 +137,6 @@ jobs:
             name: arm64
           - runner: ubuntu-latest
             name: amd64
-          - runner: s390x
-            name: s390x
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -175,8 +171,6 @@ jobs:
             name: arm64
           - runner: ubuntu-latest
             name: amd64
-          - runner: s390x
-            name: s390x
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -193,6 +187,28 @@ jobs:
       - name: Build tools
         if: steps.filter.outputs.devcontainer == 'true'
         run: make docker-build-dev-containers
+
+  # Preserve required check names while IBM s390x runners are unavailable.
+  validate-s390x:
+    name: validate - s390x
+    if: ${{ false }}
+    runs-on: s390x
+    steps:
+      - run: echo "Temporarily disabled while IBM s390x runners are unavailable."
+
+  validate-dockerfiles-s390x:
+    name: validate-dockerfiles - s390x
+    if: ${{ false }}
+    runs-on: s390x
+    steps:
+      - run: echo "Temporarily disabled while IBM s390x runners are unavailable."
+
+  validate-dev-container-s390x:
+    name: Validate dev-container - s390x
+    if: ${{ false }}
+    runs-on: s390x
+    steps:
+      - run: echo "Temporarily disabled while IBM s390x runners are unavailable."
 
   statics:
     name: Static Checks

--- a/.github/workflows/template-s390x-smoke-tests.yml
+++ b/.github/workflows/template-s390x-smoke-tests.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   smoke-tests-s390x:
     name: Validate k8s
+    # Temporarily disabled while IBM s390x runners are unavailable.
+    if: ${{ false }}
     runs-on: s390x
     steps:
       - name: Check out code


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

IBM s390x runners are unavailable, leaving PR CI, PR E2E, main and nightly workflows queued until their runner-wait timeout. I already disabled the check from being required on PRs, but they are still executed and slow down testing for other PRs.

This also blocks the whole testing pipeline on merge because they are triggered for each merged PR. 
```
RUN_ID        DATE        RESULT      URL
34386492688   2026-09-09  queued      https://github.com/kedacore/keda/actions/runs/34386492688
34360595982   2026-09-09  queued      https://github.com/kedacore/keda/actions/runs/34360595982
34348379245   2026-09-09  queued      https://github.com/kedacore/keda/actions/runs/34348379245
34347327703   2026-09-09  queued      https://github.com/kedacore/keda/actions/runs/34347327703
34333652955   2026-09-09  cancelled   https://github.com/kedacore/keda/actions/runs/34333652955
34329895703   2026-09-09  failure     https://github.com/kedacore/keda/actions/runs/34329895703
34318092583   2026-09-09  cancelled   https://github.com/kedacore/keda/actions/runs/34318092583
34281019985   2026-09-08  failure     https://github.com/kedacore/keda/actions/runs/34281019985
```

I will prepare a revert of this too so that when s390x are available again, we can turn it back on.