### PR TITLE
NATS JetStream scaler: include accounts=true in /jsz query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,6 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Event Hub Scaler**: Fix authentication failures caused by appending a duplicate `EntityPath` when `eventHubName` is provided ([#7926](https://github.com/kedacore/keda/issues/7926))
 - **Dynatrace Scaler**: Handle all documented DQL query states (`NOT_STARTED`, `FAILED`, `CANCELLED`, `RESULT_GONE`) in both the execute and poll paths; `NOT_STARTED` on either path now triggers a poll retry instead of an immediate error, and terminal error states produce descriptive messages instead of `unknown state: X` ([#7986](https://github.com/kedacore/keda/pull/7986))
 - **Github Runner Scaler**: Fix per-repository ETag job cache returning another concurrent workflow run's jobs, inflating the computed queue length when a repository has multiple simultaneous queued/in_progress runs ([#7949](https://github.com/kedacore/keda/issues/7949))
-- **NATS JetStream Scaler**: Fix `/jsz` monitoring query omitting `accounts=true`, which caused some NATS server versions to return no `account_details` at all, making the scaler always report `consumer "..." not found in stream "..."` even when the consumer exists ([#8165](https://github.com/kedacore/keda/issues/8165))
 - **Solr Scaler**: Fix a non-200 response being reported as a queue length of 0, which scaled the workload to zero during a Solr outage, an auth rejection or a missing collection instead of surfacing the error ([#8036](https://github.com/kedacore/keda/issues/8036))
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ To learn more about active deprecations, we recommend checking [GitHub Discussio
 - **Azure Event Hub Scaler**: Fix authentication failures caused by appending a duplicate `EntityPath` when `eventHubName` is provided ([#7926](https://github.com/kedacore/keda/issues/7926))
 - **Dynatrace Scaler**: Handle all documented DQL query states (`NOT_STARTED`, `FAILED`, `CANCELLED`, `RESULT_GONE`) in both the execute and poll paths; `NOT_STARTED` on either path now triggers a poll retry instead of an immediate error, and terminal error states produce descriptive messages instead of `unknown state: X` ([#7986](https://github.com/kedacore/keda/pull/7986))
 - **Github Runner Scaler**: Fix per-repository ETag job cache returning another concurrent workflow run's jobs, inflating the computed queue length when a repository has multiple simultaneous queued/in_progress runs ([#7949](https://github.com/kedacore/keda/issues/7949))
+- **NATS JetStream Scaler**: Fix `/jsz` monitoring query omitting `accounts=true`, which caused some NATS server versions to return no `account_details` at all, making the scaler always report `consumer "..." not found in stream "..."` even when the consumer exists ([#8165](https://github.com/kedacore/keda/issues/8165))
 - **Solr Scaler**: Fix a non-200 response being reported as a queue length of 0, which scaled the workload to zero during a Solr outage, an auth rejection or a missing collection instead of surfacing the error ([#8036](https://github.com/kedacore/keda/issues/8036))
 
 ### Deprecations

--- a/pkg/scalers/nats_jetstream_scaler.go
+++ b/pkg/scalers/nats_jetstream_scaler.go
@@ -348,6 +348,12 @@ func getNATSJetStreamMonitoringURL(useHTTPS bool, natsServerEndpoint string, id 
 
 	params := url.Values{}
 	params.Set("acc", id)
+	// accounts=true is required for the NATS server to include the nested
+	// account_details (and therefore stream_detail/consumer_detail) in the
+	// /jsz response at all. Without it, Accounts is always empty regardless
+	// of consumers=true/config=true, so every lookup fails with "consumer
+	// not found in stream" even when the consumer exists.
+	params.Set("accounts", "true")
 	params.Set("consumers", "true")
 	params.Set("config", "true")
 

--- a/pkg/scalers/nats_jetstream_scaler_test.go
+++ b/pkg/scalers/nats_jetstream_scaler_test.go
@@ -543,21 +543,21 @@ func TestGetNATSJetStreamMonitoringURL(t *testing.T) {
 			useHTTPS:           false,
 			natsServerEndpoint: "nats.nats:8222",
 			accountID:          "$G",
-			expectedURL:        "http://nats.nats:8222/jsz?acc=%24G&config=true&consumers=true",
+			expectedURL:        "http://nats.nats:8222/jsz?acc=%24G&accounts=true&config=true&consumers=true",
 		},
 		{
 			name:               "HTTPS scheme",
 			useHTTPS:           true,
 			natsServerEndpoint: "nats.nats:8222",
 			accountID:          "$G",
-			expectedURL:        "https://nats.nats:8222/jsz?acc=%24G&config=true&consumers=true",
+			expectedURL:        "https://nats.nats:8222/jsz?acc=%24G&accounts=true&config=true&consumers=true",
 		},
 		{
 			name:               "Account ID with ampersand is URL-encoded and cannot inject parameters",
 			useHTTPS:           false,
 			natsServerEndpoint: "nats.nats:8222",
 			accountID:          "myaccount&consumers=false",
-			expectedURL:        "http://nats.nats:8222/jsz?acc=myaccount%26consumers%3Dfalse&config=true&consumers=true",
+			expectedURL:        "http://nats.nats:8222/jsz?acc=myaccount%26consumers%3Dfalse&accounts=true&config=true&consumers=true",
 		},
 	}
 
@@ -571,6 +571,7 @@ func TestGetNATSJetStreamMonitoringURL(t *testing.T) {
 			q := parsedURL.Query()
 			assert.Equal(t, "true", q.Get("consumers"), "consumers parameter must always be true")
 			assert.Equal(t, "true", q.Get("config"), "config parameter must always be true")
+			assert.Equal(t, "true", q.Get("accounts"), "accounts parameter must always be true, otherwise the NATS server omits account_details/stream_detail/consumer_detail from the response entirely")
 			assert.Equal(t, tt.accountID, q.Get("acc"), "acc parameter must equal the raw account ID")
 		})
 	}
@@ -598,6 +599,7 @@ func TestNATSJetStreamMonitoringNodeURLEncoding(t *testing.T) {
 	q := parsedURL.Query()
 	assert.Equal(t, "true", q.Get("consumers"), "consumers parameter must always be true after node URL construction")
 	assert.Equal(t, "true", q.Get("config"), "config parameter must always be true after node URL construction")
+	assert.Equal(t, "true", q.Get("accounts"), "accounts parameter must be preserved after node URL construction")
 	assert.Equal(t, "$G", q.Get("acc"), "acc parameter must be preserved correctly in node URL")
 	assert.Equal(t, "leader.nats.svc:8222", parsedURL.Host, "node hostname must be set correctly")
 }
@@ -624,6 +626,7 @@ func TestNATSJetStreamMonitoringNodeURLByNodeEncoding(t *testing.T) {
 	q := parsedURL.Query()
 	assert.Equal(t, "true", q.Get("consumers"), "consumers parameter must always be true after node-by-node URL construction")
 	assert.Equal(t, "true", q.Get("config"), "config parameter must always be true after node-by-node URL construction")
+	assert.Equal(t, "true", q.Get("accounts"), "accounts parameter must be preserved after node-by-node URL construction")
 	assert.Equal(t, "$G", q.Get("acc"), "acc parameter must be preserved correctly in node-by-node URL")
 	assert.True(t, strings.HasPrefix(parsedURL.Host, "leader."), "node-by-node hostname must be prefixed with node name")
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [contribution guidelines](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md).
- [x] I've checked for existing issues/PRs covering this change.
- [x] I've added unit tests covering this change.
- [ ] I've added an e2e test (not applicable — bug fix to an existing scaler's request construction, no new scaling behavior).

## Relates to

Fixes #8165

## Description

`getNATSJetStreamMonitoringURL` builds the `/jsz` monitoring query with `acc`, `consumers=true`, and `config=true`, but never sets `accounts=true`. Some NATS server versions (confirmed on 2.12.7) only include the nested `account_details` — and therefore `stream_detail`/`consumer_detail` — in the response when `accounts=true` is present. Without it, `account_details` is absent from the response, so the scaler's consumer lookup always fails with `consumer "<name>" not found in stream "<stream>"`, even when the consumer exists.

This was isolated by replaying the scaler's exact query against a live server and confirming that adding only `accounts=true` (no other change) makes the response include the expected `consumer_detail` entries.

The fix adds `params.Set("accounts", "true")` to `getNATSJetStreamMonitoringURL`. Since the per-node monitoring URLs (`getNATSJetStreamMonitoringNodeURL`, `getNATSJetStreamMonitoringNodeURLByNode`) derive their query string from this same base URL, they pick up the fix automatically — updated their tests to assert on it too, for regression coverage.

## Checklist for related e2e test

Not applicable — see above.
