### PR TITLE
External Push Scaler: Activation send blocking on stream cancellation

### DIFF
--- a/pkg/scalers/external_scaler.go
+++ b/pkg/scalers/external_scaler.go
@@ -382,7 +382,11 @@ func handleIsActiveStream(ctx context.Context, scaledObjectRef *pb.ScaledObjectR
 			return err
 		}
 
-		active <- resp.Result
+		select {
+		case active <- resp.Result:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 

--- a/pkg/scalers/external_scaler_test.go
+++ b/pkg/scalers/external_scaler_test.go
@@ -2,6 +2,7 @@ package scalers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync/atomic"
@@ -672,5 +673,70 @@ func TestConvertMetricSpecResponse(t *testing.T) {
 	// First spec uses integer target
 	if specs[0].External.Target.AverageValue.Value() != 50 {
 		t.Errorf("expected target 50, got %d", specs[0].External.Target.AverageValue.Value())
+	}
+}
+
+type cancellationStreamClient struct {
+	pb.ExternalScalerClient
+	stream *cancellationActiveStream
+}
+
+func (c *cancellationStreamClient) StreamIsActive(context.Context, *pb.ScaledObjectRef, ...grpc.CallOption) (grpc.ServerStreamingClient[pb.IsActiveResponse], error) {
+	return c.stream, nil
+}
+
+type cancellationActiveStream struct {
+	grpc.ClientStream
+	ctx      context.Context
+	first    bool
+	received chan struct{}
+}
+
+func (s *cancellationActiveStream) Recv() (*pb.IsActiveResponse, error) {
+	if !s.first {
+		s.first = true
+		close(s.received)
+		return &pb.IsActiveResponse{Result: true}, nil
+	}
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+// TestHandleIsActiveStreamRespectsCancellation ensures the activation send is
+// released when the stream context is canceled, even if no receiver remains.
+func TestHandleIsActiveStreamRespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := &cancellationActiveStream{ctx: ctx, received: make(chan struct{})}
+	client := &cancellationStreamClient{stream: stream}
+	active := make(chan bool)
+	done := make(chan error, 1)
+	go func() { done <- handleIsActiveStream(ctx, &pb.ScaledObjectRef{}, client, active) }()
+
+	select {
+	case <-stream.received:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive activation from fake RPC")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("unexpected cancellation result: %v", err)
+		}
+	case <-time.After(time.Second):
+		// Drain the blocked send so a failed regression run does not leak a goroutine.
+		select {
+		case <-active:
+		case <-time.After(time.Second):
+			t.Fatal("could not drain blocked activation")
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("stream did not exit after draining activation")
+		}
+		t.Fatal("cancellation did not release the blocked activation send")
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md
-->

`handleIsActiveStream` sends each received activation to the `active` channel with an unconditional `active <- resp.Result`. Because that channel is unbuffered and the push-scaler receive loop can exit on cancellation, the stream goroutine can remain blocked on the send with no receiver, and it has no way to observe context cancellation. This creates a goroutine-leak path during push-scaler shutdown or replacement.

This change makes the send cancellation-aware by selecting on `ctx.Done()`, so the stream returns promptly when its context is canceled even if no receiver remains.

A regression test (`TestHandleIsActiveStreamRespectsCancellation`) reproduces the blocked-send scenario and asserts the function returns `context.Canceled` after cancellation; it fails without this change.

<!-- Checklist
     Please don't delete the checklist. Go through the entire list and check off what has been completed
-->

### Checklist

- [x] Tests have been added *(if applicable)*
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

<!--
  Make sure to link the related issue for this change
  If it requires multiple PRs and/or a PR on another repo as well, please use "Relates to" instead
-->
Fixes #8169

<!--
  Make sure to link the related PRs for changes such as documentation & Helm charts
-->
Relates to #
