### PR TITLE
CI: give force_activation its own namespace instead of sharing pause_scale_in's

### DIFF
--- a/tests/internals/force_activation/force_activation_test.go
+++ b/tests/internals/force_activation/force_activation_test.go
@@ -16,7 +16,7 @@ import (
 // Load environment variables from .env file
 
 const (
-	testName = "pause-scalein-test"
+	testName = "force-activation-test"
 )
 
 var (


### PR DESCRIPTION

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

`force_activation` was added as a copy of the `pause_scale_in test` and kept its `testName`, so both tests resolved to namespace `pause-scalein-test-ns` and to the same deployment, monitored deployment and ScaledObject names inside it.

Neither test is sequential, so run-all.go runs them concurrently in a randomized order. `CreateKubernetesResources` deletes the namespace before creating it and `DeleteKubernetesResources` deletes it again at the end, so whichever test reached either point first destroyed the other's resources.

The interference ran both ways. pause_scale_in lost its deployment partway through `AssertReplicaCountNotChangeDuringTimePeriod` and then failed in teardown with NotFound for all three templates, while force_activation could not create its own resources into a terminating namespace and went on to wait for a foreign deployment to scale to zero - a deployment governed by a ScaledObject annotated with paused-scale-in, so that could never happen.

Rename `testName` to force-activation-test, which no other test uses. Every identifier in the file derives from it, so the test now owns its namespace and resource names.


<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] When introducing a new scaler, I agree with the [scaling governance policy](https://github.com/kedacore/governance/blob/main/SCALERS.md)
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Tests have been added *(if applicable)*
- [x] Ensure `make generate-scalers-schema` has been run to update any outdated generated files
- [x] A PR is opened to update our Helm chart ([repo](https://github.com/kedacore/charts)) *(if applicable, ie. when deployment manifests are modified)*
- [x] A PR is opened to update the documentation on ([repo](https://github.com/kedacore/keda-docs)) *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #8161

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->

